### PR TITLE
refactor(content): Refactor the Argosy Hijacking mission

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -953,26 +953,6 @@ government "Merchant"
 	"hostile hail" "hostile civilian"
 	"hostile disabled hail" "hostile disabled"
 
-government "Merchant (Hijacked)"
-	"display name" "Merchant"
-	swizzle 5
-	"attitude toward"
-		"Republic" -.01
-		"Syndicate" -.01
-	"player reputation" 1
-	"fine" 0
-	"friendly hail" "friendly civilian"
-	"friendly disabled hail" "friendly disabled"
-	"hostile hail" "hostile pirate"
-	"hostile disabled hail" "hostile disabled"
-	"penalty for"
-		assist 0
-		disable 0
-		board 0
-		capture 0
-		destroy 0
-		atrocity 0
-
 government "Militia"
 	swizzle 2
 	color "governments: Free"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5866,19 +5866,8 @@ mission "Quicksilver Mixup 3"
 
 
 
-
-mission "Argosy Hijacking (Trigger)"
-	landing
-	invisible
-	source
-		government "Syndicate"
-	to offer
-		"combat rating" > 200
-		random < 5
-	on offer
-		fail
-
 mission "Argosy Hijacking"
+	minor
 	landing
 	name "Stop Ship Hijacking"
 	description "The <npc> was hijacked on <origin>; disable it and return to <origin>. Do not board, capture, or destroy it; Syndicated Security will deal with the hijackers in space after you have disabled it."
@@ -5887,7 +5876,8 @@ mission "Argosy Hijacking"
 		not attributes "station"
 		not near "Sol" 3
 	to offer
-		has "Argosy Hijacking (Trigger): offered"
+		"combat rating" > 200
+		random < 5
 	on offer
 		conversation
 			`You're signing the standard Syndicate landing papers with an officer on <origin>. "Everything seems to be in order. And of course, we'll have your ship refueled promptly. Have a good day, Captain <last>." He nods his head at you and starts to move off towards the next ship.`
@@ -5944,7 +5934,7 @@ mission "Argosy Hijacking"
 			fail
 		on kill
 			set "destroyed hijacked argosy"
-			dialog `You have destroyed the Moonshake Express. Its captain won't be impressed.`
+			dialog `You have destroyed the Moonshake Express. The ship's captain won't be impressed.`
 
 	on fail
 		conversation
@@ -6024,32 +6014,6 @@ mission "Argosy Hijacking"
 			`As you land, Syndicated Security have the <npc> in tow, escorted by a trio of Quicksilvers. The formation lands on one of the larger pads reserved for Syndicated Security vessels, fenced off from the rest of the spaceport.`
 			`	The hijackers, just a raucous group of young kids, are hauled out of the <npc model> by Syndicated Security personnel towards an armored van. Multiple times the kids try to run away, but after a few minutes they're finally detained; the van drives off towards the spaceport terminal.`
 			`	After the incident is wrapped up, the captain of the <npc> sends you <payment>, and a message thanking you for helping him recover his ship.`
-
-mission "Argosy Hijacking (Declined)"
-	invisible
-	landing
-	source
-		government "Syndicate"
-		not attributes "station"
-		not near "Sol" 3
-	deadline 1
-	to offer
-		has "Argosy Hijacking (Trigger): offered"
-	to complete
-		never
-	npc
-		personality launching daring uninterested
-			confusion 40
-		government "Merchant (Hijacked)"
-		ship "Argosy (Blaster)" "Moonshake Express"
-		to spawn
-			has "Argosy Hijacking: declined"
-	npc
-		personality launching disables uninterested
-		government "Syndicate"
-		fleet "Small Syndicate"
-		to spawn
-			has "Argosy Hijacking: declined"
 
 
 

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6015,6 +6015,8 @@ mission "Argosy Hijacking"
 			`	The hijackers, just a raucous group of young kids, are hauled out of the <npc model> by Syndicated Security personnel towards an armored van. Multiple times the kids try to run away, but after a few minutes they're finally detained; the van drives off towards the spaceport terminal.`
 			`	After the incident is wrapped up, the captain of the <npc> sends you <payment>, and a message thanking you for helping him recover his ship.`
 
+
+
 mission "Blind Man from Martini"
 	name "Transport a blind passenger to <planet>"
 	description "This blind man, Douglas, wishes to be transported to <destination>, so he can be with his daughter while she undergoes treatment there. He will pay you <payment>."

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6015,8 +6015,6 @@ mission "Argosy Hijacking"
 			`	The hijackers, just a raucous group of young kids, are hauled out of the <npc model> by Syndicated Security personnel towards an armored van. Multiple times the kids try to run away, but after a few minutes they're finally detained; the van drives off towards the spaceport terminal.`
 			`	After the incident is wrapped up, the captain of the <npc> sends you <payment>, and a message thanking you for helping him recover his ship.`
 
-
-
 mission "Blind Man from Martini"
 	name "Transport a blind passenger to <planet>"
 	description "This blind man, Douglas, wishes to be transported to <destination>, so he can be with his daughter while she undergoes treatment there. He will pay you <payment>."


### PR DESCRIPTION
**Refactor (Missions)**
This PR addresses some issues I've had with this mission I wrote, especially how it is triggered.

## Summary
The Argosy Hijacking mission is made of three missions; a trigger mission that tests whether the player is in Syndicate space and has >200 CR, and then a conversation mission that fires after the trigger mission has been offered, and which spawns an NPC if you accept the mission. Because missions are only ever offered once upon landing on a planet, it is not possible to make the trigger mission lead immediately to the conversation mission. Therefore, you can be offered the trigger mission, then wander out of Syndicate space, then come back and get surprised with the mission way after the trigger was meant to happen.

The reason why the trigger mission is necessary in the first place is to ensure that the third mission, which spawns an NPC if you decline the conversation mission, fires. You cannot have an NPC that will spawn if you decline a mission _and_ an NPC that will spawn if you accept a mission in the same mission definition; it doesn't work.

I've decided to just cut everything but the conversation mission, which solves the trigger issue. The gimmick of having the NPC appear when you've declined the conversation mission was something I thought wasn't worth keeping, and I've removed the government associated with it to reduce a little bit of overhead. I also added `minor` to the mission so that it doesn't happen mid-FW war either : )

## Testing Done
No.

## Save File
This save file can be used to test these changes:
Any file with >200 CR and hasn't done the mission can do it.