### PR TITLE
fix(mechanics): Fix ship parenting on takeoff with fighter flagship

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1041,7 +1041,10 @@ void PlayerInfo::SetFlagship(Ship &other)
 
 	// Make sure your ships all know who the flagship is.
 	for(const shared_ptr<Ship> &ship : ships)
-		ship->SetParent(flagship);
+	{
+		bool shouldFollowFlagship = (ship != flagship && !ship->IsParked());
+		ship->SetParent(shouldFollowFlagship ? flagship : shared_ptr<Ship>());
+	}
 
 	// Move the flagship to the beginning to the list of ships.
 	MoveFlagshipBegin(ships, flagship);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1039,13 +1039,9 @@ void PlayerInfo::SetFlagship(Ship &other)
 	// Set the new flagship pointer.
 	flagship = other.shared_from_this();
 
-	// Make sure your jump-capable ships all know who the flagship is.
+	// Make sure your ships all know who the flagship is.
 	for(const shared_ptr<Ship> &ship : ships)
-	{
-		bool shouldFollowFlagship = (ship != flagship && !ship->IsParked() &&
-			(!ship->CanBeCarried() || ship->JumpNavigation().JumpFuel() || flagship->CanBeCarried()));
-		ship->SetParent(shouldFollowFlagship ? flagship : shared_ptr<Ship>());
-	}
+		ship->SetParent(flagship);
 
 	// Move the flagship to the beginning to the list of ships.
 	MoveFlagshipBegin(ships, flagship);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1043,7 +1043,7 @@ void PlayerInfo::SetFlagship(Ship &other)
 	for(const shared_ptr<Ship> &ship : ships)
 	{
 		bool shouldFollowFlagship = (ship != flagship && !ship->IsParked() &&
-			(!ship->CanBeCarried() || ship->JumpNavigation().JumpFuel()));
+			(!ship->CanBeCarried() || ship->JumpNavigation().JumpFuel() || flagship->CanBeCarried()));
 		ship->SetParent(shouldFollowFlagship ? flagship : shared_ptr<Ship>());
 	}
 


### PR DESCRIPTION
**Bug fix**

This PR fixes an issue where ships don't get assigned a parent when all of your ships (including your flagship) can be carried.

## Summary
Currently, if you try to have a fleet of only fighters/drones, they will ignore where your flagship goes and will instead constantly go to planets to refuel (even if they have no HD or fuel capacity). (The only case where this does not happen is if your other fighters have the jump fuel attribute set; it still happens if your flagship has the HD/JD.)

With this fix, these fighters will follow the flagship around as expected. Since fighters get reparented to their carrier during takeoff, this just changes the default from 'no parent' to 'flagship'.

## Usage examples
This is helpful for fighter flagship gameplay, especially if one intends on capturing a carrier in-system using these fighters.

## Testing Done
I tested that fighters follow the flagship around and that fighters inside carriers work as before when taking off (and after deploying).