### PR TITLE
fix: Fix plural `ships` in messages when recalling/deploying a single ship

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -177,14 +177,16 @@ namespace {
 		{
 			for(Ship *ship : toDeploy)
 				ship->SetDeployOrder(true);
-			Messages::Add("Deployed " + to_string(toDeploy.size()) + " carried ships.", Messages::Importance::High);
+			string ship = (toDeploy.size() == 1 ? "ship" : "ships");
+			Messages::Add("Deployed " + to_string(toDeploy.size()) + " carried " + ship + ".", Messages::Importance::High);
 		}
 		// Otherwise, instruct the carried ships to return to their berth.
 		else if(!toRecall.empty())
 		{
 			for(Ship *ship : toRecall)
 				ship->SetDeployOrder(false);
-			Messages::Add("Recalled " + to_string(toRecall.size()) + " carried ships", Messages::Importance::High);
+			string ship = (toDeploy.size() == 1 ? "ship" : "ships");
+			Messages::Add("Recalled " + to_string(toRecall.size()) + " carried " + ship + ".", Messages::Importance::High);
 		}
 	}
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -185,7 +185,7 @@ namespace {
 		{
 			for(Ship *ship : toRecall)
 				ship->SetDeployOrder(false);
-			string ship = (toDeploy.size() == 1 ? "ship" : "ships");
+			string ship = (toRecall.size() == 1 ? "ship" : "ships");
 			Messages::Add("Recalled " + to_string(toRecall.size()) + " carried " + ship + ".", Messages::Importance::High);
 		}
 	}


### PR DESCRIPTION
**Bug fix**

This PR fixes a bug where the `Deployed/Recalled x carried ships` says `ships` for a single affected ship.

## Testing Done
I tested that the messages use the singular version.