### PR TITLE
feat(ui): A help message for managing multiple ships in the outfitter

### DIFF
--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -161,6 +161,10 @@ help "uninstalling and storage"
 	`You can also uninstall outfits directly into planetary storage by selecting the outfit and pressing U. This can be useful for if you want to shuffle outfits between ships, store outfits for future use, or simply try on different outfits. Outfits in storage can also be transferred to cargo when you go to 'purchase to cargo' mode. Outfits that are in planetary storage or cargo can be (re)installed at any outfitter without cost.`
 	`If you sell an outfit at an outfitter, then you can immediately buy it back for the same price that you sold it, so long as you do not leave the planet. This means that you do not necessarily need to worry about uninstalling outfits into planetary storage when you are changing outfits around.`
 
+help "outfitter with multiple ships"
+	`In the outfitter you can manage multiple ships at the same time. Ctrl+click a ship icon to add it to your selection. You can also use Shift+click to select a range of ships.`
+	`When you have more than one ship selected, you can install or remove outfits from all of those ships at once. Additionally, all selected ships that have the currently selected outfit installed are marked with a pointer next to their sidebar icon.`
+
 help "stranded"
 	`Oops! You just ran out of fuel in an uninhabited star system. Fortunately, other ships are willing to help you.`
 	`Press <Select next ship> to cycle through all the ships in this system. When you have a friendly one selected, press <Talk to selected ship> to hail it. You can then ask for help, and if it has fuel to spare it will fly over and transfer fuel to your ship. This is easiest for the other ship to do if your ship is nearly stationary.`

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -163,7 +163,7 @@ help "uninstalling and storage"
 
 help "outfitter with multiple ships"
 	`In the outfitter you can manage multiple ships at the same time. Ctrl+click a ship icon to add it to your selection. You can also use Shift+click to select a range of ships.`
-	`When you have more than one ship selected, you can install or remove outfits from all of those ships at once. Additionally, all selected ships that have the currently selected outfit installed are marked with a pointer next to their sidebar icon.`
+	`When you have more than one ship selected, you can install or remove outfits from all of those ships at once. Additionally, all selected ships with the currently selected outfit installed are marked with a pointer next to their sidebar icon.`
 
 help "stranded"
 	`Oops! You just ran out of fuel in an uninhabited star system. Fortunately, other ships are willing to help you.`

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -162,7 +162,7 @@ help "uninstalling and storage"
 	`If you sell an outfit at an outfitter, then you can immediately buy it back for the same price that you sold it, so long as you do not leave the planet. This means that you do not necessarily need to worry about uninstalling outfits into planetary storage when you are changing outfits around.`
 
 help "outfitter with multiple ships"
-	`In the outfitter you can manage multiple ships at the same time. Ctrl+click a ship icon to add it to your selection. You can also use Shift+click to select a range of ships.`
+	`You can manage outfits on multiple ships at the same time. Ctrl+click a ship icon to add it to your selection. You can also use Shift+click to select a range of ships.`
 	`When you have more than one ship selected, you can install or remove outfits from all of those ships at once. Additionally, all selected ships with the currently selected outfit installed are marked with a pointer next to their sidebar icon.`
 
 help "stranded"

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -101,7 +101,8 @@ void OutfitterPanel::Step()
 	if(GetUI()->IsTop(this) && !checkedHelp)
 		// Use short-circuiting to only display one of them at a time.
 		// (The first valid condition encountered will make us skip the others.)
-		if(DoHelp("outfitter") || DoHelp("cargo management") || DoHelp("uninstalling and storage") || true)
+		if(DoHelp("outfitter") || DoHelp("cargo management") || DoHelp("uninstalling and storage")
+				|| (player.Ships().size() > 1 && DoHelp("outfitter with multiple ships")) || true)
 			// Either a help message was freshly displayed, or all of them have already been seen.
 			checkedHelp = true;
 }

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -89,7 +89,7 @@ OutfitterPanel::OutfitterPanel(PlayerInfo &player)
 
 	if(player.GetPlanet())
 		outfitter = player.GetPlanet()->Outfitter();
-	
+
 	for(auto &ship : player.Ships())
 		if(ship->GetPlanet() == planet)
 			++shipsHere;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -89,6 +89,10 @@ OutfitterPanel::OutfitterPanel(PlayerInfo &player)
 
 	if(player.GetPlanet())
 		outfitter = player.GetPlanet()->Outfitter();
+	
+	for(auto &ship : player.Ships())
+		if(ship->GetPlanet() == planet)
+			++shipsHere;
 }
 
 
@@ -102,7 +106,7 @@ void OutfitterPanel::Step()
 		// Use short-circuiting to only display one of them at a time.
 		// (The first valid condition encountered will make us skip the others.)
 		if(DoHelp("outfitter") || DoHelp("cargo management") || DoHelp("uninstalling and storage")
-				|| (player.Ships().size() > 1 && DoHelp("outfitter with multiple ships")) || true)
+				|| (shipsHere > 1 && DoHelp("outfitter with multiple ships")) || true)
 			// Either a help message was freshly displayed, or all of them have already been seen.
 			checkedHelp = true;
 }

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -94,6 +94,8 @@ private:
 
 	// Keep track of how many of the outfitter help screens have been shown
 	bool checkedHelp = false;
+
+	int shipsHere;
 };
 
 

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -95,7 +95,7 @@ private:
 	// Keep track of how many of the outfitter help screens have been shown
 	bool checkedHelp = false;
 
-	int shipsHere;
+	int shipsHere = 0;
 };
 
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -296,7 +296,11 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	else if(command.Has(Command::HELP))
 	{
 		if(player.Ships().size() > 1)
+		{
+			if(isOutfitter)
+				DoHelp("outfitter with multiple ships", true);
 			DoHelp("multiple ships", true);
+		}
 		if(isOutfitter)
 		{
 			DoHelp("uninstalling and storage", true);

--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -26,6 +26,7 @@
 "help: multiple ships" 1
 "help: navigation" 1
 "help: outfitter" 1
+"help: outfitter with multiple ships" 1
 "help: cargo management" 1
 "help: uninstalling and storage" 1
 "help: ship info" 1


### PR DESCRIPTION
## Summary
Added a help message that appears when you open the outfitter with more than one ship. It explains that you can change outfits of multiple ships at once and also tells you about the "has this outfit installed" sidebar indicators.

## Testing Done
Works both automatically and manually.

## Performance Impact
N/A
