### PR TITLE
feat(ui): Allow multiple pages of controls

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -479,6 +479,19 @@ interface "controls"
 		dimensions 90 30
 		color medium
 		hover bright
+	visible if "multiple controls pages"
+	sprite "ui/dialog cancel"
+		center -115 210
+	active if "show next controls"
+	button n "_Next"
+		center -115 210
+		dimensions 70 30
+	sprite "ui/wide button"
+		center -210 210
+	active if "show previous controls"
+	button r "P_revious"
+		center -210 210
+		dimensions 90 30
 
 
 
@@ -499,16 +512,16 @@ interface "settings"
 		dimensions 90 30
 		color medium
 		hover bright
-	visible if "multiple pages"
+	visible if "multiple settings pages"
 	sprite "ui/dialog cancel"
 		center -115 210
-	active if "show next"
+	active if "show next settings"
 	button n "_Next"
 		center -115 210
 		dimensions 70 30
 	sprite "ui/wide button"
 		center -210 210
-	active if "show previous"
+	active if "show previous settings"
 	button r "P_revious"
 		center -210 210
 		dimensions 90 30

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -78,7 +78,8 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 
-	// How many pages of settings there are.
+	// How many pages of controls and settings there are.
+	const int CONTROLS_PAGE_COUNT = 2;
 	const int SETTINGS_PAGE_COUNT = 2;
 	// Hovering a preference for this many frames activates the tooltip.
 	const int HOVER_TIME = 60;
@@ -138,12 +139,18 @@ void PreferencesPanel::Draw()
 	info.SetBar("volume", Audio::Volume());
 	if(Plugins::HasChanged())
 		info.SetCondition("show plugins changed");
+	if(CONTROLS_PAGE_COUNT > 1)
+		info.SetCondition("multiple controls pages");
+	if(currentControlsPage > 0)
+		info.SetCondition("show previous controls");
+	if(currentControlsPage + 1 < CONTROLS_PAGE_COUNT)
+		info.SetCondition("show next controls");
 	if(SETTINGS_PAGE_COUNT > 1)
-		info.SetCondition("multiple pages");
+		info.SetCondition("multiple settings pages");
 	if(currentSettingsPage > 0)
-		info.SetCondition("show previous");
+		info.SetCondition("show previous settings");
 	if(currentSettingsPage + 1 < SETTINGS_PAGE_COUNT)
-		info.SetCondition("show next");
+		info.SetCondition("show next settings");
 	GameData::Interfaces().Get("menu background")->Draw(info, this);
 	string pageName = (page == 'c' ? "controls" : page == 's' ? "settings" : "plugins");
 	GameData::Interfaces().Get(pageName)->Draw(info, this);
@@ -202,15 +209,24 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 	}
 	else if(key == 'o' && page == 'p')
 		Files::OpenUserPluginFolder();
-	else if((key == 'n' || key == SDLK_PAGEUP) && currentSettingsPage < SETTINGS_PAGE_COUNT - 1)
+	else if((key == 'n' || key == SDLK_PAGEUP)
+		&& ((page == 'c' && currentControlsPage < CONTROLS_PAGE_COUNT - 1)
+		|| (page == 's' && currentSettingsPage < SETTINGS_PAGE_COUNT - 1)))
 	{
-		++currentSettingsPage;
+		if(page == 'c')
+			++currentControlsPage;
+		else
+			++currentSettingsPage;
 		selected = 0;
 		selectedItem.clear();
 	}
-	else if((key == 'r' || key == SDLK_PAGEDOWN) && currentSettingsPage > 0)
+	else if((key == 'r' || key == SDLK_PAGEDOWN)
+		&& ((page == 'c' && currentControlsPage > 0) || (page == 's' && currentSettingsPage > 0)))
 	{
-		--currentSettingsPage;
+		if(page == 'c')
+			--currentControlsPage;
+		else
+			--currentSettingsPage;
 		selected = 0;
 		selectedItem.clear();
 	}
@@ -427,13 +443,24 @@ void PreferencesPanel::DrawControls()
 	int firstY = -248;
 	table.DrawAt(Point(-130, firstY));
 
+	// About CONTROLS pagination
+	// * A NONE command means that a string from CATEGORIES should be drawn
+	//   instead of a command.
+	// * A '\t' category string indicates that the first column on this page has
+	//   ended, and the next line should be drawn at the start of the next
+	//   column.
+	// * A '\n' category string indicates that this page is complete, no further
+	//   lines should be drawn on this page.
+	// * The namespace variable CONTROLS_PAGE_COUNT should be updated to the max
+	//   page count (count of '\n' characters plus one).
 	static const string CATEGORIES[] = {
 		"Keyboard Navigation",
-		"Interface",
+		"Fleet",
+		"\t",
 		"Targeting",
 		"Weapons",
-		"Interface",
-		"Fleet"
+		"\n",
+		"Interface"
 	};
 	const string *category = CATEGORIES;
 	static const Command COMMANDS[] = {
@@ -447,8 +474,13 @@ void PreferencesPanel::DrawControls()
 		Command::LAND,
 		Command::JUMP,
 		Command::NONE,
-		Command::MAP,
-		Command::INFO,
+		Command::DEPLOY,
+		Command::FIGHT,
+		Command::GATHER,
+		Command::HOLD,
+		Command::AMMO,
+		Command::HARVEST,
+		Command::NONE,
 		Command::NONE,
 		Command::NEAREST,
 		Command::TARGET,
@@ -463,34 +495,53 @@ void PreferencesPanel::DrawControls()
 		Command::CLOAK,
 		Command::MOUSE_TURNING_HOLD,
 		Command::NONE,
+		Command::NONE,
 		Command::MENU,
+		Command::MAP,
+		Command::INFO,
 		Command::FULLSCREEN,
 		Command::FASTFORWARD,
 		Command::HELP,
-		Command::MESSAGE_LOG,
-		Command::NONE,
-		Command::DEPLOY,
-		Command::FIGHT,
-		Command::GATHER,
-		Command::HOLD,
-		Command::AMMO,
-		Command::HARVEST
+		Command::MESSAGE_LOG
 	};
-	static const Command *BREAK = &COMMANDS[19];
+
+	int page = 0;
 	for(const Command &command : COMMANDS)
 	{
-		// The "BREAK" line is where to go to the next column.
-		if(&command == BREAK)
-			table.DrawAt(Point(130, firstY));
-
+		string categoryString;
 		if(!command)
 		{
-			table.DrawGap(10);
-			table.DrawUnderline(medium);
 			if(category != end(CATEGORIES))
-				table.Draw(*category++, bright);
+				categoryString = *category++;
 			else
 				table.Advance();
+			// Check if this is a page break.
+			if(categoryString == "\n")
+			{
+				++page;
+				continue;
+			}
+		}
+		// Check if this command is on the page being displayed.
+		// If this command isn't on the page being displayed, check if it is on an earlier page.
+		// If it is, continue to the next command.
+		// Otherwise, this command is on a later page,
+		// do not continue as no further commands are to be displayed.
+		if(page < currentControlsPage)
+			continue;
+		else if(page > currentControlsPage)
+			break;
+		if(!command)
+		{
+			// Check if this is a column break.
+			if(categoryString == "\t")
+			{
+				table.DrawAt(Point(130, firstY));
+				continue;
+			}
+			table.DrawGap(10);
+			table.DrawUnderline(medium);
+			table.Draw(categoryString, bright);
 			table.Draw("Key", bright);
 			table.DrawGap(5);
 		}

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -92,6 +92,7 @@ private:
 	std::string tooltip;
 	WrappedText hoverText;
 
+	int currentControlsPage = 0;
 	int currentSettingsPage = 0;
 
 	std::string selectedPlugin;


### PR DESCRIPTION
## Summary
Currently the controls screen in the preferences is full and the "Interface" category is split across the two columns.
To make room for possible new hotkeys and put all "Interface" commands to one place, I've added a second page.
The new layout is shown in the screenshots below (and of course is subject to changes).

## Screenshots
Before (no pages):
![page0](https://github.com/endless-sky/endless-sky/assets/108272452/3a93f68d-f3b4-46af-bdcd-fbe9bdc618a4)
After (page 1):
![page1](https://github.com/endless-sky/endless-sky/assets/108272452/bb773c5d-aedc-4e3c-8a20-2bdfe571a950)
After (page 2):
![page2](https://github.com/endless-sky/endless-sky/assets/108272452/713b5f19-3293-4305-8fce-fa9232c51e6a)

## Testing Done
Tooltips still pop up, conflicting keybinds are still marked, page switching works.

## Performance Impact
N/A