### PR TITLE
fix(CI): Don't check for leading/trailing spaces in substitutions defined in missions

### DIFF
--- a/utils/contentStyle.json
+++ b/utils/contentStyle.json
@@ -125,7 +125,7 @@
 				]
 			},
 			{
-				"excludedNodes": ["^word$", "^replace$"],
+				"excludedNodes": ["^word$", "^replace$", "^substitutions$"],
 				"checks": [
 					{
 						"description": "whitespace before end of text",


### PR DESCRIPTION
**Bug fix**

This PR loosens the restrictions on in-mission substitutions in the content style checker.

## Summary
Adds the `substitutions` node to the excluded nodes for these checks, similar to how they exclude `word` and `phrase`. This was previously causing issues in #9757 (https://github.com/endless-sky/endless-sky/actions/runs/8268384341/job/22621129434)

## Testing Done
I tested that the issue above is no longer detected.