### PR TITLE
Bugfix: give Cruiser in `FWC Cebalrai 1B` Combat Drones instead of Lances.

### DIFF
--- a/data/human/free worlds 3 checkmate.txt
+++ b/data/human/free worlds 3 checkmate.txt
@@ -312,7 +312,7 @@ mission "FWC Cebalrai 1B"
 				names "republic fighter"
 			variant
 				"Cruiser"
-				"Lance" 4
+				"Combat Drone" 4
 				"Frigate" 2
 
 


### PR DESCRIPTION
**Bug fix**

## Summary
Cruisers have drone bays, not fighter bays, so they should be using drones rather than fighters.