### PR TITLE
Fix mission distance calculation with distance calculation settings

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1352,6 +1352,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	result.illegalCargoMessage = Phrase::ExpandPhrases(illegalCargoMessage);
 	result.failIfDiscovered = failIfDiscovered;
 
+	result.distanceCalcSettings = distanceCalcSettings;
 	int jumps = result.CalculateJumps(sourceSystem);
 
 	int64_t payload = static_cast<int64_t>(result.cargoSize) + 10 * static_cast<int64_t>(result.passengers);


### PR DESCRIPTION
**Bug fix**

## Summary
When a new mission is being instantiated, the number of jumps it is expected to require is calculated by the new mission object, not the template mission.
Currently, the distance calculation settings are not copied from the template mission to the new mission. This means that, when the expected number of jump for the new mission is calculated, it does not account for the distance calculation settings.

This PR copies the distance calculation settings from the template into the new mission prior to calculating its expected number of jumps, so it actualy uses the settings for that.

## Testing Done
Visit Allhome and check the job board.
The jobs that involve traveling to a planet in human space now have varying payments, based on the actual number of jumps and payload amount, instead of all having the same payment.
