### PR TITLE
Fix plugin checkbox click zones

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -952,7 +952,7 @@ void PreferencesPanel::DrawPlugins()
 
 		topLeft.X() += 6.;
 		topLeft.Y() += 7.;
-		Rectangle zoneBounds = Rectangle::FromCorner(pluginListBox.Center() + topLeft, {sprite->Width(), sprite->Height()});
+		Rectangle zoneBounds = spriteBounds + pluginListBox.Center();
 
 		// Only include the zone as clickable if it's within the drawing area.
 		bool displayed = table.GetPoint().Y() > pluginListClip->Top() - 20 &&

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -950,8 +950,6 @@ void PreferencesPanel::DrawPlugins()
 		Rectangle spriteBounds = Rectangle::FromCorner(topLeft, Point(sprite->Width(), sprite->Height()));
 		SpriteShader::Draw(sprite, spriteBounds.Center());
 
-		topLeft.X() += 6.;
-		topLeft.Y() += 7.;
 		Rectangle zoneBounds = spriteBounds + pluginListBox.Center();
 
 		// Only include the zone as clickable if it's within the drawing area.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -946,7 +946,7 @@ void PreferencesPanel::DrawPlugins()
 			table.DrawHighlight(back);
 
 		const Sprite *sprite = box[plugin.currentState];
-		Point topLeft = table.GetRowBounds().TopLeft() - Point(sprite->Width(), 0.);
+		const Point topLeft = table.GetRowBounds().TopLeft() - Point(sprite->Width(), 0.);
 		Rectangle spriteBounds = Rectangle::FromCorner(topLeft, Point(sprite->Width(), sprite->Height()));
 		SpriteShader::Draw(sprite, spriteBounds.Center());
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #9920

## Summary
Fixed the problem described in the linked issue.

I believe the click zone for the checkboxes was originally actually a little smaller.
Would something like this be preferable over what is shown in the screenshot in the table?
![image](https://github.com/endless-sky/endless-sky/assets/20605679/fae54875-fb44-4ac5-a6b3-ce9a43d09293)

## Screenshots
I've added highlights over the click zone for demonstration purposes:
before | after
-- | --
![image](https://github.com/endless-sky/endless-sky/assets/20605679/c4237deb-8313-4c19-bcfa-04b22d263fea) | ![image](https://github.com/endless-sky/endless-sky/assets/20605679/8be11d34-14e3-4b33-a0a1-a88e39b1d506)

## Testing Done
Click around the checkbox. The click zone is now centred on the sprite properly.

## Save File
N/A - a save file won't help you test this.
