### PR TITLE
fix(ui): Correctly handle arrow keys with no item selected in the shop

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -1263,9 +1263,12 @@ void ShopPanel::MainUp()
 		return;
 
 	vector<Zone>::const_iterator it = Selected();
-	// Special case: nothing is selected.  Start from the first item.
+	// Special case: nothing is selected. Start from the first item.
 	if(it == zones.end())
+	{
 		it = zones.begin();
+		previousX = it->Center().X();
+	}
 
 	const double previousY = it->Center().Y();
 	while(it != zones.begin() && it->Center().Y() == previousY)
@@ -1298,8 +1301,10 @@ void ShopPanel::MainDown()
 	if(it == zones.end())
 	{
 		mainScroll = 0.;
-		selectedShip = zones.begin()->GetShip();
-		selectedOutfit = zones.begin()->GetOutfit();
+		it = zones.begin();
+		selectedShip = it->GetShip();
+		selectedOutfit = it->GetOutfit();
+		previousX = it->Center().X();
 		return;
 	}
 


### PR DESCRIPTION
**Bug fix**

## Summary
To reproduce the bug:
1. Open a shipyard/outfitter, but don't select anything.
2. Press down arrow key - the first item should be selected now.
3. Press down again - the shop selects an item from the middle of the next row.

With this fix, when you press down the second time, it selects the first item from the next row (which is right under the previously selected item).

The same applies to scrolling up.

## Testing Done
Opened the outfitter and somehow it works.

## Performance Impact
N/A
