### PR TITLE
fix(content): Ensure player can't access planetary facilities while evacuating Vara Ke'stai and Varu Mer'ek

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2303,7 +2303,7 @@ mission "Wanderers Evacuation 1B Remove Facilities"
 	invisible
 	source "Vara Ke'stai"
 	to offer
-		has "Wanderers Evacuation 1: done"
+		has "Wanderers Evacuation 1B: offered"
 	on offer
 		event "remove vara ke'stai facilities"
 
@@ -2313,23 +2313,6 @@ event "remove vara ke'stai facilities"
 		remove outfitter
 		remove "required reputation"
 		remove tribute
-		add port
-			recharges fuel
-			description `This is a desert world, but the Wanderers are working little by little to make the desert bloom: planting hardy shrubs and cacti that eventually transform the sand into a soil that can hold moisture. In some regions, especially closer to the poles, the deserts have given way to dense forests, but near the equator there are still large stretches of dry and barren sand, broken by the occasional belt of green where a narrow river winds between the dunes.`
-
-mission "Wanderers Evacuation 1B Remove Refueling"
-	landing
-	invisible
-	source "Vara Ke'stai"
-	to offer
-		has "Wanderers Evacuation 1B Remove Facilities: offered"
-		not "event: wanderers: more systems lost"
-	on offer
-		event "remove vara ke'stai refueling"
-
-event "remove vara ke'stai refueling"
-	planet "Vara Ke'stai"
-		remove spaceport
 
 
 mission "Wanderers Evacuation 1C"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2313,6 +2313,8 @@ event "remove vara ke'stai facilities"
 		remove outfitter
 		remove "required reputation"
 		remove tribute
+		add port
+			recharges fuel
 
 
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1786,7 +1786,7 @@ mission "Wanderers Invaded 3"
 		has "Wanderers Invaded 2: done"
 	on offer
 		log "Helped to defend a Wanderer planet from an Unfettered attack. But, the Wanderers now plan to abandon that planet. The Wanderers seem very hesitant to actually stand their ground and fight back."
-		event "remove varu mer'ek facilities"
+		event "wanderers: varu mer'ek evacuated"
 		conversation
 			`It appears that the very last of the civilians are ready for transport to <planet>; a large crowd is gathered in the spaceport, but nearly all the buildings are vacant. Incongruously, a few Wanderers are busy sweeping the sidewalks, watering plants, and making other efforts to tidy up the port, as if to make it as presentable as possible for the Unfettered when they land.`
 			`	Isai greets you and asks if she can ride along with you. "These are the last of the civilians," she says. "The [warriors, defenders] will remain behind until everyone is [safe, away], then they will join us on <planet>. But most important is that the transports reach <planet> unharmed. Will you escort them?"`
@@ -1820,7 +1820,7 @@ mission "Wanderers Invaded 3"
 
 
 
-event "remove varu mer'ek facilities"
+event "wanderers: varu mer'ek evacuated"
 	planet "Varu Mer'ek"
 		remove spaceport
 		remove shipyard
@@ -2289,7 +2289,7 @@ mission "Wanderers Evacuation 1B"
 	to offer
 		has "Wanderers Evacuation 1: done"
 	on offer
-		event "remove vara ke'stai facilities"
+		event "wanderers: vara ke'stai evacuated"
 		conversation
 			`The Wanderer transports land in the spaceport and begin loading passengers. The village appears to be almost empty; all but the last few stragglers have already left. As on Varu Mer'ek before it was captured, they seem to have taken pains to leave their village as neat and tidy as possible. In similar circumstances, a human government would probably have chosen to burn everything of value to the ground rather than let it fall into enemy hands.`
 				launch
@@ -2308,7 +2308,7 @@ mission "Wanderers Evacuation 1B"
 	on visit
 		dialog `You've landed on <planet>, but not all of the Riptide transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
 
-event "remove vara ke'stai facilities"
+event "wanderers: vara ke'stai evacuated
 	planet "Vara Ke'stai"
 		remove spaceport
 		remove outfitter

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1786,6 +1786,7 @@ mission "Wanderers Invaded 3"
 		has "Wanderers Invaded 2: done"
 	on offer
 		log "Helped to defend a Wanderer planet from an Unfettered attack. But, the Wanderers now plan to abandon that planet. The Wanderers seem very hesitant to actually stand their ground and fight back."
+		event "remove vara mer'ek facilities"
 		conversation
 			`It appears that the very last of the civilians are ready for transport to <planet>; a large crowd is gathered in the spaceport, but nearly all the buildings are vacant. Incongruously, a few Wanderers are busy sweeping the sidewalks, watering plants, and making other efforts to tidy up the port, as if to make it as presentable as possible for the Unfettered when they land.`
 			`	Isai greets you and asks if she can ride along with you. "These are the last of the civilians," she says. "The [warriors, defenders] will remain behind until everyone is [safe, away], then they will join us on <planet>. But most important is that the transports reach <planet> unharmed. Will you escort them?"`
@@ -1802,7 +1803,7 @@ mission "Wanderers Invaded 3"
 			`	"Okay," you say, "I'll help protect the transports."`
 			label end
 			`	"Thank you," she says. "As before, do not [wait, tarry] or join in the fighting. Just bring our people safely to <planet>."`
-				accept
+				launch
 	on accept
 		event "capture of ik'kara'ka" 2
 	
@@ -1816,6 +1817,15 @@ mission "Wanderers Invaded 3"
 	on visit
 		dialog
 			`You have reached <planet>, but the Wanderer transports, or your ship carrying Isai, have not all arrived yet. You should take off and wait for them to catch up with you.`
+
+
+
+event "remove vara mer'ek facilities"
+	planet "Vara Mer'ek"
+		remove spaceport
+		remove outfitter
+		remove "required reputation"
+		remove tribute
 
 
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2308,7 +2308,7 @@ mission "Wanderers Evacuation 1B"
 	on visit
 		dialog `You've landed on <planet>, but not all of the Riptide transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
 
-event "wanderers: vara ke'stai evacuated
+event "wanderers: vara ke'stai evacuated"
 	planet "Vara Ke'stai"
 		remove spaceport
 		remove outfitter

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2315,6 +2315,7 @@ event "remove vara ke'stai facilities"
 		remove tribute
 		add port
 			recharges fuel
+			description `This is a desert world, but the Wanderers are working little by little to make the desert bloom: planting hardy shrubs and cacti that eventually transform the sand into a soil that can hold moisture. In some regions, especially closer to the poles, the deserts have given way to dense forests, but near the equator there are still large stretches of dry and barren sand, broken by the occasional belt of green where a narrow river winds between the dunes.`
 
 
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2298,7 +2298,7 @@ mission "Wanderers Evacuation 1B"
 
 
 
-mission "Wanderers Evacuation 1B Remove Spaceport"
+mission "Wanderers Evacuation 1B Remove Facilities"
 	landing
 	invisible
 	source "Vara Ke'stai"
@@ -2317,6 +2317,19 @@ event "remove vara ke'stai facilities"
 			recharges fuel
 			description `This is a desert world, but the Wanderers are working little by little to make the desert bloom: planting hardy shrubs and cacti that eventually transform the sand into a soil that can hold moisture. In some regions, especially closer to the poles, the deserts have given way to dense forests, but near the equator there are still large stretches of dry and barren sand, broken by the occasional belt of green where a narrow river winds between the dunes.`
 
+mission "Wanderers Evacuation 1B Remove Refueling"
+	landing
+	invisible
+	source "Vara Ke'stai"
+	to offer
+		has "Wanderers Evacuation 1B Remove Facilities: offered"
+		not "event: wanderers: more systems lost"
+	on offer
+		event "remove vara ke'stai refueling"
+
+event "remove vara ke'stai refuelling"
+	planet "Vara Ke'stai"
+		remove spaceport
 
 
 mission "Wanderers Evacuation 1C"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1786,7 +1786,7 @@ mission "Wanderers Invaded 3"
 		has "Wanderers Invaded 2: done"
 	on offer
 		log "Helped to defend a Wanderer planet from an Unfettered attack. But, the Wanderers now plan to abandon that planet. The Wanderers seem very hesitant to actually stand their ground and fight back."
-		event "remove vara mer'ek facilities"
+		event "remove varu mer'ek facilities"
 		conversation
 			`It appears that the very last of the civilians are ready for transport to <planet>; a large crowd is gathered in the spaceport, but nearly all the buildings are vacant. Incongruously, a few Wanderers are busy sweeping the sidewalks, watering plants, and making other efforts to tidy up the port, as if to make it as presentable as possible for the Unfettered when they land.`
 			`	Isai greets you and asks if she can ride along with you. "These are the last of the civilians," she says. "The [warriors, defenders] will remain behind until everyone is [safe, away], then they will join us on <planet>. But most important is that the transports reach <planet> unharmed. Will you escort them?"`
@@ -1820,8 +1820,8 @@ mission "Wanderers Invaded 3"
 
 
 
-event "remove vara mer'ek facilities"
-	planet "Vara Mer'ek"
+event "remove varu mer'ek facilities"
+	planet "Varu Mer'ek"
 		remove spaceport
 		remove outfitter
 		remove "required reputation"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2280,7 +2280,7 @@ mission "Wanderers Evacuation 1B"
 	on offer
 		conversation
 			`The Wanderer transports land in the spaceport and begin loading passengers. The village appears to be almost empty; all but the last few stragglers have already left. As on Varu Mer'ek before it was captured, they seem to have taken pains to leave their village as neat and tidy as possible. In similar circumstances, a human government would probably have chosen to burn everything of value to the ground rather than let it fall into enemy hands.`
-				accept
+				launch
 	npc accompany save
 		government "Wanderer"
 		personality timid escort

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2327,7 +2327,7 @@ mission "Wanderers Evacuation 1B Remove Refueling"
 	on offer
 		event "remove vara ke'stai refueling"
 
-event "remove vara ke'stai refuelling"
+event "remove vara ke'stai refueling"
 	planet "Vara Ke'stai"
 		remove spaceport
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2278,6 +2278,7 @@ mission "Wanderers Evacuation 1B"
 	to offer
 		has "Wanderers Evacuation 1: done"
 	on offer
+		event "remove vara ke'stai facilities"
 		conversation
 			`The Wanderer transports land in the spaceport and begin loading passengers. The village appears to be almost empty; all but the last few stragglers have already left. As on Varu Mer'ek before it was captured, they seem to have taken pains to leave their village as neat and tidy as possible. In similar circumstances, a human government would probably have chosen to burn everything of value to the ground rather than let it fall into enemy hands.`
 				launch
@@ -2295,17 +2296,6 @@ mission "Wanderers Evacuation 1B"
 		fleet "Large Unfettered" 3
 	on visit
 		dialog `You've landed on <planet>, but not all of the Riptide transports carrying the refugees are in the system. Better depart and wait for them all to arrive.`
-
-
-
-mission "Wanderers Evacuation 1B Remove Facilities"
-	landing
-	invisible
-	source "Vara Ke'stai"
-	to offer
-		has "Wanderers Evacuation 1B: offered"
-	on offer
-		event "remove vara ke'stai facilities"
 
 event "remove vara ke'stai facilities"
 	planet "Vara Ke'stai"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -2298,6 +2298,24 @@ mission "Wanderers Evacuation 1B"
 
 
 
+mission "Wanderers Evacuation 1B Remove Spaceport"
+	landing
+	invisible
+	source "Vara Ke'stai"
+	to offer
+		has "Wanderers Evacuation 1: done"
+	on offer
+		event "remove vara ke'stai facilities"
+
+event "remove vara ke'stai facilities"
+	planet "Vara Ke'stai"
+		remove spaceport
+		remove outfitter
+		remove "required reputation"
+		remove tribute
+
+
+
 mission "Wanderers Evacuation 1C"
 	landing
 	name "Escort to <planet>"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1823,6 +1823,7 @@ mission "Wanderers Invaded 3"
 event "remove varu mer'ek facilities"
 	planet "Varu Mer'ek"
 		remove spaceport
+		remove shipyard
 		remove outfitter
 		remove "required reputation"
 		remove tribute


### PR DESCRIPTION
**Bug fix**
This PR addresses the bug/feature described in #8067 by ThrawnCA.

## Summary
Changes the `accept` end word to `launch` to prevent the player from accessing the deserted outfitter and trading center, since you're there to transport a bunch of people in a hurry, not buy millions of credits' worth of goods.