### PR TITLE
fix(content): split off "CCOR Logistics" fleet from Large CCOR fleet

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2095,6 +2095,13 @@ fleet "Large CCOR"
 		"Saber (CCOR Gatling)"
 		"Enforcer (CCOR)"
 		"Berserker (CCOR)"
+
+fleet "CCOR Logistics"
+	government "Pirate"
+	names "pirate"
+	cargo 1
+	personality
+		timid secretive coward harvests
 	variant 1
 		"Hauler II"
 	variant 1

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2101,7 +2101,7 @@ fleet "CCOR Logistics"
 	names "pirate"
 	cargo 1
 	personality
-		timid secretive coward harvests
+		timid secretive coward appeasing
 	variant 1
 		"Hauler II"
 	variant 1

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -5019,6 +5019,7 @@ system Alpherg
 	fleet "Large Southern Pirates" 2000
 	fleet "Small CCOR" 3800
 	fleet "Large CCOR" 6000
+	fleet "CCOR Logistics" 9000
 	object
 		sprite star/g-giant
 		period 10
@@ -6522,6 +6523,7 @@ system Belenos
 	fleet "Large Southern Pirates" 2000
 	fleet "Small CCOR" 3800
 	fleet "Large CCOR" 5000
+	fleet "CCOR Logistics" 8000
 	object
 		sprite star/f8
 		period 10
@@ -8686,6 +8688,7 @@ system Citadelle
 	fleet "Large Southern Pirates" 2500
 	fleet "Small CCOR" 3800
 	fleet "Large CCOR" 4500
+	fleet "CCOR Logistics" 6000
 	object
 		sprite star/k0
 		period 15
@@ -14529,6 +14532,7 @@ system Fumalsamakah
 	fleet "Large Southern Pirates" 2000
 	fleet "Small CCOR" 3800
 	fleet "Large CCOR" 6000
+	fleet "CCOR Logistics" 9000
 	object
 		sprite star/b5
 		period 10


### PR DESCRIPTION
**Bug fix**
This PR addresses the bug/feature described on Discord various times.

## Summary
This PR creates a new fleet, "CCOR Logistics", which exclusively contains the CCOR variants of the Hogshead and Haulers, so they don't appear in CCOR planetary defense fleets. Also adds those fleets to the CCOR systems. All numbers I just guessed (lmao), I'm open to suggestions.
