### PR TITLE
feat(content): Upgrade Ryk Bartlett's fleet, give him a Bulwark

### DIFF
--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1838,11 +1838,20 @@ mission "FW Albatross 2A"
 		fleet
 			names pirate
 			variant
-				"Argosy (Proton)"
 				"Modified Argosy (Gatling)"
 				"Hawk (Plasma)"
 				"Hawk"
 				"Sparrow" 3
+	npc
+		personality timid staying plunders coward disables
+		system Orvala
+		government Pirate
+		"cargo settings"
+			commodities "Heavy Metals"
+		fleet
+			names pirate
+			variant
+				"Argosy (Proton)"
 
 
 

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1835,7 +1835,7 @@ mission "FW Albatross 2A"
 		personality staying plunders disables
 		system Orvala
 		government Pirate
-		fleet "Small Southern Pirates" 3
+		fleet "Large Southern Pirates" 2
 
 
 

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1835,7 +1835,14 @@ mission "FW Albatross 2A"
 		personality staying plunders disables
 		system Orvala
 		government Pirate
-		fleet "Large Southern Pirates" 2
+		fleet
+			names pirate
+			variant
+				"Argosy (Proton)"
+				"Modified Argosy (Gatling)"
+				"Hawk (Plasma)"
+				"Hawk"
+				"Sparrow" 3
 
 
 

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1828,7 +1828,7 @@ mission "FW Albatross 2A"
 		personality staying plunders disables heroic nemesis target
 		system Orvala
 		government Pirate
-		ship "Bastion (Heavy)" "Dread"
+		ship "Bulwark (Heavy)" "Dread"
 		dialog "You have destroyed Ryk Bartlett's ship. Hopefully now the elders on Albatross will be more inclined to bargain with the Free Worlds."
 	
 	npc


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**
This PR addresses something I keep making jokes about but never solving.

## Summary
It has been mentioned how strange it is for Ryk Bartlett to dominate an entire planet yet his flagship is only a Bastion. This PR makes him a bit more unique by changing that Bastion for a Bulwark. It also upgrades his fleet from 3 Small Southern Pirates fleets to 2 Large Southern Pirates fleets, which could be anything from 8 Sparrows (lmao) to 2 Falcons. Could change this down to 1, but narratively it makes sense if he has a big strong fleet, he needs some cargo space to move those heavy metals he's plundering too.

## Testing Done
Yes. It was pretty easy, but then again, I had a Cruiser.

## Save File
Old save but this should do:
[Stavro Mueller.txt](https://github.com/endless-sky/endless-sky/files/14719273/Stavro.Mueller.txt)
