### PR TITLE
fix(content): Allow quantum keystone jobs to offer properly

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -1896,9 +1896,11 @@ mission "Superstitious Hai [7]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
-		has "outfit (installed): Shield Beetle Pendant"
-		has "outfit: Tree Skeleton Key Stone"
+		or
+			has "outfit (installed): Quantum Keystone"
+			has "outfit (installed): Quantum Key Stone"
+			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -1925,9 +1927,11 @@ mission "Superstitious Hai [8]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
-		has "outfit (installed): Shield Beetle Pendant"
-		has "outfit: Tree Skeleton Key Stone"
+		or
+			has "outfit (installed): Quantum Keystone"
+			has "outfit (installed): Quantum Key Stone"
+			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -1955,9 +1959,11 @@ mission "Superstitious Hai [9]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
-		has "outfit (installed): Shield Beetle Pendant"
-		has "outfit: Tree Skeleton Key Stone"
+		or
+			has "outfit (installed): Quantum Keystone"
+			has "outfit (installed): Quantum Key Stone"
+			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -1986,9 +1992,11 @@ mission "Superstitious Hai [10]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
-		has "outfit (installed): Shield Beetle Pendant"
-		has "outfit: Tree Skeleton Key Stone"
+		or
+			has "outfit (installed): Quantum Keystone"
+			has "outfit (installed): Quantum Key Stone"
+			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -2017,9 +2025,11 @@ mission "Superstitious Hai [11]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
-		has "outfit (installed): Shield Beetle Pendant"
-		has "outfit: Tree Skeleton Key Stone"
+		or
+			has "outfit (installed): Quantum Keystone"
+			has "outfit (installed): Quantum Key Stone"
+			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -2048,9 +2058,11 @@ mission "Superstitious Hai [12]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
-		has "outfit (installed): Shield Beetle Pendant"
-		has "outfit: Tree Skeleton Key Stone"
+		or
+			has "outfit (installed): Quantum Keystone"
+			has "outfit (installed): Quantum Key Stone"
+			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -1898,9 +1898,7 @@ mission "Superstitious Hai [7]"
 	to accept
 		or
 			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Quantum Key Stone"
 			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -1929,9 +1927,7 @@ mission "Superstitious Hai [8]"
 	to accept
 		or
 			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Quantum Key Stone"
 			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -1961,9 +1957,7 @@ mission "Superstitious Hai [9]"
 	to accept
 		or
 			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Quantum Key Stone"
 			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -1994,9 +1988,7 @@ mission "Superstitious Hai [10]"
 	to accept
 		or
 			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Quantum Key Stone"
 			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -2027,9 +2019,7 @@ mission "Superstitious Hai [11]"
 	to accept
 		or
 			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Quantum Key Stone"
 			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -2060,9 +2050,7 @@ mission "Superstitious Hai [12]"
 	to accept
 		or
 			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Quantum Key Stone"
 			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -1899,6 +1899,7 @@ mission "Superstitious Hai [7]"
 		or
 			has "outfit (installed): Quantum Keystone"
 			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -1928,6 +1929,7 @@ mission "Superstitious Hai [8]"
 		or
 			has "outfit (installed): Quantum Keystone"
 			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -1958,6 +1960,7 @@ mission "Superstitious Hai [9]"
 		or
 			has "outfit (installed): Quantum Keystone"
 			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -1989,6 +1992,7 @@ mission "Superstitious Hai [10]"
 		or
 			has "outfit (installed): Quantum Keystone"
 			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -2020,6 +2024,7 @@ mission "Superstitious Hai [11]"
 		or
 			has "outfit (installed): Quantum Keystone"
 			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination
@@ -2051,6 +2056,7 @@ mission "Superstitious Hai [12]"
 		or
 			has "outfit (installed): Quantum Keystone"
 			has "outfit (installed): Shield Beetle Pendant"
+			has "outfit (installed): Tree Skeleton Key Stone"
 	source
 		government "Hai"
 	destination


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in PR #9872.

## Summary
Fixes a bug that prevents some quantum keystone jobs from offering. Specifically, you would need to have the quantum keystone and shield beetle pendant installed and have the tree skeleton key stone. I fixed it so that you just need to have one of the three keystones mentioned installed.

## Testing Done

Should be blocked
- [x] No keystones
- [x] Quantum Keystone in cargo

Should be able to be accepted for both jobs
- [x] Quantum Keystone installed
- [x] Quantum Keystone installed on non-flagship
- [x] Quantum Keystone installed, Shield Beetle Pendant in cargo
- [x] Quantum Keystone + Shield Beetle Pendant installed
- [x] Quantum Keystone + Shield Beetle Pendant + Tree Skeleton Key Stone installed

Should be able to be accepted for less restrictive job only
- [x] Shield Beetle Pendant installed
- [x] Tree Skeleton Key Stone installed
- [x] Shield Beetle Pendant installed, Quantum Keystone in cargo
- [x] Shield Beetle Pendant installed, Tree Skeleton Key Stone in cargo
- [x] Shield Beetle Pendant and Tree Skeleton Key Stone installed

## Save File
This save file can be used to test these changes: 
[Test Pilot~Quantum Keystone Only.txt](https://github.com/endless-sky/endless-sky/files/14717501/Test.Pilot.Quantum.Keystone.Only.txt)
[Test Pilot~Non Remnant Keystones.txt](https://github.com/endless-sky/endless-sky/files/14717502/Test.Pilot.Non.Remnant.Keystones.txt)