### PR TITLE
fix(content): Replace `Kraz Basics` and `Delta V Basics` with `Syndicate Basics` and `Lovelace Basics` on New China, and replace the Militia defense fleet with a Republic defense fleet on Geyser

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2979,6 +2979,8 @@ planet "New China"
 	spaceport `The "new port" here was built several centuries ago, when the grand but impractical spaceport built by the original settlers had deteriorated to the point where it was no longer usable. This port is much simpler by comparison: just a ring of landing pads of various sizes around a large central building with ten levels of warehouse space accessible by freight elevator.`
 	spaceport `	There are always locals hanging around the port, some of them mere children, who are trying to find a cheap ride off-planet.`
 	outfitter "Common Outfits"
+	outfitter "Lovelace Basics"
+	outfitter "Syndicate Basics"
 	outfitter "Ammo South"
 	security 0.1
 	tribute 1400

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -1725,7 +1725,7 @@ planet Geyser
 	security 0.3
 	tribute 1300
 		threshold 3500
-		fleet "Large Militia" 20
+		fleet "Small Republic" 20
 
 planet Ghneoe
 	attributes uninhabited
@@ -2981,7 +2981,6 @@ planet "New China"
 	outfitter "Common Outfits"
 	outfitter "Ammo South"
 	outfitter "Delta V Basics"
-	outfitter "Kraz Basics"
 	security 0.1
 	tribute 1400
 		threshold 4000

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2980,7 +2980,6 @@ planet "New China"
 	spaceport `	There are always locals hanging around the port, some of them mere children, who are trying to find a cheap ride off-planet.`
 	outfitter "Common Outfits"
 	outfitter "Ammo South"
-	outfitter "Delta V Basics"
 	security 0.1
 	tribute 1400
 		threshold 4000


### PR DESCRIPTION
**Bug fix**
This PR addresses a bug some people have noticed about Geyser and New China but never have seemed to question.

## Summary
Kraz shouldn't be selling stuff all the way over in New China, and Geyser should be defended by Navy fleets, because, like, Earth's right there man!

If people like the fact that New China's the only place you can get Brigs and Tactical Scanners in the north without going to a pirate planet, I was additionally thinking of making a sales category that includes the brig and have it sell around the Near Earth area.

~~Edit: It has been suggested that Bounty may have been a pirate planet in the past, I could put something of note there.~~

Derpy says New China should instead sell Syndicate and Lovelace Basics stuff, which sounds good to me.

## Testing Done
I mean...

## Save File
Please.
