### PR TITLE
Fix various crashes when loading/unloading images

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -490,6 +490,9 @@ void Engine::Step(bool isActive)
 	events.swap(eventQueue);
 	eventQueue.clear();
 
+	// Process any outstanding sprites that need to be uploaded to the GPU.
+	queue.ProcessSyncTasks();
+
 	// The calculation thread was paused by MainPanel before calling this function, so it is safe to access things.
 	const shared_ptr<Ship> flagship = player.FlagshipPtr();
 	const StellarObject *object = player.GetStellarObject();

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -329,14 +329,14 @@ void GameData::Preload(TaskQueue &queue, const Sprite *sprite)
 	// This sprite is not currently preloaded. Check to see whether we already
 	// have the maximum number of sprites loaded, in which case the oldest one
 	// must be unloaded to make room for this one.
-	const string &name = sprite->Name();
 	pit = preloaded.begin();
 	while(pit != preloaded.end())
 	{
 		++pit->second;
 		if(pit->second >= 20)
 		{
-			SpriteSet::Modify(name)->Unload();
+			// Unloading needs to be queued on the main thread.
+			queue.Run({}, [name = pit->first->Name()] { SpriteSet::Modify(name)->Unload(); });
 			pit = preloaded.erase(pit);
 		}
 		else

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -68,6 +68,8 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	// landscapes for this system are loaded before showing the planet panel.
 	TaskQueue queue;
 	GameData::Preload(queue, planet.Landscape());
+	queue.Wait();
+	queue.ProcessSyncTasks();
 }
 
 

--- a/source/TaskQueue.cpp
+++ b/source/TaskQueue.cpp
@@ -105,28 +105,20 @@ void TaskQueue::ProcessSyncTasks()
 
 
 
-// Whether there are any outstanding tasks left in this queue, including any outstanding tasks
-// that need to be executed on the main thread.
-bool TaskQueue::IsDone() const
+// Waits for all of this queue's task to finish. Ignores any sync tasks to be processed.
+void TaskQueue::Wait()
 {
-	{
-		lock_guard<mutex> lock(asyncMutex);
-		if(!futures.empty())
-			return false;
-	}
-
-	lock_guard lock(syncMutex);
-	return syncTasks.empty();
+	while(!IsDone())
+		this_thread::yield();
 }
 
 
 
-// Waits for all of this queue's task to finish while properly processing any outstanding main thread tasks.
-void TaskQueue::Wait()
+// Whether there are any outstanding async tasks left in this queue.
+bool TaskQueue::IsDone() const
 {
-	// Process tasks while any task is still being executed.
-	while(!IsDone())
-		ProcessSyncTasks();
+	lock_guard<mutex> lock(asyncMutex);
+	return futures.empty();
 }
 
 
@@ -155,7 +147,8 @@ void TaskQueue::ThreadLoop() noexcept
 
 			// Execute the task.
 			try {
-				task.async();
+				if(task.async)
+					task.async();
 			}
 			catch(...)
 			{

--- a/source/TaskQueue.h
+++ b/source/TaskQueue.h
@@ -66,12 +66,13 @@ public:
 	// Process any tasks to be scheduled to be executed on the main thread.
 	void ProcessSyncTasks();
 
-	// Whether there are any outstanding tasks left in this queue, including any outstanding tasks
-	// that need to be executed on the main thread.
-	bool IsDone() const;
-
-	// Waits for all of this queue's task to finish while properly processing any outstanding main thread tasks.
+	// Waits for all of this queue's task to finish. Ignores any sync tasks to be processed.
 	void Wait();
+
+
+private:
+	// Whether there are any outstanding async tasks left in this queue.
+	bool IsDone() const;
 
 
 public:

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -140,7 +140,8 @@ int main(int argc, char *argv[])
 
 		// Begin loading the game data.
 		bool isConsoleOnly = loadOnly || printTests || printData;
-		auto dataFuture = GameData::BeginLoad(queue, isConsoleOnly, debugMode, isTesting && !debugMode);
+		auto dataFuture = GameData::BeginLoad(queue, isConsoleOnly, debugMode,
+			isConsoleOnly || (isTesting && !debugMode));
 
 		// If we are not using the UI, or performing some automated task, we should load
 		// all data now.


### PR DESCRIPTION
## Fix Details

Fixes various lingering crashes from #6928 

- while unloading landscapes
- `-p` while having plugins

Also correctly unload old landscapes (this was somehow broken ever since MZ changed that part of the code 7 years ago lmao).

## Testing Done

Ran the changes, still works and no longer crashes! Also enabled a thread sanitizer to catch any possible race conditions, and none were found.
 