### PR TITLE
Fix custom port button name when using "add port"

### DIFF
--- a/source/Port.cpp
+++ b/source/Port.cpp
@@ -45,8 +45,9 @@ namespace {
 void Port::Load(const DataNode &node)
 {
 	loaded = true;
-	if(node.Size() > 1)
-		name = node.Token(1);
+	const int nameIndex = 1 + (node.Token(0) == "add");
+	if(node.Size() > nameIndex)
+		name = node.Token(nameIndex);
 
 	for(const DataNode &child : node)
 	{


### PR DESCRIPTION
**Bug fix**

## Summary
The port always uses the second token in the "port" line as its "name" (the text shown on the spaceport button.)
But, if "add port" was used, the second token is "port" and a special name (if provided) would be the third token.
This PR checks if hte first token is "add" and, if it is, looks at the third token for the name, instead of the second.

## Screenshots
![image](https://github.com/endless-sky/endless-sky/assets/20605679/a8d88d2a-0346-4127-851f-cd16fc09575d)

## Usage examples
N/A

## Testing Done
Use the attached save file with and without this change.

## Save File
This save file can be used to test these changes:
[warp core vara ke stai abandonment~original.txt](https://github.com/endless-sky/endless-sky/files/14734109/warp.core.vara.ke.stai.abandonment.original.txt)
Ignore the disabled mission.
