### PR TITLE
feat(Balance): Cut the asteroid scanner's price in half

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -228,7 +228,7 @@ outfit "Outfit Scanner"
 
 outfit "Asteroid Scanner"
 	category "Systems"
-	cost 122000
+	cost 61000
 	thumbnail "outfit/asteroid scanner"
 	"mass" 6
 	"outfit space" -6


### PR DESCRIPTION
**Balance**

This PR cuts the Asteroid Scanner's price in half.

## Summary
Buffed the Asteroid Scanner by cutting its price in half, from 122,000 -> 61,000 credits. There's been a decent amount of discourse on the discord over mining's place in the meta, and it's widely regarded that mining is most beneficial to early-game players as systems have fixed asteroid/day caps. It's also been pointed out that mining requires a fairly significant investment compared to other forms of income, such as trading, transport missions, or looting/capturing. More specifically, the 61,000 credit pricetag allows a starting Sparrow pilot to afford the asteroid scanner by selling only some frivolous things like one of their beams or their shield generator, rather than needing to commit to selling their Hyperdrive to scrounge up the money (they could also just do a few basic passenger or small courier missions).

## Testing Done
I looked in-game and the Asteroid Scanner's price was cut in half.

## Save File
N/A, the Asteroid Scanner can be found in many human outfitters.

## Performance Impact
I divided a number by two.
