### PR TITLE
Fix to Baianus description

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -286,8 +286,8 @@ planet Babiali
 planet Baianus
 	attributes frozen uninhabited
 	landscape land/snow20
-	description `This frozen water world is reminiscent of Triton back in Sol: the surface is little more than a shattered wasteland of ice and the occasional rock outcropping, but the unbreathably thin atmosphere contains countless tantalizing traces of chemicals that suggest that something more might exist below the surface.`
-	description `	Unlike Triton, however, Baianus is regularly wracked by both waves of heat and energy, and a stay of any length on the surface is likely to see waves of auroras accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
+	description `From a distance this large, icy moon is superficially reminiscent of Titan back in Sol: it is similarly exposed to it's giant parent's radiation belts, and scans indicate countless tantalizing traces of chemicals that suggest there may be something more to it than it appears.`
+	description `	Unlike Titan, however, the surface of  Baianus is little more than a shattered wasteland of ice and rock that is regularly wracked by both waves of heat and energy. A stay of any length on the surface is likely to see waves of auroras swirl through it's unbreathably thin atmosphere, accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
 	government Uninhabited
 
 planet Bailey

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -286,8 +286,8 @@ planet Babiali
 planet Baianus
 	attributes frozen uninhabited
 	landscape land/snow20
-	description `This frozen water world is reminiscent of Titan back in Sol: the surface is little more than a shattered wasteland of ice and the occasional rock outcropping, but the unbreathably thin atmosphere contains countless tantalizing traces of chemicals that suggest that something more might exist below the surface.`
-	description `	Unlike Titan, however, Baianus is regularly wracked by both waves of heat and energy, and a stay of any length on the surface is likely to see waves of auroras accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
+	description `This frozen water world is reminiscent of Triton back in Sol: the surface is little more than a shattered wasteland of ice and the occasional rock outcropping, but the unbreathably thin atmosphere contains countless tantalizing traces of chemicals that suggest that something more might exist below the surface.`
+	description `	Unlike Triton, however, Baianus is regularly wracked by both waves of heat and energy, and a stay of any length on the surface is likely to see waves of auroras accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
 	government Uninhabited
 
 planet Bailey

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -287,7 +287,7 @@ planet Baianus
 	attributes frozen uninhabited
 	landscape land/snow20
 	description `From a distance this large, icy moon is superficially reminiscent of Titan back in Sol: it is similarly exposed to it's giant parent's radiation belts, and scans indicate countless tantalizing traces of chemicals that suggest there may be something more to it than it appears.`
-	description `	Unlike Titan, however, the surface of  Baianus is little more than a shattered wasteland of ice and rock that is regularly wracked by both waves of heat and energy. A stay of any length on the surface is likely to see waves of auroras swirl through it's unbreathably thin atmosphere, accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
+	description `	Unlike Titan, however, the surface of Baianus is little more than a shattered wasteland of ice and rock that is regularly wracked by both waves of heat and energy. A stay of any length on the surface is likely to see waves of auroras swirl through it's unbreathably thin atmosphere, accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
 	government Uninhabited
 
 planet Bailey

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -286,7 +286,7 @@ planet Babiali
 planet Baianus
 	attributes frozen uninhabited
 	landscape land/snow20
-	description `From a distance this large, icy moon is superficially reminiscent of Titan back in Sol: it is similarly exposed to it's giant parent's radiation belts, and scans indicate countless tantalizing traces of chemicals that suggest there may be something more to it than it appears.`
+	description `From a distance, this large, icy moon is superficially reminiscent of Titan back in Sol: it is similarly exposed to its giant parent's radiation belts, and scans indicate countless tantalizing traces of chemicals that suggest there may be something more to the moon than it appears.`
 	description `	Unlike Titan, however, the surface of Baianus is little more than a shattered wasteland of ice and rock that is regularly wracked by both waves of heat and energy. A stay of any length on the surface is likely to see waves of auroras swirl through it's unbreathably thin atmosphere, accompanied by glows and sparks rippling across the terrain. Your environmental system strongly recommends remaining inside your ship whenever ion storms are active.`
 	government Uninhabited
 


### PR DESCRIPTION
As reported by [DoomKorath on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1221444227796434964), the description of the planet Baianus erroneously refers to 'Titan' when it most likely should be referring to 'Triton'.
