### PR TITLE
Simplify CMake build on Linux and MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
-cmake_minimum_required(VERSION 3.21..3.25)
+cmake_minimum_required(VERSION 3.16...3.29)
 
 include(CMakeDependentOption)
-option(ES_USE_VCPKG "Use vcpkg to get dependencies." ON)
+if(UNIX AND NOT APPLE)
+	option(ES_USE_VCPKG "Use vcpkg to get dependencies." OFF)
+else()
+	option(ES_USE_VCPKG "Use vcpkg to get dependencies." ON)
+endif()
 cmake_dependent_option(ES_GLES "Build the game with OpenGL ES" OFF UNIX OFF)
-cmake_dependent_option(ES_FLATPAK "Build the game inside the Flatpak runtime" OFF UNIX OFF)
 cmake_dependent_option(ES_STEAM "Build the game for the Steam Linux runtime" OFF UNIX OFF)
-cmake_dependent_option(ES_USE_SYSTEM_LIBRARIES "Use system libraries instead of the vcpkg ones." ON UNIX OFF)
+cmake_dependent_option(ES_USE_SYSTEM_LIBRARIES "Use system libraries instead of the vcpkg ones." ON APPLE OFF)
 cmake_dependent_option(ES_CREATE_BUNDLE "Create a Bundle instead of an executable. Not suitable for development purposes." OFF APPLE OFF)
 
 # Support Debug and Release configurations.
@@ -42,13 +45,9 @@ if(NOT ES_USE_SYSTEM_LIBRARIES)
 	list(APPEND VCPKG_MANIFEST_FEATURES "system-libs")
 endif()
 
-# Tell vcpkg to use system libraries that are missing on the respective platform.
-if(ES_FLATPAK)
-	list(APPEND VCPKG_MANIFEST_FEATURES "flatpak-libs")
-elseif(ES_STEAM)
+# Tell vcpkg to use system libraries that are missing in the Steam runtime.
+if(ES_STEAM)
 	list(APPEND VCPKG_MANIFEST_FEATURES "steam-libs")
-elseif(APPLE)
-	list(APPEND VCPKG_MANIFEST_FEATURES "macos-libs")
 endif()
 
 # Various helpful options for IDEs.
@@ -133,7 +132,7 @@ if(UNIX)
 		find_path(UUID_INCLUDE uuid/uuid.h /usr/local/include /usr/include)
 		target_link_libraries(ExternalLibraries INTERFACE "${UUID_LIB}")
 		target_include_directories(ExternalLibraries INTERFACE "${UUID_INCLUDE}")
-	elseif(ES_USE_SYSTEM_LIBRARIES)
+	elseif(NOT ES_USE_VCPKG OR ES_USE_SYSTEM_LIBRARIES)
 		find_library(UUID_LIB uuid)
 		target_link_libraries(ExternalLibraries INTERFACE "${UUID_LIB}")
 	else()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,6 +30,7 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
+        "ES_USE_VCPKG": "ON",
         "ES_USE_SYSTEM_LIBRARIES": "OFF"
       },
       "condition": {
@@ -51,6 +52,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
+        "ES_USE_VCPKG": "ON",
         "ES_USE_SYSTEM_LIBRARIES": "OFF",
         "BUILD_TESTING": "OFF"
       },

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -50,9 +50,9 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 ### Linux
 
 You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12.
-If your distro does not provide up-to-date version of these libraries, you will need to tell CMake to build the libraries from source by passing `-DES_USE_SYSTEM_LIBRARIES=OFF` while configuring. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
+If your distro does not provide up-to-date version of these libraries, you can use vcpkg to build the necessary libraries from source by passing `-DES_USE_VCPKG=ON`. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
 
-In addition to the below dependencies, you will also need CMake 3.21 or newer. You can get the latest version from the [offical website](https://cmake.org/download/).
+In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [offical website](https://cmake.org/download/).
 
 
 <details>
@@ -76,6 +76,8 @@ gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL
 ## Building the game
 
 ### Building from the command line
+
+(Note: This commands require CMake 3.21+. If you are using a lower version of CMake you will not be able to use the presets mentioned in this section.)
 
 Here's a summary of every command you will need for development:
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,10 @@
 {
-  "dependencies": [],
+  "dependencies": [
+    {
+      "name": "openal-soft",
+      "platform": "osx"
+    }
+  ],
   "features": {
     "system-libs": {
       "description": "System libraries required to build ES.",
@@ -26,23 +31,10 @@
         "sdl2"
       ]
     },
-    "flatpak-libs": {
-      "description": "System libraries missing in the Flatpak runtime.",
-      "dependencies": [
-        "libmad",
-        "glew"
-      ]
-    },
     "steam-libs": {
       "description": "System libraries not provided in the Steam Sniper Runtime.",
       "dependencies": [
         "libmad"
-      ]
-    },
-    "macos-libs": {
-      "description": "System libraries that are always needed on MacOS.",
-      "dependencies": [
-        "openal-soft"
       ]
     }
   }


### PR DESCRIPTION
## Feature Details

- Drop required CMake version to 3.16. However, 3.21 is still highly recommended since it makes it easier to build and run the unit/integration tests.
- Stop using Vcpkg by default on Linux.
- Remove custom Flatpak code, it is not necessary anymore.
- Simplify MacOS dependency declaration
- Adjusted build instructions accordingly
- Fix syntax error while specifying CMake version range
- Increase highest supported CMake version to 3.29

/cc @thewierdnut 

## Testing Done

Works correctly on Linux. CI will test everything else.