### PR TITLE
fix(typo): Replace two mentions of "Burthensider" with "Burthenian"

### DIFF
--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -722,7 +722,7 @@ mission "Burthen Triathlon"
 
 			action
 				payment -2
-			`	You hand over a couple credits for the drink and leave the tent, sipping with some difficulty as you go. The Burthensider at the counter advises you not to drink too much of it at once, and not to drop the cup "unless you want a munted foot for a few weeks."`
+			`	You hand over a couple credits for the drink and leave the tent, sipping with some difficulty as you go. The Burthenian at the counter advises you not to drink too much of it at once, and not to drop the cup "unless you want a munted foot for a few weeks."`
 				goto "leave tent"
 
 			label antigrav
@@ -747,7 +747,7 @@ mission "Burthen Triathlon"
 				goto end
 
 			label "after tent"
-			`	As he nears the finish line the Burthensiders' enthusiastic cheers, whoops, and hollers erupt from the crowd, and the camera drones, their repulsors now calibrated for Burthen's gravity, circle around the finishing straight. Just over the crowd a loudspeaker announces, "And here comes the winner of the Syndicate Athletics Burthen Triathlon, the world triathlete champion, competitor number fifty-eight: Samuel Abernathy!"`
+			`	As he nears the finish line the Burthenians' enthusiastic cheers, whoops, and hollers erupt from the crowd, and the camera drones, their repulsors now calibrated for Burthen's gravity, circle around the finishing straight. Just over the crowd a loudspeaker announces, "And here comes the winner of the Syndicate Athletics Burthen Triathlon, the world triathlete champion, competitor number fifty-eight: Samuel Abernathy!"`
 
 			label "end"
 			`	Abernathy doesn't slow down until he's within an arm's length of the finishing line; as he crosses it he seizes the tape, making a yelp of simultaneous joy and relief. He holds the tape up before everybody in the crowd and at the cameras pointed at him, taking in the attention (and catching his breath) before accepting a bottle of water from someone on the sidelines.`


### PR DESCRIPTION
**Typo fix**
This PR addresses something I noticed while I was making another PR.

## Summary
In https://github.com/endless-sky/endless-sky/pull/9455 the people of Burthen were originally called Burthensiders; however this was later changed to Burthenian. It seems like I missed a couple while I was making the change.