### PR TITLE
Feat(data): Implement Engine Slot system

### DIFF
--- a/data/_deprecated/deprecated outfits.txt
+++ b/data/_deprecated/deprecated outfits.txt
@@ -230,6 +230,7 @@ outfit "Afterburner"
 	category "Engines"
 	"cost" 70000
 	thumbnail "outfit/afterburner"
+	"afterburner slot" -1
 	"mass" 10
 	"outfit space" -10
 	"engine capacity" -10

--- a/data/_deprecated/deprecated outfits.txt
+++ b/data/_deprecated/deprecated outfits.txt
@@ -58,6 +58,8 @@ outfit "Korath Ark'torbal Thruster"
 	category "Engines"
 	"cost" 40000
 	thumbnail "outfit/unknown"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 17
 	"outfit space" -17
 	"engine capacity" -17
@@ -73,6 +75,7 @@ outfit "Korath Ark'parat Steering"
 	category "Engines"
 	"cost" 36000
 	thumbnail "outfit/unknown"
+	"steering slot" -1
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
@@ -85,6 +88,8 @@ outfit "Korath Jak'torbal Thruster"
 	category "Engines"
 	"cost" 317000
 	thumbnail "outfit/unknown"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 89
 	"outfit space" -89
 	"engine capacity" -89
@@ -100,6 +105,7 @@ outfit "Korath Jak'parat Steering"
 	category "Engines"
 	"cost" 2740000
 	thumbnail "outfit/unknown"
+	"steering slot" -1
 	"mass" 67
 	"outfit space" -67
 	"engine capacity" -67
@@ -126,6 +132,7 @@ outfit "Reverse Thruster"
 	category "Engines"
 	"cost" 140000
 	thumbnail "outfit/reverse thruster"
+	"reverse thruster slot" -1
 	"mass" 22
 	"outfit space" -22
 	"weapon capacity" -22

--- a/data/_deprecated/deprecated ships.txt
+++ b/data/_deprecated/deprecated ships.txt
@@ -32,9 +32,9 @@ ship "Korath Dredger"
 		"outfit space" 763
 		"weapon capacity" 276
 		"engine capacity" 206
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 300
 			"shield damage" 4600
@@ -112,9 +112,9 @@ ship "Korath Raider"
 		"outfit space" 777
 		"weapon capacity" 339
 		"engine capacity" 159
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 250
 			"shield damage" 3600
@@ -185,9 +185,9 @@ ship "Korath Chaser"
 		"outfit space" 92
 		"weapon capacity" 25
 		"engine capacity" 30
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 48
 			"shield damage" 320
@@ -229,9 +229,9 @@ ship "Korath World-Ship"
 		"outfit space" 839
 		"weapon capacity" 314
 		"engine capacity" 165
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000

--- a/data/_deprecated/deprecated ships.txt
+++ b/data/_deprecated/deprecated ships.txt
@@ -32,6 +32,9 @@ ship "Korath Dredger"
 		"outfit space" 763
 		"weapon capacity" 276
 		"engine capacity" 206
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 300
 			"shield damage" 4600
@@ -109,6 +112,9 @@ ship "Korath Raider"
 		"outfit space" 777
 		"weapon capacity" 339
 		"engine capacity" 159
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 250
 			"shield damage" 3600
@@ -179,6 +185,9 @@ ship "Korath Chaser"
 		"outfit space" 92
 		"weapon capacity" 25
 		"engine capacity" 30
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 48
 			"shield damage" 320
@@ -220,6 +229,9 @@ ship "Korath World-Ship"
 		"outfit space" 839
 		"weapon capacity" 314
 		"engine capacity" 165
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000

--- a/data/_deprecated/deprecated ships.txt
+++ b/data/_deprecated/deprecated ships.txt
@@ -693,6 +693,7 @@ ship "Korath Chaser" "Korath Chaser (Digger)"
 ship "Korath Chaser" "Korath Chaser (World-Ship)"
 	add attributes
 		"atmosphere scan" 1
+		"afterburner slot" 1
 	outfits
 		"Generator (Candle Class)"
 		"Systems Core (Tiny)"

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -141,7 +141,7 @@ help "navigation"
 
 help "outfitter"
 	`Here, you can buy new equipment for your ship. Your ship has a limited amount of "outfit space," and most outfits use up some of that space.`
-	`Some types of outfits have other requirements as well. For example, only some of your outfit space can be used for engines or weapons; this is your ship's "engine capacity" and "weapon capacity." Guns and missile launchers also require a free "gun port," and turrets require a free "turret mount." Also, missiles can only be bought if you have the right launcher installed.`
+	`Some types of outfits have other requirements as well. For example, only some of your outfit space can be used for engines or weapons; this is your ship's "engine capacity" and "weapon capacity." Propulsion systems will require an open slot to install them in, and most ships only have 1 slot for thrusters and another for steering. Guns and missile launchers also require a free "gun port," and turrets require a free "turret mount." Also, missiles can only be bought if you have the right launcher installed.`
 	`Use your scroll wheel or click and drag, to scroll the view.`
 	`As in the trading and shipyard panels, you can hold down Shift, Control, or Alt to buy 5, 20, or 500 of an outfit at once, or multiple keys for larger amounts.`
 	`You can also press F to search the outfitter for a specific item.`

--- a/data/bunrodea/bunrodea outfits.txt
+++ b/data/bunrodea/bunrodea outfits.txt
@@ -223,6 +223,8 @@ outfit "Chiisana Rift Thruster"
 	category "Engines"
 	cost 130000
 	thumbnail "outfit/chiisana rift thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 11
 	"outfit space" -11
 	"engine capacity" -11
@@ -240,6 +242,8 @@ outfit "Nami Rift Thruster"
 	category "Engines"
 	cost 262000
 	thumbnail "outfit/nami rift thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 19
 	"outfit space" -19
 	"engine capacity" -19
@@ -257,6 +261,8 @@ outfit "Ookii Rift Thruster"
 	category "Engines"
 	cost 512000
 	thumbnail "outfit/ookii rift thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
@@ -274,6 +280,8 @@ outfit "Subarashii Rift Thruster"
 	category "Engines"
 	cost 1004000
 	thumbnail "outfit/subarashii rift thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 55
 	"outfit space" -55
 	"engine capacity" -55
@@ -290,6 +298,7 @@ outfit "Chiisana Rift Steering"
 	category "Engines"
 	cost 201000
 	thumbnail "outfit/chiisana rift steering"
+	"steering slot" -1
 	"mass" 17
 	"outfit space" -17
 	"engine capacity" -17
@@ -302,6 +311,7 @@ outfit "Nami Rift Steering"
 	category "Engines"
 	cost 442000
 	thumbnail "outfit/nami rift steering"
+	"steering slot" -1
 	"mass" 31
 	"outfit space" -31
 	"engine capacity" -31
@@ -314,6 +324,7 @@ outfit "Ookii Rift Steering"
 	category "Engines"
 	cost 940000
 	thumbnail "outfit/ookii rift steering"
+	"steering slot" -1
 	"mass" 53
 	"outfit space" -53
 	"engine capacity" -53
@@ -326,6 +337,7 @@ outfit "Subarashii Rift Steering"
 	category "Engines"
 	cost 1577000
 	thumbnail "outfit/subarashii rift steering"
+	"steering slot" -1
 	"mass" 90
 	"outfit space" -90
 	"engine capacity" -90

--- a/data/bunrodea/bunrodea ships.txt
+++ b/data/bunrodea/bunrodea ships.txt
@@ -27,6 +27,9 @@ ship "Kaiken"
 		"outfit space" 121
 		"weapon capacity" 35
 		"engine capacity" 45
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -74,6 +77,9 @@ ship "Sasumata"
 		"outfit space" 397
 		"weapon capacity" 122
 		"engine capacity" 126
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"cloak" .05
 		"cloaking energy" 10
 		"cloaking fuel" .05
@@ -138,6 +144,9 @@ ship "Tanto"
 		"outfit space" 231
 		"weapon capacity" 56
 		"engine capacity" 102
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -190,6 +199,9 @@ ship "Ararebo"
 		"outfit space" 594
 		"weapon capacity" 112
 		"engine capacity" 108
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 200
 			"shield damage" 2000
@@ -257,6 +269,9 @@ ship "Tekkan"
 		"outfit space" 321
 		"weapon capacity" 100
 		"engine capacity" 85
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 140
 			"shield damage" 1400
@@ -313,6 +328,9 @@ ship "Kunai"
 		"outfit space" 407
 		"weapon capacity" 158
 		"engine capacity" 102
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 210
 			"shield damage" 2100
@@ -371,6 +389,9 @@ ship "Kama"
 		"outfit space" 573
 		"weapon capacity" 247
 		"engine capacity" 121
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 350
 			"shield damage" 3500
@@ -438,6 +459,9 @@ ship "Chigiriki"
 		"outfit space" 747
 		"weapon capacity" 504
 		"engine capacity" 145
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 410
 			"shield damage" 4100

--- a/data/bunrodea/bunrodea ships.txt
+++ b/data/bunrodea/bunrodea ships.txt
@@ -27,9 +27,9 @@ ship "Kaiken"
 		"outfit space" 121
 		"weapon capacity" 35
 		"engine capacity" 45
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -77,9 +77,9 @@ ship "Sasumata"
 		"outfit space" 397
 		"weapon capacity" 122
 		"engine capacity" 126
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"cloak" .05
 		"cloaking energy" 10
 		"cloaking fuel" .05
@@ -144,9 +144,9 @@ ship "Tanto"
 		"outfit space" 231
 		"weapon capacity" 56
 		"engine capacity" 102
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -199,9 +199,9 @@ ship "Ararebo"
 		"outfit space" 594
 		"weapon capacity" 112
 		"engine capacity" 108
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 200
 			"shield damage" 2000
@@ -269,9 +269,9 @@ ship "Tekkan"
 		"outfit space" 321
 		"weapon capacity" 100
 		"engine capacity" 85
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 140
 			"shield damage" 1400
@@ -328,9 +328,9 @@ ship "Kunai"
 		"outfit space" 407
 		"weapon capacity" 158
 		"engine capacity" 102
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 210
 			"shield damage" 2100
@@ -389,9 +389,9 @@ ship "Kama"
 		"outfit space" 573
 		"weapon capacity" 247
 		"engine capacity" 121
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 350
 			"shield damage" 3500
@@ -459,9 +459,9 @@ ship "Chigiriki"
 		"outfit space" 747
 		"weapon capacity" 504
 		"engine capacity" 145
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 410
 			"shield damage" 4100

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -378,7 +378,7 @@ outfit "Small Steering Module"
 		Coalition
 	"cost" 60000
 	thumbnail "outfit/small steering module"
-	"steering slot" -1
+	"steering slot" -0.25
 	"mass" 7
 	"outfit space" -7
 	"engine capacity" -7
@@ -396,17 +396,18 @@ outfit "Large Steering Module"
 		Coalition
 	"cost" 269000
 	thumbnail "outfit/large steering module"
-	"steering slot" -1
+	"steering slot" -0.5
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
-	"turn" 747
-	"turning energy" 1.0
-	"turning heat" 6.5
+	"turn" 536.4
+	"turning energy" 0.78
+	"turning heat" 5.4
 	"steering flare sprite" "effect/coalition flare/large"
 		"frame rate" 7
 	"steering flare sound" "atomic small"
 	description "By focusing on small, modular engines rather than the massive capital ship drives that most other species develop, the Coalition loses some of the potential efficiency for very large ships, but gains a considerable amount of flexibility."
+	description "Like the large thruster module, the large steering module is actually trio of small steering modules with a mounting framework that takes up half a standard steering mounting slot."
 
 outfit "Enforcer Confrontation Gear"
 	category "Hand to Hand"

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -298,6 +298,8 @@ outfit "Small Thrust Module"
 		Coalition
 	"cost" 66000
 	thumbnail "outfit/small thrust module"
+	"thruster slot" -0.25
+	"afterburner slot" 1
 	"mass" 9
 	"outfit space" -9
 	"engine capacity" -9
@@ -308,6 +310,7 @@ outfit "Small Thrust Module"
 		"frame rate" 10
 	"flare sound" "atomic tiny"
 	description "This tiny thruster produces a considerable amount of thrust... but also a considerable amount of heat."
+	description "In order to optimize the production costs of propulsion systems for their vast transportation network, Coalition engineers opted to perfect a single thrust module that could be installed in varying configurations. As a result, up to four of these can be installed in a typical thruster slot."
 
 outfit "Large Thrust Module"
 	category "Engines"
@@ -315,16 +318,19 @@ outfit "Large Thrust Module"
 		Coalition
 	"cost" 292000
 	thumbnail "outfit/large thrust module"
+	"thruster slot" -0.5
+	"afterburner slot" 1
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
-	"thrust" 30.6
-	"thrusting energy" 1.7
-	"thrusting heat" 11
+	"thrust" 24.9
+	"thrusting energy" 1.38
+	"thrusting heat" 9
 	"flare sprite" "effect/coalition flare/large"
 		"frame rate" 7
 	"flare sound" "atomic small"
-	description "Coalition engineers prefer to focus on perfecting a few versatile designs rather than producing a wide range of them. This thruster is quite efficient, but large ships will need several of them stacked together to produce sufficient thrust."
+	description "Coalition engineers prefer to focus on perfecting a few versatile designs rather than producing a wide range of them. As their large ships would require many of them stacked together to produce sufficient thrust, they created an array installation that incorporates three modules into a single mounting framework. Since two of these modules can be installed in a typical slot, it allows ships that require large amounts of thrust to incorporate six modules in a standard slot."
+	description "In order to facilitate the utilization of their modular designs, most ships of Coalition design have additional mounting brackets beyond the typical single standard slot."
 
 outfit "Small Reverse Module"
 	category "Engines"
@@ -332,6 +338,7 @@ outfit "Small Reverse Module"
 		Coalition
 	"cost" 66000
 	thumbnail "outfit/small reverse module"
+	"reverse thruster slot" -0.25
 	"mass" 9
 	"outfit space" -9
 	"weapon capacity" -9
@@ -342,6 +349,7 @@ outfit "Small Reverse Module"
 		"frame rate" 10
 	"reverse flare sound" "atomic tiny"
 	description "Placing this tiny thruster in the front of a freighter or transport allows Coalition merchants to considerably improve their energy efficiency, which is of great benefit when relying on solar power."
+	description "Thanks to the modular design, four of these modules can be stacked in the standard reverse thruster slot."
 	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."
 
 outfit "Large Reverse Module"
@@ -350,16 +358,18 @@ outfit "Large Reverse Module"
 		Coalition
 	"cost" 292000
 	thumbnail "outfit/large reverse module"
+	"reverse thruster slot" -0.5
 	"mass" 32
 	"outfit space" -32
 	"weapon capacity" -32
-	"reverse thrust" 30.6
-	"reverse thrusting energy" 1.7
-	"reverse thrusting heat" 11
+	"reverse thrust" 24.9
+	"reverse thrusting energy" 1.38
+	"reverse thrusting heat" 9
 	"reverse flare sprite" "effect/coalition flare/large"
 		"frame rate" 7
 	"reverse flare sound" "atomic small"
-	description "With their significant weapons capacity left unused in peacetime, captains of larger Coalition freighters and transports can use Large Reverse Modules to rapidly slow their ships, allowing them to save both time and energy."
+	description "Like their large thruster modules, these are actually a framework array that incorporates three small reverse modules. With their significant weapons capacity left unused in peacetime, captains of larger Coalition freighters and transports can use Large Reverse Modules to rapidly slow their ships, allowing them to save both time and energy."
+	description "Thanks to the modular design, two of these modules can be stacked in the standard reverse thruster slot. This effectively allows 6 reverse thrust modules to be installed in a standard slot."
 	description "	Because a reverse thruster must be facing forwards, it must be installed in the weapon section of your ship instead of the engine section."
 
 outfit "Small Steering Module"
@@ -368,6 +378,7 @@ outfit "Small Steering Module"
 		Coalition
 	"cost" 60000
 	thumbnail "outfit/small steering module"
+	"steering slot" -1
 	"mass" 7
 	"outfit space" -7
 	"engine capacity" -7
@@ -385,6 +396,7 @@ outfit "Large Steering Module"
 		Coalition
 	"cost" 269000
 	thumbnail "outfit/large steering module"
+	"steering slot" -1
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -31,9 +31,9 @@ ship "Arach Courier"
 		"outfit space" 148
 		"weapon capacity" 39
 		"engine capacity" 40
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 20
 			"shield damage" 200
@@ -93,9 +93,9 @@ ship "Arach Freighter"
 		"outfit space" 349
 		"weapon capacity" 132
 		"engine capacity" 92
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -166,9 +166,9 @@ ship "Arach Hulk"
 		"outfit space" 520
 		"weapon capacity" 208
 		"engine capacity" 148
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -245,9 +245,9 @@ ship "Arach Spindle"
 		"outfit space" 434
 		"weapon capacity" 138
 		"engine capacity" 148
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -359,9 +359,9 @@ ship "Arach Transport"
 		"outfit space" 281
 		"weapon capacity" 96
 		"engine capacity" 70
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -431,9 +431,9 @@ ship "Heliarch Breacher"
 		"outfit space" 372
 		"weapon capacity" 112
 		"engine capacity" 106
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 150
 			"shield damage" 1200
@@ -552,9 +552,9 @@ ship "Heliarch Hunter"
 		"outfit space" 552
 		"weapon capacity" 201
 		"engine capacity" 141
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 200
 			"shield damage" 2700
@@ -741,9 +741,9 @@ ship "Heliarch Interdictor"
 		"outfit space" 544
 		"weapon capacity" 179
 		"engine capacity" 135
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 250
 			"shield damage" 3000
@@ -917,9 +917,9 @@ ship "Heliarch Judicator"
 		"outfit space" 524
 		"weapon capacity" 164
 		"engine capacity" 114
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 250
 			"shield damage" 2800
@@ -1104,9 +1104,9 @@ ship "Heliarch Neutralizer"
 		"outfit space" 367
 		"weapon capacity" 72
 		"engine capacity" 102
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 150
 			"shield damage" 1800
@@ -1228,9 +1228,9 @@ ship "Heliarch Punisher"
 		"outfit space" 885
 		"weapon capacity" 352
 		"engine capacity" 187
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 400
 			"shield damage" 4800
@@ -1472,9 +1472,9 @@ ship "Heliarch Pursuer"
 		"outfit space" 105
 		"weapon capacity" 19
 		"engine capacity" 36
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 15
 			"shield damage" 150
@@ -1534,9 +1534,9 @@ ship "Heliarch Rover"
 		"outfit space" 125
 		"weapon capacity" 24
 		"engine capacity" 32
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 15
 			"shield damage" 150
@@ -1595,9 +1595,9 @@ ship "Heliarch Stalker"
 		"outfit space" 133
 		"weapon capacity" 43
 		"engine capacity" 16
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 15
 			"shield damage" 150
@@ -1656,9 +1656,9 @@ ship "Kimek Briar"
 		"outfit space" 245
 		"weapon capacity" 89
 		"engine capacity" 60
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 34
 			"shield damage" 340
@@ -1720,9 +1720,9 @@ ship "Kimek Spire"
 		"outfit space" 489
 		"weapon capacity" 256
 		"engine capacity" 129
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 140
 			"shield damage" 1400
@@ -1795,9 +1795,9 @@ ship "Kimek Thistle"
 		"outfit space" 321
 		"weapon capacity" 118
 		"engine capacity" 87
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -1883,9 +1883,9 @@ ship "Kimek Thorn"
 		"outfit space" 133
 		"weapon capacity" 40
 		"engine capacity" 38
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 14
 			"shield damage" 140
@@ -1945,9 +1945,9 @@ ship "Saryd Runabout"
 		"outfit space" 172
 		"weapon capacity" 44
 		"engine capacity" 42
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 22
 			"shield damage" 220
@@ -2005,9 +2005,9 @@ ship "Saryd Sojourner"
 		"outfit space" 568
 		"weapon capacity" 202
 		"engine capacity" 156
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		weapon
 			"blast radius" 200
 			"shield damage" 2000
@@ -2102,9 +2102,9 @@ ship "Saryd Traveler"
 		"outfit space" 466
 		"weapon capacity" 177
 		"engine capacity" 79
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1.5
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2.5
 		"asteroid scan power" 36
 		"atmosphere scan" 100
 		weapon
@@ -2180,9 +2180,9 @@ ship "Saryd Visitor"
 		"outfit space" 320
 		"weapon capacity" 90
 		"engine capacity" 57
-		"reverse thruster slot" 1
-		"steering slot" 1.5
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2.5
+		"thruster slot" 2
 		weapon
 			"blast radius" 42
 			"shield damage" 420

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -32,7 +32,7 @@ ship "Arach Courier"
 		"weapon capacity" 39
 		"engine capacity" 40
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 20
@@ -94,7 +94,7 @@ ship "Arach Freighter"
 		"weapon capacity" 132
 		"engine capacity" 92
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 80
@@ -167,7 +167,7 @@ ship "Arach Hulk"
 		"weapon capacity" 208
 		"engine capacity" 148
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 120
@@ -246,7 +246,7 @@ ship "Arach Spindle"
 		"weapon capacity" 138
 		"engine capacity" 148
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 100
@@ -360,7 +360,7 @@ ship "Arach Transport"
 		"weapon capacity" 96
 		"engine capacity" 70
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 40
@@ -432,7 +432,7 @@ ship "Heliarch Breacher"
 		"weapon capacity" 112
 		"engine capacity" 106
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 150
@@ -553,7 +553,7 @@ ship "Heliarch Hunter"
 		"weapon capacity" 201
 		"engine capacity" 141
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 200
@@ -742,7 +742,7 @@ ship "Heliarch Interdictor"
 		"weapon capacity" 179
 		"engine capacity" 135
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 250
@@ -918,7 +918,7 @@ ship "Heliarch Judicator"
 		"weapon capacity" 164
 		"engine capacity" 114
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 250
@@ -1105,7 +1105,7 @@ ship "Heliarch Neutralizer"
 		"weapon capacity" 72
 		"engine capacity" 102
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 150
@@ -1229,7 +1229,7 @@ ship "Heliarch Punisher"
 		"weapon capacity" 352
 		"engine capacity" 187
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 400
@@ -1473,7 +1473,7 @@ ship "Heliarch Pursuer"
 		"weapon capacity" 19
 		"engine capacity" 36
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 15
@@ -1535,7 +1535,7 @@ ship "Heliarch Rover"
 		"weapon capacity" 24
 		"engine capacity" 32
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 15
@@ -1596,7 +1596,7 @@ ship "Heliarch Stalker"
 		"weapon capacity" 43
 		"engine capacity" 16
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 15
@@ -1657,7 +1657,7 @@ ship "Kimek Briar"
 		"weapon capacity" 89
 		"engine capacity" 60
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 34
@@ -1721,7 +1721,7 @@ ship "Kimek Spire"
 		"weapon capacity" 256
 		"engine capacity" 129
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 140
@@ -1796,7 +1796,7 @@ ship "Kimek Thistle"
 		"weapon capacity" 118
 		"engine capacity" 87
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 60
@@ -1884,7 +1884,7 @@ ship "Kimek Thorn"
 		"weapon capacity" 40
 		"engine capacity" 38
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 14
@@ -1946,7 +1946,7 @@ ship "Saryd Runabout"
 		"weapon capacity" 44
 		"engine capacity" 42
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 22
@@ -2006,7 +2006,7 @@ ship "Saryd Sojourner"
 		"weapon capacity" 202
 		"engine capacity" 156
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		weapon
 			"blast radius" 200
@@ -2103,7 +2103,7 @@ ship "Saryd Traveler"
 		"weapon capacity" 177
 		"engine capacity" 79
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1.5
 		"asteroid scan power" 36
 		"atmosphere scan" 100
@@ -2181,7 +2181,7 @@ ship "Saryd Visitor"
 		"weapon capacity" 90
 		"engine capacity" 57
 		"reverse thruster slot" 1
-		"steering slot" 1
+		"steering slot" 1.5
 		"thruster slot" 1
 		weapon
 			"blast radius" 42

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -31,6 +31,9 @@ ship "Arach Courier"
 		"outfit space" 148
 		"weapon capacity" 39
 		"engine capacity" 40
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 20
 			"shield damage" 200
@@ -90,6 +93,9 @@ ship "Arach Freighter"
 		"outfit space" 349
 		"weapon capacity" 132
 		"engine capacity" 92
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -160,6 +166,9 @@ ship "Arach Hulk"
 		"outfit space" 520
 		"weapon capacity" 208
 		"engine capacity" 148
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -236,6 +245,9 @@ ship "Arach Spindle"
 		"outfit space" 434
 		"weapon capacity" 138
 		"engine capacity" 148
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -347,6 +359,9 @@ ship "Arach Transport"
 		"outfit space" 281
 		"weapon capacity" 96
 		"engine capacity" 70
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -416,6 +431,9 @@ ship "Heliarch Breacher"
 		"outfit space" 372
 		"weapon capacity" 112
 		"engine capacity" 106
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 150
 			"shield damage" 1200
@@ -534,6 +552,9 @@ ship "Heliarch Hunter"
 		"outfit space" 552
 		"weapon capacity" 201
 		"engine capacity" 141
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 200
 			"shield damage" 2700
@@ -720,6 +741,9 @@ ship "Heliarch Interdictor"
 		"outfit space" 544
 		"weapon capacity" 179
 		"engine capacity" 135
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 250
 			"shield damage" 3000
@@ -893,6 +917,9 @@ ship "Heliarch Judicator"
 		"outfit space" 524
 		"weapon capacity" 164
 		"engine capacity" 114
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 250
 			"shield damage" 2800
@@ -1077,6 +1104,9 @@ ship "Heliarch Neutralizer"
 		"outfit space" 367
 		"weapon capacity" 72
 		"engine capacity" 102
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 150
 			"shield damage" 1800
@@ -1198,6 +1228,9 @@ ship "Heliarch Punisher"
 		"outfit space" 885
 		"weapon capacity" 352
 		"engine capacity" 187
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 400
 			"shield damage" 4800
@@ -1439,6 +1472,9 @@ ship "Heliarch Pursuer"
 		"outfit space" 105
 		"weapon capacity" 19
 		"engine capacity" 36
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 15
 			"shield damage" 150
@@ -1498,6 +1534,9 @@ ship "Heliarch Rover"
 		"outfit space" 125
 		"weapon capacity" 24
 		"engine capacity" 32
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 15
 			"shield damage" 150
@@ -1556,6 +1595,9 @@ ship "Heliarch Stalker"
 		"outfit space" 133
 		"weapon capacity" 43
 		"engine capacity" 16
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 15
 			"shield damage" 150
@@ -1614,6 +1656,9 @@ ship "Kimek Briar"
 		"outfit space" 245
 		"weapon capacity" 89
 		"engine capacity" 60
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 34
 			"shield damage" 340
@@ -1675,6 +1720,9 @@ ship "Kimek Spire"
 		"outfit space" 489
 		"weapon capacity" 256
 		"engine capacity" 129
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 140
 			"shield damage" 1400
@@ -1747,6 +1795,9 @@ ship "Kimek Thistle"
 		"outfit space" 321
 		"weapon capacity" 118
 		"engine capacity" 87
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -1832,6 +1883,9 @@ ship "Kimek Thorn"
 		"outfit space" 133
 		"weapon capacity" 40
 		"engine capacity" 38
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 14
 			"shield damage" 140
@@ -1891,6 +1945,9 @@ ship "Saryd Runabout"
 		"outfit space" 172
 		"weapon capacity" 44
 		"engine capacity" 42
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 22
 			"shield damage" 220
@@ -1948,6 +2005,9 @@ ship "Saryd Sojourner"
 		"outfit space" 568
 		"weapon capacity" 202
 		"engine capacity" 156
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		weapon
 			"blast radius" 200
 			"shield damage" 2000
@@ -2042,6 +2102,9 @@ ship "Saryd Traveler"
 		"outfit space" 466
 		"weapon capacity" 177
 		"engine capacity" 79
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1.5
 		"asteroid scan power" 36
 		"atmosphere scan" 100
 		weapon
@@ -2117,6 +2180,9 @@ ship "Saryd Visitor"
 		"outfit space" 320
 		"weapon capacity" 90
 		"engine capacity" 57
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 42
 			"shield damage" 420

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -32,9 +32,9 @@ ship "Archon"
 		"outfit space" 1300
 		"weapon capacity" 1125
 		"engine capacity" 200
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 100000
 		"energy generation" 1000
 		"heat generation" 17

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -32,6 +32,9 @@ ship "Archon"
 		"outfit space" 1300
 		"weapon capacity" 1125
 		"engine capacity" 200
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 100000
 		"energy generation" 1000
 		"heat generation" 17

--- a/data/gegno/gegno outfits.txt
+++ b/data/gegno/gegno outfits.txt
@@ -147,6 +147,8 @@ outfit "RG15 Torch Thruster"
 		"Gegno Civilian"
 	cost 17000
 	thumbnail "outfit/small torch thruster vi"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 31
 	"outfit space" -31
 	"engine capacity" -31
@@ -165,6 +167,7 @@ outfit "RG15 Torch Steering"
 		"Gegno Civilian"
 	cost 15000
 	thumbnail "outfit/small torch steering vi"
+	"steering slot" -1
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
@@ -183,6 +186,8 @@ outfit "RG18 Torch Thruster"
 		"Gegno Civilian"
 	cost 38000
 	thumbnail "outfit/medium torch thruster vi"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 51
 	"outfit space" -51
 	"engine capacity" -51
@@ -201,6 +206,7 @@ outfit "RG18 Torch Steering"
 		"Gegno Civilian"
 	cost 32000
 	thumbnail "outfit/medium torch steering vi"
+	"steering slot" -1
 	"mass" 39
 	"outfit space" -39
 	"engine capacity" -39
@@ -222,6 +228,8 @@ outfit "RG3 Torch Thruster"
 		"Vi Lord"
 	cost 84000
 	thumbnail "outfit/large torch thruster vi"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 83
 	"outfit space" -83
 	"engine capacity" -83
@@ -243,6 +251,7 @@ outfit "RG3 Torch Steering"
 		"Vi Lord"
 	cost 70000
 	thumbnail "outfit/large torch steering vi"
+	"steering slot" -1
 	"mass" 64
 	"outfit space" -64
 	"engine capacity" -64
@@ -264,6 +273,9 @@ outfit "SC-1 Plasma Engines"
 		"Scin Architect"
 	cost 21200
 	thumbnail "outfit/tiny plasma engines scin"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 21
 	"outfit space" -21
 	"engine capacity" -21
@@ -289,6 +301,8 @@ outfit "SC-12 Plasma Thruster"
 		"Scin Adjutant"
 	cost 20900
 	thumbnail "outfit/small plasma thruster scin"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
@@ -308,6 +322,7 @@ outfit "SC-12 Plasma Steering"
 		"Scin Adjutant"
 	cost 17000
 	thumbnail "outfit/small plasma steering scin"
+	"steering slot" -1
 	"mass" 19
 	"outfit space" -19
 	"engine capacity" -19
@@ -327,6 +342,8 @@ outfit "SC-14 Plasma Thruster"
 		"Scin Adjutant"
 	cost 52500
 	thumbnail "outfit/medium plasma thruster scin"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 45
 	"outfit space" -45
 	"engine capacity" -45
@@ -346,6 +363,7 @@ outfit "SC-14 Plasma Steering"
 		"Scin Adjutant"
 	cost 41500
 	thumbnail "outfit/medium plasma steering scin"
+	"steering slot" -1
 	"mass" 34
 	"outfit space" -34
 	"engine capacity" -34
@@ -367,6 +385,9 @@ outfit "SC-15 Plasma Thrusters"
 		"Scin Architect"
 	cost 170400
 	thumbnail "outfit/large plasma engines scin"
+	"reverse thruster slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 112
 	"outfit space" -112
 	"engine capacity" -112

--- a/data/gegno/gegno ships.txt
+++ b/data/gegno/gegno ships.txt
@@ -33,9 +33,9 @@ ship "Shale"
 		"outfit space" 113
 		"weapon capacity" 0
 		"engine capacity" 58
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 18
 			"shield damage" 40
@@ -74,9 +74,9 @@ ship "Dolomite"
 		"outfit space" 152
 		"weapon capacity" 0
 		"engine capacity" 81
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 72
 			"shield damage" 320
@@ -120,9 +120,9 @@ ship "Conglomerate"
 		"outfit space" 253
 		"weapon capacity" 0
 		"engine capacity" 146
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 124
 			"shield damage" 960
@@ -171,9 +171,9 @@ ship "Granofel"
 		"outfit space" 230
 		"weapon capacity" 0
 		"engine capacity" 151
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 96
 			"shield damage" 480
@@ -222,9 +222,9 @@ ship "Gypsum"
 		"outfit space" 240
 		"weapon capacity" 42
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"drill port" 1
 		"drill lock" -1
 		weapon
@@ -274,9 +274,9 @@ ship "Corundum"
 		"outfit space" 316
 		"weapon capacity" 64
 		"engine capacity" 162
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"drill spar" 2
 		weapon
 			"blast radius" 84
@@ -353,9 +353,9 @@ ship "Protolith"
 		"outfit space" 942
 		"weapon capacity" 0
 		"engine capacity" 480
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 4
 		weapon
 			"blast radius" 360
 			"shield damage" 1860
@@ -416,9 +416,9 @@ ship "Dunite"
 		"outfit space" 115
 		"weapon capacity" 22
 		"engine capacity" 56
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 10
 			"shield damage" 20
@@ -464,9 +464,9 @@ ship "Augen"
 		"outfit space" 1868
 		"weapon capacity" 1073
 		"engine capacity" 460
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 4
 		weapon
 			"blast radius" 450
 			"shield damage" 2000
@@ -588,9 +588,9 @@ ship "Slate"
 		"outfit space" 122
 		"weapon capacity" 0
 		"engine capacity" 58
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 18
 			"shield damage" 40
@@ -630,9 +630,9 @@ ship "Schist"
 		"outfit space" 298
 		"weapon capacity" 100
 		"engine capacity" 96
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 71
 			"shield damage" 310
@@ -709,9 +709,9 @@ ship "Eclogite"
 		"outfit space" 285
 		"weapon capacity" 96
 		"engine capacity" 94
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 210
@@ -762,9 +762,9 @@ ship "Diorite"
 		"outfit space" 453
 		"weapon capacity" 195
 		"engine capacity" 140
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 90
 			"shield damage" 540
@@ -832,9 +832,9 @@ ship "Hornfel"
 		"outfit space" 508
 		"weapon capacity" 240
 		"engine capacity" 94
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 90
 			"shield damage" 600
@@ -959,9 +959,9 @@ ship "Gneiss"
 		"outfit space" 841
 		"weapon capacity" 504
 		"engine capacity" 150
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 150
 			"shield damage" 1150
@@ -1034,9 +1034,9 @@ ship "Granulite"
 		"outfit space" 651
 		"weapon capacity" 216
 		"engine capacity" 203
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 280
 			"shield damage" 1550
@@ -1115,9 +1115,9 @@ ship "Halite"
 		"outfit space" 78
 		"weapon capacity" 30
 		"engine capacity" 21
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 14
 			"shield damage" 160
@@ -1161,9 +1161,9 @@ ship "Mica"
 		"outfit space" 118
 		"weapon capacity" 0
 		"engine capacity" 50
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 18
 			"shield damage" 40
@@ -1203,9 +1203,9 @@ ship "Coesite"
 		"outfit space" 264
 		"weapon capacity" 86
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 40
 			"shield damage" 240
@@ -1260,9 +1260,9 @@ ship "Tridymite"
 		"outfit space" 200
 		"weapon capacity" 0
 		"engine capacity" 86
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 
 		"outfit scan power" 18
 		"outfit scan efficiency" 8
@@ -1316,9 +1316,9 @@ ship "Felsic"
 		"outfit space" 322
 		"weapon capacity" 109
 		"engine capacity" 106
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 74
 			"shield damage" 340
@@ -1371,9 +1371,9 @@ ship "Feldspar"
 		"outfit space" 566
 		"weapon capacity" 234
 		"engine capacity" 172
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 180
 			"shield damage" 1650
@@ -1460,9 +1460,9 @@ ship "Epidote"
 		"outfit space" 552
 		"weapon capacity" 166
 		"engine capacity" 182
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 216
 			"shield damage" 1920
@@ -1526,9 +1526,9 @@ ship "Kyanite"
 		"outfit space" 380
 		"weapon capacity" 202
 		"engine capacity" 160
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 21300
 		"energy generation" 11.3
 		"heat generation" 27.2

--- a/data/gegno/gegno ships.txt
+++ b/data/gegno/gegno ships.txt
@@ -33,6 +33,9 @@ ship "Shale"
 		"outfit space" 113
 		"weapon capacity" 0
 		"engine capacity" 58
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 18
 			"shield damage" 40
@@ -71,6 +74,9 @@ ship "Dolomite"
 		"outfit space" 152
 		"weapon capacity" 0
 		"engine capacity" 81
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 72
 			"shield damage" 320
@@ -114,6 +120,9 @@ ship "Conglomerate"
 		"outfit space" 253
 		"weapon capacity" 0
 		"engine capacity" 146
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 124
 			"shield damage" 960
@@ -162,6 +171,9 @@ ship "Granofel"
 		"outfit space" 230
 		"weapon capacity" 0
 		"engine capacity" 151
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 96
 			"shield damage" 480
@@ -210,6 +222,9 @@ ship "Gypsum"
 		"outfit space" 240
 		"weapon capacity" 42
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"drill port" 1
 		"drill lock" -1
 		weapon
@@ -259,6 +274,9 @@ ship "Corundum"
 		"outfit space" 316
 		"weapon capacity" 64
 		"engine capacity" 162
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"drill spar" 2
 		weapon
 			"blast radius" 84
@@ -335,6 +353,9 @@ ship "Protolith"
 		"outfit space" 942
 		"weapon capacity" 0
 		"engine capacity" 480
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 360
 			"shield damage" 1860
@@ -395,6 +416,9 @@ ship "Dunite"
 		"outfit space" 115
 		"weapon capacity" 22
 		"engine capacity" 56
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 10
 			"shield damage" 20
@@ -440,6 +464,9 @@ ship "Augen"
 		"outfit space" 1868
 		"weapon capacity" 1073
 		"engine capacity" 460
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 450
 			"shield damage" 2000
@@ -561,6 +588,9 @@ ship "Slate"
 		"outfit space" 122
 		"weapon capacity" 0
 		"engine capacity" 58
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 18
 			"shield damage" 40
@@ -600,6 +630,9 @@ ship "Schist"
 		"outfit space" 298
 		"weapon capacity" 100
 		"engine capacity" 96
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 71
 			"shield damage" 310
@@ -676,6 +709,9 @@ ship "Eclogite"
 		"outfit space" 285
 		"weapon capacity" 96
 		"engine capacity" 94
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 36
 			"shield damage" 210
@@ -726,6 +762,9 @@ ship "Diorite"
 		"outfit space" 453
 		"weapon capacity" 195
 		"engine capacity" 140
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 90
 			"shield damage" 540
@@ -793,6 +832,9 @@ ship "Hornfel"
 		"outfit space" 508
 		"weapon capacity" 240
 		"engine capacity" 94
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 90
 			"shield damage" 600
@@ -917,6 +959,9 @@ ship "Gneiss"
 		"outfit space" 841
 		"weapon capacity" 504
 		"engine capacity" 150
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 150
 			"shield damage" 1150
@@ -989,6 +1034,9 @@ ship "Granulite"
 		"outfit space" 651
 		"weapon capacity" 216
 		"engine capacity" 203
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 280
 			"shield damage" 1550
@@ -1067,6 +1115,9 @@ ship "Halite"
 		"outfit space" 78
 		"weapon capacity" 30
 		"engine capacity" 21
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 14
 			"shield damage" 160
@@ -1110,6 +1161,9 @@ ship "Mica"
 		"outfit space" 118
 		"weapon capacity" 0
 		"engine capacity" 50
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 18
 			"shield damage" 40
@@ -1149,6 +1203,9 @@ ship "Coesite"
 		"outfit space" 264
 		"weapon capacity" 86
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 40
 			"shield damage" 240
@@ -1203,6 +1260,9 @@ ship "Tridymite"
 		"outfit space" 200
 		"weapon capacity" 0
 		"engine capacity" 86
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 
 		"outfit scan power" 18
 		"outfit scan efficiency" 8
@@ -1256,6 +1316,9 @@ ship "Felsic"
 		"outfit space" 322
 		"weapon capacity" 109
 		"engine capacity" 106
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 74
 			"shield damage" 340
@@ -1308,6 +1371,9 @@ ship "Feldspar"
 		"outfit space" 566
 		"weapon capacity" 234
 		"engine capacity" 172
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 180
 			"shield damage" 1650
@@ -1394,6 +1460,9 @@ ship "Epidote"
 		"outfit space" 552
 		"weapon capacity" 166
 		"engine capacity" 182
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 216
 			"shield damage" 1920
@@ -1457,6 +1526,9 @@ ship "Kyanite"
 		"outfit space" 380
 		"weapon capacity" 202
 		"engine capacity" 160
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 21300
 		"energy generation" 11.3
 		"heat generation" 27.2

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -590,6 +590,9 @@ outfit `"Baellie" Atomic Engines`
 	category "Engines"
 	"cost" 230000
 	thumbnail "outfit/tiny atomic engines hai"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 22
 	"outfit space" -22
 	"engine capacity" -22
@@ -611,6 +614,8 @@ outfit `"Basrem" Atomic Thruster`
 	category "Engines"
 	"cost" 150000
 	thumbnail "outfit/tiny atomic thruster hai"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 18
 	"outfit space" -18
 	"engine capacity" -18
@@ -626,6 +631,8 @@ outfit `"Benga" Atomic Thruster`
 	category "Engines"
 	"cost" 300000
 	thumbnail "outfit/small atomic thruster hai"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -28
@@ -641,6 +648,8 @@ outfit `"Biroo" Atomic Thruster`
 	category "Engines"
 	"cost" 610000
 	thumbnail "outfit/medium atomic thruster hai"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 44
 	"outfit space" -44
 	"engine capacity" -44
@@ -656,6 +665,8 @@ outfit `"Bondir" Atomic Thruster`
 	category "Engines"
 	"cost" 1100000
 	thumbnail "outfit/large atomic thruster hai"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 63
 	"outfit space" -63
 	"engine capacity" -63
@@ -671,6 +682,8 @@ outfit `"Bufaer" Atomic Thruster`
 	category "Engines"
 	"cost" 2400000
 	thumbnail "outfit/huge atomic thruster hai"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 104
 	"outfit space" -104
 	"engine capacity" -104
@@ -686,6 +699,7 @@ outfit `"Basrem" Reverse Thruster`
 	category "Engines"
 	"cost" 150000
 	thumbnail "outfit/tiny atomic reverse hai"
+	"reverse thruster slot" -1
 	"mass" 18
 	"outfit space" -18
 	"weapon capacity" -18
@@ -701,6 +715,7 @@ outfit `"Benga" Reverse Thruster`
 	category "Engines"
 	"cost" 300000
 	thumbnail "outfit/small atomic reverse hai"
+	"reverse thruster slot" -1
 	"mass" 28
 	"outfit space" -28
 	"weapon capacity" -28
@@ -716,6 +731,7 @@ outfit `"Biroo" Reverse Thruster`
 	category "Engines"
 	"cost" 610000
 	thumbnail "outfit/medium atomic reverse hai"
+	"reverse thruster slot" -1
 	"mass" 44
 	"outfit space" -44
 	"weapon capacity" -44
@@ -731,6 +747,7 @@ outfit `"Basrem" Atomic Steering`
 	category "Engines"
 	"cost" 120000
 	thumbnail "outfit/tiny atomic steering hai"
+	"steering slot" -1
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
@@ -746,6 +763,7 @@ outfit `"Benga" Atomic Steering`
 	category "Engines"
 	"cost" 250000
 	thumbnail "outfit/small atomic steering hai"
+	"steering slot" -1
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
@@ -761,6 +779,7 @@ outfit `"Biroo" Atomic Steering`
 	category "Engines"
 	"cost" 530000
 	thumbnail "outfit/medium atomic steering hai"
+	"steering slot" -1
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
@@ -776,6 +795,7 @@ outfit `"Bondir" Atomic Steering`
 	category "Engines"
 	"cost" 950000
 	thumbnail "outfit/large atomic steering hai"
+	"steering slot" -1
 	"mass" 49
 	"outfit space" -49
 	"engine capacity" -49
@@ -791,6 +811,7 @@ outfit `"Bufaer" Atomic Steering`
 	category "Engines"
 	"cost" 2100000
 	thumbnail "outfit/huge atomic steering hai"
+	"steering slot" -1
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -265,6 +265,9 @@ ship "Geodesic Geocoris"
 		"outfit space" 555
 		"weapon capacity" 250
 		"engine capacity" 134
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 5200
 		"shield generation" 6.0
 		"shield energy" 8.8

--- a/data/hai/hai reveal 1 intro.txt
+++ b/data/hai/hai reveal 1 intro.txt
@@ -265,9 +265,9 @@ ship "Geodesic Geocoris"
 		"outfit space" 555
 		"weapon capacity" 250
 		"engine capacity" 134
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 5200
 		"shield generation" 6.0
 		"shield energy" 8.8

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -29,9 +29,9 @@ ship "Aphid"
 		"outfit space" 185
 		"weapon capacity" 37
 		"engine capacity" 48
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -100,9 +100,9 @@ ship "Centipede"
 		"outfit space" 375
 		"weapon capacity" 78
 		"engine capacity" 88
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -215,9 +215,9 @@ ship "Cicada"
 		"outfit space" 323
 		"weapon capacity" 89
 		"engine capacity" 64
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 960
@@ -270,9 +270,9 @@ ship "Flea"
 		"outfit space" 63
 		"weapon capacity" 13
 		"engine capacity" 22
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"automaton" 1
 		weapon
 			"blast radius" 6
@@ -321,9 +321,9 @@ ship "Geocoris"
 		"outfit space" 582
 		"weapon capacity" 172
 		"engine capacity" 94
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 300
 			"shield damage" 3000
@@ -407,9 +407,9 @@ ship "Grasshopper"
 		"outfit space" 198
 		"weapon capacity" 47
 		"engine capacity" 61
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 180
@@ -499,9 +499,9 @@ ship "Lightning Bug"
 		"outfit space" 278
 		"weapon capacity" 87
 		"engine capacity" 93
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 84
 			"shield damage" 840
@@ -600,9 +600,9 @@ ship "Ladybug"
 		"outfit space" 460
 		"weapon capacity" 170
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 
 		# Expensive features mentioned in description:
 		"ramscoop" 0.25
@@ -742,9 +742,9 @@ ship "Pond Strider"
 		"outfit space" 354
 		"weapon capacity" 144
 		"engine capacity" 76
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 200
 			"shield damage" 1500
@@ -891,9 +891,9 @@ ship "Sea Scorpion"
 		"outfit space" 510
 		"weapon capacity" 188
 		"engine capacity" 117
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 84
 			"shield damage" 840
@@ -1046,9 +1046,9 @@ ship "Scarab"
 		"outfit space" 231
 		"weapon capacity" 49
 		"engine capacity" 93
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 52
 			"shield damage" 540
@@ -1100,9 +1100,9 @@ ship "Shield Beetle"
 		"outfit space" 798
 		"weapon capacity" 333
 		"engine capacity" 150
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 4000
@@ -1488,9 +1488,9 @@ ship "Emperor Beetle"
 		"cargo space" 27
 		"weapon capacity" 352
 		"engine capacity" 139
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		# Expensive features inherited from Ladybug-era technology, with some fuel (and improved heat dissipation):
 		"heat dissipation" 0.7
 		"tactical scan power" 30
@@ -1606,9 +1606,9 @@ ship "Solifuge"
 		"outfit space" 828
 		"weapon capacity" 342
 		"engine capacity" 166
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 450
 			"shield damage" 4500
@@ -1785,9 +1785,9 @@ ship "Violin Spider"
 		"outfit space" 92
 		"weapon capacity" 23
 		"engine capacity" 30
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1844,9 +1844,9 @@ ship "Water Bug"
 		"outfit space" 368
 		"weapon capacity" 145
 		"engine capacity" 64
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 124
 			"shield damage" 1240

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -29,6 +29,9 @@ ship "Aphid"
 		"outfit space" 185
 		"weapon capacity" 37
 		"engine capacity" 48
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -97,6 +100,9 @@ ship "Centipede"
 		"outfit space" 375
 		"weapon capacity" 78
 		"engine capacity" 88
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -209,6 +215,9 @@ ship "Cicada"
 		"outfit space" 323
 		"weapon capacity" 89
 		"engine capacity" 64
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 960
@@ -261,6 +270,9 @@ ship "Flea"
 		"outfit space" 63
 		"weapon capacity" 13
 		"engine capacity" 22
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"automaton" 1
 		weapon
 			"blast radius" 6
@@ -309,6 +321,9 @@ ship "Geocoris"
 		"outfit space" 582
 		"weapon capacity" 172
 		"engine capacity" 94
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 300
 			"shield damage" 3000
@@ -392,6 +407,9 @@ ship "Grasshopper"
 		"outfit space" 198
 		"weapon capacity" 47
 		"engine capacity" 61
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 36
 			"shield damage" 180
@@ -481,6 +499,9 @@ ship "Lightning Bug"
 		"outfit space" 278
 		"weapon capacity" 87
 		"engine capacity" 93
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 84
 			"shield damage" 840
@@ -579,6 +600,9 @@ ship "Ladybug"
 		"outfit space" 460
 		"weapon capacity" 170
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 
 		# Expensive features mentioned in description:
 		"ramscoop" 0.25
@@ -718,6 +742,9 @@ ship "Pond Strider"
 		"outfit space" 354
 		"weapon capacity" 144
 		"engine capacity" 76
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 200
 			"shield damage" 1500
@@ -864,6 +891,9 @@ ship "Sea Scorpion"
 		"outfit space" 510
 		"weapon capacity" 188
 		"engine capacity" 117
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 84
 			"shield damage" 840
@@ -1016,6 +1046,9 @@ ship "Scarab"
 		"outfit space" 231
 		"weapon capacity" 49
 		"engine capacity" 93
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 52
 			"shield damage" 540
@@ -1067,6 +1100,9 @@ ship "Shield Beetle"
 		"outfit space" 798
 		"weapon capacity" 333
 		"engine capacity" 150
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 4000
@@ -1452,6 +1488,9 @@ ship "Emperor Beetle"
 		"cargo space" 27
 		"weapon capacity" 352
 		"engine capacity" 139
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		# Expensive features inherited from Ladybug-era technology, with some fuel (and improved heat dissipation):
 		"heat dissipation" 0.7
 		"tactical scan power" 30
@@ -1567,6 +1606,9 @@ ship "Solifuge"
 		"outfit space" 828
 		"weapon capacity" 342
 		"engine capacity" 166
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 450
 			"shield damage" 4500
@@ -1743,6 +1785,9 @@ ship "Violin Spider"
 		"outfit space" 92
 		"weapon capacity" 23
 		"engine capacity" 30
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1799,6 +1844,9 @@ ship "Water Bug"
 		"outfit space" 368
 		"weapon capacity" 145
 		"engine capacity" 64
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 124
 			"shield damage" 1240

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -100,6 +100,9 @@ outfit "X1050 Ion Engines"
 	index 10
 	"cost" 20000
 	thumbnail "outfit/tiny ion engines"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
@@ -125,6 +128,8 @@ outfit "X1700 Ion Thruster"
 	index 17
 	"cost" 12000
 	thumbnail "outfit/tiny ion thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 16
 	"outfit space" -16
 	"engine capacity" -16
@@ -143,6 +148,8 @@ outfit "X2700 Ion Thruster"
 	index 27
 	"cost" 26000
 	thumbnail "outfit/small ion thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 27
 	"outfit space" -27
 	"engine capacity" -27
@@ -161,6 +168,8 @@ outfit "X3700 Ion Thruster"
 	index 37
 	"cost" 58000
 	thumbnail "outfit/medium ion thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 46
 	"outfit space" -46
 	"engine capacity" -46
@@ -179,6 +188,8 @@ outfit "X4700 Ion Thruster"
 	index 47
 	"cost" 128000
 	thumbnail "outfit/large ion thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 79
 	"outfit space" -79
 	"engine capacity" -79
@@ -197,6 +208,8 @@ outfit "X5700 Ion Thruster"
 	index 57
 	"cost" 281000
 	thumbnail "outfit/huge ion thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 121
 	"outfit space" -121
 	"engine capacity" -121
@@ -216,6 +229,7 @@ outfit "X1200 Ion Steering"
 	index 12
 	"cost" 10000
 	thumbnail "outfit/tiny ion steering"
+	"steering slot" -1
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
@@ -234,6 +248,7 @@ outfit "X2200 Ion Steering"
 	index 22
 	"cost" 21000
 	thumbnail "outfit/small ion steering"
+	"steering slot" -1
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
@@ -252,6 +267,7 @@ outfit "X3200 Ion Steering"
 	index 32
 	"cost" 46000
 	thumbnail "outfit/medium ion steering"
+	"steering slot" -1
 	"mass" 35
 	"outfit space" -35
 	"engine capacity" -35
@@ -270,6 +286,7 @@ outfit "X4200 Ion Steering"
 	index 42
 	"cost" 102000
 	thumbnail "outfit/large ion steering"
+	"steering slot" -1
 	"mass" 59
 	"outfit space" -59
 	"engine capacity" -59
@@ -288,6 +305,7 @@ outfit "X5200 Ion Steering"
 	index 52
 	"cost" 225000
 	thumbnail "outfit/huge ion steering"
+	"steering slot" -1
 	"mass" 89
 	"outfit space" -89
 	"engine capacity" -89
@@ -307,6 +325,7 @@ outfit "X1100 Ion Reverse Thruster"
 	index 18
 	"cost" 12000
 	thumbnail "outfit/reverse thruster ion"
+	"reverse thruster slot" -1
 	"mass" 16
 	"outfit space" -16
 	"weapon capacity" -16
@@ -327,6 +346,8 @@ outfit "Chipmunk Plasma Thruster"
 	index 15
 	"cost" 20000
 	thumbnail "outfit/tiny plasma thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
@@ -345,6 +366,8 @@ outfit "Greyhound Plasma Thruster"
 	index 25
 	"cost" 45000
 	thumbnail "outfit/small plasma thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 34
 	"outfit space" -34
 	"engine capacity" -34
@@ -363,6 +386,8 @@ outfit "Impala Plasma Thruster"
 	index 35
 	"cost" 99000
 	thumbnail "outfit/medium plasma thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 58
 	"outfit space" -58
 	"engine capacity" -58
@@ -381,6 +406,8 @@ outfit "Orca Plasma Thruster"
 	index 45
 	"cost" 217000
 	thumbnail "outfit/large plasma thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 98
 	"outfit space" -98
 	"engine capacity" -98
@@ -399,6 +426,8 @@ outfit "Tyrant Plasma Thruster"
 	index 55
 	"cost" 389000
 	thumbnail "outfit/huge plasma thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 129
 	"outfit space" -129
 	"engine capacity" -129
@@ -418,6 +447,7 @@ outfit "Chipmunk Plasma Steering"
 	index 12
 	"cost" 16000
 	thumbnail "outfit/tiny plasma steering"
+	"steering slot" -1
 	"mass" 15
 	"outfit space" -15
 	"engine capacity" -15
@@ -436,6 +466,7 @@ outfit "Greyhound Plasma Steering"
 	index 22
 	"cost" 36000
 	thumbnail "outfit/small plasma steering"
+	"steering slot" -1
 	"mass" 26
 	"outfit space" -26
 	"engine capacity" -26
@@ -454,6 +485,7 @@ outfit "Impala Plasma Steering"
 	index 32
 	"cost" 79000
 	thumbnail "outfit/medium plasma steering"
+	"steering slot" -1
 	"mass" 43
 	"outfit space" -43
 	"engine capacity" -43
@@ -472,6 +504,7 @@ outfit "Orca Plasma Steering"
 	index 42
 	"cost" 174000
 	thumbnail "outfit/large plasma steering"
+	"steering slot" -1
 	"mass" 74
 	"outfit space" -74
 	"engine capacity" -74
@@ -490,6 +523,7 @@ outfit "Tyrant Plasma Steering"
 	index 52
 	"cost" 324700
 	thumbnail "outfit/huge plasma steering"
+	"steering slot" -1
 	"mass" 101
 	"outfit space" -101
 	"engine capacity" -101
@@ -509,6 +543,7 @@ outfit "Capybara Reverse Thruster"
 	index 18
 	"cost" 20000
 	thumbnail "outfit/reverse thruster plasma"
+	"reverse thruster slot" -1
 	"mass" 20
 	"outfit space" -20
 	"weapon capacity" -20
@@ -529,6 +564,8 @@ outfit "A120 Atomic Thruster"
 	index 15
 	"cost" 140000
 	thumbnail "outfit/tiny atomic thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 22
 	"outfit space" -22
 	"engine capacity" -22
@@ -546,6 +583,8 @@ outfit "A250 Atomic Thruster"
 	index 25
 	"cost" 280000
 	thumbnail "outfit/small atomic thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 34
 	"outfit space" -34
 	"engine capacity" -34
@@ -563,6 +602,8 @@ outfit "A370 Atomic Thruster"
 	index 35
 	"cost" 560000
 	thumbnail "outfit/medium atomic thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 53
 	"outfit space" -53
 	"engine capacity" -53
@@ -580,6 +621,8 @@ outfit "A520 Atomic Thruster"
 	index 45
 	"cost" 1120000
 	thumbnail "outfit/large atomic thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 82
 	"outfit space" -82
 	"engine capacity" -82
@@ -597,6 +640,8 @@ outfit "A860 Atomic Thruster"
 	index 55
 	"cost" 2240000
 	thumbnail "outfit/huge atomic thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 127
 	"outfit space" -127
 	"engine capacity" -127
@@ -615,6 +660,7 @@ outfit "A125 Atomic Steering"
 	index 12
 	"cost" 120000
 	thumbnail "outfit/tiny atomic steering"
+	"steering slot" -1
 	"mass" 16
 	"outfit space" -16
 	"engine capacity" -16
@@ -632,6 +678,7 @@ outfit "A255 Atomic Steering"
 	index 22
 	"cost" 240000
 	thumbnail "outfit/small atomic steering"
+	"steering slot" -1
 	"mass" 25
 	"outfit space" -25
 	"engine capacity" -25
@@ -649,6 +696,7 @@ outfit "A375 Atomic Steering"
 	index 32
 	"cost" 480000
 	thumbnail "outfit/medium atomic steering"
+	"steering slot" -1
 	"mass" 38
 	"outfit space" -38
 	"engine capacity" -38
@@ -666,6 +714,7 @@ outfit "A525 Atomic Steering"
 	index 42
 	"cost" 960000
 	thumbnail "outfit/large atomic steering"
+	"steering slot" -1
 	"mass" 60
 	"outfit space" -60
 	"engine capacity" -60
@@ -683,6 +732,7 @@ outfit "A865 Atomic Steering"
 	index 52
 	"cost" 1920000
 	thumbnail "outfit/huge atomic steering"
+	"steering slot" -1
 	"mass" 92
 	"outfit space" -92
 	"engine capacity" -92
@@ -701,6 +751,7 @@ outfit "AR120 Reverse Thruster"
 	index 18
 	"cost" 140000
 	thumbnail "outfit/reverse thruster"
+	"reverse thruster slot" -1
 	"mass" 22
 	"outfit space" -22
 	"weapon capacity" -22

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -17,6 +17,7 @@ outfit "Volcano Afterburner"
 	index 10
 	"cost" 70000
 	thumbnail "outfit/afterburner"
+	"afterburner slot" -1
 	"mass" 10
 	"outfit space" -10
 	"engine capacity" -10
@@ -43,6 +44,7 @@ outfit "Caldera Afterburner"
 	index 20
 	"cost" 390000
 	thumbnail "outfit/caldera afterburner"
+	"afterburner slot" -1
 	"mass" 37
 	"outfit space" -37
 	"engine capacity" -37
@@ -70,6 +72,7 @@ outfit "Ionic Afterburner"
 	index 30
 	"cost" 340000
 	thumbnail "outfit/ionic afterburner"
+	"afterburner slot" -1
 	"mass" 16
 	"outfit space" -16
 	"engine capacity" -16

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -283,6 +283,9 @@ ship "Unknown Ship Type"
 		"outfit space" 810
 		"weapon capacity" 390
 		"engine capacity" 210
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -340,6 +343,9 @@ ship "Kestrel"
 		"outfit space" 810
 		"weapon capacity" 390
 		"engine capacity" 210
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -283,9 +283,9 @@ ship "Unknown Ship Type"
 		"outfit space" 810
 		"weapon capacity" 390
 		"engine capacity" 210
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -343,9 +343,9 @@ ship "Kestrel"
 		"outfit space" 810
 		"weapon capacity" 390
 		"engine capacity" 210
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -29,9 +29,9 @@ ship "Marauder Arrow"
 		"outfit space" 210
 		"weapon capacity" 55
 		"engine capacity" 95
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 27
@@ -131,9 +131,9 @@ ship "Marauder Bounder"
 		"outfit space" 240
 		"weapon capacity" 80
 		"engine capacity" 115
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 35
@@ -244,9 +244,9 @@ ship "Marauder Falcon"
 		"outfit space" 620
 		"weapon capacity" 275
 		"engine capacity" 165
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .15
 		weapon
 			"blast radius" 170
@@ -378,9 +378,9 @@ ship "Marauder Firebird"
 		"outfit space" 450
 		"weapon capacity" 175
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 110
@@ -497,9 +497,9 @@ ship "Marauder Leviathan"
 		"outfit space" 680
 		"weapon capacity" 265
 		"engine capacity" 140
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .15
 		weapon
 			"blast radius" 90
@@ -624,9 +624,9 @@ ship "Marauder Manta"
 		"outfit space" 400
 		"weapon capacity" 155
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 90
@@ -755,9 +755,9 @@ ship "Marauder Quicksilver"
 		"outfit space" 265
 		"weapon capacity" 65
 		"engine capacity" 75
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 45
@@ -919,9 +919,9 @@ ship "Marauder Raven"
 		"outfit space" 310
 		"weapon capacity" 115
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 65
@@ -1031,9 +1031,9 @@ ship "Marauder Splinter"
 		"outfit space" 450
 		"weapon capacity" 165
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .25
 		weapon
 			"blast radius" 60

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -29,6 +29,9 @@ ship "Marauder Arrow"
 		"outfit space" 210
 		"weapon capacity" 55
 		"engine capacity" 95
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 27
@@ -128,6 +131,9 @@ ship "Marauder Bounder"
 		"outfit space" 240
 		"weapon capacity" 80
 		"engine capacity" 115
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 35
@@ -238,6 +244,9 @@ ship "Marauder Falcon"
 		"outfit space" 620
 		"weapon capacity" 275
 		"engine capacity" 165
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .15
 		weapon
 			"blast radius" 170
@@ -369,6 +378,9 @@ ship "Marauder Firebird"
 		"outfit space" 450
 		"weapon capacity" 175
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 110
@@ -485,6 +497,9 @@ ship "Marauder Leviathan"
 		"outfit space" 680
 		"weapon capacity" 265
 		"engine capacity" 140
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .15
 		weapon
 			"blast radius" 90
@@ -609,6 +624,9 @@ ship "Marauder Manta"
 		"outfit space" 400
 		"weapon capacity" 155
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 90
@@ -737,6 +755,9 @@ ship "Marauder Quicksilver"
 		"outfit space" 265
 		"weapon capacity" 65
 		"engine capacity" 75
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 45
@@ -898,6 +919,9 @@ ship "Marauder Raven"
 		"outfit space" 310
 		"weapon capacity" 115
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 65
@@ -1007,6 +1031,9 @@ ship "Marauder Splinter"
 		"outfit space" 450
 		"weapon capacity" 165
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .25
 		weapon
 			"blast radius" 60

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2701,6 +2701,7 @@ ship "Mammoth"
 		"outfit space" 536
 		"weapon capacity" 294
 		"engine capacity" 114
+		"afterburner slot" 1
 		"reverse thruster slot" 2
 		"steering slot" 2
 		"thruster slot" 2

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -29,9 +29,9 @@ ship "Aerie"
 		"outfit space" 390
 		"weapon capacity" 150
 		"engine capacity" 95
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -96,9 +96,9 @@ ship "Argosy"
 		"outfit space" 270
 		"weapon capacity" 90
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -160,9 +160,9 @@ ship "Arrow"
 		"outfit space" 180
 		"weapon capacity" 50
 		"engine capacity" 75
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 24
 			"shield damage" 240
@@ -218,9 +218,9 @@ ship "Auxiliary"
 		"outfit space" 720
 		"weapon capacity" 160
 		"engine capacity" 200
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -338,9 +338,9 @@ ship "Bactrian"
 		"outfit space" 740
 		"weapon capacity" 300
 		"engine capacity" 180
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -412,9 +412,9 @@ ship "Barb"
 		"outfit space" 85
 		"weapon capacity" 28
 		"engine capacity" 22
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -461,9 +461,9 @@ ship "Bastion"
 		"outfit space" 470
 		"weapon capacity" 190
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -528,9 +528,9 @@ ship "Behemoth"
 		"outfit space" 510
 		"weapon capacity" 280
 		"engine capacity" 90
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 140
 			"shield damage" 1400
@@ -593,9 +593,9 @@ ship "Berserker"
 		"outfit space" 200
 		"weapon capacity" 35
 		"engine capacity" 65
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -647,9 +647,9 @@ ship "Blackbird"
 		"outfit space" 350
 		"weapon capacity" 90
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -703,9 +703,9 @@ ship "Bounder"
 		"outfit space" 220
 		"weapon capacity" 50
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -751,9 +751,9 @@ ship "Boxwing"
 		"heat dissipation" .27
 		"outfit space" 45
 		"engine capacity" 28
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"cargo space" 80
 		weapon
 			"blast radius" 12
@@ -795,9 +795,9 @@ ship "Bulk Freighter"
 		"outfit space" 410
 		"weapon capacity" 180
 		"engine capacity" 85
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -859,9 +859,9 @@ ship "Bulwark"
 		"outfit space" 521
 		"weapon capacity" 223
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"threshold percentage" .08
 		weapon
 			"blast radius" 120
@@ -928,9 +928,9 @@ ship "Carrier"
 		"outfit space" 820
 		"weapon capacity" 370
 		"engine capacity" 210
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 300
 			"shield damage" 3000
@@ -1023,9 +1023,9 @@ ship "Class C Freighter"
 		"outfit space" 410
 		"weapon capacity" 150
 		"engine capacity" 85
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 200
 			"shield damage" 2000
@@ -1117,9 +1117,9 @@ ship "Clipper"
 		"outfit space" 260
 		"weapon capacity" 60
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -1170,9 +1170,9 @@ ship "Combat Drone"
 		"outfit space" 58
 		"weapon capacity" 8
 		"engine capacity" 28
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 5
 			"shield damage" 50
@@ -1214,12 +1214,12 @@ ship "Container Transport"
 		"outfit space" 410
 		"weapon capacity" 180
 		"engine capacity" 85
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -1281,9 +1281,9 @@ ship "Corvette"
 		"outfit space" 420
 		"weapon capacity" 150
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -1348,9 +1348,9 @@ ship "Cruiser"
 		"outfit space" 760
 		"weapon capacity" 320
 		"engine capacity" 170
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -1430,9 +1430,9 @@ ship "Cutthroat"
 		"outfit space" 282
 		"weapon capacity" 60
 		"engine capacity" 111
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -1489,9 +1489,9 @@ ship "Dagger"
 		"outfit space" 90
 		"weapon capacity" 20
 		"engine capacity" 35
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1543,9 +1543,9 @@ ship "Dreadnought"
 		"outfit space" 790
 		"weapon capacity" 360
 		"engine capacity" 190
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -1612,9 +1612,9 @@ ship "Dropship"
 		"outfit space" 100
 		"weapon capacity" 16
 		"engine capacity" 40
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1661,9 +1661,9 @@ ship "Enforcer"
 		"outfit space" 210
 		"weapon capacity" 55
 		"engine capacity" 60
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 34
 			"shield damage" 340
@@ -1715,9 +1715,9 @@ ship "Falcon"
 		"outfit space" 560
 		"weapon capacity" 250
 		"engine capacity" 150
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -1782,9 +1782,9 @@ ship "Finch"
 		"outfit space" 110
 		"weapon capacity" 20
 		"engine capacity" 40
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1834,9 +1834,9 @@ ship "Firebird"
 		"outfit space" 400
 		"weapon capacity" 160
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -1896,9 +1896,9 @@ ship "Flivver"
 		"outfit space" 130
 		"weapon capacity" 16
 		"engine capacity" 45
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -1945,9 +1945,9 @@ ship "Freighter"
 		"outfit space" 250
 		"weapon capacity" 80
 		"engine capacity" 70
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -2002,9 +2002,9 @@ ship "Frigate"
 		"outfit space" 410
 		"weapon capacity" 170
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -2070,9 +2070,9 @@ ship "Fury"
 		"outfit space" 160
 		"weapon capacity" 40
 		"engine capacity" 60
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 24
 			"shield damage" 240
@@ -2127,9 +2127,9 @@ ship "Gunboat"
 		"outfit space" 270
 		"weapon capacity" 100
 		"engine capacity" 90
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 72
 			"shield damage" 720
@@ -2185,9 +2185,9 @@ ship "Hauler"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -2247,9 +2247,9 @@ ship "Hauler II"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2311,9 +2311,9 @@ ship "Hauler III"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -2375,9 +2375,9 @@ ship "Hawk"
 		"outfit space" 200
 		"weapon capacity" 50
 		"engine capacity" 70
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -2426,9 +2426,9 @@ ship "Headhunter"
 		"outfit space" 250
 		"weapon capacity" 60
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 44
 			"shield damage" 440
@@ -2482,9 +2482,9 @@ ship "Heavy Shuttle"
 		"outfit space" 130
 		"weapon capacity" 16
 		"engine capacity" 65
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -2528,9 +2528,9 @@ ship "Hogshead"
 		"outfit space" 320
 		"weapon capacity" 80
 		"engine capacity" 90
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 51
 			"shield damage" 510
@@ -2586,9 +2586,9 @@ ship "Lance"
 		"outfit space" 100
 		"weapon capacity" 20
 		"engine capacity" 30
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -2638,9 +2638,9 @@ ship "Leviathan"
 		"outfit space" 620
 		"weapon capacity" 240
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2701,9 +2701,9 @@ ship "Mammoth"
 		"outfit space" 536
 		"weapon capacity" 294
 		"engine capacity" 114
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"scan interference" 2
 		weapon
 			"blast radius" 140
@@ -2777,9 +2777,9 @@ ship "Manta"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2832,9 +2832,9 @@ ship "Mining Drone"
 		"outfit space" 62
 		"weapon capacity" 12
 		"engine capacity" 28
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 3
 			"shield damage" 30
@@ -2876,9 +2876,9 @@ ship "Modified Argosy"
 		"outfit space" 340
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2941,9 +2941,9 @@ ship "Mule"
 		"outfit space" 440
 		"weapon capacity" 170
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -3008,9 +3008,9 @@ ship "Nest"
 		"outfit space" 400
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3074,9 +3074,9 @@ ship "Nighthawk"
 		"outfit space" 362
 		"weapon capacity" 102
 		"engine capacity" 123
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3135,9 +3135,9 @@ ship "Osprey"
 		"outfit space" 450
 		"weapon capacity" 180
 		"engine capacity" 130
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -3199,9 +3199,9 @@ ship "Protector"
 		"outfit space" 590
 		"weapon capacity" 230
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -3266,9 +3266,9 @@ ship "Quicksilver"
 		"outfit space" 240
 		"weapon capacity" 60
 		"engine capacity" 70
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -3317,9 +3317,9 @@ ship "Rainmaker"
 		"outfit space" 240
 		"weapon capacity" 70
 		"engine capacity" 50
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -3376,9 +3376,9 @@ ship "Raven"
 		"outfit space" 280
 		"weapon capacity" 100
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3436,9 +3436,9 @@ ship "Roost"
 		"outfit space" 450
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -3507,9 +3507,9 @@ ship "Saber"
 		"outfit space" 280
 		"weapon capacity" 105
 		"engine capacity" 90
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 72
 			"shield damage" 720
@@ -3567,9 +3567,9 @@ ship "Scout"
 		"outfit space" 220
 		"weapon capacity" 40
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -3622,9 +3622,9 @@ ship "Scrapper"
 		"outfit space" 125
 		"weapon capacity" 12
 		"engine capacity" 58
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 10
 			"shield damage" 80
@@ -3671,9 +3671,9 @@ ship "Shuttle"
 		"outfit space" 120
 		"weapon capacity" 10
 		"engine capacity" 60
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -3719,9 +3719,9 @@ ship "Skein"
 		"outfit space" 500
 		"weapon capacity" 140
 		"engine capacity" 80
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -3796,9 +3796,9 @@ ship "Sparrow"
 		"outfit space" 130
 		"weapon capacity" 25
 		"engine capacity" 40
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -3847,9 +3847,9 @@ ship "Splinter"
 		"outfit space" 400
 		"weapon capacity" 150
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3908,9 +3908,9 @@ ship "Star Barge"
 		"outfit space" 130
 		"weapon capacity" 20
 		"engine capacity" 40
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -3956,9 +3956,9 @@ ship "Star Queen"
 		"outfit space" 360
 		"weapon capacity" 120
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -4021,9 +4021,9 @@ ship "Sunder"
 		"outfit space" 230
 		"weapon capacity" 50
 		"engine capacity" 90
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 28
 			"shield damage" 280
@@ -4081,9 +4081,9 @@ ship "Surveillance Drone"
 		"outfit space" 53
 		"weapon capacity" 0
 		"engine capacity" 28
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 3
 			"shield damage" 30
@@ -4122,9 +4122,9 @@ ship "Valkyrie"
 		"outfit space" 400
 		"weapon capacity" 170
 		"engine capacity" 76
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -4187,9 +4187,9 @@ ship "Vanguard"
 		"outfit space" 560
 		"weapon capacity" 220
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -4255,9 +4255,9 @@ ship "Wasp"
 		"outfit space" 150
 		"weapon capacity" 28
 		"engine capacity" 60
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 20
 			"shield damage" 200

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -29,6 +29,9 @@ ship "Aerie"
 		"outfit space" 390
 		"weapon capacity" 150
 		"engine capacity" 95
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -93,6 +96,9 @@ ship "Argosy"
 		"outfit space" 270
 		"weapon capacity" 90
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -154,6 +160,9 @@ ship "Arrow"
 		"outfit space" 180
 		"weapon capacity" 50
 		"engine capacity" 75
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 24
 			"shield damage" 240
@@ -209,6 +218,9 @@ ship "Auxiliary"
 		"outfit space" 720
 		"weapon capacity" 160
 		"engine capacity" 200
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -326,6 +338,9 @@ ship "Bactrian"
 		"outfit space" 740
 		"weapon capacity" 300
 		"engine capacity" 180
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -397,6 +412,9 @@ ship "Barb"
 		"outfit space" 85
 		"weapon capacity" 28
 		"engine capacity" 22
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -443,6 +461,9 @@ ship "Bastion"
 		"outfit space" 470
 		"weapon capacity" 190
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -507,6 +528,9 @@ ship "Behemoth"
 		"outfit space" 510
 		"weapon capacity" 280
 		"engine capacity" 90
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 140
 			"shield damage" 1400
@@ -569,6 +593,9 @@ ship "Berserker"
 		"outfit space" 200
 		"weapon capacity" 35
 		"engine capacity" 65
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -620,6 +647,9 @@ ship "Blackbird"
 		"outfit space" 350
 		"weapon capacity" 90
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -673,6 +703,9 @@ ship "Bounder"
 		"outfit space" 220
 		"weapon capacity" 50
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -718,6 +751,9 @@ ship "Boxwing"
 		"heat dissipation" .27
 		"outfit space" 45
 		"engine capacity" 28
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"cargo space" 80
 		weapon
 			"blast radius" 12
@@ -759,6 +795,9 @@ ship "Bulk Freighter"
 		"outfit space" 410
 		"weapon capacity" 180
 		"engine capacity" 85
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -820,6 +859,9 @@ ship "Bulwark"
 		"outfit space" 521
 		"weapon capacity" 223
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"threshold percentage" .08
 		weapon
 			"blast radius" 120
@@ -886,6 +928,9 @@ ship "Carrier"
 		"outfit space" 820
 		"weapon capacity" 370
 		"engine capacity" 210
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 300
 			"shield damage" 3000
@@ -978,6 +1023,9 @@ ship "Class C Freighter"
 		"outfit space" 410
 		"weapon capacity" 150
 		"engine capacity" 85
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 200
 			"shield damage" 2000
@@ -1069,6 +1117,9 @@ ship "Clipper"
 		"outfit space" 260
 		"weapon capacity" 60
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -1119,6 +1170,9 @@ ship "Combat Drone"
 		"outfit space" 58
 		"weapon capacity" 8
 		"engine capacity" 28
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 5
 			"shield damage" 50
@@ -1160,6 +1214,12 @@ ship "Container Transport"
 		"outfit space" 410
 		"weapon capacity" 180
 		"engine capacity" 85
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -1221,6 +1281,9 @@ ship "Corvette"
 		"outfit space" 420
 		"weapon capacity" 150
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -1285,6 +1348,9 @@ ship "Cruiser"
 		"outfit space" 760
 		"weapon capacity" 320
 		"engine capacity" 170
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -1364,6 +1430,9 @@ ship "Cutthroat"
 		"outfit space" 282
 		"weapon capacity" 60
 		"engine capacity" 111
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -1420,6 +1489,9 @@ ship "Dagger"
 		"outfit space" 90
 		"weapon capacity" 20
 		"engine capacity" 35
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1471,6 +1543,9 @@ ship "Dreadnought"
 		"outfit space" 790
 		"weapon capacity" 360
 		"engine capacity" 190
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -1537,6 +1612,9 @@ ship "Dropship"
 		"outfit space" 100
 		"weapon capacity" 16
 		"engine capacity" 40
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1583,6 +1661,9 @@ ship "Enforcer"
 		"outfit space" 210
 		"weapon capacity" 55
 		"engine capacity" 60
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 34
 			"shield damage" 340
@@ -1634,6 +1715,9 @@ ship "Falcon"
 		"outfit space" 560
 		"weapon capacity" 250
 		"engine capacity" 150
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -1698,6 +1782,9 @@ ship "Finch"
 		"outfit space" 110
 		"weapon capacity" 20
 		"engine capacity" 40
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1747,6 +1834,9 @@ ship "Firebird"
 		"outfit space" 400
 		"weapon capacity" 160
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -1806,6 +1896,9 @@ ship "Flivver"
 		"outfit space" 130
 		"weapon capacity" 16
 		"engine capacity" 45
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -1852,6 +1945,9 @@ ship "Freighter"
 		"outfit space" 250
 		"weapon capacity" 80
 		"engine capacity" 70
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -1906,6 +2002,9 @@ ship "Frigate"
 		"outfit space" 410
 		"weapon capacity" 170
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -1971,6 +2070,9 @@ ship "Fury"
 		"outfit space" 160
 		"weapon capacity" 40
 		"engine capacity" 60
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 24
 			"shield damage" 240
@@ -2025,6 +2127,9 @@ ship "Gunboat"
 		"outfit space" 270
 		"weapon capacity" 100
 		"engine capacity" 90
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 72
 			"shield damage" 720
@@ -2080,6 +2185,9 @@ ship "Hauler"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -2139,6 +2247,9 @@ ship "Hauler II"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2200,6 +2311,9 @@ ship "Hauler III"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -2261,6 +2375,9 @@ ship "Hawk"
 		"outfit space" 200
 		"weapon capacity" 50
 		"engine capacity" 70
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 30
 			"shield damage" 300
@@ -2309,6 +2426,9 @@ ship "Headhunter"
 		"outfit space" 250
 		"weapon capacity" 60
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 44
 			"shield damage" 440
@@ -2362,6 +2482,9 @@ ship "Heavy Shuttle"
 		"outfit space" 130
 		"weapon capacity" 16
 		"engine capacity" 65
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -2405,6 +2528,9 @@ ship "Hogshead"
 		"outfit space" 320
 		"weapon capacity" 80
 		"engine capacity" 90
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 51
 			"shield damage" 510
@@ -2460,6 +2586,9 @@ ship "Lance"
 		"outfit space" 100
 		"weapon capacity" 20
 		"engine capacity" 30
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -2509,6 +2638,9 @@ ship "Leviathan"
 		"outfit space" 620
 		"weapon capacity" 240
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2569,6 +2701,9 @@ ship "Mammoth"
 		"outfit space" 536
 		"weapon capacity" 294
 		"engine capacity" 114
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"scan interference" 2
 		weapon
 			"blast radius" 140
@@ -2642,6 +2777,9 @@ ship "Manta"
 		"outfit space" 350
 		"weapon capacity" 140
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2694,6 +2832,9 @@ ship "Mining Drone"
 		"outfit space" 62
 		"weapon capacity" 12
 		"engine capacity" 28
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 3
 			"shield damage" 30
@@ -2735,6 +2876,9 @@ ship "Modified Argosy"
 		"outfit space" 340
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -2797,6 +2941,9 @@ ship "Mule"
 		"outfit space" 440
 		"weapon capacity" 170
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -2861,6 +3008,9 @@ ship "Nest"
 		"outfit space" 400
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -2924,6 +3074,9 @@ ship "Nighthawk"
 		"outfit space" 362
 		"weapon capacity" 102
 		"engine capacity" 123
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -2982,6 +3135,9 @@ ship "Osprey"
 		"outfit space" 450
 		"weapon capacity" 180
 		"engine capacity" 130
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -3043,6 +3199,9 @@ ship "Protector"
 		"outfit space" 590
 		"weapon capacity" 230
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -3107,6 +3266,9 @@ ship "Quicksilver"
 		"outfit space" 240
 		"weapon capacity" 60
 		"engine capacity" 70
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -3155,6 +3317,9 @@ ship "Rainmaker"
 		"outfit space" 240
 		"weapon capacity" 70
 		"engine capacity" 50
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 40
 			"shield damage" 400
@@ -3211,6 +3376,9 @@ ship "Raven"
 		"outfit space" 280
 		"weapon capacity" 100
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3268,6 +3436,9 @@ ship "Roost"
 		"outfit space" 450
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -3336,6 +3507,9 @@ ship "Saber"
 		"outfit space" 280
 		"weapon capacity" 105
 		"engine capacity" 90
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 72
 			"shield damage" 720
@@ -3393,6 +3567,9 @@ ship "Scout"
 		"outfit space" 220
 		"weapon capacity" 40
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -3445,6 +3622,9 @@ ship "Scrapper"
 		"outfit space" 125
 		"weapon capacity" 12
 		"engine capacity" 58
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 10
 			"shield damage" 80
@@ -3491,6 +3671,9 @@ ship "Shuttle"
 		"outfit space" 120
 		"weapon capacity" 10
 		"engine capacity" 60
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -3536,6 +3719,9 @@ ship "Skein"
 		"outfit space" 500
 		"weapon capacity" 140
 		"engine capacity" 80
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -3610,6 +3796,9 @@ ship "Sparrow"
 		"outfit space" 130
 		"weapon capacity" 25
 		"engine capacity" 40
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -3658,6 +3847,9 @@ ship "Splinter"
 		"outfit space" 400
 		"weapon capacity" 150
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3716,6 +3908,9 @@ ship "Star Barge"
 		"outfit space" 130
 		"weapon capacity" 20
 		"engine capacity" 40
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 16
 			"shield damage" 160
@@ -3761,6 +3956,9 @@ ship "Star Queen"
 		"outfit space" 360
 		"weapon capacity" 120
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 60
 			"shield damage" 600
@@ -3823,6 +4021,9 @@ ship "Sunder"
 		"outfit space" 230
 		"weapon capacity" 50
 		"engine capacity" 90
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 28
 			"shield damage" 280
@@ -3880,6 +4081,9 @@ ship "Surveillance Drone"
 		"outfit space" 53
 		"weapon capacity" 0
 		"engine capacity" 28
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 3
 			"shield damage" 30
@@ -3918,6 +4122,9 @@ ship "Valkyrie"
 		"outfit space" 400
 		"weapon capacity" 170
 		"engine capacity" 76
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -3980,6 +4187,9 @@ ship "Vanguard"
 		"outfit space" 560
 		"weapon capacity" 220
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 160
 			"shield damage" 1600
@@ -4045,6 +4255,9 @@ ship "Wasp"
 		"outfit space" 150
 		"weapon capacity" 28
 		"engine capacity" 60
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 20
 			"shield damage" 200

--- a/data/iije/iije.txt
+++ b/data/iije/iije.txt
@@ -34,6 +34,9 @@ ship "Jje"
 		"outfit space" 10
 		"weapon capacity" 10
 		"engine capacity" 10
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		
 		"hull repair rate" 1
 		"atmosphere scan" 10
@@ -87,6 +90,9 @@ ship "Ayym"
 		"outfit space" 10
 		"weapon capacity" 10
 		"engine capacity" 10
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		
 		"hull repair rate" 2
 		"ramscoop" 10

--- a/data/iije/iije.txt
+++ b/data/iije/iije.txt
@@ -34,9 +34,9 @@ ship "Jje"
 		"outfit space" 10
 		"weapon capacity" 10
 		"engine capacity" 10
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		
 		"hull repair rate" 1
 		"atmosphere scan" 10
@@ -90,9 +90,9 @@ ship "Ayym"
 		"outfit space" 10
 		"weapon capacity" 10
 		"engine capacity" 10
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		
 		"hull repair rate" 2
 		"ramscoop" 10

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -401,6 +401,9 @@ outfit "Maeri Engine Nacelles"
 	category "Engines"
 	"cost" 928000
 	thumbnail "outfit/ka'het maeri engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 59
 	"outfit space" -76
 	"engine capacity" -59
@@ -423,6 +426,9 @@ outfit "Ka'het Sustainer Nacelles"
 	category "Engines"
 	"cost" 357000
 	thumbnail "outfit/ka'het sustainer engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 27
 	"outfit space" -34
 	"engine capacity" -27
@@ -445,6 +451,9 @@ outfit "Telis Engine Nacelles"
 	category "Engines"
 	"cost" 1372000
 	thumbnail "outfit/ka'het telis engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 81
 	"outfit space" -101
 	"engine capacity" -81
@@ -466,6 +475,9 @@ outfit "Vareti Engine Block"
 	category "Engines"
 	"cost" 1815000
 	thumbnail "outfit/ka'het vareti engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 137
 	"outfit space" -168
 	"engine capacity" -137
@@ -487,6 +499,9 @@ outfit "Ka'het Compact Engine"
 	category "Engines"
 	"cost" 172000
 	thumbnail "outfit/ka'het compact engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 21
 	"outfit space" -26
 	"engine capacity" -21

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -426,8 +426,8 @@ outfit "Ka'het Sustainer Nacelles"
 	category "Engines"
 	"cost" 357000
 	thumbnail "outfit/ka'het sustainer engine"
-	"steering slot" -1
-	"thruster slot" -1
+	"steering slot" -0.5
+	"thruster slot" -0.5
 	"afterburner slot" 1
 	"mass" 27
 	"outfit space" -34

--- a/data/kahet/kahet ships.txt
+++ b/data/kahet/kahet ships.txt
@@ -34,6 +34,9 @@ ship "Maeri'het"
 		"outfit space" 383
 		"weapon capacity" 184
 		"engine capacity" 86
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 10000
 		"energy generation" 28.3
 		"heat generation" 32
@@ -137,6 +140,9 @@ ship "Telis'het"
 		"outfit space" 673
 		"weapon capacity" 254
 		"engine capacity" 138
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 28000
 		"energy generation" 37.4
 		"heat generation" 40
@@ -276,6 +282,9 @@ ship "Vareti'het"
 		"outfit space" 914
 		"weapon capacity" 372
 		"engine capacity" 150
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 41000
 		"energy generation" 61.2
 		"heat generation" 46
@@ -469,6 +478,9 @@ ship "Selii'mar"
 		"outfit space" 77
 		"weapon capacity" 18
 		"engine capacity" 21
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 48
 			"shield damage" 320
@@ -500,6 +512,9 @@ ship "Faes'mar"
 		"cargo space" 102
 		"outfit space" 113
 		"engine capacity" 21
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 52
 			"shield damage" 410
@@ -549,6 +564,9 @@ ship "Fetri'sei"
 		"outfit space" 383
 		"weapon capacity" 184
 		"engine capacity" 86
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 10000
 		"energy generation" 23.3
 		"heat generation" 32

--- a/data/kahet/kahet ships.txt
+++ b/data/kahet/kahet ships.txt
@@ -34,9 +34,9 @@ ship "Maeri'het"
 		"outfit space" 383
 		"weapon capacity" 184
 		"engine capacity" 86
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 10000
 		"energy generation" 28.3
 		"heat generation" 32
@@ -140,9 +140,9 @@ ship "Telis'het"
 		"outfit space" 673
 		"weapon capacity" 254
 		"engine capacity" 138
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 28000
 		"energy generation" 37.4
 		"heat generation" 40
@@ -282,9 +282,9 @@ ship "Vareti'het"
 		"outfit space" 914
 		"weapon capacity" 372
 		"engine capacity" 150
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 41000
 		"energy generation" 61.2
 		"heat generation" 46
@@ -478,9 +478,9 @@ ship "Selii'mar"
 		"outfit space" 77
 		"weapon capacity" 18
 		"engine capacity" 21
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 48
 			"shield damage" 320
@@ -512,9 +512,9 @@ ship "Faes'mar"
 		"cargo space" 102
 		"outfit space" 113
 		"engine capacity" 21
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 52
 			"shield damage" 410
@@ -564,9 +564,9 @@ ship "Fetri'sei"
 		"outfit space" 383
 		"weapon capacity" 184
 		"engine capacity" 86
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 10000
 		"energy generation" 23.3
 		"heat generation" 32

--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -214,6 +214,7 @@ outfit "Afterburner (Asteroid Class)"
 	category "Engines"
 	"cost" 136000
 	thumbnail "outfit/tiny korath afterburner"
+	"afterburner slot" -1
 	"mass" 9
 	"outfit space" -9
 	"engine capacity" -5
@@ -232,6 +233,7 @@ outfit "Afterburner (Comet Class)"
 	category "Engines"
 	"cost" 299000
 	thumbnail "outfit/small korath afterburner"
+	"afterburner slot" -1
 	"mass" 19
 	"outfit space" -19
 	"engine capacity" -19
@@ -248,6 +250,7 @@ outfit "Afterburner (Lunar Class)"
 	category "Engines"
 	"cost" 647000
 	thumbnail "outfit/medium korath afterburner"
+	"afterburner slot" -1
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
@@ -264,6 +267,7 @@ outfit "Afterburner (Planetary Class)"
 	category "Engines"
 	"cost" 1459000
 	thumbnail "outfit/large korath afterburner"
+	"afterburner slot" -1
 	"mass" 55
 	"outfit space" -55
 	"engine capacity" -55
@@ -281,6 +285,7 @@ outfit "Afterburner (Stellar Class)"
 	category "Engines"
 	"cost" 3280000
 	thumbnail "outfit/huge korath afterburner"
+	"afterburner slot" -1
 	"mass" 94
 	"outfit space" -94
 	"engine capacity" -94

--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -365,6 +365,9 @@ outfit "Engine (Meteor Class)"
 	category "Engines"
 	"cost" 187000
 	thumbnail "outfit/tiny korath engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 18
 	"outfit space" -18
 	"engine capacity" -18
@@ -387,6 +390,7 @@ outfit "Bow Drive (Meteor Class)"
 	category "Engines"
 	"cost" 187000
 	thumbnail "outfit/korath bow drive"
+	"reverse thruster slot" -1
 	"mass" 18
 	"outfit space" -18
 	"engine capacity" -15
@@ -410,6 +414,7 @@ outfit "Reverser (Asteroid Class)"
 	category "Engines"
 	"cost" 113000
 	thumbnail "outfit/tiny korath reverser"
+	"reverse thruster slot" -1
 	"mass" 14
 	"outfit space" -14
 	"engine capacity" -7
@@ -428,6 +433,7 @@ outfit "Reverser (Comet Class)"
 	category "Engines"
 	"cost" 249000
 	thumbnail "outfit/small korath reverser"
+	"reverse thruster slot" -1
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -12
@@ -446,6 +452,7 @@ outfit "Reverser (Lunar Class)"
 	category "Engines"
 	"cost" 539000
 	thumbnail "outfit/medium korath reverser"
+	"reverse thruster slot" -1
 	"mass" 40
 	"outfit space" -40
 	"engine capacity" -20
@@ -464,6 +471,7 @@ outfit "Reverser (Planetary Class)"
 	category "Engines"
 	"cost" 1216000
 	thumbnail "outfit/large korath reverser"
+	"reverse thruster slot" -1
 	"mass" 68
 	"outfit space" -68
 	"engine capacity" -34
@@ -482,6 +490,7 @@ outfit "Reverser (Stellar Class)"
 	category "Engines"
 	"cost" 2733000
 	thumbnail "outfit/huge korath reverser"
+	"reverse thruster slot" -1
 	"mass" 118
 	"outfit space" -118
 	"engine capacity" -59
@@ -501,6 +510,8 @@ outfit "Thruster (Asteroid Class)"
 	category "Engines"
 	"cost" 113000
 	thumbnail "outfit/tiny korath thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 14
 	"outfit space" -14
 	"engine capacity" -14
@@ -517,6 +528,8 @@ outfit "Thruster (Comet Class)"
 	category "Engines"
 	"cost" 249000
 	thumbnail "outfit/small korath thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -24
@@ -533,6 +546,8 @@ outfit "Thruster (Lunar Class)"
 	category "Engines"
 	"cost" 539000
 	thumbnail "outfit/medium korath thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 40
 	"outfit space" -40
 	"engine capacity" -40
@@ -549,6 +564,8 @@ outfit "Thruster (Planetary Class)"
 	category "Engines"
 	"cost" 1216000
 	thumbnail "outfit/large korath thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 68
 	"outfit space" -68
 	"engine capacity" -68
@@ -565,6 +582,8 @@ outfit "Thruster (Stellar Class)"
 	category "Engines"
 	"cost" 2733000
 	thumbnail "outfit/huge korath thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 118
 	"outfit space" -118
 	"engine capacity" -118
@@ -581,6 +600,7 @@ outfit "Steering (Asteroid Class)"
 	category "Engines"
 	"cost" 95000
 	thumbnail "outfit/tiny korath steering"
+	"steering slot" -1
 	"mass" 10
 	"outfit space" -10
 	"engine capacity" -10
@@ -597,6 +617,7 @@ outfit "Steering (Comet Class)"
 	category "Engines"
 	"cost" 221000
 	thumbnail "outfit/small korath steering"
+	"steering slot" -1
 	"mass" 18
 	"outfit space" -18
 	"engine capacity" -18
@@ -613,6 +634,7 @@ outfit "Steering (Lunar Class)"
 	category "Engines"
 	"cost" 473000
 	thumbnail "outfit/medium korath steering"
+	"steering slot" -1
 	"mass" 30
 	"outfit space" -30
 	"engine capacity" -30
@@ -629,6 +651,7 @@ outfit "Steering (Planetary Class)"
 	category "Engines"
 	"cost" 1077000
 	thumbnail "outfit/large korath steering"
+	"steering slot" -1
 	"mass" 52
 	"outfit space" -52
 	"engine capacity" -52
@@ -645,6 +668,7 @@ outfit "Steering (Stellar Class)"
 	category "Engines"
 	"cost" 2435000
 	thumbnail "outfit/huge korath steering"
+	"steering slot" -1
 	"mass" 89
 	"outfit space" -89
 	"engine capacity" -89
@@ -660,6 +684,8 @@ outfit "Arkrof GP Hybrid Thruster"
 	category "Engines"
 	"cost" 165000
 	thumbnail "outfit/tiny efreti thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 19
 	"outfit space" -19
 	"engine capacity" -19
@@ -675,6 +701,8 @@ outfit "Farves GP Hybrid Thruster"
 	category "Engines"
 	"cost" 405000
 	thumbnail "outfit/small efreti thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 33
 	"outfit space" -33
 	"engine capacity" -33
@@ -690,6 +718,8 @@ outfit "Gaktem GP Hybrid Thruster"
 	category "Engines"
 	"cost" 883000
 	thumbnail "outfit/medium efreti thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 57
 	"outfit space" -57
 	"engine capacity" -57
@@ -705,6 +735,8 @@ outfit "Nelmeb GP Hybrid Thruster"
 	category "Engines"
 	"cost" 1649000
 	thumbnail "outfit/large efreti thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 86
 	"outfit space" -86
 	"engine capacity" -86
@@ -721,6 +753,7 @@ outfit "Arkrof GP Hybrid Steering"
 	category "Engines"
 	"cost" 131000
 	thumbnail "outfit/tiny efreti steering"
+	"steering slot" -1
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
@@ -736,6 +769,7 @@ outfit "Farves GP Hybrid Steering"
 	category "Engines"
 	"cost" 413000
 	thumbnail "outfit/small efreti steering"
+	"steering slot" -1
 	"mass" 24
 	"outfit space" -24
 	"engine capacity" -24
@@ -752,6 +786,7 @@ outfit "Gaktem GP Hybrid Steering"
 	category "Engines"
 	"cost" 833000
 	thumbnail "outfit/medium efreti steering"
+	"steering slot" -1
 	"mass" 42
 	"outfit space" -42
 	"engine capacity" -42
@@ -768,6 +803,7 @@ outfit "Nelmeb GP Hybrid Steering"
 	category "Engines"
 	"cost" 1439000
 	thumbnail "outfit/large efreti steering"
+	"steering slot" -1
 	"mass" 67
 	"outfit space" -67
 	"engine capacity" -67

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -31,9 +31,9 @@ ship "Rano'erek"
 		"outfit space" 763
 		"weapon capacity" 276
 		"engine capacity" 206
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 300
 			"shield damage" 4600
@@ -116,9 +116,9 @@ ship "Palavret"
 		"outfit space" 777
 		"weapon capacity" 339
 		"engine capacity" 159
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 250
 			"shield damage" 3600
@@ -195,9 +195,9 @@ ship "Tubfalet"
 		"outfit space" 871
 		"weapon capacity" 377
 		"engine capacity" 212
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 250
 			"shield damage" 3700
@@ -310,9 +310,9 @@ ship "'nra'ret"
 		"outfit space" 943
 		"weapon capacity" 407
 		"engine capacity" 177
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 300
 			"shield damage" 4400
@@ -385,9 +385,9 @@ ship "'olofez"
 		"outfit space" 92
 		"weapon capacity" 25
 		"engine capacity" 30
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 48
 			"shield damage" 320
@@ -427,9 +427,9 @@ ship "Kas'ik Tek 7"
 		"cargo space" 4
 		"outfit space" 48
 		"engine capacity" 18
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"atmosphere scan" 100
 		"outfit scan power" 18
 		"outfit scan efficiency" 20
@@ -474,9 +474,9 @@ ship "Rai'alorej"
 		"outfit space" 856
 		"weapon capacity" 237
 		"engine capacity" 195
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 600
 			"shield damage" 9000
@@ -557,9 +557,9 @@ ship "Ikatila'ej"
 		"outfit space" 1314
 		"weapon capacity" 440
 		"engine capacity" 259
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"spinal mount" 1
 		weapon
 			"blast radius" 600
@@ -636,9 +636,9 @@ ship "Lor'kas Ik 577"
 		"outfit space" 883
 		"weapon capacity" 338
 		"engine capacity" 238
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -714,9 +714,9 @@ ship "Ra'gru Ik 618"
 		"outfit space" 1278
 		"weapon capacity" 633
 		"engine capacity" 263
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -802,9 +802,9 @@ ship "Kas'lor Ik 582"
 		"outfit space" 839
 		"weapon capacity" 321
 		"engine capacity" 241
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -877,9 +877,9 @@ ship "Lor'nag Ik 590"
 		"outfit space" 856
 		"weapon capacity" 321
 		"engine capacity" 241
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -954,9 +954,9 @@ ship "Ra'at Ik 621"
 		"outfit space" 999
 		"weapon capacity" 407
 		"engine capacity" 277
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -1045,9 +1045,9 @@ ship "Kasichara A'awoj"
 		"outfit space" 1038
 		"weapon capacity" 331
 		"engine capacity" 251
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -1117,9 +1117,9 @@ ship "Korsmanath A'awoj"
 		"outfit space" 3180
 		"weapon capacity" 1148
 		"engine capacity" 480
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"atmosphere scan" 100
 		weapon
 			"blast radius" 400
@@ -1355,9 +1355,9 @@ ship "Echo-Galleon"
 		"outfit space" 721
 		"weapon capacity" 285
 		"engine capacity" 155
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 1000
 			"shield damage" 4000
@@ -1420,9 +1420,9 @@ ship "Arch-Carrack"
 		"outfit space" 582
 		"weapon capacity" 193
 		"engine capacity" 147
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"disruption resistance" 0.24
 		"disruption resistance energy" 2.4
 		"disruption resistance heat" 2.4
@@ -1486,9 +1486,9 @@ ship "Charm-Shallop"
 		"outfit space" 473
 		"weapon capacity" 158
 		"engine capacity" 129
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"disruption resistance" 0.2
 		"disruption resistance energy" 2
 		"disruption resistance heat" 2
@@ -1548,9 +1548,9 @@ ship "Kar Ik Vot 349"
 		"outfit space" 1054
 		"weapon capacity" 447
 		"engine capacity" 173
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .8
 		"ramscoop" 3
 		weapon
@@ -1618,9 +1618,9 @@ ship "Tek Far 71 - Lek"
 		"outfit space" 533
 		"weapon capacity" 235
 		"engine capacity" 102
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .7
 		"ramscoop" 3
 		weapon
@@ -1701,9 +1701,9 @@ ship "Tek Far 78 - Osk"
 		"outfit space" 611
 		"weapon capacity" 272
 		"engine capacity" 117
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .7
 		"ramscoop" 3
 		weapon
@@ -1784,9 +1784,9 @@ ship "Tek Far 109"
 		"outfit space" 491
 		"weapon capacity" 217
 		"engine capacity" 98
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .7
 		"ramscoop" 3
 		weapon
@@ -1875,9 +1875,9 @@ ship "Met Par Tek 53"
 		"outfit space" 610
 		"weapon capacity" 213
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .65
 		"ramscoop" 3
 		weapon
@@ -1935,9 +1935,9 @@ ship "Far Lek 14"
 		"outfit space" 65
 		"weapon capacity" 11
 		"engine capacity" 24
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .6
 		weapon
 			"blast radius" 5
@@ -1978,9 +1978,9 @@ ship "Far Osk 27"
 		"outfit space" 99
 		"weapon capacity" 22
 		"engine capacity" 24
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .6
 		weapon
 			"blast radius" 12
@@ -2025,9 +2025,9 @@ ship "Model 8"
 		"outfit space" 220
 		"weapon capacity" 49
 		"engine capacity" 60
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .60
 		"ramscoop" 3
 		weapon
@@ -2075,9 +2075,9 @@ ship "Model 16"
 		"outfit space" 426
 		"weapon capacity" 149
 		"engine capacity" 107
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .65
 		"ramscoop" 3
 		weapon
@@ -2132,9 +2132,9 @@ ship "Model 32"
 		"outfit space" 481
 		"weapon capacity" 205
 		"engine capacity" 110
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .70
 		"ramscoop" 3
 		weapon
@@ -2190,9 +2190,9 @@ ship "Model 64"
 		"outfit space" 567
 		"weapon capacity" 263
 		"engine capacity" 114
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .74
 		"ramscoop" 3
 		weapon
@@ -2250,9 +2250,9 @@ ship "Model 128"
 		"outfit space" 713
 		"weapon capacity" 344
 		"engine capacity" 132
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .77
 		"ramscoop" 3
 		weapon
@@ -2311,9 +2311,9 @@ ship "Model 256"
 		"outfit space" 857
 		"weapon capacity" 393
 		"engine capacity" 145
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .79
 		"ramscoop" 3
 		weapon
@@ -2374,9 +2374,9 @@ ship "Model 512"
 		"outfit space" 994
 		"weapon capacity" 440
 		"engine capacity" 161
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"self destruct" .80
 		"ramscoop" 3
 		weapon

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -31,6 +31,9 @@ ship "Rano'erek"
 		"outfit space" 763
 		"weapon capacity" 276
 		"engine capacity" 206
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 300
 			"shield damage" 4600
@@ -113,6 +116,9 @@ ship "Palavret"
 		"outfit space" 777
 		"weapon capacity" 339
 		"engine capacity" 159
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 250
 			"shield damage" 3600
@@ -189,6 +195,9 @@ ship "Tubfalet"
 		"outfit space" 871
 		"weapon capacity" 377
 		"engine capacity" 212
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 250
 			"shield damage" 3700
@@ -301,6 +310,9 @@ ship "'nra'ret"
 		"outfit space" 943
 		"weapon capacity" 407
 		"engine capacity" 177
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 300
 			"shield damage" 4400
@@ -373,6 +385,9 @@ ship "'olofez"
 		"outfit space" 92
 		"weapon capacity" 25
 		"engine capacity" 30
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 48
 			"shield damage" 320
@@ -412,6 +427,9 @@ ship "Kas'ik Tek 7"
 		"cargo space" 4
 		"outfit space" 48
 		"engine capacity" 18
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"atmosphere scan" 100
 		"outfit scan power" 18
 		"outfit scan efficiency" 20
@@ -456,6 +474,9 @@ ship "Rai'alorej"
 		"outfit space" 856
 		"weapon capacity" 237
 		"engine capacity" 195
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 600
 			"shield damage" 9000
@@ -536,6 +557,9 @@ ship "Ikatila'ej"
 		"outfit space" 1314
 		"weapon capacity" 440
 		"engine capacity" 259
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"spinal mount" 1
 		weapon
 			"blast radius" 600
@@ -612,6 +636,9 @@ ship "Lor'kas Ik 577"
 		"outfit space" 883
 		"weapon capacity" 338
 		"engine capacity" 238
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -687,6 +714,9 @@ ship "Ra'gru Ik 618"
 		"outfit space" 1278
 		"weapon capacity" 633
 		"engine capacity" 263
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -772,6 +802,9 @@ ship "Kas'lor Ik 582"
 		"outfit space" 839
 		"weapon capacity" 321
 		"engine capacity" 241
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -844,6 +877,9 @@ ship "Lor'nag Ik 590"
 		"outfit space" 856
 		"weapon capacity" 321
 		"engine capacity" 241
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -918,6 +954,9 @@ ship "Ra'at Ik 621"
 		"outfit space" 999
 		"weapon capacity" 407
 		"engine capacity" 277
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -1006,6 +1045,9 @@ ship "Kasichara A'awoj"
 		"outfit space" 1038
 		"weapon capacity" 331
 		"engine capacity" 251
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 8000
@@ -1075,6 +1117,9 @@ ship "Korsmanath A'awoj"
 		"outfit space" 3180
 		"weapon capacity" 1148
 		"engine capacity" 480
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"atmosphere scan" 100
 		weapon
 			"blast radius" 400
@@ -1310,6 +1355,9 @@ ship "Echo-Galleon"
 		"outfit space" 721
 		"weapon capacity" 285
 		"engine capacity" 155
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 1000
 			"shield damage" 4000
@@ -1372,6 +1420,9 @@ ship "Arch-Carrack"
 		"outfit space" 582
 		"weapon capacity" 193
 		"engine capacity" 147
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"disruption resistance" 0.24
 		"disruption resistance energy" 2.4
 		"disruption resistance heat" 2.4
@@ -1435,6 +1486,9 @@ ship "Charm-Shallop"
 		"outfit space" 473
 		"weapon capacity" 158
 		"engine capacity" 129
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"disruption resistance" 0.2
 		"disruption resistance energy" 2
 		"disruption resistance heat" 2
@@ -1494,6 +1548,9 @@ ship "Kar Ik Vot 349"
 		"outfit space" 1054
 		"weapon capacity" 447
 		"engine capacity" 173
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .8
 		"ramscoop" 3
 		weapon
@@ -1561,6 +1618,9 @@ ship "Tek Far 71 - Lek"
 		"outfit space" 533
 		"weapon capacity" 235
 		"engine capacity" 102
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .7
 		"ramscoop" 3
 		weapon
@@ -1641,6 +1701,9 @@ ship "Tek Far 78 - Osk"
 		"outfit space" 611
 		"weapon capacity" 272
 		"engine capacity" 117
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .7
 		"ramscoop" 3
 		weapon
@@ -1721,6 +1784,9 @@ ship "Tek Far 109"
 		"outfit space" 491
 		"weapon capacity" 217
 		"engine capacity" 98
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .7
 		"ramscoop" 3
 		weapon
@@ -1809,6 +1875,9 @@ ship "Met Par Tek 53"
 		"outfit space" 610
 		"weapon capacity" 213
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .65
 		"ramscoop" 3
 		weapon
@@ -1866,6 +1935,9 @@ ship "Far Lek 14"
 		"outfit space" 65
 		"weapon capacity" 11
 		"engine capacity" 24
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .6
 		weapon
 			"blast radius" 5
@@ -1906,6 +1978,9 @@ ship "Far Osk 27"
 		"outfit space" 99
 		"weapon capacity" 22
 		"engine capacity" 24
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .6
 		weapon
 			"blast radius" 12
@@ -1950,6 +2025,9 @@ ship "Model 8"
 		"outfit space" 220
 		"weapon capacity" 49
 		"engine capacity" 60
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .60
 		"ramscoop" 3
 		weapon
@@ -1997,6 +2075,9 @@ ship "Model 16"
 		"outfit space" 426
 		"weapon capacity" 149
 		"engine capacity" 107
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .65
 		"ramscoop" 3
 		weapon
@@ -2051,6 +2132,9 @@ ship "Model 32"
 		"outfit space" 481
 		"weapon capacity" 205
 		"engine capacity" 110
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .70
 		"ramscoop" 3
 		weapon
@@ -2106,6 +2190,9 @@ ship "Model 64"
 		"outfit space" 567
 		"weapon capacity" 263
 		"engine capacity" 114
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .74
 		"ramscoop" 3
 		weapon
@@ -2163,6 +2250,9 @@ ship "Model 128"
 		"outfit space" 713
 		"weapon capacity" 344
 		"engine capacity" 132
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .77
 		"ramscoop" 3
 		weapon
@@ -2221,6 +2311,9 @@ ship "Model 256"
 		"outfit space" 857
 		"weapon capacity" 393
 		"engine capacity" 145
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .79
 		"ramscoop" 3
 		weapon
@@ -2281,6 +2374,9 @@ ship "Model 512"
 		"outfit space" 994
 		"weapon capacity" 440
 		"engine capacity" 161
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"self destruct" .80
 		"ramscoop" 3
 		weapon

--- a/data/korath/korath variants.txt
+++ b/data/korath/korath variants.txt
@@ -485,6 +485,7 @@ ship "'olofez" "'olofez (Digger)"
 ship "'olofez" "'olofez (World-Ship)"
 	add attributes
 		"atmosphere scan" 1
+		"afterburner slot" 1
 	outfits
 		"Generator (Candle Class)"
 		"Systems Core (Tiny)"
@@ -553,6 +554,8 @@ ship "Lor'kas Ik 577" "Lor'kas Ik 577 (Digger)"
 
 
 ship "Ra'gru Ik 618" "Ra'gru Ik 618 (Crippled)"
+	add attributes
+		"steering slot" 1
 	outfits
 		"Shunt-Strike Turret" 2
 		"Warder Anti-Missile"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -642,6 +642,7 @@ ship "Modified Osprey"
 		"outfit space" 2172
 		"weapon capacity" 851
 		"engine capacity" 499
+		"afterburner slot" 4
 		"reverse thruster slot" 2
 		"steering slot" 4
 		"thruster slot" 2
@@ -829,7 +830,7 @@ ship "Ursa Polaris"
 		"engine capacity" 301
 		"reverse thruster slot" 2
 		"steering slot" 2
-		"thruster slot" 2
+		"thruster slot" 3
 		weapon
 			"blast radius" 1000
 			"shield damage" 4000

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -374,9 +374,9 @@ person "Captain Nate"
 			"outfit space" 1215
 			"weapon capacity" 450
 			"engine capacity" 330
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+			"reverse thruster slot" 1
+			"steering slot" 1
+			"thruster slot" 1
 			weapon
 				"blast radius" 160
 				"shield damage" 1600

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -37,9 +37,9 @@ person "Michael Zahniser"
 			"outfit space" 2400
 			"weapon capacity" 900
 			"engine capacity" 400
-			"reverse thruster slot" 1
+			"reverse thruster slot" 2
 			"steering slot" 2
-			"thruster slot" 1
+			"thruster slot" 2
 		outfits
 			"Ion Cannon" 12
 			"Electron Turret" 4
@@ -253,9 +253,9 @@ ship "Marauder Fury"
 		"outfit space" 256
 		"weapon capacity" 96
 		"engine capacity" 100
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"ramscoop" 2
 		weapon
 			"blast radius" 36
@@ -374,9 +374,9 @@ person "Captain Nate"
 			"outfit space" 1215
 			"weapon capacity" 450
 			"engine capacity" 330
-			"reverse thruster slot" 1
-			"steering slot" 1
-			"thruster slot" 1
+			"reverse thruster slot" 2
+			"steering slot" 2
+			"thruster slot" 2
 			weapon
 				"blast radius" 160
 				"shield damage" 1600
@@ -488,9 +488,9 @@ ship "Lampyrid-Class Transport"
 		"cargo space" 160
 		"outfit space" 260
 		"engine capacity" 105
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -642,7 +642,7 @@ ship "Modified Osprey"
 		"outfit space" 2172
 		"weapon capacity" 851
 		"engine capacity" 499
-		"reverse thruster slot" 1
+		"reverse thruster slot" 2
 		"steering slot" 4
 		"thruster slot" 2
 		"afterburner fuel" -.678
@@ -827,8 +827,8 @@ ship "Ursa Polaris"
 		"outfit space" 1768
 		"weapon capacity" 861
 		"engine capacity" 301
-		"reverse thruster slot" 1
-		"steering slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
 		"thruster slot" 2
 		weapon
 			"blast radius" 1000
@@ -1253,9 +1253,9 @@ ship "Marauder Bactrian"
 		"outfit space" 1526
 		"weapon capacity" 1000
 		"engine capacity" 220
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -1458,7 +1458,7 @@ ship "Modified Boxwing"
 		"outfit space" 350
 		"weapon capacity" 130
 		"engine capacity" 100
-		"reverse thruster slot" 1
+		"reverse thruster slot" 2
 		"steering slot" 2
 		"thruster slot" 2
 		weapon
@@ -1567,9 +1567,9 @@ ship "Modified Battleship"
 		"outfit space" 1152
 		"weapon capacity" 592
 		"engine capacity" 123
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"spinal mount" 1
 		weapon
 			"blast radius" 340
@@ -1811,8 +1811,8 @@ ship "Modified Ladybug"
 		"outfit space" 647
 		"weapon capacity" 206
 		"engine capacity" 153
-		"reverse thruster slot" 1
-		"steering slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
 		"thruster slot" 2
 
 		# Features from original Ladybug:
@@ -2031,9 +2031,9 @@ ship "Waverider"
 		"outfit space" 346
 		"weapon capacity" 120
 		"engine capacity" 54
-		"reverse thruster slot" 1
+		"reverse thruster slot" 2
 		"steering slot" 2
-		"thruster slot" 1
+		"thruster slot" 2
 		weapon
 			"blast radius" 340
 			"shield damage" 3400

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -37,6 +37,9 @@ person "Michael Zahniser"
 			"outfit space" 2400
 			"weapon capacity" 900
 			"engine capacity" 400
+			"reverse thruster slot" 1
+			"steering slot" 2
+			"thruster slot" 1
 		outfits
 			"Ion Cannon" 12
 			"Electron Turret" 4
@@ -250,6 +253,9 @@ ship "Marauder Fury"
 		"outfit space" 256
 		"weapon capacity" 96
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"ramscoop" 2
 		weapon
 			"blast radius" 36
@@ -368,6 +374,9 @@ person "Captain Nate"
 			"outfit space" 1215
 			"weapon capacity" 450
 			"engine capacity" 330
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 			weapon
 				"blast radius" 160
 				"shield damage" 1600
@@ -479,6 +488,9 @@ ship "Lampyrid-Class Transport"
 		"cargo space" 160
 		"outfit space" 260
 		"engine capacity" 105
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 100
 			"shield damage" 1000
@@ -630,6 +642,9 @@ ship "Modified Osprey"
 		"outfit space" 2172
 		"weapon capacity" 851
 		"engine capacity" 499
+		"reverse thruster slot" 1
+		"steering slot" 4
+		"thruster slot" 2
 		"afterburner fuel" -.678
 		"afterburner heat" -30
 		"ramscoop" 6
@@ -812,6 +827,9 @@ ship "Ursa Polaris"
 		"outfit space" 1768
 		"weapon capacity" 861
 		"engine capacity" 301
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 2
 		weapon
 			"blast radius" 1000
 			"shield damage" 4000
@@ -1235,6 +1253,9 @@ ship "Marauder Bactrian"
 		"outfit space" 1526
 		"weapon capacity" 1000
 		"engine capacity" 220
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600
@@ -1437,6 +1458,9 @@ ship "Modified Boxwing"
 		"outfit space" 350
 		"weapon capacity" 130
 		"engine capacity" 100
+		"reverse thruster slot" 1
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 12
 			"shield damage" 120
@@ -1543,6 +1567,9 @@ ship "Modified Battleship"
 		"outfit space" 1152
 		"weapon capacity" 592
 		"engine capacity" 123
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"spinal mount" 1
 		weapon
 			"blast radius" 340
@@ -1784,6 +1811,9 @@ ship "Modified Ladybug"
 		"outfit space" 647
 		"weapon capacity" 206
 		"engine capacity" 153
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 2
 
 		# Features from original Ladybug:
 		"ramscoop" 0.5
@@ -2001,6 +2031,9 @@ ship "Waverider"
 		"outfit space" 346
 		"weapon capacity" 120
 		"engine capacity" 54
+		"reverse thruster slot" 1
+		"steering slot" 2
+		"thruster slot" 1
 		weapon
 			"blast radius" 340
 			"shield damage" 3400

--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -243,6 +243,8 @@ outfit "Pug Akfar Thruster"
 	category "Engines"
 	"cost" 608000
 	thumbnail "outfit/pug akfar thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 43
 	"outfit space" -43
 	"engine capacity" -43
@@ -258,6 +260,7 @@ outfit "Pug Akfar Steering"
 	category "Engines"
 	"cost" 472000
 	thumbnail "outfit/pug akfar steering"
+	"steering slot" -1
 	"mass" 33
 	"outfit space" -33
 	"engine capacity" -33
@@ -273,6 +276,8 @@ outfit "Pug Cormet Thruster"
 	category "Engines"
 	"cost" 1050000
 	thumbnail "outfit/pug cormet thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 60
 	"outfit space" -60
 	"engine capacity" -60
@@ -288,6 +293,7 @@ outfit "Pug Cormet Steering"
 	category "Engines"
 	"cost" 880000
 	thumbnail "outfit/pug cormet steering"
+	"steering slot" -1
 	"mass" 46
 	"outfit space" -46
 	"engine capacity" -46
@@ -303,6 +309,8 @@ outfit "Pug Lohmar Thruster"
 	category "Engines"
 	"cost" 1740000
 	thumbnail "outfit/pug lohmar thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 84
 	"outfit space" -84
 	"engine capacity" -84
@@ -318,6 +326,7 @@ outfit "Pug Lohmar Steering"
 	category "Engines"
 	"cost" 1580000
 	thumbnail "outfit/pug lohmar steering"
+	"steering slot" -1
 	"mass" 64
 	"outfit space" -64
 	"engine capacity" -64

--- a/data/pug/pug ships.txt
+++ b/data/pug/pug ships.txt
@@ -29,6 +29,9 @@ ship "Pug Zibruka"
 		"outfit space" 180
 		"weapon capacity" 68
 		"engine capacity" 76
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 1000
 		"energy generation" 10
 		"heat generation" 20
@@ -79,6 +82,9 @@ ship "Pug Enfolta"
 		"outfit space" 360
 		"weapon capacity" 184
 		"engine capacity" 106
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 2000
 		"energy generation" 22
 		"heat generation" 32
@@ -134,6 +140,9 @@ ship "Pug Maboro"
 		"outfit space" 560
 		"weapon capacity" 309
 		"engine capacity" 148
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 4000
 		"energy generation" 32
 		"heat generation" 48
@@ -191,6 +200,9 @@ ship "Pug Arfecta"
 		"outfit space" 640
 		"weapon capacity" 390
 		"engine capacity" 220
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 10000
 		"energy generation" 200
 		"heat generation" 10

--- a/data/pug/pug ships.txt
+++ b/data/pug/pug ships.txt
@@ -29,9 +29,9 @@ ship "Pug Zibruka"
 		"outfit space" 180
 		"weapon capacity" 68
 		"engine capacity" 76
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 1000
 		"energy generation" 10
 		"heat generation" 20
@@ -82,9 +82,9 @@ ship "Pug Enfolta"
 		"outfit space" 360
 		"weapon capacity" 184
 		"engine capacity" 106
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 2000
 		"energy generation" 22
 		"heat generation" 32
@@ -140,9 +140,9 @@ ship "Pug Maboro"
 		"outfit space" 560
 		"weapon capacity" 309
 		"engine capacity" 148
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 4000
 		"energy generation" 32
 		"heat generation" 48
@@ -200,9 +200,9 @@ ship "Pug Arfecta"
 		"outfit space" 640
 		"weapon capacity" 390
 		"engine capacity" 220
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 10000
 		"energy generation" 200
 		"heat generation" 10

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -111,6 +111,8 @@ outfit "Medium Graviton Thruster"
 	category "Engines"
 	"cost" 20000000
 	thumbnail "outfit/medium quarg thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 70
 	"outfit space" -70
 	"engine capacity" -70
@@ -127,6 +129,7 @@ outfit "Medium Graviton Steering"
 	category "Engines"
 	"cost" 16000000
 	thumbnail "outfit/medium quarg steering"
+	"steering slot" -1
 	"mass" 50
 	"outfit space" -50
 	"engine capacity" -50

--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -29,9 +29,9 @@ ship "Quarg Skylark"
 		"outfit space" 600
 		"weapon capacity" 200
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"hull repair rate" 5
 		"hull energy" 5
 		"ramscoop" 10
@@ -86,9 +86,9 @@ ship "Quarg Wardragon"
 		"outfit space" 600
 		"weapon capacity" 200
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"hull repair rate" 5
 		"hull energy" 5
 		"ramscoop" 10

--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -29,6 +29,9 @@ ship "Quarg Skylark"
 		"outfit space" 600
 		"weapon capacity" 200
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"hull repair rate" 5
 		"hull energy" 5
 		"ramscoop" 10
@@ -83,6 +86,9 @@ ship "Quarg Wardragon"
 		"outfit space" 600
 		"weapon capacity" 200
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"hull repair rate" 5
 		"hull energy" 5
 		"ramscoop" 10

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -699,6 +699,9 @@ outfit "Anvil-Class Engine"
 		Remnant
 	"cost" 290000
 	thumbnail "outfit/tiny remnant engine"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 26
 	"outfit space" -26
 	"engine capacity" -26
@@ -729,6 +732,8 @@ outfit "Crucible-Class Thruster"
 		Remnant
 	"cost" 200000
 	thumbnail "outfit/small remnant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
@@ -753,6 +758,8 @@ outfit "Forge-Class Thruster"
 		Remnant
 	"cost" 441000
 	thumbnail "outfit/medium remnant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 39
 	"outfit space" -39
 	"engine capacity" -39
@@ -777,6 +784,8 @@ outfit "Smelter-Class Thruster"
 		Remnant
 	"cost" 984000
 	thumbnail "outfit/large remnant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 76
 	"outfit space" -76
 	"engine capacity" -76
@@ -801,6 +810,7 @@ outfit "Crucible-Class Steering"
 		Remnant
 	"cost" 172000
 	thumbnail "outfit/small remnant steering"
+	"steering slot" -1
 	"mass" 14
 	"outfit space" -14
 	"engine capacity" -14
@@ -819,6 +829,7 @@ outfit "Forge-Class Steering"
 		Remnant
 	"cost" 393000
 	thumbnail "outfit/medium remnant steering"
+	"steering slot" -1
 	"mass" 28
 	"outfit space" -28
 	"engine capacity" -28
@@ -837,6 +848,7 @@ outfit "Smelter-Class Steering"
 		Remnant
 	"cost" 880000
 	thumbnail "outfit/large remnant steering"
+	"steering slot" -1
 	"mass" 55
 	"outfit space" -55
 	"engine capacity" -55

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -674,6 +674,7 @@ outfit "Bellows-Class Afterburner"
 	category "Engines"
 	"cost" 640000
 	thumbnail "outfit/remnant afterburner"
+	"afterburner slot" -1
 	"mass" 8
 	"outfit space" -7
 	"engine capacity" -7

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -35,9 +35,9 @@ ship "Albatross"
 		"outfit space" 672
 		"weapon capacity" 236
 		"engine capacity" 142
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 5.2
 		"shield energy" 4.6
 		"hull repair rate" 1.5
@@ -293,9 +293,9 @@ ship "Modified Dromedary"
 		"outfit space" 740
 		"weapon capacity" 270
 		"engine capacity" 195
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"solar collection" 1.1
 		"outfit scan power" 18
 		"outfit scan efficiency" 48
@@ -501,9 +501,9 @@ ship "Gull"
 		"outfit space" 311
 		"weapon capacity" 83
 		"engine capacity" 101
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 1.6
 		"shield energy" 1.1
 		"hull repair rate" 0.7
@@ -664,7 +664,7 @@ ship "Heron"
 		"outfit space" 2150
 		"weapon capacity" 470
 		"engine capacity" 800
-		"reverse thruster slot" 1
+		"reverse thruster slot" 2
 		"steering slot" 5
 		"thruster slot" 5
 		"shield generation" 15
@@ -834,9 +834,9 @@ ship "Ibis"
 		"outfit space" 427
 		"weapon capacity" 147
 		"engine capacity" 109
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 3.5
 		"shield energy" 3.1
 		"hull repair rate" 1.2
@@ -949,9 +949,9 @@ ship "Merganser"
 		"reverse flare sound" "plasma tiny"
 		"weapon capacity" 85
 		"engine capacity" 70
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 10
 			"shield damage" 100
@@ -1027,9 +1027,9 @@ ship "Pelican"
 		"outfit space" 480
 		"weapon capacity" 157
 		"engine capacity" 144
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 2.7
 		"shield energy" 1.8
 		"hull repair rate" 1
@@ -1112,9 +1112,9 @@ ship "Penguin"
 		"outfit space" 109
 		"weapon capacity" 33
 		"engine capacity" 54
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 1
 		"shield energy" 0.5
 		"hull repair rate" 2
@@ -1220,9 +1220,9 @@ ship "Peregrine"
 		"outfit space" 552
 		"weapon capacity" 220
 		"engine capacity" 171
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 2
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 3
 		"shield generation" 4.9
 		"shield energy" 3.0
 		"hull repair rate" 2.5
@@ -1339,9 +1339,9 @@ ship "Petrel"
 		"outfit space" 133
 		"weapon capacity" 33
 		"engine capacity" 34
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 0.36
 		"shield energy" 0.24
 		"hull repair rate" 0.82
@@ -1401,9 +1401,9 @@ ship "Puffin"
 		"cargo space" 8
 		"outfit space" 80
 		"engine capacity" 26
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 0.6
 		"shield energy" 0.4
 		"hull repair rate" 1.2
@@ -1456,9 +1456,9 @@ ship "Smew"
 		"outfit space" 80
 		"weapon capacity" 10
 		"engine capacity" 46
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"energy capacity" 3000
 		"ion resistance" 0.002
 		"scramble resistance" 0.002
@@ -1545,9 +1545,9 @@ ship "Starling"
 		"outfit space" 316
 		"weapon capacity" 83
 		"engine capacity" 94
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 1.8
 		"shield energy" 1.2
 		"hull repair rate" 0.8
@@ -1707,9 +1707,9 @@ ship "Tern"
 		"outfit space" 76
 		"weapon capacity" 16
 		"engine capacity" 26
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"shield generation" 0.25
 		"shield energy" 0.16
 		"hull repair rate" 0.55

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -35,6 +35,9 @@ ship "Albatross"
 		"outfit space" 672
 		"weapon capacity" 236
 		"engine capacity" 142
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 5.2
 		"shield energy" 4.6
 		"hull repair rate" 1.5
@@ -290,6 +293,9 @@ ship "Modified Dromedary"
 		"outfit space" 740
 		"weapon capacity" 270
 		"engine capacity" 195
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"solar collection" 1.1
 		"outfit scan power" 18
 		"outfit scan efficiency" 48
@@ -495,6 +501,9 @@ ship "Gull"
 		"outfit space" 311
 		"weapon capacity" 83
 		"engine capacity" 101
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 1.6
 		"shield energy" 1.1
 		"hull repair rate" 0.7
@@ -655,6 +664,9 @@ ship "Heron"
 		"outfit space" 2150
 		"weapon capacity" 470
 		"engine capacity" 800
+		"reverse thruster slot" 1
+		"steering slot" 5
+		"thruster slot" 5
 		"shield generation" 15
 		"shield energy" 1.8
 		"hull repair rate" 15
@@ -822,6 +834,9 @@ ship "Ibis"
 		"outfit space" 427
 		"weapon capacity" 147
 		"engine capacity" 109
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 3.5
 		"shield energy" 3.1
 		"hull repair rate" 1.2
@@ -934,6 +949,9 @@ ship "Merganser"
 		"reverse flare sound" "plasma tiny"
 		"weapon capacity" 85
 		"engine capacity" 70
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 10
 			"shield damage" 100
@@ -1009,6 +1027,9 @@ ship "Pelican"
 		"outfit space" 480
 		"weapon capacity" 157
 		"engine capacity" 144
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 2.7
 		"shield energy" 1.8
 		"hull repair rate" 1
@@ -1091,6 +1112,9 @@ ship "Penguin"
 		"outfit space" 109
 		"weapon capacity" 33
 		"engine capacity" 54
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 1
 		"shield energy" 0.5
 		"hull repair rate" 2
@@ -1196,6 +1220,9 @@ ship "Peregrine"
 		"outfit space" 552
 		"weapon capacity" 220
 		"engine capacity" 171
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 2
 		"shield generation" 4.9
 		"shield energy" 3.0
 		"hull repair rate" 2.5
@@ -1312,6 +1339,9 @@ ship "Petrel"
 		"outfit space" 133
 		"weapon capacity" 33
 		"engine capacity" 34
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 0.36
 		"shield energy" 0.24
 		"hull repair rate" 0.82
@@ -1371,6 +1401,9 @@ ship "Puffin"
 		"cargo space" 8
 		"outfit space" 80
 		"engine capacity" 26
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 0.6
 		"shield energy" 0.4
 		"hull repair rate" 1.2
@@ -1423,6 +1456,9 @@ ship "Smew"
 		"outfit space" 80
 		"weapon capacity" 10
 		"engine capacity" 46
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"energy capacity" 3000
 		"ion resistance" 0.002
 		"scramble resistance" 0.002
@@ -1509,6 +1545,9 @@ ship "Starling"
 		"outfit space" 316
 		"weapon capacity" 83
 		"engine capacity" 94
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 1.8
 		"shield energy" 1.2
 		"hull repair rate" 0.8
@@ -1668,6 +1707,9 @@ ship "Tern"
 		"outfit space" 76
 		"weapon capacity" 16
 		"engine capacity" 26
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"shield generation" 0.25
 		"shield energy" 0.16
 		"hull repair rate" 0.55

--- a/data/rulei/rulei ships.txt
+++ b/data/rulei/rulei ships.txt
@@ -37,9 +37,9 @@ ship "vyu-Ir"
 		"outfit space" 1000
 		"weapon capacity" 1000
 		"engine capacity" 1000
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		
 		"energy capacity" 60000
 		"energy generation" 80

--- a/data/rulei/rulei ships.txt
+++ b/data/rulei/rulei ships.txt
@@ -37,6 +37,9 @@ ship "vyu-Ir"
 		"outfit space" 1000
 		"weapon capacity" 1000
 		"engine capacity" 1000
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		
 		"energy capacity" 60000
 		"energy generation" 80

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -70,6 +70,9 @@ outfit "Fission Drive"
 	category "Engines"
 	cost 2650000
 	thumbnail "outfit/fissiondrive"
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 71
 	"outfit space" -71
 	"engine capacity" -38
@@ -96,6 +99,10 @@ outfit "Fusion Drive"
 	category "Engines"
 	cost 80000000
 	thumbnail "outfit/fusiondrive"
+	"reverse thruster slot" -1
+	"steering slot" -1
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 480
 	"outfit space" -480
 	"engine capacity" -230

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -30,9 +30,9 @@ ship "Emerald Sword"
 		"outfit space" 1190
 		"weapon capacity" 512
 		"engine capacity" 230
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"spinal mount" 1
 		weapon
 			"blast radius" 993
@@ -183,9 +183,9 @@ ship "Black Diamond"
 		"outfit space" 152
 		"weapon capacity" 35
 		"engine capacity" 38
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"hull repair rate" 1
 		"hull delay" 60
 		weapon

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -30,6 +30,9 @@ ship "Emerald Sword"
 		"outfit space" 1190
 		"weapon capacity" 512
 		"engine capacity" 230
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"spinal mount" 1
 		weapon
 			"blast radius" 993
@@ -180,6 +183,9 @@ ship "Black Diamond"
 		"outfit space" 152
 		"weapon capacity" 35
 		"engine capacity" 38
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"hull repair rate" 1
 		"hull delay" 60
 		weapon

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -426,6 +426,8 @@ outfit "Type 1 Radiant Thruster"
 		"Wanderer Outfits"
 	"cost" 135000
 	thumbnail "outfit/tiny radiant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
@@ -444,6 +446,8 @@ outfit "Type 2 Radiant Thruster"
 		"Wanderer Outfits"
 	"cost" 390000
 	thumbnail "outfit/small radiant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 27
 	"outfit space" -27
 	"engine capacity" -27
@@ -462,6 +466,8 @@ outfit "Type 3 Radiant Thruster"
 		"Wanderer Outfits"
 	"cost" 750000
 	thumbnail "outfit/medium radiant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 42
 	"outfit space" -42
 	"engine capacity" -42
@@ -480,6 +486,8 @@ outfit "Type 4 Radiant Thruster"
 		"Wanderer Outfits"
 	"cost" 1370000
 	thumbnail "outfit/large radiant thruster"
+	"thruster slot" -1
+	"afterburner slot" 1
 	"mass" 65
 	"outfit space" -65
 	"engine capacity" -65
@@ -498,6 +506,7 @@ outfit "Type 1 Radiant Steering"
 		"Wanderer Outfits"
 	"cost" 115000
 	thumbnail "outfit/tiny radiant steering"
+	"steering slot" -1
 	"mass" 9
 	"outfit space" -9
 	"engine capacity" -9
@@ -516,6 +525,7 @@ outfit "Type 2 Radiant Steering"
 		"Wanderer Outfits"
 	"cost" 325000
 	thumbnail "outfit/small radiant steering"
+	"steering slot" -1
 	"mass" 20
 	"outfit space" -20
 	"engine capacity" -20
@@ -534,6 +544,7 @@ outfit "Type 3 Radiant Steering"
 		"Wanderer Outfits"
 	"cost" 590000
 	thumbnail "outfit/medium radiant steering"
+	"steering slot" -1
 	"mass" 30
 	"outfit space" -30
 	"engine capacity" -30
@@ -552,6 +563,7 @@ outfit "Type 4 Radiant Steering"
 		"Wanderer Outfits"
 	"cost" 1100000
 	thumbnail "outfit/large radiant steering"
+	"steering slot" -1
 	"mass" 47
 	"outfit space" -47
 	"engine capacity" -47

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -28,6 +28,9 @@ ship "Earth Shaper"
 		"cargo space" 27
 		"outfit space" 59
 		"engine capacity" 26
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"atmosphere scan" 100
 		weapon
 			"blast radius" 10
@@ -65,6 +68,9 @@ ship "Flycatcher"
 		"outfit space" 86
 		"weapon capacity" 28
 		"engine capacity" 26
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 10
 			"shield damage" 100
@@ -109,6 +115,9 @@ ship "Summer Leaf"
 		"outfit space" 320
 		"weapon capacity" 84
 		"engine capacity" 103
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 70
 			"shield damage" 700
@@ -159,6 +168,9 @@ ship "Autumn Leaf"
 		"outfit space" 361
 		"weapon capacity" 103
 		"engine capacity" 117
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -221,6 +233,9 @@ ship "Strong Wind"
 		"outfit space" 493
 		"weapon capacity" 198
 		"engine capacity" 114
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		"asteroid scan power" 100
 		"atmosphere scan" 100
 		"tactical scan power" 25
@@ -279,6 +294,9 @@ ship "Tempest"
 		"outfit space" 607
 		"weapon capacity" 271
 		"engine capacity" 122
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -402,6 +420,9 @@ ship "Derecho"
 		"outfit space" 796
 		"weapon capacity" 342
 		"engine capacity" 164
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 340
 			"shield damage" 3400
@@ -532,6 +553,9 @@ ship "Hurricane"
 		"outfit space" 960
 		"weapon capacity" 428
 		"engine capacity" 140
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 400
 			"shield damage" 4000
@@ -672,6 +696,9 @@ ship "Cool Breeze"
 		"outfit space" 192
 		"weapon capacity" 41
 		"engine capacity" 62
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -729,6 +756,9 @@ ship "Winter Gale"
 		"outfit space" 478
 		"weapon capacity" 171
 		"engine capacity" 120
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -832,6 +862,9 @@ ship "Deep River"
 		"outfit space" 363
 		"weapon capacity" 177
 		"engine capacity" 83
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -921,6 +954,9 @@ ship "Deep River Transport"
 		"outfit space" 321
 		"weapon capacity" 114
 		"engine capacity" 83
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -973,6 +1009,9 @@ ship "Riptide"
 		"outfit space" 488
 		"weapon capacity" 98
 		"engine capacity" 186
+		"reverse thruster slot" 1
+		"steering slot" 1
+		"thruster slot" 1
 		weapon
 			"blast radius" 260
 			"shield damage" 2600

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -28,9 +28,9 @@ ship "Earth Shaper"
 		"cargo space" 27
 		"outfit space" 59
 		"engine capacity" 26
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"atmosphere scan" 100
 		weapon
 			"blast radius" 10
@@ -68,9 +68,9 @@ ship "Flycatcher"
 		"outfit space" 86
 		"weapon capacity" 28
 		"engine capacity" 26
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 10
 			"shield damage" 100
@@ -115,9 +115,9 @@ ship "Summer Leaf"
 		"outfit space" 320
 		"weapon capacity" 84
 		"engine capacity" 103
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 70
 			"shield damage" 700
@@ -168,9 +168,9 @@ ship "Autumn Leaf"
 		"outfit space" 361
 		"weapon capacity" 103
 		"engine capacity" 117
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800
@@ -233,9 +233,9 @@ ship "Strong Wind"
 		"outfit space" 493
 		"weapon capacity" 198
 		"engine capacity" 114
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		"asteroid scan power" 100
 		"atmosphere scan" 100
 		"tactical scan power" 25
@@ -294,9 +294,9 @@ ship "Tempest"
 		"outfit space" 607
 		"weapon capacity" 271
 		"engine capacity" 122
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -420,9 +420,9 @@ ship "Derecho"
 		"outfit space" 796
 		"weapon capacity" 342
 		"engine capacity" 164
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 340
 			"shield damage" 3400
@@ -553,9 +553,9 @@ ship "Hurricane"
 		"outfit space" 960
 		"weapon capacity" 428
 		"engine capacity" 140
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 400
 			"shield damage" 4000
@@ -696,9 +696,9 @@ ship "Cool Breeze"
 		"outfit space" 192
 		"weapon capacity" 41
 		"engine capacity" 62
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -756,9 +756,9 @@ ship "Winter Gale"
 		"outfit space" 478
 		"weapon capacity" 171
 		"engine capacity" 120
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 120
 			"shield damage" 1200
@@ -862,9 +862,9 @@ ship "Deep River"
 		"outfit space" 363
 		"weapon capacity" 177
 		"engine capacity" 83
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -954,9 +954,9 @@ ship "Deep River Transport"
 		"outfit space" 321
 		"weapon capacity" 114
 		"engine capacity" 83
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 280
 			"shield damage" 2800
@@ -1009,9 +1009,9 @@ ship "Riptide"
 		"outfit space" 488
 		"weapon capacity" 98
 		"engine capacity" 186
-		"reverse thruster slot" 1
-		"steering slot" 1
-		"thruster slot" 1
+		"reverse thruster slot" 2
+		"steering slot" 2
+		"thruster slot" 2
 		weapon
 			"blast radius" 260
 			"shield damage" 2600

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -218,7 +218,7 @@ void MapOutfitterPanel::DrawItems()
 					info += " of weapon space";
 				else if(space && -outfit->Get("engine capacity") == space)
 					info += " of engine space";
-				else if (space && -outfit->Get("afterburner slot") == space)
+				else if(space && -outfit->Get("afterburner slot") == space)
 					info += " of engine space";
 				else
 					info += " of outfit space";

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -218,6 +218,8 @@ void MapOutfitterPanel::DrawItems()
 					info += " of weapon space";
 				else if(space && -outfit->Get("engine capacity") == space)
 					info += " of engine space";
+				else if (space && -outfit->Get("afterburner slot") == space)
+					info += " of engine space";
 				else
 					info += " of outfit space";
 			}

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -330,7 +330,7 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 	requirementsHeight += 10;
 
 	bool hasContent = false;
-	static const vector<string> BEFORE = {"outfit space", "weapon capacity", "engine capacity"};
+	static const vector<string> BEFORE = {"outfit space", "weapon capacity", "engine capacity", "afterburner slot", "reverse thruster slot", "steering slot", "thruster slot"};
 	for(const auto &attr : BEFORE)
 	{
 		if(outfit.Get(attr) < 0)
@@ -400,7 +400,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	// tag them with "added" and show them first. They conveniently
 	// don't use SCALE or BOOLEAN_ATTRIBUTES.
 	static const vector<string> EXPECTED_NEGATIVE = {
-		"outfit space", "weapon capacity", "engine capacity", "gun ports", "turret mounts"
+		"outfit space", "weapon capacity", "engine capacity", "afterburner slot", "reverse thruster slot", "steering slot", "thruster slot", "gun ports", "turret mounts"
 	};
 
 	for(const string &attr : EXPECTED_NEGATIVE)

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -330,7 +330,8 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 	requirementsHeight += 10;
 
 	bool hasContent = false;
-	static const vector<string> BEFORE = {"outfit space", "weapon capacity", "engine capacity", "afterburner slot", "reverse thruster slot", "steering slot", "thruster slot"};
+	static const vector<string> BEFORE = {"outfit space", "weapon capacity", "engine capacity", "afterburner slot",
+		"reverse thruster slot", "steering slot", "thruster slot"};
 	for(const auto &attr : BEFORE)
 	{
 		if(outfit.Get(attr) < 0)
@@ -400,7 +401,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	// tag them with "added" and show them first. They conveniently
 	// don't use SCALE or BOOLEAN_ATTRIBUTES.
 	static const vector<string> EXPECTED_NEGATIVE = {
-		"outfit space", "weapon capacity", "engine capacity", "afterburner slot", "reverse thruster slot", "steering slot", "thruster slot", "gun ports", "turret mounts"
+		"outfit space", "weapon capacity", "engine capacity", "afterburner slot", "reverse thruster slot",
+		"steering slot", "thruster slot", "gun ports", "turret mounts"
 	};
 
 	for(const string &attr : EXPECTED_NEGATIVE)

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -441,6 +441,30 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 				+ Format::CargoString(engineNeeded, "engine space") + ", and this ship has "
 				+ Format::MassString(engineSpace) + " free.";
 
+		int afterburnerSlotNeeded = -selectedOutfit->Get("afterburner slot");
+		int afterburnerSlotFree = playerShip->Attributes().Get("afterburner slot");
+		if(afterburnerSlotNeeded && !afterburnerSlotFree)
+			return "This afterbuner is designed to be installed in an afterburner slot, "
+				"but your ship does not have any unused afterburner slots available.";
+
+		int reverseThrusterSlotNeeded = -selectedOutfit->Get("reverse thruster slot");
+		int reverseThrusterSlotFree = playerShip->Attributes().Get("reverse thruster slot");
+		if(reverseThrusterSlotNeeded && !reverseThrusterSlotFree)
+			return "This reverse thruster is designed to be installed in a reverse thruster slot, "
+				"but your ship does not have any unused reverse thruster slots available.";
+
+		int steeringSlotNeeded = -selectedOutfit->Get("steering slot");
+		int steeringSlotFree = playerShip->Attributes().Get("steering slot");
+		if(steeringSlotNeeded && !steeringSlotFree)
+			return "This steering is designed to be installed in a steering slot, "
+				"but your ship does not have any unused steering slots available.";
+
+		int thrusterSlotNeeded = -selectedOutfit->Get("thruster slot");
+		int thrusterSlotFree = playerShip->Attributes().Get("thruster slot");
+		if(thrusterSlotNeeded && !thrusterSlotFree)
+			return "This thruster is designed to be installed in a thruster slot, "
+				"but your ship does not have any unused thruster slots available.";
+
 		if(selectedOutfit->Category() == "Ammunition")
 			return !playerShip->OutfitCount(selectedOutfit) ?
 				"This outfit is ammunition for a weapon. "

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -147,8 +147,9 @@ namespace {
 			cout << "model" << ',' << "category" << ',' << "chassis cost" << ',' << "loaded cost" << ',' << "shields" << ','
 				<< "hull" << ',' << "mass" << ',' << "drag" << ',' << "heat dissipation" << ','
 				<< "required crew" << ',' << "bunks" << ',' << "cargo space" << ',' << "fuel" << ','
-				<< "outfit space" << ',' << "weapon capacity" << ',' << "engine capacity" << ',' << "gun mounts" << ','
-				<< "turret mounts" << ',' << "fighter bays" << ',' << "drone bays" << '\n';
+				<< "outfit space" << ',' << "weapon capacity" << ',' << "engine capacity" << ','
+				<< "afterburner slot" << ',' << "reverse thruster slot" << ',' << "steering slot" << ',' << "thruster slot" << ',' 
+				<< "gun mounts" << ',' << "turret mounts" << ',' << "fighter bays" << ',' << "drone bays" << '\n';
 
 			for(auto &it : GameData::Ships())
 			{
@@ -178,6 +179,10 @@ namespace {
 				cout << attributes.Get("outfit space") << ',';
 				cout << attributes.Get("weapon capacity") << ',';
 				cout << attributes.Get("engine capacity") << ',';
+				cout << attributes.Get("afterburner slot") << ',';
+				cout << attributes.Get("reverse thruster slot") << ',';
+				cout << attributes.Get("steering slot") << ',';
+				cout << attributes.Get("thruster slot") << ',';
 
 				int numTurrets = 0;
 				int numGuns = 0;
@@ -201,7 +206,8 @@ namespace {
 			cout << "model" << ',' << "category" << ',' << "cost" << ',' << "shields" << ','
 				<< "hull" << ',' << "mass" << ',' << "required crew" << ',' << "bunks" << ','
 				<< "cargo space" << ',' << "fuel" << ',' << "outfit space" << ',' << "weapon capacity" << ','
-				<< "engine capacity" << ',' << "speed" << ',' << "accel" << ',' << "turn" << ','
+				<< "engine capacity" << "afterburner slot" << ',' << "reverse thruster slot" << ',' << "steering slot" << ','
+				<< "thruster slot" << ',' << "speed" << ',' << "accel" << ',' << "turn" << ','
 				<< "energy generation" << ',' << "max energy usage" << ',' << "energy capacity" << ','
 				<< "idle/max heat" << ',' << "max heat generation" << ',' << "max heat dissipation" << ','
 				<< "gun mounts" << ',' << "turret mounts" << ',' << "fighter bays" << ','
@@ -232,6 +238,10 @@ namespace {
 				cout << ship.BaseAttributes().Get("outfit space") << ',';
 				cout << ship.BaseAttributes().Get("weapon capacity") << ',';
 				cout << ship.BaseAttributes().Get("engine capacity") << ',';
+				cout << ship.BaseAttributes().Get("afterburner slot") << ',';
+				cout << ship.BaseAttributes().Get("reverse thruster slot") << ',';
+				cout << ship.BaseAttributes().Get("steering slot") << ',';
+				cout << ship.BaseAttributes().Get("thruster slot") << ',';
 				cout << (attributes.Get("drag") ? (60. * attributes.Get("thrust") / attributes.Get("drag")) : 0) << ',';
 				cout << 3600. * attributes.Get("thrust") / mass << ',';
 				cout << 60. * attributes.Get("turn") / mass << ',';
@@ -437,7 +447,8 @@ namespace {
 		auto PrintEngineStats = []() -> void
 		{
 			cout << "name" << ',' << "cost" << ',' << "mass" << ',' << "outfit space" << ','
-				<< "engine capacity" << ',' << "thrust/s" << ',' << "thrust energy/s" << ','
+				<< "engine capacity" << "afterburner slot" << ',' << "reverse thruster slot" << ',' << "steering slot" << ','
+				<< "thruster slot" << ',' << "thrust/s" << ',' << "thrust energy/s" << ','
 				<< "thrust heat/s" << ',' << "turn/s" << ',' << "turn energy/s" << ','
 				<< "turn heat/s" << ',' << "reverse thrust/s" << ',' << "reverse energy/s" << ','
 				<< "reverse heat/s" << ',' << "afterburner thrust/s" << ',' << "afterburner energy/s" << ','
@@ -455,6 +466,10 @@ namespace {
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
 				cout << outfit.Get("engine capacity") << ',';
+				cout << outfit.Get("afterburner slot") << ',';
+				cout << outfit.Get("reverse thruster slot") << ',';
+				cout << outfit.Get("steering slot") << ',';
+				cout << outfit.Get("thruster slot") << ',';
 				cout << outfit.Get("thrust") * 3600. << ',';
 				cout << outfit.Get("thrusting energy") * 60. << ',';
 				cout << outfit.Get("thrusting heat") * 60. << ',';

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -148,7 +148,7 @@ namespace {
 				<< "hull" << ',' << "mass" << ',' << "drag" << ',' << "heat dissipation" << ','
 				<< "required crew" << ',' << "bunks" << ',' << "cargo space" << ',' << "fuel" << ','
 				<< "outfit space" << ',' << "weapon capacity" << ',' << "engine capacity" << ','
-				<< "afterburner slot" << ',' << "reverse thruster slot" << ',' << "steering slot" << ',' << "thruster slot" << ',' 
+				<< "afterburner slot" << ',' << "reverse thruster slot" << ',' << "steering slot" << ',' << "thruster slot" << ','
 				<< "gun mounts" << ',' << "turret mounts" << ',' << "fighter bays" << ',' << "drone bays" << '\n';
 
 			for(auto &it : GameData::Ships())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -814,7 +814,8 @@ void Ship::FinishLoading(bool isNewInstance)
 
 	// Issue warnings if this ship has is misconfigured, e.g. is missing required values
 	// or has negative outfit, cargo, weapon, or engine capacity.
-	for(auto &&attr : set<string>{"outfit space", "cargo space", "weapon capacity", "engine capacity"})
+	for(auto &&attr : set<string>{"outfit space", "cargo space", "weapon capacity", "engine capacity",
+		"afterburner slot", "reverse thruster slot", "steering slot", "thruster slot"})
 	{
 		double val = attributes.Get(attr);
 		if(val < 0)

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -292,6 +292,10 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		"outfit space free:", "outfit space",
 		"    weapon capacity:", "weapon capacity",
 		"    engine capacity:", "engine capacity",
+		"afterburner slots free:", "afterburner slot",
+		"reverse thruster slots free:", "reverse thruster slot",
+		"steering slots free:", "steering slot",
+		"thruster slots free:", "thruster slot",
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts"
 	};


### PR DESCRIPTION
**Code / Content / Balance**

## Summary
Manoeuvrability and propulsion is a source of a lot of problems in Endless Sky. As currently implemented, propulsion systems are basically a liquid that is poured into the available engine space, with as many systems as can fit being shoved in, in whatever combination is desired, generally with a goal to fill up the available engine space. This makes it hard to differentiate ships, hard to differentiate propulsion systems, substantially advantages larger ships over small ones, promotes afterburner abuse, and contributes to the current meta of "bigger is always better, in every way" since it is common for bigger ships to be able to out manoeuvre smaller ships. 

~~Note: this is purely implemented in data. There are no code changes.~~

This has become a code+data PR, as code has been added so that the slots are displayed to the player, checked for errors, will display appropriate specific error messages, and is included in the checks. Builds that have negative slots will be flagged.

## Problems targeted

1. There is a general (although not universal) agreement that small ships need a purpose, and need some sort of advantage versus larger ships. A common sentiment is that - at least within use categories - small ships should be generally faster and more manoeuvrable than larger ships. However, since ships can equip as many thrusters as they have space for, larger thrusters have greater thrust/space density because if they didn't, large ships would just fill the space with small thrusters instead. Bigger has to be better otherwise there is no reason to use the bigger options.
2. Since all outfits can be installed in any quantity anywhere, all have to be balanced as if a ship may well have dozens of them, which makes it challenging to give individual thrusters meaningful benefits, and almost impossible to give small thrusters meaningful side benefits, since they have to be balanced against the possibility of being extensively stacked.
3. Given that afterburners currently are just stand alone outfits, players can install them *instead of* thrusters. This means that afterburners have to be balanced not as occasional use boosts, but rather as potentially constant-use thrusters-with-a-fuel-cost. While thrusters-with-fuel-cost is a perfectly valid thing that some family of thrusters should have, it's not what afterburners are or should be. This potential use results in afterburners needing to be balanced for a situation that shouldn't logically be happening. It's built right into the name. *After* burners. By definition, they aren't afterburners if there is no initial burning. (leaving aside that none of our thrusters are actually burning anything...)

## Details

This implements a slot system on all ships. Namely, as a general rule, every ship gets the following slots:
* 1 reverse thruster slot
* 1 steering slot
* 1 thruster slot

Then, as a general rule, all thrusters are consume 1 thruster slot and provide 1 afterburner slot, all steering consume 1 steering slot, all reverse thrusters consume 1 reverse thruster slot, and all afterburners consume 1 afterburner slot. 

The exception is Coalition outfits. Some descriptive elements have emphasized their philosophy of modularity. This has doubled down on that, by having the coalition small modules only take 0.25 of the appropriate slot; and coalition ships get 1.5 slots. The large module has been adjusted slightly to be exactly 3 small modules in a framework that only takes 0.5 slots. This means that coalition ships can effectively have anywhere from 1 to 9 small modules worth of modules of a particular type. Yes, each module gives 1 afterburner, so a degree of afterburner abuse is still possible if one opts to go with 4 small modules, but it significantly reduces the magnitude of the problem. Given that large modules only give 1 afterburner slot, and take up slightly more space than 3 small modules, if a ship is only using 3 it is *better* to just use 3 small modules instead. Not by much, but a bit. The only advantage it gains is the fact that it saves 0.25 worth of slot per trio of modules. (on a per thrust basis, small and large modules are identical in terms of energy and heat production). This gives Coalition modules a strong and unique advantage of being massively more capable of utilizing every last ton of space, at appropriate cost. Where other factions have to pick one of typically a trio of sizes according to the space available, the coalition just fills it all (rather like the current method).

This is intended to be something of a model for other engine families where smaller engines have noticeable and potentially significant advantages over larger ones, including specifically in the primary metric of thrust per space. The primary advantage of a larger engine is that it provides more total thrust. For most ships with a single slot, it doesn't matter if the tiny engine has twice the thrust/space of the bigger engine, if they have the space for the bigger engine and it provides double the total thrust of the smaller one. Likewise, this provides an opportunity to take a hard look at engine families and their benefits.

For instance, a medium plasma thruster might be smaller but somewhat higher efficiency than the medium ionic. This would provide an upgrade route with the one replacing the other for maybe no gain in total thrust, but a gain in space. However, since they both take up 1 slot, that extra space isn't going to be available to stack up an additional tiny thruster. This allows for potentially allowing greater flexibility in engines and their performance, and potential upgrade options since we don't have to worry about an upgrade saving too much space and allowing an additional thruster to be stacked in there.

It is anticipated that some ships may be identified as being designed for a specific use case. For instance, the Flivver mentions speed, and sounds like a racing ship. It could have an extra thruster slot, giving it an additional measure of flexibility in optimizing its thrust. Since slots are in addition to engine space, not replacing it, this doesn't give the Flivver additional thrust directly, it just makes it easier to make full use of it. Likewise, another ship might be build for agility rather than speed, and it could have an extra turning slot, with the same impact of making it easier to optimize its turning. This could allow content creators to give ships a bit more character; rather than the current system where we only get to pick between "Fast in every way" or "slow in every way", with a hull of a ship built to be a drag racer looking functionally identical to a ship built for acrobatics. This would allow players to retain the freedom to ignore that, as they already do, but impose a gentle restriction in making it easier to customize the ship in the direction it is designed for.

## Potential additional changes or follow-up work

- [ ] Balance engines within this context.
- [ ] Identify ships designed for speed or agility.

## Usage examples

Values can be any number, including decimals. These are positive where a slot is being provided (usually on ships), and negative where they are being filled up (usually on outfits).

```
"reverse thruster slot" 1
"steering slot" 1
"thruster slot" 1
"afterburner slot" 1
```

## Testing Done
Played the game and tired outfitting ships.

## Save File
Any pilot, any time, with any ship purchased while this PR is active.

## Performance Impact
N/a
