### PR TITLE
fix(ui): Fix timestamp tooltip not displaying properly for save files

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -51,35 +51,34 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// Return a pair containing settings to use for time formatting.
-	pair<const char*, const char*> TimestampFormatString(Preferences::DateFormat format)
+	// Return format string containing settings to use for time formatting.
+	const char* TimestampFormatString(Preferences::DateFormat format)
 	{
-		// pair<string, string>: Linux (1st) and Windows (2nd) format strings.
 		switch(format)
 		{
 			case Preferences::DateFormat::YMD:
-				return make_pair("%F %T", "%F %T");
+				return "%F %T";
 			case Preferences::DateFormat::MDY:
-				return make_pair("%I:%M %p on %b %d, %Y", "%I:%M %p on %b %d, %Y");
+				return "%I:%M %p on %b %d, %Y", "%I:%M %p on %b %d, %Y";
 			case Preferences::DateFormat::DMY:
 			default:
-				return make_pair("%I:%M %p on %d %b %Y", "%I:%M %p on %d %b %Y");
+				return "%I:%M %p on %d %b %Y";
 		}
 	}
 
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
+		char* format = TimestampFormatString(Preferences::GetDateFormat());
 		stringstream ss;
 
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		ss << std::put_time(&date, format.second);
+		ss << std::put_time(&date, format);
 #else
 		const tm *date = localtime(&timestamp);
-		ss << std::put_time(date, format.first);
+		ss << std::put_time(date, format);
 #endif
 		return ss.str();
 	}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -71,8 +71,8 @@ namespace {
 	string TimestampString(time_t timestamp)
 	{
 		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
-		static const size_t BUF_SIZE = 26;
-		char str[BUF_SIZE + 1];
+		static const size_t BUF_SIZE = 25;
+		char str[BUF_SIZE];
 
 #ifdef _WIN32
 		tm date;

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -52,35 +52,36 @@ using namespace std;
 
 namespace {
 	// Return a pair containing settings to use for time formatting.
-	pair<pair<const char*, const char*>, size_t> TimestampFormatString(Preferences::DateFormat format)
+	pair<const char*, const char*> TimestampFormatString(Preferences::DateFormat format)
 	{
 		// pair<string, string>: Linux (1st) and Windows (2nd) format strings.
-		// size_t: Size of format string (required by strftime)
 		switch(format)
 		{
 			case Preferences::DateFormat::YMD:
-				return make_pair(make_pair("%F %T", "%F %T"), 26);
+				return make_pair("%F %T", "%F %T");
 			case Preferences::DateFormat::MDY:
-				return make_pair(make_pair("%-I:%M %p on %b %-d, %Y", "%#I:%M %p on %b %#d, %Y"), 25);
+				return make_pair("%-I:%M %p on %b %-d, %Y", "%#I:%M %p on %b %#d, %Y");
 			case Preferences::DateFormat::DMY:
 			default:
-				return make_pair(make_pair("%-I:%M %p on %-d %b %Y", "%#I:%M %p on %#d %b %Y"), 24);
+				return make_pair("%-I:%M %p on %-d %b %Y", "%#I:%M %p on %#d %b %Y");
 		}
 	}
 
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		pair<pair<const char*, const char*>, size_t> format = TimestampFormatString(Preferences::GetDateFormat());
-		char str[27]; // Will not be more than 27 bytes including the null terminator
+		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
+		// size_t: Size of format string (required by strftime)
+		static const size_t BUF_SIZE = 26;
+		char str[BUF_SIZE + 1];
 
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		std::strftime(str, format.second, format.first.second, &date);
+		std::strftime(str, BUF_SIZE, format.second, &date);
 #else
 		const tm *date = localtime(&timestamp);
-		std::strftime(str, format.second, format.first.first, date);
+		std::strftime(str, BUF_SIZE, format.first, date);
 #endif
 		return str;
 	}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -71,7 +71,6 @@ namespace {
 	string TimestampString(time_t timestamp)
 	{
 		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
-		// size_t: Size of format string (required by strftime)
 		static const size_t BUF_SIZE = 26;
 		char str[BUF_SIZE + 1];
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -43,8 +43,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cstdlib>
-#include <iomanip>
-#include <sstream>
 #include <stdexcept>
 #include <utility>
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -52,7 +52,7 @@ using namespace std;
 
 namespace {
 	// Return a format string containing settings to use for time formatting.
-	const char * TimestampFormatString(Preferences::DateFormat format)
+	const char *TimestampFormatString(Preferences::DateFormat format)
 	{
 		switch(format)
 		{

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -81,7 +81,7 @@ namespace {
 		const tm *date = localtime(&timestamp);
 		ss << std::put_time(date, format.first);
 #endif
-		return str;
+		return ss.str();
 	}
 
 	// Extract the date from this pilot's most recent save.

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -51,7 +51,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// Return format string containing settings to use for time formatting.
+	// Return a format string containing settings to use for time formatting.
 	const char* TimestampFormatString(Preferences::DateFormat format)
 	{
 		switch(format)

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -72,11 +72,9 @@ namespace {
 	string TimestampString(time_t timestamp)
 	{
 		pair<pair<const char*, const char*>, size_t> format = TimestampFormatString(Preferences::GetDateFormat());
-
 		char str[27]; // Will not be more than 27 bytes including the null terminator
 
-#if defined(_WIN32)
-		
+#ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
 		std::strftime(str, format.second, &date, format.first.second);

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -52,7 +52,7 @@ using namespace std;
 
 namespace {
 	// Return a format string containing settings to use for time formatting.
-	const char* TimestampFormatString(Preferences::DateFormat format)
+	const char * TimestampFormatString(Preferences::DateFormat format)
 	{
 		switch(format)
 		{
@@ -69,7 +69,7 @@ namespace {
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		char* format = TimestampFormatString(Preferences::GetDateFormat());
+		char *format = TimestampFormatString(Preferences::GetDateFormat());
 		stringstream ss;
 
 #ifdef _WIN32

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -77,12 +77,11 @@ namespace {
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		std::strftime(str, BUF_SIZE, format.second, &date);
+		return string(str, std::strftime(str, BUF_SIZE, format.second, &date));
 #else
 		const tm *date = localtime(&timestamp);
-		std::strftime(str, BUF_SIZE, format.first, date);
+		return string(str, std::strftime(str, BUF_SIZE, format.first, date));
 #endif
-		return str;
 	}
 
 	// Extract the date from this pilot's most recent save.

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -77,10 +77,10 @@ namespace {
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		std::strftime(str, format.second, &date, format.first.second);
+		std::strftime(str, format.second, format.first.second, &date);
 #else
 		const tm *date = localtime(&timestamp);
-		std::strftime(str, format.second, &date, format.first.second);
+		std::strftime(str, format.second, format.first.second, &date);
 #endif
 		return str;
 	}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -52,7 +52,7 @@ using namespace std;
 
 namespace {
 	// Return a pair containing settings to use for time formatting.
-	pair<pair<const char*, const char*>, int> TimestampFormatString(Preferences::DateFormat format)
+	pair<pair<const char*, const char*>, size_t> TimestampFormatString(Preferences::DateFormat format)
 	{
 		// pair<string, string>: Linux (1st) and Windows (2nd) format strings.
 		// size_t: Size of format string (required by strftime)

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -77,10 +77,10 @@ namespace {
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		std::strftime(str, format.second, format.first.second, &date);
+		std::strftime(str, format.second, format.first.second, date);
 #else
 		const tm *date = localtime(&timestamp);
-		std::strftime(str, format.second, format.first.second, &date);
+		std::strftime(str, format.second, format.first.second, date);
 #endif
 		return str;
 	}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -69,7 +69,7 @@ namespace {
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		char *format = TimestampFormatString(Preferences::GetDateFormat());
+		const char *format = TimestampFormatString(Preferences::GetDateFormat());
 		stringstream ss;
 
 #ifdef _WIN32

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -80,7 +80,7 @@ namespace {
 		std::strftime(str, format.second, format.first.second, &date);
 #else
 		const tm *date = localtime(&timestamp);
-		std::strftime(str, format.second, format.first.second, date);
+		std::strftime(str, format.second, format.first.first, date);
 #endif
 		return str;
 	}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -43,6 +43,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cstdlib>
+#include <iomanip>
+#include <sstream>
 #include <stdexcept>
 #include <utility>
 
@@ -50,36 +52,35 @@ using namespace std;
 
 namespace {
 	// Return a pair containing settings to use for time formatting.
-	pair<pair<string, string>, size_t> TimestampFormatString(Preferences::DateFormat fmt)
+	pair<const char*, const char*> TimestampFormatString(Preferences::DateFormat format)
 	{
-		// pair<string, string>: Linux (1st) and Windows (2nd) format strings
-		// size_t: BUF_SIZE
-		if(fmt == Preferences::DateFormat::YMD)
-			return make_pair(make_pair("%F %T", "%F %T"), 26);
-		if(fmt == Preferences::DateFormat::MDY)
-			return make_pair(make_pair("%-I:%M %p on %b %-d, %Y", "%#I:%M %p on %b %#d, %Y"), 25);
-		if(fmt == Preferences::DateFormat::DMY)
-			return make_pair(make_pair("%-I:%M %p on %-d %b %Y", "%#I:%M %p on %#d %b %Y"), 24);
-
-		// Return YYYY-MM-DD by default.
-		return make_pair(make_pair("%F %T", "%F %T"), 26);
+		// pair<string, string>: Linux (1st) and Windows (2nd) format strings.
+		switch(format)
+		{
+			case Preferences::DateFormat::YMD:
+				return make_pair("%F %T", "%F %T");
+			case Preferences::DateFormat::MDY:
+				return make_pair("%I:%M %p on %b %d, %Y", "%I:%M %p on %b %d, %Y");
+			case Preferences::DateFormat::DMY:
+			default:
+				return make_pair("%I:%M %p on %d %b %Y", "%I:%M %p on %d %b %Y");
+		}
 	}
 
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		pair<pair<string, string>, size_t> fmt = TimestampFormatString(Preferences::GetDateFormat());
-		char* buf = static_cast<char*>(std::malloc(fmt.second));
+		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
+		stringstream ss;
 
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		auto str = string(buf, strftime(buf, fmt.second, fmt.first.second.c_str(), &date));
+		ss << std::put_time(&date, format.second);
 #else
 		const tm *date = localtime(&timestamp);
-		auto str = string(buf, strftime(buf, fmt.second, fmt.first.first.c_str(), date));
+		ss << std::put_time(date, format.first);
 #endif
-		std::free(buf);
 		return str;
 	}
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -77,7 +77,7 @@ namespace {
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		std::strftime(str, format.second, format.first.second, date);
+		std::strftime(str, format.second, format.first.second, &date);
 #else
 		const tm *date = localtime(&timestamp);
 		std::strftime(str, format.second, format.first.second, date);

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -59,7 +59,7 @@ namespace {
 			case Preferences::DateFormat::YMD:
 				return "%F %T";
 			case Preferences::DateFormat::MDY:
-				return "%I:%M %p on %b %d, %Y", "%I:%M %p on %b %d, %Y";
+				return "%I:%M %p on %b %d, %Y";
 			case Preferences::DateFormat::DMY:
 			default:
 				return "%I:%M %p on %d %b %Y";

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -51,34 +51,35 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// Return a format string containing settings to use for time formatting.
-	const char *TimestampFormatString(Preferences::DateFormat format)
+	// Return a pair containing settings to use for time formatting.
+	pair<const char*, const char*> TimestampFormatString(Preferences::DateFormat format)
 	{
+		// pair<string, string>: Linux (1st) and Windows (2nd) format strings.
 		switch(format)
 		{
 			case Preferences::DateFormat::YMD:
-				return "%F %T";
+				return make_pair("%F %T", "%F %T");
 			case Preferences::DateFormat::MDY:
-				return "%I:%M %p on %b %d, %Y";
+				return make_pair("%-I:%M %p on %b %-d, %Y", "%#I:%M %p on %b %#d, %Y");
 			case Preferences::DateFormat::DMY:
 			default:
-				return "%I:%M %p on %d %b %Y";
+				return make_pair("%-I:%M %p on %-d %b %Y", "%#I:%M %p on %#d %b %Y");
 		}
 	}
 
 	// Convert a time_t to a human-readable time and date.
 	string TimestampString(time_t timestamp)
 	{
-		const char *format = TimestampFormatString(Preferences::GetDateFormat());
+		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
 		stringstream ss;
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
 		tm date;
 		localtime_s(&date, &timestamp);
-		ss << std::put_time(&date, format);
+		ss << std::put_time(&date, format.second);
 #else
 		const tm *date = localtime(&timestamp);
-		ss << std::put_time(date, format);
+		ss << std::put_time(date, format.first);
 #endif
 		return ss.str();
 	}


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #9971.

## Summary
This fixes the format strings for the date/time, as the program that interpreted the date/time format was changed but the format strings weren’t.

## Screenshots
Before commit 3f890aa4c343b974d120879d7408d77dbb43540a
![image](https://github.com/endless-sky/endless-sky/assets/109186806/7125615a-0a00-4875-b4af-90c3f506e92b)
After commit 3f890aa4c343b974d120879d7408d77dbb43540a
![image](https://github.com/endless-sky/endless-sky/assets/109186806/ce686210-97c1-442a-b2dc-cfe11ef2645e)
After this commit:
![image](https://github.com/endless-sky/endless-sky/assets/109186806/7125615a-0a00-4875-b4af-90c3f506e92b)


## Testing Done
Tested that the issue was no longer present (linux, windows through WINE)

## Save File
This save file can be used to test these changes:
Any save file will work. Here, take one: [Test Pilot.txt](https://github.com/endless-sky/endless-sky/files/14898702/Test.Pilot.txt)

## Performance Impact
None