### PR TITLE
fix(content): Clarify FS27 description

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -1927,7 +1927,7 @@ ship "Far Osk 27"
 	gun 13 -8
 	explode "tiny explosion" 25
 	explode "small explosion" 15
-	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support weaponry than any comparable human ship."
+	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support more weaponry than any comparable human ship."
 	description "	Fighters do not come equipped with a hyperdrive. You cannot carry a fighter unless you have a ship in your fleet with a fighter bay."
 
 

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -1927,7 +1927,7 @@ ship "Far Osk 27"
 	gun 13 -8
 	explode "tiny explosion" 25
 	explode "small explosion" 15
-	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support far weaponry than any comparable human ship."
+	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support weaponry than any comparable human ship."
 	description "	Fighters do not come equipped with a hyperdrive. You cannot carry a fighter unless you have a ship in your fleet with a fighter bay."
 
 

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -1927,7 +1927,7 @@ ship "Far Osk 27"
 	gun 13 -8
 	explode "tiny explosion" 25
 	explode "small explosion" 15
-	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to carry far more weaponry than any comparable human ship."
+	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support far weaponry than any comparable human ship."
 	description "	Fighters do not come equipped with a hyperdrive. You cannot carry a fighter unless you have a ship in your fleet with a fighter bay."
 
 

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -1927,7 +1927,7 @@ ship "Far Osk 27"
 	gun 13 -8
 	explode "tiny explosion" 25
 	explode "small explosion" 15
-	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support more weaponry than any comparable human ship."
+	description "Because it is piloted by a computer and has no need for a cockpit or life support systems, the FS27 fighter is able to support a thicker hull, more shields, and more powerful guns than any comparable human ship."
 	description "	Fighters do not come equipped with a hyperdrive. You cannot carry a fighter unless you have a ship in your fleet with a fighter bay."
 
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the issue described in issue #9957.

## Summary
Zitchas pointed out that the description of the FS27 implied that it would have far more weapon space than human fighters. While at the time the description was made, it had more weapon space, now this implication would be inaccurate. As suggested by @xX-Dillinger-Xx and @warp-core, I have opted to change the description to be more clear. Though I am not sold on this new description either, I still think it is an improvement, and this way the issue won’t be forgotten about.

## Testing Done
TBD: Check that the description is actually changed

## Save File
This save file can be used to test these changes: I can’t provide any save files that don’t require a plugin (omnis or all content), so you’ll have to just read the description yourself.