### PR TITLE
Link GLEW::glew instead of GLEW::GLEW in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ else()
 		target_compile_definitions(EndlessSkyLib PUBLIC GL_SILENCE_DEPRECATION)
 	else()
 		# GLEW is only needed on Linux and Windows.
-		target_link_libraries(ExternalLibraries INTERFACE GLEW::GLEW)
+		target_link_libraries(ExternalLibraries INTERFACE GLEW::glew)
 	endif()
 endif()
 


### PR DESCRIPTION
**CI/CD/Testing**

My Nix setup shits itself if `GLEW::GLEW` is used, for some reason.

From my understanding, `GLEW::GLEW` just uses `GLEW::glew` anyways if we're not statically linking glew, which I'm _pretty_ sure we aren't ever doing.

Pinging @quyykk for build-related stuff