### PR TITLE
Fix(content): Remove outfit scanning capabilities from Grey's person ship

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -1789,8 +1789,6 @@ ship "Modified Ladybug"
 		"ramscoop" 0.5
 		"cargo scan power" 5
 		"cargo scan efficiency" 16
-		"outfit scan power" 17
-		"outfit scan efficiency" 15
 		"tactical scan power" 25
 		"atmosphere scan" 100
 		"asteroid scan power" 30


### PR DESCRIPTION
**Bug fix (sort of)**

This PR addresses the issue described in discussion #9974, specifically @MasterOfGrey's comment at https://github.com/endless-sky/endless-sky/discussions/9974#discussioncomment-9065672

## Summary
Removed outfit scanning power and efficiency from the Modified Ladybug, to prevent it from doing outfit scans. Kept other scanning attributes.

## Testing Done
None

## Save File
N/A
