### PR TITLE
fix(content): Block Lunarium: Questions from finishing if you are assiting the heliarchs and explain why

### DIFF
--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1856,6 +1856,8 @@ mission "Lunarium: Questions"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 		not "assisting lunarium"
+	to complete
+		not "assisting heliarchy"
 	to fail
 		or
 			has "joined the heliarchs"
@@ -1865,6 +1867,8 @@ mission "Lunarium: Questions"
 			`As you prepare to land on <origin>, your monitor starts producing a low hum, stops, then starts again. This keeps up for nearly a minute until a message pops up. "Captain <last>, come to trust you our comrades have, thanks to your consistent help to our cause. Interested we are in your continuous support, so that free the Coalition, together we can. Come to <destination> you must. Meet with you, our leaders will, so that discuss an important task with them, you may. Have an available bunk in your ship, you should."`
 			`	The message cuts off shortly after you finish reading it. Your monitor is back to normal, and no humming sound can be heard. You mark <planet> on your map.`
 				accept
+	on visit
+		dialog `You are currently assisting the Heliarchy. Cancel or finish any missions you have for them if you want to join the Lunarium.`
 
 mission "Lunarium: Quarg Interview"
 	name "The Interview"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 by Arachi-Lover
+# qCopyright (c) 2022 by Arachi-Lover
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1,4 +1,4 @@
-# qCopyright (c) 2022 by Arachi-Lover
+# Copyright (c) 2022 by Arachi-Lover
 #
 # Endless Sky is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1227755770750177360).

## Summary
In https://github.com/endless-sky/endless-sky/commit/2cc4256f2aea1943f772ae5cf87df48babd34412, I fixed an issue where the Heliarch join mission would silently disappear if you were assisting the Lunarium and landed on Ring of Friendship, but I didn’t fix the same issue on the Lunarium side. This PR fixes that.

## Screenshots
![image](https://github.com/endless-sky/endless-sky/assets/109186806/607fbd84-1ab8-4b27-a80d-5a3f1d907ea6)

## Testing Done
Tested that the Lunarium meeting mission was postponed with a pop-up instead of disappearing.

## Save File
This save file can be used to test these changes: [Dag Roth.txt](https://github.com/endless-sky/endless-sky/files/14939925/Dag.Roth.txt)
Thanks @Dagroth1 
