### PR TITLE
Reduce combat rating kestrel.txt

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -16,6 +16,9 @@ mission "Kestrel Testing"
 	description "Travel to the <waypoints> system to fight and disable a prototype warship that Tarazed Corporation is testing. Do not destroy the ship, or you will lose your payment and your opportunity to buy one."
 	source "Wayfarer"
 	waypoint "Umbral"
+	# The Kestrel is a secret that can only be unlocked after completing the rest of the game. Combat rating is used to track gameplay progression.
+	# After finding the Kestrel once, the threshold is lowered so players can use the ship during the human campaign on a later playthrough.
+	# Any requests to reduce the requirements will be rejected.
 	to offer
 		or
 			"combat rating" > 6000

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -18,7 +18,7 @@ mission "Kestrel Testing"
 	waypoint "Umbral"
 	to offer
 		or
-			"combat rating" > 8000
+			"combat rating" > 6000
 			and
 				"combat rating" > 2000
 				has "global: unlocked kestrel"


### PR DESCRIPTION
**Balance**

This PR addresses the bug/feature described in discussion https://github.com/endless-sky/endless-sky/discussions/9980

## Summary
Simply reduces the combat rating required for the Kestrel mission to trigger from 8000 >> 6000.

I think the Kestrel mission comes too late. I don't agree with Saugia's comment on https://github.com/endless-sky/endless-sky/pull/8578#issuecomment-1484178674 that "It's not designed to be rewarding to the player in a progressive way based on their place in campaigns or combat in the game." Why not? It's a nice combat ship progression from a Falcon/Leviathan, a nice alternative to a Bactrian, and is still outclassed by the various alien ships the player will gain access to. 

Waiting until a combat rating of 8K basically guarantees the ship will be a fairly useless novelty, which I think is a waste.

Even if a new player has a combat rating of 6K then they still have to find the mission on Tarazad.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
none

## Save File
Any pilot above 6K combat rating

## Artwork Checklist
n/a

## Performance Impact
n/a
