### PR TITLE
fix(content): Add back instances of "ser" and explain what it means in the Skadenga and Stones of Our Fathers missions

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -110,12 +110,18 @@ planet "Sies Upi"
 					to display
 						has "Stone of our Fathers: ser"
 						not "Stone of our Fathers: ser 2"
+						not "Stone of our Fathers: ser 3"
+				`	"Is 'ser' different from 'sir'?"`
+					goto "ser 3"
 				clear "Stone of our Fathers: ser"
 				clear "Stone of our Fathers: ser 2"
+				clear "Stone of our Fathers: ser 3"
 			label ser
 				set "Stone of our Fathers: ser"
 			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
 			label "ser 2"
 				set "Stone of our Fathers: ser 2"
 			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn.`
-
+			label "ser 3"
+				set "Stone of our Fathers: ser 3"
+			`	The old man gives you a gruff nod and says, "Ah, I see. Can be confusing for a newcomer, I s'pose. What's 'tween a fella's legs gots nothing to do with it. Just like I said before, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -105,8 +105,17 @@ planet "Sies Upi"
 				`	"Why are you calling me 'ser'?"`
 					goto ser
 						not "Stone of our Fathers: ser"
+				`	"Does 'ser' just apply to men?"`
+					goto "ser 2"
+					to display
+						has "Stone of our Fathers: ser"
+						not "Stone of our Fathers: ser 2"
 				clear "Stone of our Fathers: ser"
+				clear "Stone of our Fathers: ser 2"
 			label ser
 				set "Stone of our Fathers: ser"
 			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
+			label "ser 2"
+				set "Stone of our Fathers: ser 2"
+			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`
 

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -43,7 +43,6 @@
 		"Diamond Grey"
 		"Grey Wolf"
 				`	"The Grey Goose."`
-			`	He stops and frowns. "Look at me, rambling like an ol' man. Ser, Captain, I'd like to pay you <payment> to take me home, to <destination>."`
 			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`
 			`	Cygnet strokes his mustache. "Tod Copper. Tod Copper. Tell you what, that name doesn' ring a bell. Heck, I don' even keep track of names 'less I get someone impor'ant. If ya lookin' for someone in particular to buy, can I get a description?"`
 					goto shotdown
@@ -53,12 +52,6 @@
 		"oder"
 		" Grat"
 			`	"Fantastic, you understand the situation," she says, though her tone is much more businesslike than the wording would imply. "In that case, if you could please take this to Earth and communicate with your various governments we can begin a dialogue on how best to deal with this current scenario."`
-			`	"Hello, ser! I hope you've been enjoying your stay in our state of the art spaceport! But why stay cooped up in here, when you could be out there?" She gestures toward the windows.`
-			`	"So ser," she continues, "what do you say? Should I sign you up for the VIP Winter-Wonder Excursion Package for a special time limited-only offer of 2,000 credits?"`
-			`	The woman frowns, but nods knowingly. "I am afraid, ser, most seem to think the way you do. Still, if you ever run into anyone out there who might be interested, let them know. We could really use the work." With that, she turns and walks briskly back to her booth.`
-			`	The woman's face lights up, and you get the sense that she isn't used to hearing "yes" very often. "Oh, that is wonderful ser, just wonderful!"`
-			`	She puts her finger to her ear and says, "Hjlod, we have a customer! Get the crawler warmed up!" The woman then drops her hand and waves to you. "Right this way, ser! And might I add - you will not be disappointed." She chatters excitedly about the cultural, artistic and scientific merits of the trip as she leads you toward a large pressure hatch.`
-			`	The woman's face, red with the cold, looks crest-fallen, but unsurprised, like she was half expecting this outcome. "Brunhilda can be an... intimidating vehicle, it's true. But she is safe ser, I assure you. Either way, I'll take you back to the spaceport."`
 			`	The uneventful journey to the boiling ice river of Slidr is suddenly interrupted when a deep tremor followed by a thunderous boom shakes the Ice-Crawler to its core and causes it to slip on the disturbed ice and snow. Somewhere outside, subsequent rumble starts to build rapidly. After Hjlod regains control of the crawler, she immediately veers away from the noise. "That vas Nifel-quake, and loud noise was avalanche, or landslide, maybe both. This is not good."`
 			`	By the time you are on your feet, Hjlod has already gathered up numerous supplies and is preparing to open the hatch and dig her way to the surface. She looks at you. "Nothing to vorry about. Happens all time. Vell, not really. First time this happen, but Hjlod not let you die, probably. I can lead us to settlement not far from here."`
 			`	Hjlod abruptly stops and glares at you. "You are fool. You vill certainly die, and you endanger me in process. This is no game, valk only vhere I valk or die."`
@@ -102,26 +95,3 @@ planet "Sies Upi"
 		log "Minor People" "Torrey and Irene" `Torrey Dupont, an activist, is friends with SMDP militia NCO Irene Brower. You delivered a package for them.`
 		"Brin"
 		"exis"
-				`	"Why are you calling me 'ser'?"`
-					goto ser
-						not "Stone of our Fathers: ser"
-				`	"Does 'ser' just apply to men?"`
-					goto "ser 2"
-					to display
-						has "Stone of our Fathers: ser"
-						not "Stone of our Fathers: ser 2"
-						not "Stone of our Fathers: ser 3"
-				`	"Is 'ser' different from 'sir'?"`
-					goto "ser 3"
-				clear "Stone of our Fathers: ser"
-				clear "Stone of our Fathers: ser 2"
-				clear "Stone of our Fathers: ser 3"
-			label ser
-				set "Stone of our Fathers: ser"
-			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
-			label "ser 2"
-				set "Stone of our Fathers: ser 2"
-			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn.`
-			label "ser 3"
-				set "Stone of our Fathers: ser 3"
-			`	The old man gives you a gruff nod and says, "Ah, I see. Can be confusing for a newcomer, I s'pose. What's 'tween a fella's legs gots nothing to do with it. Just like I said before, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -102,3 +102,10 @@ planet "Sies Upi"
 		log "Minor People" "Torrey and Irene" `Torrey Dupont, an activist, is friends with SMDP militia NCO Irene Brower. You delivered a package for them.`
 		"Brin"
 		"exis"
+				`	"Why are you calling me 'ser'?"`
+					goto ser
+						not "Stone of our Fathers: ser"
+				clear "Stone of our Fathers: ser"
+				set "Stone of our Fathers: ser"
+			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
+

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -43,6 +43,7 @@
 		"Diamond Grey"
 		"Grey Wolf"
 				`	"The Grey Goose."`
+			`	He stops and frowns. "Look at me, rambling like an ol' man. Ser, Captain, I'd like to pay you <payment> to take me home, to <destination>."`
 			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`
 			`	Cygnet strokes his mustache. "Tod Copper. Tod Copper. Tell you what, that name doesn' ring a bell. Heck, I don' even keep track of names 'less I get someone impor'ant. If ya lookin' for someone in particular to buy, can I get a description?"`
 					goto shotdown
@@ -52,6 +53,12 @@
 		"oder"
 		" Grat"
 			`	"Fantastic, you understand the situation," she says, though her tone is much more businesslike than the wording would imply. "In that case, if you could please take this to Earth and communicate with your various governments we can begin a dialogue on how best to deal with this current scenario."`
+			`	"Hello, ser! I hope you've been enjoying your stay in our state of the art spaceport! But why stay cooped up in here, when you could be out there?" She gestures toward the windows.`
+			`	"So ser," she continues, "what do you say? Should I sign you up for the VIP Winter-Wonder Excursion Package for a special time limited-only offer of 2,000 credits?"`
+			`	The woman frowns, but nods knowingly. "I am afraid, ser, most seem to think the way you do. Still, if you ever run into anyone out there who might be interested, let them know. We could really use the work." With that, she turns and walks briskly back to her booth.`
+			`	The woman's face lights up, and you get the sense that she isn't used to hearing "yes" very often. "Oh, that is wonderful ser, just wonderful!"`
+			`	She puts her finger to her ear and says, "Hjlod, we have a customer! Get the crawler warmed up!" The woman then drops her hand and waves to you. "Right this way, ser! And might I add - you will not be disappointed." She chatters excitedly about the cultural, artistic and scientific merits of the trip as she leads you toward a large pressure hatch.`
+			`	The woman's face, red with the cold, looks crest-fallen, but unsurprised, like she was half expecting this outcome. "Brunhilda can be an... intimidating vehicle, it's true. But she is safe ser, I assure you. Either way, I'll take you back to the spaceport."`
 			`	The uneventful journey to the boiling ice river of Slidr is suddenly interrupted when a deep tremor followed by a thunderous boom shakes the Ice-Crawler to its core and causes it to slip on the disturbed ice and snow. Somewhere outside, subsequent rumble starts to build rapidly. After Hjlod regains control of the crawler, she immediately veers away from the noise. "That vas Nifel-quake, and loud noise was avalanche, or landslide, maybe both. This is not good."`
 			`	By the time you are on your feet, Hjlod has already gathered up numerous supplies and is preparing to open the hatch and dig her way to the surface. She looks at you. "Nothing to vorry about. Happens all time. Vell, not really. First time this happen, but Hjlod not let you die, probably. I can lead us to settlement not far from here."`
 			`	Hjlod abruptly stops and glares at you. "You are fool. You vill certainly die, and you endanger me in process. This is no game, valk only vhere I valk or die."`

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -106,6 +106,7 @@ planet "Sies Upi"
 					goto ser
 						not "Stone of our Fathers: ser"
 				clear "Stone of our Fathers: ser"
+			label ser
 				set "Stone of our Fathers: ser"
 			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
 

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -95,3 +95,5 @@ planet "Sies Upi"
 		log "Minor People" "Torrey and Irene" `Torrey Dupont, an activist, is friends with SMDP militia NCO Irene Brower. You delivered a package for them.`
 		"Brin"
 		"exis"
+			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn.`
+			`	The old man gives you a gruff nod and says, "Ah, I see. Can be confusing for a newcomer, I s'pose. What's 'tween a fella's legs gots nothing to do with it. Just like I said before, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -117,5 +117,5 @@ planet "Sies Upi"
 			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
 			label "ser 2"
 				set "Stone of our Fathers: ser 2"
-			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`
+			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn.`
 

--- a/.codespell.words.exclude
+++ b/.codespell.words.exclude
@@ -1,3 +1,4 @@
 aesthetic
 aesthetics
 aesthetically
+ser

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2472,27 +2472,47 @@ mission "Stone of our Fathers 1"
 			`Helheim's spaceport has all the constant hustle and bustle of a boomtown. It's dirty, lively, and packed with workers. As you walk through the spaceport, an aged man in a worn and weathered roustabout jacket waves his arm toward you and approaches you.`
 			`	"You've got the look of one who knows a ship inside and out," he says. "Name's Skaldgar, ain't much for ships; earth, soil, and rock are my domain. But I do got a need to travel." He pauses as a wistful look briefly passes over his face. "I left, you see, decades ago. No goodbye. No note. Just... left. Living with others, taking care of others, hard on a man like me. I like solitude, peace, and work. But now my bones are brittle: the radiation, earth-rot as we call it, has taken hold and my time is running out. And I find, I don't want to be alone anymore."`
 			`	He stops and frowns. "Look at me, rambling like an ol' man. Ser, Captain, I'd like to pay you <payment> to take me home, to <destination>."`
+			label choice
 			choice
 				`	"If you have coin, I have room."`
 				`	"I guess I can take a small detour."`
+				`	"Why are you calling me 'ser'?"`
+					goto ser
+					to display
+						not "Stone of our Fathers: ser"
 				`	(Shake my head. I have better things to do than bus old men around.)`
 					goto decline
+
+			action
+				clear "Stone of our Fathers: ser"
 			`	He nods, grunts, and heads to your ship with a small knapsack cradled under his arm, clearly ready to travel to <planet> at a moment's notice.`
 				accept
+
+			label ser
+			action
+				set "Stone of our Fathers: ser"
+			`	"You're not from around here, are ya? Ser's just what decent folk call each other in the Deep. Sign of respect and the like. Though I am hearing it less and less these days. Old ways being forgotten, but ain't that the way of things?"`
+			`	He pauses for a moment as if reflecting on this, then says, "Well, what do you say? <payment> for transportation to <planet>?"`
+				goto choice
+
 			label decline
+			action
+				clear "Stone of our Fathers: ser"
 			`	With a disappointed look on his face, he nods once and slides back into the endless sea of people.`
 				decline
+
 	on visit
 		dialog `You have reached <planet>, but your escort carrying Skaldgar has not arrived! Better depart and wait for your escorts to arrive in this star system.`
+
 	on complete
 		payment 15000
 		event "Stone waiting" 30
 		dialog `Skaldgar is as clean as you've seen him: scrubbed, shaved and wearing clothes that are respectable, if a few decades out of style. His eyes glisten, and he turns to you.`
 			`	"I've made a lot of mistakes in my life. Comin' home, even if I'm hated - or worse, forgotten - ain't one of them. Thank ya kindly for the passage."`
 			`	You wish the old codger a joyful homecoming, and watch as he disappears into the sleepy spaceport.`
-		
-event "Stone waiting"
 
+
+event "Stone waiting"
 
 
 mission "Stone of our Fathers 2"

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2485,20 +2485,17 @@ mission "Stone of our Fathers 1"
 					to display
 						has "Stone of our Fathers: ser"
 						not "Stone of our Fathers: ser 2"
-						not "Stone of our Fathers: ser 3"
 				`	"Is 'ser' different from 'sir'?"`
 					goto "ser 3"
 					to display
 						has "Stone of our Fathers: ser"
 						not "Stone of our Fathers: ser 2"
-						not "Stone of our Fathers: ser 3"
 				`	(Shake my head. I have better things to do than bus old men around.)`
 					goto decline
 
 			action
 				clear "Stone of our Fathers: ser"
 				clear "Stone of our Fathers: ser 2"
-				clear "Stone of our Fathers: ser 3"
 			`	He nods, grunts, and heads to your ship with a small knapsack cradled under his arm, clearly ready to travel to <planet> at a moment's notice.`
 				accept
 
@@ -2517,7 +2514,7 @@ mission "Stone of our Fathers 1"
 
 			label "ser 3"
 			action
-				set "Stone of our Fathers: ser 3"
+				set "Stone of our Fathers: ser 2"
 			`	The old man gives you a gruff nod and says, "Ah, I see. Can be confusing for a newcomer, I s'pose. What's 'tween a fella's legs gots nothing to do with it. Just like I said before, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`
 
 			label "back to the point"
@@ -2528,7 +2525,6 @@ mission "Stone of our Fathers 1"
 			action
 				clear "Stone of our Fathers: ser"
 				clear "Stone of our Fathers: ser 2"
-				clear "Stone of our Fathers: ser 3"
 			`	With a disappointed look on his face, he nods once and slides back into the endless sea of people.`
 				decline
 

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2485,12 +2485,20 @@ mission "Stone of our Fathers 1"
 					to display
 						has "Stone of our Fathers: ser"
 						not "Stone of our Fathers: ser 2"
+						not "Stone of our Fathers: ser 3"
+				`	"Is 'ser' different from 'sir'?"`
+					goto "ser 3"
+					to display
+						has "Stone of our Fathers: ser"
+						not "Stone of our Fathers: ser 2"
+						not "Stone of our Fathers: ser 3"
 				`	(Shake my head. I have better things to do than bus old men around.)`
 					goto decline
 
 			action
 				clear "Stone of our Fathers: ser"
 				clear "Stone of our Fathers: ser 2"
+				clear "Stone of our Fathers: ser 3"
 			`	He nods, grunts, and heads to your ship with a small knapsack cradled under his arm, clearly ready to travel to <planet> at a moment's notice.`
 				accept
 
@@ -2505,6 +2513,14 @@ mission "Stone of our Fathers 1"
 			action
 				set "Stone of our Fathers: ser 2"
 			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn.`
+				goto "back to the point"
+
+			label "ser 3"
+			action
+				set "Stone of our Fathers: ser 3"
+			`	The old man gives you a gruff nod and says, "Ah, I see. Can be confusing for a newcomer, I s'pose. What's 'tween a fella's legs gots nothing to do with it. Just like I said before, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`
+
+			label "back to the point"
 			`	"Now, I'd like to know whether you can take me to <planet>."`
 				goto choice
 
@@ -2512,6 +2528,7 @@ mission "Stone of our Fathers 1"
 			action
 				clear "Stone of our Fathers: ser"
 				clear "Stone of our Fathers: ser 2"
+				clear "Stone of our Fathers: ser 3"
 			`	With a disappointed look on his face, he nods once and slides back into the endless sea of people.`
 				decline
 

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2471,7 +2471,7 @@ mission "Stone of our Fathers 1"
 		conversation
 			`Helheim's spaceport has all the constant hustle and bustle of a boomtown. It's dirty, lively, and packed with workers. As you walk through the spaceport, an aged man in a worn and weathered roustabout jacket waves his arm toward you and approaches you.`
 			`	"You've got the look of one who knows a ship inside and out," he says. "Name's Skaldgar, ain't much for ships; earth, soil, and rock are my domain. But I do got a need to travel." He pauses as a wistful look briefly passes over his face. "I left, you see, decades ago. No goodbye. No note. Just... left. Living with others, taking care of others, hard on a man like me. I like solitude, peace, and work. But now my bones are brittle: the radiation, earth-rot as we call it, has taken hold and my time is running out. And I find, I don't want to be alone anymore."`
-			`	He stops and frowns. "Look at me, rambling like an ol' man. Captain, I'd like to pay you <payment> to take me home, to <destination>."`
+			`	He stops and frowns. "Look at me, rambling like an ol' man. Ser, Captain, I'd like to pay you <payment> to take me home, to <destination>."`
 			choice
 				`	"If you have coin, I have room."`
 				`	"I guess I can take a small detour."`
@@ -2787,20 +2787,20 @@ mission "Home for Skadenga 1"
 			`There is a feeling of deep melancholy in the nearly deserted spaceport. A few plaques adorn the walls, proudly boasting of earlier times when Nifel was a place of relevance in the galactic community. Most are old images of researchers and doctors and their miracle cures.`
 			`	But now this place is a ghost-town, and you walk its empty halls unsure of why you even bothered to explore it in the first place.`
 			`	You turn a corner and find a woman standing near a booth with blown up images of ice-covered scenery. She waves at you excitedly.`
-			`	"Hello, Captain! I hope you've been enjoying your stay in our state of the art spaceport! But why stay cooped up in here, when you could be out there?" She gestures toward the windows.`
+			`	"Hello, ser! I hope you've been enjoying your stay in our state of the art spaceport! But why stay cooped up in here, when you could be out there?" She gestures toward the windows.`
 			`	"Explore the breath-taking Glaesisvellir ice-plains, or the boiling Slidr river. We'll even take you to the Hrimbrimr valley where the famous Rigellian cure was discovered!`
-			`	"So Captain," she continues, "what do you say? Should I sign you up for the VIP Winter-Wonder Excursion Package for a special time limited-only offer of 2,000 credits?"`
+			`	"So ser," she continues, "what do you say? Should I sign you up for the VIP Winter-Wonder Excursion Package for a special time limited-only offer of 2,000 credits?"`
 			choice
 				`	"Sure, I'd love to see more of this world."`
 					goto excursion
 				`	"No, uh, thanks. Freezing to death in the frigid tundra doesn't sound like a good time to me."`
-			`	The woman frowns, but nods knowingly. "I am afraid, Captain, most seem to think the way you do. Still, if you ever run into anyone out there who might be interested, let them know. We could really use the work." With that, she turns and walks briskly back to her booth.`
+			`	The woman frowns, but nods knowingly. "I am afraid, ser, most seem to think the way you do. Still, if you ever run into anyone out there who might be interested, let them know. We could really use the work." With that, she turns and walks briskly back to her booth.`
 				decline
 			label excursion
 			action
 				payment -2000
-			`	The woman's face lights up, and you get the sense that she isn't used to hearing "yes" very often. "Oh, that is wonderful Captain, just wonderful!"`
-			`	She puts her finger to her ear and says, "Hjlod, we have a customer! Get the crawler warmed up!" The woman then drops her hand and waves to you. "Right this way, Captain! And might I add - you will not be disappointed." She chatters excitedly about the cultural, artistic and scientific merits of the trip as she leads you toward a large pressure hatch.`
+			`	The woman's face lights up, and you get the sense that she isn't used to hearing "yes" very often. "Oh, that is wonderful ser, just wonderful!"`
+			`	She puts her finger to her ear and says, "Hjlod, we have a customer! Get the crawler warmed up!" The woman then drops her hand and waves to you. "Right this way, ser! And might I add - you will not be disappointed." She chatters excitedly about the cultural, artistic and scientific merits of the trip as she leads you toward a large pressure hatch.`
 			`	She hits a switch and the hatch opens; she then escorts you into a frigid maintenance dock. A loud, ugly vehicle is whirring at the center of a mess of broken and discarded parts. "There she is!" The woman is nearly shouting as she speaks over the mechanical hum. "We call her Brunhilda, the Queen of the Ice, a most.. durable vehicle, capable of giving you an authentic ice-explorer experience!"`
 			`	The Ice-Crawler, Brunhilda, looks less than dependable to you. It appears to be a run-down, mishmash of parts and jury-rigged technology forced onto a three century old Ice-Crawler, probably used by the original colonists.`
 			choice
@@ -2818,7 +2818,7 @@ mission "Home for Skadenga 1"
 				`	(Key my signature.)`
 					goto yolo
 				`	"I've changed my mind. I am going to pass on this excursion."`
-			`	The woman's face, red with the cold, looks crest-fallen, but unsurprised, like she was half expecting this outcome. "Brunhilda can be an... intimidating vehicle, it's true. But she is safe Captain, I assure you. Either way, I'll take you back to the spaceport."`
+			`	The woman's face, red with the cold, looks crest-fallen, but unsurprised, like she was half expecting this outcome. "Brunhilda can be an... intimidating vehicle, it's true. But she is safe ser, I assure you. Either way, I'll take you back to the spaceport."`
 			`	With that, you follow the woman back to the warm and nearly empty spaceport, where she leaves you to return to her forlorn booth.`
 				decline
 			label yolo

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2504,7 +2504,8 @@ mission "Stone of our Fathers 1"
 			label "ser 2"
 			action
 				set "Stone of our Fathers: ser 2"
-			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`
+			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn.`
+			`	"Now, I'd like to know whether you can take me to <planet>."`
 				goto choice
 
 			label decline

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2480,11 +2480,17 @@ mission "Stone of our Fathers 1"
 					goto ser
 					to display
 						not "Stone of our Fathers: ser"
+				`	"Does 'ser' just apply to men?"`
+					goto "ser 2"
+					to display
+						has "Stone of our Fathers: ser"
+						not "Stone of our Fathers: ser 2"
 				`	(Shake my head. I have better things to do than bus old men around.)`
 					goto decline
 
 			action
 				clear "Stone of our Fathers: ser"
+				clear "Stone of our Fathers: ser 2"
 			`	He nods, grunts, and heads to your ship with a small knapsack cradled under his arm, clearly ready to travel to <planet> at a moment's notice.`
 				accept
 
@@ -2495,9 +2501,16 @@ mission "Stone of our Fathers 1"
 			`	He pauses for a moment as if reflecting on this, then says, "Well, what do you say? <payment> for transportation to <planet>?"`
 				goto choice
 
+			label "ser 2"
+			action
+				set "Stone of our Fathers: ser 2"
+			`	The old man narrows his eyes at you and his mouth falls slightly open like he's trying to make sense of a puzzle. Finally he says, "What's the bits between a fella's legs gotta do with anything? I already said, 'Ser' is just what decent folk call each other; ain't nothing more to it. Don't matter if you're a guy, gal, or anything else. Hel, I reckon I'd even call an elf 'Ser' if they done me a good turn."`
+				goto choice
+
 			label decline
 			action
 				clear "Stone of our Fathers: ser"
+				clear "Stone of our Fathers: ser 2"
 			`	With a disappointed look on his face, he nods once and slides back into the endless sea of people.`
 				decline
 


### PR DESCRIPTION
**Content fix**
This PR addresses something SpearDane brought up while we were working on Saga's Saga.

## Summary
In #9622 all instances of "ser" were changed to "Captain" to make the dialogue more gender neutral (as the captain is never given a gender, being an extension of the player). However, "ser" is actually used in literature as a gender neutral form of address, and is not to be confused with "sir". It is meant to be used in the Deep somewhat regularly, but "especially by more traditional communities".

See: https://en.wiktionary.org/wiki/ser#English