### PR TITLE
fix(map ui): Draw distance to the selected system after mission markers

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -319,13 +319,15 @@ void MapPanel::Draw()
 	DrawSystems();
 	DrawNames();
 	DrawMissions();
-	DrawSelectedSystem();
 }
 
 
 
 void MapPanel::FinishDrawing(const string &buttonCondition)
 {
+	// Display the name of and distance to the selected system.
+	DrawSelectedSystem();
+
 	// Draw the buttons to switch to other map modes.
 
 	// Remember which buttons we're showing.
@@ -1210,7 +1212,7 @@ void MapPanel::DrawTravelPlan()
 
 
 
-// Fill in the top-middle header bar that names the selected system, and indicates its distance.
+// Display the name of and distance to the selected system.
 void MapPanel::DrawSelectedSystem()
 {
 	const Sprite *sprite = SpriteSet::Get("ui/selected system");

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -75,7 +75,9 @@ public:
 	virtual void Step() override;
 	virtual void Draw() override;
 
-	// Draw map mode buttons, escort/storage tooltips, and the non-routable system warning.
+	// Draw elements common for all map panels that need to be placed
+	// on top of everything else. This includes distance info, map mode buttons,
+	// escort/storage tooltips, and the non-routable system warning.
 	void FinishDrawing(const std::string &buttonCondition);
 
 	static void DrawMiniMap(const PlayerInfo &player, float alpha, const System *const jump[2], int step);


### PR DESCRIPTION
**Bug fix**

## Summary
Moved DrawSelectedSystem from MapPanel::Draw to MapPanel::FinishDrawing to fix MissionPanel's rings overlapping with the distance info box. Also updated the comment of DrawSelectedSystem to match its comment in the header file.

## Screenshots
Before:
![3](https://github.com/endless-sky/endless-sky/assets/108272452/293bd6b4-34f2-48fa-939a-20de5596c5ea)
After:
![4](https://github.com/endless-sky/endless-sky/assets/108272452/8e618882-f0d1-4ab1-9eea-8455a225b0ac)

## Testing Done
See the screenshots above.

## Performance Impact
N/A
