### PR TITLE
feat(content): Add some additional mentions of how Tele'ek's Molt is progressing to the last few missions in Wanderers Middle

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3137,7 +3137,7 @@ mission "Wanderers: Sestor: Factory 1"
 				`	"Are you sure that they really want peace? They aren't trying to trick you?"`
 			`	Rek says, "It is hard to be sure. Their culture is very different from the Kor Efret; even some of their language and gestures are new to me. But they have behaved peacefully toward us so far; we must hope that their peacefulness continues."`
 			label next
-			`	Tele'ek says, "You must bring the [exile, outcast] ships to <planet> and keep them from being destroyed by the drones [along the way?]. There, they will [attempt, accomplish] what they have promised, and shut down the factories. Your only role will be to [shield, protect] them, and we will give you some of our warships to [assist, accompany] you." He gestures with a wing towards a number of Wanderer vessels being loaded with supplies and prepared for battle. You notice a type of weapon you don't recognize mounted on some of them.`
+			`	Tele'ek says, "You must bring the [exile, outcast] ships to <planet> and keep them from being destroyed by the drones [along the way?]. There, they will [attempt, accomplish] what they have promised, and shut down the factories. Your only role will be to [shield, protect] them, and we will give you some of our warships to [assist, accompany] you." He gestures with a straggly, slightly misshapen wing towards a number of Wanderer vessels being loaded with supplies and prepared for battle. You notice a type of weapon you don't recognize mounted on some of them.`
 			choice
 				`	"Are those ships carrying a new type of weapon?"`
 				`	"Sounds like a good plan. Let's get going!"`
@@ -3417,7 +3417,7 @@ mission "Wanderers: Sestor: Final: Patched"
 	on offer
 		event "wanderers: exiles hostile" 4
 		conversation
-			`When you meet with the Wanderer leaders, Sobari Tele'ek tells you, "We have received word from our [scouts, observers] that the Sestor drones are [dwindling, reducing] in numbers and will soon be no more. We owe you our [gratitude, thanks]. But, the Mereti tell us a more worrisome [tale, story]."`
+			`When you meet with the Wanderer leaders, Sobari Tele'ek tells you, "We have received word from our [scouts, observers] that the Sestor drones are [dwindling, reducing] in numbers and will soon be no more. We owe you our [gratitude, thanks]. But, the Mereti tell us a more worrisome [tale, story]." You notice that although he has grown larger, he appears to be having trouble standing upright, and hence his head is at roughly the same height as yours.`
 			`	Meto Pa'aret says, "The Mereti [contacted, communicated with] me and said that one of their stations was [raided, infiltrated] by the Korath exiles, and some of their [machinery, equipment] was stolen. The Mereti did not [fight, attack] the exiles because they thought they were [friends, allies]. Captain <last>, can you bring Rek to visit the [exiles, outcasts] and learn what their plans are?"`
 			choice
 				`	"Sure, I would be glad to."`


### PR DESCRIPTION
**Content**

## Summary
Currently, the last mention we get of Tele'ek's Molt is in `"Wanderers: Sestor: Scan Drones"`, where we get the line "He has lost half of his feathers - his whole face is bare and scaly - but rather than wasting away like Rek he has gained considerable weight, and now towers over you."
After this, there is a whole story arc, including several meetings with Tele'ek, in which this is not mentioned further. With Rek, the progression of his Molt is mentioned almost every time we meet him, but with Tele'ek, it almost seems forgotten.

This PR adds a couple more mentions of how Tele'ek's condition is progressing to the occasions where you meet with him towards the end of Wanderers Middle.