### PR TITLE
Add mention of the CCOR in a FW pirate recon mission

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -980,6 +980,19 @@ mission "FW Pirates 1"
 			
 			label agree
 			`	"So, here's the plan," he says. "These four systems belong to the pirates." He points to them on the map. "We want you to scout out all four systems. Just a quick fly-through, no need to land on their planets. Then report back to us, and we'll decide what our next step will be."`
+				choice
+					`	"Sounds good."`
+						goto leave
+					`	"What about the pirate systems to the north of Men?"`
+			`	Tomek shrugs. "Simply put, those worlds aren't a threat to us right now. From what we can gather, most of the pirate factions there are mainly focused on internal power struggles at the moment rather than piracy in the Rim. Those CCOR guerrillas are more than enough to keep any pirate warlords there busy for the immediate future."`
+				choice
+					`	"CCOR?"`
+						goto ccor
+					`	"Understood."`
+						goto leave
+				label ccor
+			`	Tomek looks suprised. "I assumed you knew. The Confederated Councils of the Outer Rim was a government that sought to practice its own particular flavor of communism outside of Republic influence. They fell around 50 years ago, and their former planets have since been under the control of a mixture of pirate gangs and guerrillas looking to restore the CCOR. I wouldn't worry about them too much - at this point the CCOR is little more than a pirate gang themselves."`
+				label leave
 			`	As you are about to leave, he says, "Oh, one other thing: you've been approved for a salary raise to 2,100 credits. We figure that helping you maintain a slightly larger ship is a worthwhile investment. Congratulations, Captain."`
 				accept
 	


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Added an opportunity for the player to ask Tomek about the former CCOR planets to the north of Men. He then gives a very brief description of them and their history.
This is a small step towards integrating the new ex-CCOR planets into current storylines such as FW, making the CCOR feel more cohesive with the rest of the game's lore. This also gives an opportunity for the player to learn about the CCOR outside of planet and spaceport descriptions.

## Testing Done
TBD
