### PR TITLE
refactor: Separate hiring panel calculations from drawing

### DIFF
--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -85,6 +85,8 @@ bool HiringPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 // Calculate statistics for the flagship and the fleet.
 void HiringPanel::Calculate()
 {
+	info = Information();
+
 	const Ship *flagship = player.Flagship();
 
 	int flagshipBunks = 0;

--- a/source/HiringPanel.h
+++ b/source/HiringPanel.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef HIRING_PANEL_H_
 #define HIRING_PANEL_H_
 
+#include "Information.h"
 #include "Panel.h"
 
 class PlayerInfo;
@@ -39,10 +40,17 @@ protected:
 
 
 private:
+	// Calculate statistics for the flagship and the fleet.
+	void Calculate();
+
+
+private:
 	PlayerInfo &player;
 
 	int maxHire;
 	int maxFire;
+
+	Information info;
 };
 
 


### PR DESCRIPTION
## Summary
There were a few reports on Discord that it's possible to fire so much crew that the flagship is left with less crew members than it requires. I wasn't able to reproduce the bug, but it inspired me to look at the code. I'm not sure if decoupling calculating and drawing will fix this bug, but it definitely won't hurt (currently the values determining how much crew you can hire/fire are recalculated in each frame in `Draw`). So, I added a new `Calculate` function, which is called at construction and when handling hiring/firing crew.

## Testing Done
yes™

## Performance Impact
N/A
