### PR TITLE
(bugfix) Correct indentation in Gohl's mission choices

### DIFF
--- a/data/quarg/quarg missions.txt
+++ b/data/quarg/quarg missions.txt
@@ -391,12 +391,12 @@ mission "Ask Quarg About Coalition Late"
 			choice
 				`	"Is that a threat?"`
 					goto threat
-						to display
-							not "ask quarg coalition late: threat"
+					to display
+						not "ask quarg coalition late: threat"
 				`	"What if I do want to aid the Heliarchs?"`
 					goto aid
-						to display
-							not "ask quarg coalition late: aid"
+					to display
+						not "ask quarg coalition late: aid"
 			label threat
 			action
 				set "ask quarg coalition late: threat"
@@ -416,12 +416,12 @@ mission "Ask Quarg About Coalition Late"
 			choice
 				`	"Will the Quarg help us fight the Heliarchs?"`
 					goto help
-						to display
-							not "ask quarg coalition late: help"
+					to display
+						not "ask quarg coalition late: help"
 				`	"Any tips on how to fight them?"`
 					goto tips
-						to display
-							not "ask quarg coalition late: tips"
+					to display
+						not "ask quarg coalition late: tips"
 			label help
 			action
 				set "ask quarg coalition late: help"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10007

## Summary
Some choices meant to disappear after picking them once (to prevent an infinite loop of the same choice) weren't disappearing.

The `to display` blocks of the choices were indented once further than they should be, which led to this.
This PR simply removes one indent from them.