### PR TITLE
feat(enhancement): Allow the `action` node to accept missions

### DIFF
--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -194,6 +194,8 @@ void GameAction::LoadSingle(const DataNode &child)
 		fail.insert(child.Token(1));
 	else if(key == "fail")
 		failCaller = true;
+	else if(key == "accept" && child.Size() >= 2)
+		accept.insert(child.Token(1));
 	else
 		conditions.Add(child);
 }
@@ -239,6 +241,8 @@ void GameAction::Save(DataWriter &out) const
 		out.Write("fail", name);
 	if(failCaller)
 		out.Write("fail");
+	for(const string &name : accept)
+		out.Write("accept", name);
 
 	conditions.Save(out);
 }

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -92,6 +92,9 @@ private:
 	// When this action is performed, the mission that called this action is failed.
 	bool failCaller = false;
 
+	// When this action is performed, the missions with these names are accepted.
+	std::set<std::string> accept;
+
 	ConditionSet conditions;
 };
 


### PR DESCRIPTION
**Feature**
This PR partly addresses the feature described in #9486

## Summary
Adds a new action, `accept`, which works like this:
```
action
  accept <mission name>
```
It immediately accepts a mission separate to the current mission upon this action node being reached.

## Usage examples
Missions that need different yet predefined NPC fleets immediately after launch:
```
mission "Destroy the Navy?"
	on offer
		conversation
			`You have a nuke and the entire Sol defense fleet is in front of you.`
			choice
				`  (Destroy the fleet.)`
				`  (Don't destroy the fleet.)`
					goto pacifist

			action
				accept "Weak Fleet"
			`You manage to destroy parts of the fleet, but some survive!"`
				launch

			label pacifist
			action
				accept "Full Fleet"
			`Even though you had the opportunity to destroy the entire Sol fleet you inexplicably decide not to. And now they're coming for you!`
				launch

mission "Weak Fleet"
	npc kill
		government "Republic"
		fleet "Small Republic"


mission "Full Fleet"
	npc kill
		government "Republic"
		fleet "Large Republic" 50
```

Missions that need to immediately track deadlines of differing length, which need to be displayed to the player in the mission panel (i.e. events can't be used to track them)
```
mission "Get some stuff"
	on offer
		conversation
			`Can you get me some happy sticks from Albatross and some ringworld shavings from Greenrock? My dealer for happy sticks leaves on the 15th, and my dealer for ringworld shavings goes into hiding on the 27th. (Today is the 2nd.)`
				accept

	on accept
		accept "Happy Sticks"
		accept "Ringworld Shavings"

mission "Happy Sticks"
	description "Get these happy sticks from <destination> before <date>."
	deadline 13
	destination "Albatross"

mission "Ringworld Shavings"
	description "Get some ringworld shavings from <destination> before <date>."
	deadline 25
	destination "Greenrock"
```

And probably more.

## Testing Done
Tested using two basic missions, whereupon accepting the first mission through the conversation screen caused the second mission's conversation screen to appear.

```
mission "Test"
	source
		government "Republic"
	on offer
		conversation
			`Yes or no?`
			choice
				`	"Yes!"`
				`	"No."`
					decline

			action
				accept "Test 2"
			`	Okay.`

mission "Test 2"
	on offer
		conversation
			`If it worked, you should get this message.`
```

Also did the "Get some Stuff" mission and confirmed two missions were accepted.

## Videos
Using the above mission:

https://github.com/endless-sky/endless-sky/assets/115441627/7432330e-8bf0-481b-85b2-6decce559f1d

## Performance Impact
~~Unsure? I don't code.~~ If I've missed something critical, please tell me; if there's a lot to change I'm fine with closing the PR. But on the off chance this is it (lol)...