### PR TITLE
fix: Remove outdated watchdog

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_random_links.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_random_links.txt
@@ -1,3 +1,17 @@
+# Copyright (c) 2023 by Hurleveur
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+
 test-data "link switch"
 	category "savegame"
 	contents

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_random_links.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_random_links.txt
@@ -69,7 +69,6 @@ test "Condition Links"
 		# empty inputs to make time pass
 		input
 			command jump
-		watchdog 12000
 		label firstjump
 		branch firstjump
 			"flagship system: World's End" == 0
@@ -77,7 +76,6 @@ test "Condition Links"
 		# make sure we didn't end up in the wrong system
 		assert
 			"flagship system: Over the Rainbow" == 0
-		watchdog 12000
 		apply
 			"test: flagship system: World's End" = "flagship system: World's End"
 		input


### PR DESCRIPTION
**Bug fix (merged outdated test)**

This PR removes an outdated watchdog which I accidentally merged as part of a rebase/merge of PR #7987

## Summary
Watchdog code was removed from testing in 2023, but I merged an older PR and overlooked the test-failure which I should have seen.

## Testing Done
CI tests are working as expected, but I overlooked a failing CI test.
This PR also goes through CI testing, so I should pay more attention this time.
