### PR TITLE
fix(content): make the <npc> substitution in Wanderers: Mereti: The Plant 5 point to the right npc

### DIFF
--- a/data/wanderer/wanderer missions.txt
+++ b/data/wanderer/wanderer missions.txt
@@ -134,14 +134,6 @@ mission "Wanderers: Mereti: The Plant 5"
 		conversation
 			`The Mereti drones follow you and the <npc> down to the planet, landing nearby. You and Va'ika watch as the plant is carefully, almost ceremoniously, taken and placed in the ground.`
 			`	After the plant has been suitably placed, Va'ika turns to you. "I will stay here for some time to [supervise, observe] the work, but it will soon be time for me to [depart, return] and oversee the healing of other worlds. I thank you most [gratefully, sincerely] for your help, <first>."`
-	npc accompany save
-		government Wanderer
-		personality escort
-		system "Iyech'yek"
-		fleet
-			names "wanderer"
-			variant
-				"Strong Wind"
 	npc
 		government "Kor Mereti"
 		personality timid launching
@@ -150,6 +142,14 @@ mission "Wanderers: Mereti: The Plant 5"
 			names "kor mereti"
 			variant
 				"Model 16" 3
+	npc accompany save
+		government Wanderer
+		personality escort
+		system "Iyech'yek"
+		fleet
+			names "wanderer"
+			variant
+				"Strong Wind"
 
 event "mereti visiting eneremprukt"
 	system eneremprukt

--- a/data/wanderer/wanderer missions.txt
+++ b/data/wanderer/wanderer missions.txt
@@ -159,6 +159,7 @@ event "field of mereti plants"
 
 mission "Wanderers: Mereti: The Plant Epilogue"
 	minor
+	landing
 	invisible
 	source "Sopi Lefarkata"
 	to offer


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature spotted by Arachi

## Summary
The mission should reference the Wanderer ship, not the Mereti ones.

## Testing Done
Played through the mission and read the relevant conversation. Confirmed that the name was a Wanderer-sounding one and not a mereti one.
![image](https://github.com/endless-sky/endless-sky/assets/18634983/b601fc12-1fb0-44fa-8544-3a9dead16c96)
