### PR TITLE
fix(typo): Minor spelling in cognizance (hanger)

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -965,7 +965,7 @@ mission "Remnant: Cognizance 22"
 	on complete
 		payment 250000
 		conversation
-			`You have barely cleared the security perimeter when your commlink chimes twice with a notification of a logistics credit of <payment> being deposited to your account, closely following a message to land on pad 3E5 near the research hanger Taely has been working in.`
+			`You have barely cleared the security perimeter when your commlink chimes twice with a notification of a logistics credit of <payment> being deposited to your account, closely following a message to land on pad 3E5 near the research hangar Taely has been working in.`
 
 
 
@@ -1056,7 +1056,7 @@ mission "Remnant: Cognizance 23"
 	on complete
 		event "remnant: merganser fleet"
 		conversation
-			`You disembark to the sight of Taely striding across the tarmac, but she veers away from you at the last minute to pat the nose of one of the Mergansers. She runs a finger gently along a weapon score for a moment, then turns to face you. "So, the Korath are still capable fighters, I see." She pauses, her eyes take on a distant look for a second before she continues. "But you have returned with the flock intact. Come, join us for a meal and tell me how they fared." She leads you into the hanger where a bunch of engineers and technicians are gathered in one corner with a rack full of food trays. They enthusiastically greet you and the Merganser pilots, and quickly pull you into discussions of how the Mergansers handled their first patrol.`
+			`You disembark to the sight of Taely striding across the tarmac, but she veers away from you at the last minute to pat the nose of one of the Mergansers. She runs a finger gently along a weapon score for a moment, then turns to face you. "So, the Korath are still capable fighters, I see." She pauses, her eyes take on a distant look for a second before she continues. "But you have returned with the flock intact. Come, join us for a meal and tell me how they fared." She leads you into the hangar where a bunch of engineers and technicians are gathered in one corner with a rack full of food trays. They enthusiastically greet you and the Merganser pilots, and quickly pull you into discussions of how the Mergansers handled their first patrol.`
 			`	Before long the technicians and pilots are trading stories while the Mergansers overshadow the group. Sometimes they poke various engineers or technicians, and the technicians frequently share messages from their commlinks. Apparently they have them hooked up to the Mergansers, so the ships are sharing their own accounts of the patrol. After several hours of the festivities, Taely announces that everyone needs to get to sleep because tomorrow is a new day. As everyone bids their farewells, you note that they include the ships, with most people patting or stroking one or more of the ships on their way out.`
 			`	"Stop by the cafeteria tomorrow morning, <first>. There will be more you can help with, if you are interested." With that, she gestures farewell and heads off at a brisk pace.`
 


### PR DESCRIPTION
**Typo fix**
`hanger` -> `hangar` (in 2 places)
## Summary
The widely used standard is that a `hangar` is a storage building for aircraft (or spacecraft) and a `hanger` is a device to hang clothes. Merriam-Webster has an article specifically about this: https://www.merriam-webster.com/grammar/hangar-vs-hanger .

