### PR TITLE
feat(balance): Tone down the missile strength and turn rate of the Firelight, so that it is less excessively difficult to evade and/or shoot down.

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -987,7 +987,7 @@ outfit "Firelight Activated"
 		"lifetime" 140
 		"acceleration" 1.6
 		"drag" .1
-		"turn" 2
+		"turn" 1.7
 		"homing" 4
 		"infrared tracking" .5
 		"optical tracking" .7

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -951,7 +951,7 @@ outfit "Firelight Missile Bank"
 		"trigger radius" 30
 		"blast radius" 60
 		"hit force" 100
-		"missile strength" 60
+		"missile strength" 30
 		submunition "Firelight Turning"
 		"stream"
 	description "As the Firestorm Torpedo does not require full reactor shielding or safety interlocks, Korath engineers were able to create the Firelight by further scaling down the reactor element to fit in a missile casing for use on and against smaller vessels."
@@ -973,7 +973,7 @@ outfit "Firelight Turning"
 		"trigger radius" 30
 		"blast radius" 60
 		"hit force" 60
-		"missile strength" 60
+		"missile strength" 30
 		"submunition" "Firelight Activated"
 
 outfit "Firelight Activated"
@@ -999,7 +999,7 @@ outfit "Firelight Activated"
 		"burn damage" 10
 		"corrosion damage" 2
 		"hit force" 400
-		"missile strength" 60
+		"missile strength" 30
 
 effect "firelight ring"
 	sprite "effect/firestorm ring"


### PR DESCRIPTION
**Balance**

This PR addresses the bug/feature described on discord various times in various places

## Summary
Drop the missile strength from 60 to 30 for all three stages, and drop the turn rate from 2 to 1.7 for the activated stage.

Currently, it is excessively difficult to shoot down or evade the Firelight, so facing opponents with firelights simply becomes a case of taking all the hits and hoping you have enough HP and/or regen that the opponent runs out of ammunition. This makes it more possible to avoid damage from firelights rather than needing to tank it.