### PR TITLE
fix(typo): "cloaking shield" -> "cloaking shields"

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -132,7 +132,7 @@ tip "cloaking fuel:"
 tip "cloaking heat:"
 	`Heat generated per second when cloaked.`
 
-tip "cloaking shield:"
+tip "cloaking shields:"
 	`Shields consumed per second while cloaked.`
 
 tip "cloaking shield delay:"

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -136,7 +136,7 @@ namespace {
 		{"cloaking heat", 0.},
 		{"cloaking hull", 0.},
 		{"cloaking repair delay", 0.},
-		{"cloaking shield", 0.},
+		{"cloaking shields", 0.},
 		{"cloaking shield delay", 0.},
 		{"cloaked firing", 0.},
 

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -53,7 +53,7 @@ namespace {
 		{"cloaking energy", 0},
 		{"cloaking fuel", 0},
 		{"cloaking heat", 0},
-		{"cloaking shield", 0},
+		{"cloaking shields", 0},
 		{"cloaked firing", 0},
 		{"cooling", 0},
 		{"cooling energy", 0},

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4158,7 +4158,7 @@ void Ship::DoCloakDecision()
 	const double cloakingFuel = attributes.Get("cloaking fuel");
 	const double cloakingEnergy = attributes.Get("cloaking energy");
 	const double cloakingHull = attributes.Get("cloaking hull");
-	const double cloakingShield = attributes.Get("cloaking shield");
+	const double cloakingShield = attributes.Get("cloaking shields");
 	bool canCloak = (!isDisabled && cloakingSpeed > 0. && !cloakDisruption
 		&& fuel >= cloakingFuel && energy >= cloakingEnergy
 		&& MinimumHull() < hull - cloakingHull && shields >= cloakingShield);


### PR DESCRIPTION
## Summary
Renamed the "cloaking shield" attribute to "cloaking shields" to make it consistent with other similar attributes ("firing shields", "thrusting shields" etc.).

## Testing Done
None.
