### PR TITLE
Update some cloaking tooltips

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -118,10 +118,10 @@ tip "cargo space needed:"
 	`Tons of cargo space this outfit uses up.`
 
 tip "cloak:"
-	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking. Ships cannot fire while cloaked, except if they have the related "cloaked action" attribute.`
+	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking. Ships cannot fire while cloaked, except if they have the related "cloaked firing" attribute.`
 
 tip "cloak by mass:"
-	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking. Ships of mass above 1000 will cloak slower, and below will cloak faster. Ships cannot fire while cloaked, except if they have the related "cloaked action" attribute.`
+	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking. Ships of mass above 1000 will cloak slower, and below will cloak faster. Ships cannot fire while cloaked, except if they have the related "cloaked firing" attribute.`
 
 tip "cloaking energy:"
 	`Energy consumed per second when cloaked.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -121,7 +121,7 @@ tip "cloak:"
 	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking. Ships cannot fire while cloaked, except if they have the related "cloaked firing" attribute.`
 
 tip "cloak by mass:"
-	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking. Ships of mass above 1000 will cloak slower, and below will cloak faster. Ships cannot fire while cloaked, except if they have the related "cloaked firing" attribute.`
+	`This outfit allows your ship to cloak. The value represents how long it takes to fully activate or deactivate cloaking for a ship with 1000 mass. The higher a ships mass, the slower the cloak works, the lower its mass, the faster the cloak works. Ships cannot fire while cloaked, except if they have the related "cloaked firing" attribute.`
 
 tip "cloaking energy:"
 	`Energy consumed per second when cloaked.`


### PR DESCRIPTION
**Bug fix**

## Summary
The "cloaked action" attribute was removed from #7025 prior to it being merged, but these tooltips were never updated to reflect that.
I've also updated the tooltip for "cloak by mass" to better describe how it relates to the mass of a ship.
