### PR TITLE
Don't select Graffias as a target for Free Worlds "Scouting Run" jobs

### DIFF
--- a/data/human/free worlds war jobs.txt
+++ b/data/human/free worlds war jobs.txt
@@ -60,6 +60,7 @@ mission "FW Scout Run [0]"
 	waypoint
 		distance 1 2
 		government "Republic"
+		not system "Graffias"
 	on visit
 		dialog phrase "generic waypoint on visit"
 	on complete
@@ -85,9 +86,11 @@ mission "FW Scout Run [1]"
 	waypoint
 		distance 2 3
 		government "Republic"
+		not system "Graffias"
 	waypoint
 		distance 2 3
 		government "Republic"
+		not system "Graffias"
 	on visit
 		dialog phrase "generic waypoint on visit"
 	on complete
@@ -113,9 +116,11 @@ mission "FW Scout Run [2]"
 	waypoint
 		distance 2 3
 		government "Republic"
+		not system "Graffias"
 	waypoint
 		distance 3 4
 		government "Republic"
+		not system "Graffias"
 	on visit
 		dialog phrase "generic waypoint on visit"
 	on complete


### PR DESCRIPTION
**Bug fix**

## Summary
It seems very strange for these jobs to ask the player to scout Graffias, given that it is deep within Free Worlds space. There is no way any Navy ships could get there without passing through several Free Worlds systems first.
In particular, selecting Graffias as the scouting target doesn't really serve the purpose of having the player travel into Republic space. While the system is technically allied with the Republic, it has no Navy fleets, and is only one jump away from Free Worlds space, with no other hyperlinks.

## Testing Done
No
