### PR TITLE
Feat(events): Allow explicit 0 for events to apply directly

### DIFF
--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -187,7 +187,7 @@ void GameAction::LoadSingle(const DataNode &child)
 	}
 	else if(key == "event" && hasValue)
 	{
-		int minDays = (child.Size() >= 3 ? child.Value(2) : 0);
+		int minDays = (child.Size() >= 3 ? child.Value(2) : 1);
 		int maxDays = (child.Size() >= 4 ? child.Value(3) : minDays);
 		if(maxDays < minDays)
 			swap(minDays, maxDays);

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -62,7 +62,6 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	text.SetFont(FontSet::Get(14));
 	text.SetAlignment(Alignment::JUSTIFIED);
 	text.SetWrapWidth(480);
-	text.Wrap(planet.Description());
 
 	// Since the loading of landscape images is deferred, make sure that the
 	// landscapes for this system are loaded before showing the planet panel.
@@ -144,10 +143,8 @@ void PlanetPanel::Draw()
 	{
 		Rectangle box = ui.GetBox("content");
 		if(box.Width() != text.WrapWidth())
-		{
 			text.SetWrapWidth(box.Width());
-			text.Wrap(planet.Description());
-		}
+		text.Wrap(planet.Description());
 		text.Draw(box.TopLeft(), *GameData::Colors().Get("bright"));
 	}
 }

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -586,8 +586,19 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 // Add an event that will happen at the given date.
 void PlayerInfo::AddEvent(const GameEvent &event, const Date &date)
 {
-	gameEvents.push_back(event);
-	gameEvents.back().SetDate(date);
+	// Check the event should be applied directly.
+	if(date <= this->date)
+	{
+		GameEvent eventCopy = event;
+		list<DataNode> eventChanges = {eventCopy.Apply(*this)};
+		if(!eventChanges.empty())
+			AddChanges(eventChanges);
+	}
+	else
+	{
+		gameEvents.push_back(event);
+		gameEvents.back().SetDate(date);
+	}
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -586,7 +586,7 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 // Add an event that will happen at the given date.
 void PlayerInfo::AddEvent(const GameEvent &event, const Date &date)
 {
-	// Check the event should be applied directly.
+	// Check if the event should be applied directly.
 	if(date <= this->date)
 	{
 		GameEvent eventCopy = event;

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -37,7 +37,6 @@ SpaceportPanel::SpaceportPanel(PlayerInfo &player)
 	text.SetFont(FontSet::Get(14));
 	text.SetAlignment(Alignment::JUSTIFIED);
 	text.SetWrapWidth(ui.GetBox("content").Width());
-	text.Wrap(port.Description());
 
 	// Query the news interface to find out the wrap width.
 	// TODO: Allow Interface to handle wrapped text directly.
@@ -93,6 +92,7 @@ void SpaceportPanel::Draw()
 		return;
 
 	Rectangle box = ui.GetBox("content");
+	text.Wrap(port.Description());
 	text.Draw(box.TopLeft(), *GameData::Colors().Get("bright"));
 
 	if(hasNews)


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #6719 and as requested by @bene-dictator 

## Summary
Up til now events were only applied on the next increment of date. This PR allows for an explicit time to event of 0, which mean the event gets applied when the game action is triggered.
Take this example:
```html
event "war begins"
	system Sol
		government "Free Worlds"

mission "Name2"
	job
	repeat
	on accept
		event "war begins" 0
```
The map changes will be seen as soon as the mission gets accepted


## Testing Done
I used the test mission to test it once with explicit 0 and without, worked like expected, with explicit 0 map changes were seen directly, without I had to depart

## Performance Impact
N/A

## Side Note
I looked through the data files and there is no place where event gets used with a 0, so no need to change anything there.
