### PR TITLE
feat(content): Prevent "Deep: Interrogation" from offering during the Main Campaign

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -802,7 +802,10 @@ mission "Deep: Interrogation"
 		attributes "spaceport"
 	to offer
 		has "Deep Archaeology 5: done"
-	
+		or
+			not "chosen sides"
+			has "main plot completed"
+
 	on offer
 		log `Was interrogated by the Deep for helping Albert Foster. The Deep now knows that Albert Foster thinks that there is an artificial singularity on Midgard.`
 		conversation "deep: questioning"

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -805,7 +805,7 @@ mission "Deep: Interrogation"
 		or
 			not "chosen sides"
 			has "main plot completed"
-
+	
 	on offer
 		log `Was interrogated by the Deep for helping Albert Foster. The Deep now knows that Albert Foster thinks that there is an artificial singularity on Midgard.`
 		conversation "deep: questioning"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the bug/feature described in issue #7465 

## Summary
This PR adds offer conditions to "Deep: Interrogation" so it doesn't offer during the middle of the main campaign, by making it so it can't offer once you've chosen a side, and only after you have completed the main plot if you have. This is the same thing done with other Deep missions.

## Testing Done
I no longer get the interrogation conversation when first landing on Valhalla, nor do I have it offered in the save file (however I did get a Skadenga conversation on Nifel). Removing the "chosen sides" condition made it offer again.

## Save File
Used the save from the issue.