### PR TITLE
fix(content): "Remnant: Continue Research" no longer offers if you've completed the missions after it

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1711,7 +1711,11 @@ mission "Deep: Remnant: Continue Research"
 	to offer
 		has "event: deep: remnant: rest period"
 		has "deep: did reveal remnant"
-		not "Deep: Remnant: Engines: done"
+
+# If the player finished the following missions prior to the addition of this one in v0.9.15, it will offer and lead to nothing.
+
+		not "Deep: Remnant: Engines: offer"
+
 	on offer
 		conversation
 			`You receive a message from Ivan, the Deep scientist who you helped to discover the Remnant in the Ember Waste. "Captain <last>, it's been so long. The Deep has finally finished reviewing our research in the Ember Waste, and we've been approved for further funding! Please meet us on <destination> if you wish to assist us again. Your help would be appreciated, but we will make progress even if you're unable to help."`

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1711,6 +1711,7 @@ mission "Deep: Remnant: Continue Research"
 	to offer
 		has "event: deep: remnant: rest period"
 		has "deep: did reveal remnant"
+		not "Deep: Remnant: Engines: done"
 	on offer
 		conversation
 			`You receive a message from Ivan, the Deep scientist who you helped to discover the Remnant in the Ember Waste. "Captain <last>, it's been so long. The Deep has finally finished reviewing our research in the Ember Waste, and we've been approved for further funding! Please meet us on <destination> if you wish to assist us again. Your help would be appreciated, but we will make progress even if you're unable to help."`

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1714,7 +1714,7 @@ mission "Deep: Remnant: Continue Research"
 
 # If the player finished the following missions prior to the addition of this one in v0.9.15, it will offer and lead to nothing.
 
-		not "Deep: Remnant: Engines: offer"
+		not "Deep: Remnant: Engines: offered"
 
 	on offer
 		conversation

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1711,9 +1711,7 @@ mission "Deep: Remnant: Continue Research"
 	to offer
 		has "event: deep: remnant: rest period"
 		has "deep: did reveal remnant"
-
-# If the player finished the following missions prior to the addition of this one in v0.9.15, it will offer and lead to nothing.
-
+		# If the player received subsequent missions prior to the addition of this one in v0.9.15, do not offer this one.
 		not "Deep: Remnant: Engines: offered"
 
 	on offer


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #6637 (assuming I understand it correctly)

## Summary
In commit 7686991, Deep Remnant missions were re-organized with the introduction of the "Deep: Remnant: Continue Research" mission. If the player has completed this mission series prior to this addition, this mission will offer and lead to nothing. This PR adds a condition check for this using "not: offered" (the next mission doesn't give the player a second chance if declined), so if the player has finished the following missions, this one won't offer. (If we want this as separate mission, I can do that).

This doesn't apply to saves that have the mission already active, which would be very few. If we want to include those cases as well, I can add a patch mission for that.

## Testing Done
None yet.