### PR TITLE
feat(code): Ensuring label and line positions adapt to Weapons box positioning

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -494,8 +494,8 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 
 	int index = 0;
 	const double centerX = bounds.Center().X();
-	const double labelCenter[2] = {-.5 * LABEL_WIDTH - LABEL_DX, LABEL_DX + .5 * LABEL_WIDTH};
-	const double fromX[2] = {-LABEL_DX + LABEL_PAD, LABEL_DX - LABEL_PAD};
+	const double labelCenter[2] = {centerX -.5 * LABEL_WIDTH - LABEL_DX, centerX + LABEL_DX + .5 * LABEL_WIDTH};
+	const double fromX[2] = { centerX - LABEL_DX + LABEL_PAD, centerX + LABEL_DX - LABEL_PAD};
 	static const double LINE_HEIGHT = 20.;
 	static const double TEXT_OFF = .5 * (LINE_HEIGHT - font.Height());
 	static const Point LINE_SIZE(LABEL_WIDTH, LINE_HEIGHT);

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -494,7 +494,7 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 
 	int index = 0;
 	const double centerX = bounds.Center().X();
-	const double labelCenter[2] = {centerX -.5 * LABEL_WIDTH - LABEL_DX, centerX + LABEL_DX + .5 * LABEL_WIDTH};
+	const double labelCenter[2] = {centerX - .5 * LABEL_WIDTH - LABEL_DX, centerX + LABEL_DX + .5 * LABEL_WIDTH};
 	const double fromX[2] = { centerX - LABEL_DX + LABEL_PAD, centerX + LABEL_DX - LABEL_PAD};
 	static const double LINE_HEIGHT = 20.;
 	static const double TEXT_OFF = .5 * (LINE_HEIGHT - font.Height());


### PR DESCRIPTION
**Bug fix and/or mechanics enhancement**
If the user decides to adjust the size of the Weapons box in the Ship Info display Panel by changing the values present in Interfaces.txt, then the hoverbox and line positions will not display correctly.

In its current state, hoverbox and line placement only works if the weapon box is centered on 0.

## Summary
This merely adds `centerX` to these two lines. In vanilla with default values, this is 0, and thus there is no change to the game. 

By including centerX which is already there in the previous line, the Weapon box can be adjusted in size in interfaces.txt without any code updates required.

In other words, this makes the existing code much more resilient to changes that a regular user could make to their data files.

## Screenshots
![WIP Ship hardpoint display D](https://github.com/endless-sky/endless-sky/assets/32169904/7d787e16-7055-4ebb-8546-f865b93be8b2)
Note: Yes, this is a picture of HardpointInfoPanel from Delta, with a bunch of other stuff that is irrelevant to this PR. The code for the ship weapon display sprite in the middle is the same code, and has different interface.txt values, demonstrating it in action.


## Performance Impact
none
