### PR TITLE
feat(content): Separate the Kestrel from "Tarazed Advanced" shipyard

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -277,6 +277,27 @@ event "kestrel available: more bays"
 		add shipyard "Kestrel"
 
 
+# Remove the Kestrel from Tarazed Advanced for saves that obtained it prior to 0.10.7.
+
+mission "Kestrel Sales Patch'
+	invisible
+	landing
+	to offer
+		has "kestrel available"
+	on offer
+		event "kestrel sales patch"
+		fail
+	
+event "kestrel sales patch"
+	planet Wayfarer
+		add shipyard "Kestrel"
+	shipyard "Tarazed Advanced"
+		remove "Kestrel (More Weapons)"
+		remove "Kestrel (More Enginess)"
+		remove "Kestrel (More Shields)"
+		remove "Kestrel (More Bays)"
+
+
 ship "Unknown Ship Type"
 	sprite "ship/kestrel"
 	thumbnail "thumbnail/kestrel"

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -249,23 +249,32 @@ mission "Kestrel Available"
 				decline
 
 
+shipyard "Kestrel"
 
 event "kestrel available: more weapons"
 	set "kestrel available"
-	shipyard "Tarazed Advanced"
+	shipyard "Kestrel"
 		"Kestrel (More Weapons)"
+	planet Tarazed
+		add shipyard "Kestrel"
 event "kestrel available: more engines"
 	set "kestrel available"
-	shipyard "Tarazed Advanced"
+	shipyard "Kestrel"
 		"Kestrel (More Engines)"
+	planet Tarazed
+		add shipyard "Kestrel"
 event "kestrel available: more shields"
 	set "kestrel available"
-	shipyard "Tarazed Advanced"
+	shipyard "Kestrel"
 		"Kestrel (More Shields)"
+	planet Tarazed
+		add shipyard "Kestrel"
 event "kestrel available: more bays"
 	set "kestrel available"
-	shipyard "Tarazed Advanced"
+	shipyard "Kestrel"
 		"Kestrel (More Bays)"
+	planet Tarazed
+		add shipyard "Kestrel"
 
 
 ship "Unknown Ship Type"

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -277,27 +277,6 @@ event "kestrel available: more bays"
 		add shipyard "Kestrel"
 
 
-# Remove the Kestrel from Tarazed Advanced for saves that obtained it prior to 0.10.7.
-
-mission "Kestrel Sales Patch"
-	invisible
-	landing
-	to offer
-		has "kestrel available"
-	on offer
-		event "kestrel sales patch"
-		fail
-	
-event "kestrel sales patch"
-	planet Wayfarer
-		add shipyard "Kestrel"
-	shipyard "Tarazed Advanced"
-		remove "Kestrel (More Weapons)"
-		remove "Kestrel (More Enginess)"
-		remove "Kestrel (More Shields)"
-		remove "Kestrel (More Bays)"
-
-
 ship "Unknown Ship Type"
 	sprite "ship/kestrel"
 	thumbnail "thumbnail/kestrel"

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -255,25 +255,25 @@ event "kestrel available: more weapons"
 	set "kestrel available"
 	shipyard "Kestrel"
 		"Kestrel (More Weapons)"
-	planet Tarazed
+	planet Wayfarer
 		add shipyard "Kestrel"
 event "kestrel available: more engines"
 	set "kestrel available"
 	shipyard "Kestrel"
 		"Kestrel (More Engines)"
-	planet Tarazed
+	planet Wayfarer
 		add shipyard "Kestrel"
 event "kestrel available: more shields"
 	set "kestrel available"
 	shipyard "Kestrel"
 		"Kestrel (More Shields)"
-	planet Tarazed
+	planet Wayfarer
 		add shipyard "Kestrel"
 event "kestrel available: more bays"
 	set "kestrel available"
 	shipyard "Kestrel"
 		"Kestrel (More Bays)"
-	planet Tarazed
+	planet Wayfarer
 		add shipyard "Kestrel"
 
 

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -279,7 +279,7 @@ event "kestrel available: more bays"
 
 # Remove the Kestrel from Tarazed Advanced for saves that obtained it prior to 0.10.7.
 
-mission "Kestrel Sales Patch'
+mission "Kestrel Sales Patch"
 	invisible
 	landing
 	to offer


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
In #7719, the "Tarazed Advanced" shipyard was added to Zug through an event to implicate the FW's acquisition of more advanced ships for their fleets during the war. However, the Kestrel Easter Egg ship is also found in this shipyard. From my understanding, "Tarazed Advanced" was originally meant to be only found on Tarazed. Now that it is on Zug, the Kestrel can be sold there too.

As an easter egg, the encounter and mission series the player has with the Kestrel is intended to be directed at the player as a player (specifically through this individual on Tarazed), not necessarily the player as a "special" pilot within the universe of ES. The Kestrel being sold at Zug can be confusing and seem odd as it implies the FW has means of production for it.

This PR gives the Kestrel its own unique shipyard on Tarazed, separating it from Tarazed Advanced so it isn't randomly sold on Zug. I haven't included a patch for this for saves with the events already established, but I could.

## Testing Done
None yet, will do soon.

## Save File
This save file can be used to test these changes:
Soon.