### PR TITLE
Feat(ships): Add "auto explosion" tag to create explosions fitting to the ship

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -268,7 +268,7 @@ void Outfit::Load(const DataNode &node)
 			thumbnail = SpriteSet::Get(child.Token(1));
 		else if(child.Token(0) == "weapon")
 			LoadWeapon(child);
-		else if(child.Token(0) == "auto blast")
+		else if(child.Token(0) == "auto explosion")
 			// Create an explosion that is fitting for this ship, will only work if
 			// shields and hull come before.
 			LoadExplosion(

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -268,6 +268,16 @@ void Outfit::Load(const DataNode &node)
 			thumbnail = SpriteSet::Get(child.Token(1));
 		else if(child.Token(0) == "weapon")
 			LoadWeapon(child);
+		else if(child.Token(0) == "auto blast")
+			// Create an explosion that is fitting for this ship, will only work if
+			// shields and hull come before.
+			LoadExplosion(
+				(attributes["shields"] + attributes["hull"]) * 0.01,
+				(attributes["shields"] + attributes["hull"]) * 0.10,
+				(attributes["shields"] + attributes["hull"]) * 0.05,
+				(attributes["shields"] + attributes["hull"]) * 0.15
+
+			);
 		else if(child.Token(0) == "ammo" && child.Size() >= 2)
 		{
 			// Non-weapon outfits can have ammo so that storage outfits

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -393,6 +393,18 @@ void Weapon::LoadWeapon(const DataNode &node)
 
 
 
+// Load attributes that represent a ship explosion.
+void Weapon::LoadExplosion(double blastRadius, double shieldDamage, double hullDamage, double hitForce)
+{
+	isWeapon = true;
+	this->blastRadius = blastRadius;
+	damage[SHIELD_DAMAGE] = shieldDamage;
+	damage[HULL_DAMAGE] = hullDamage;
+	damage[HIT_FORCE] = hitForce;
+}
+
+
+
 bool Weapon::IsWeapon() const
 {
 	return isWeapon;

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -59,6 +59,8 @@ public:
 public:
 	// Load from a "weapon" node, either in an outfit, a ship (explosion), or a hazard.
 	void LoadWeapon(const DataNode &node);
+	// Load attributes that represent a ship explosion.
+	void LoadExplosion(double blastRadius, double shieldDamage, double hullDamage, double hitForce);
 	bool IsWeapon() const;
 
 	// Get assets used by this weapon.


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in ~~my dreams~~ a stream by saug

## Summary
This takes the default explosion formula from the wiki:

> 
    "blast radius" (Typical value: (shields + hull) * .01)
    "shield damage" (Typical value: (shields + hull) * .10)
    "hull damage" (Typical value: (shields + hull) * .05)
    "hit force" (Typical value: (shields + hull) * .15)

and implements it in game with the name "auto explosion"
this tag should be placed after the shields and hull values as it relies on them for calculation
it can be useful for not having the worry about changing explosion values everytime you change the ships hull/shields as it updates them automatically, note that this only works in data files and not in saves, as the automatically created weapon will be normally saved


## Usage examples
Instead of:
```html
ship "Arrow"
	sprite "ship/arrow"
	thumbnail "thumbnail/arrow"
	attributes
		category "Transport"
		"cost" 1200000
		"shields" 2000
		"hull" 400
		[...]
		weapon
			"blast radius" 24
			"shield damage" 240
			"hull damage" 120
			"hit force" 360
```
now do:
```html
ship "Arrow"
	sprite "ship/arrow"
	thumbnail "thumbnail/arrow"
	attributes
		category "Transport"
		"cost" 1200000
		"shields" 2000
		"hull" 400
		[...]
		"auto explosion"
```

## Testing Done
not yet



