### PR TITLE
fix(balance): Adjust explosion stats for the Korsmanath A'awoj and Echo-galleon to follow the trend in explosions from other comparable Korath ships.

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -1077,10 +1077,10 @@ ship "Korsmanath A'awoj"
 		"engine capacity" 480
 		"atmosphere scan" 100
 		weapon
-			"blast radius" 400
-			"shield damage" 8000
-			"hull damage" 4000
-			"hit force" 12000
+			"blast radius" 800
+			"shield damage" 15000
+			"hull damage" 7500
+			"hit force" 22500
 	outfits
 		"Banisher Grav-Turret" 7
 		"Langrage Hyper-Heaver" 3
@@ -1311,10 +1311,10 @@ ship "Echo-Galleon"
 		"weapon capacity" 285
 		"engine capacity" 155
 		weapon
-			"blast radius" 1000
-			"shield damage" 4000
-			"hull damage" 2000
-			"hit force" 6000
+			"blast radius" 360
+			"shield damage" 7200
+			"hull damage" 3600
+			"hit force" 10800
 	outfits
 		"Digger Mining Beam" 4
 		"Grab-Strike Turret" 2


### PR DESCRIPTION
**Balance**

This PR addresses the bug/feature I noticed just now.

## Summary
The Korsmanath A'awoj used the same explosion stats as the Kasichara A'awoj and the numbered world-ships, which meant that despite being the largest ship in the game it had a smaller explosion than the Ikatila'ej and Rai'alorej. The explosion has been increased to be larger and more damaging than that of those two ships.

The Echo-galleon had an extremely large explosion (larger than any other ship I could find, actually) with oddly low damage (lower than the smaller Arch-carrack also produced by the Efreti). This has been adjusted to instead be similar to, but slightly weaker than, the explosions of the Kasichara A'awoj and the numbered world-ships, with which the Echo-galleon shares a common origin.