### PR TITLE
fix(content): You only have to visit the system with the pirate fleet in Pact Recon 3

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -147,15 +147,16 @@ mission "Pact Recon 3"
 		attributes "dirt belt" "near earth" "rim" "south"
 		not government "Pirate"
 	destination "Glaze"
-	waypoint "Boral"
-	waypoint "Hintar"
-	waypoint "Naper"
-	waypoint "Orvala"
+	mark "Boral"
+	mark "Hintar"
+	mark "Naper"
+	mark "Orvala"
 	to offer
 		random < 40
 		has "Pact Recon 2: done"
 		not "event: war begins"
-	
+	to complete
+		has "fw located pirate fleet"
 	on offer
 		dialog `Once again, you receive a message from Freya Winters. "We have another mission for you," she says, "this one a bit more dangerous. We've heard rumors of a pirate fleet amassing in one of the seldom-visited systems in the Dirt Belt, and we need to know where they are. Interested in helping to track them down? As before, you don't need to fight, just observe them."`
 	
@@ -165,13 +166,22 @@ mission "Pact Recon 3"
 		system "Naper"
 		fleet "Small Southern Pirates" 3
 		fleet "Large Northern Pirates"
-	
 	on visit
-		dialog phrase "generic waypoint on visit"
+		dialog `You have reached <planet>, but you haven't located the pirate fleet yet! Better depart and make sure you visit <marks>.`
 	on complete
+		clear "fw located pirate fleet"
 		payment 80000
 		dialog `You report to Freya that you found a sizable pirate fleet in the Naper system, as well as spotting some pirates elsewhere. She thanks you, and pays you <payment>. "Thank you for your assistance," she says. "Again, I'll be in touch if we need you."`
-
+	on enter "Boral"
+		unmark "Boral"
+	on enter "Hintar"
+		unmark "Hintar"
+	on enter "Naper"
+		unmark "Naper"
+		set "fw located pirate fleet"
+		dialog `You have located the pirate fleet. Time to head back to <planet> to report to Freya what you found.`
+	on enter "Orvala"
+		unmark "Orvala"
 
 
 mission "Pact Questioning"

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -178,7 +178,7 @@ mission "Pact Recon 3"
 		set "fw located pirate fleet"
 		dialog `You have located the pirate fleet. Time to head back to <planet> to report to Freya what you found.`
 	on visit
-		dialog `You have reached <planet>, but you haven't located the pirate fleet yet! Better depart and make sure you visit <marks>.`
+		dialog `You have reached <planet>, but you haven't located the pirate fleet yet! Better depart and make sure you have checked <marks>.`
 	to complete
 		has "fw located pirate fleet"
 	on complete

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -173,8 +173,8 @@ mission "Pact Recon 3"
 	on enter "Naper"
 		unmark "Boral"
 		unmark "Hintar"
-		unmark "Naper"
 		unmark "Orvala"
+		unmark "Naper"
 		set "fw located pirate fleet"
 		dialog `You have located the pirate fleet. Time to head back to <planet> to report to Freya what you found.`
 	on visit

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -184,6 +184,7 @@ mission "Pact Recon 3"
 		unmark "Orvala"
 
 
+
 mission "Pact Questioning"
 	landing
 	source

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -142,7 +142,7 @@ mission "Pact Recon 2"
 mission "Pact Recon 3"
 	landing
 	name "Pirate Reconnaissance"
-	description "Fly through the <waypoints> systems, searching for a gathering pirate fleet. Report to the Pact on <destination> when you are done."
+	description "Fly through the <marks> systems, searching for a gathering pirate fleet. Report to the Pact on <destination> once you have located them."
 	source
 		attributes "dirt belt" "near earth" "rim" "south"
 		not government "Pirate"
@@ -164,6 +164,7 @@ mission "Pact Recon 3"
 		system "Naper"
 		fleet "Small Southern Pirates" 3
 		fleet "Large Northern Pirates"
+
 	on enter "Boral"
 		unmark "Boral"
 	on enter "Hintar"

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -155,8 +155,6 @@ mission "Pact Recon 3"
 		random < 40
 		has "Pact Recon 2: done"
 		not "event: war begins"
-	to complete
-		has "fw located pirate fleet"
 	on offer
 		dialog `Once again, you receive a message from Freya Winters. "We have another mission for you," she says, "this one a bit more dangerous. We've heard rumors of a pirate fleet amassing in one of the seldom-visited systems in the Dirt Belt, and we need to know where they are. Interested in helping to track them down? As before, you don't need to fight, just observe them."`
 	
@@ -166,22 +164,27 @@ mission "Pact Recon 3"
 		system "Naper"
 		fleet "Small Southern Pirates" 3
 		fleet "Large Northern Pirates"
-	on visit
-		dialog `You have reached <planet>, but you haven't located the pirate fleet yet! Better depart and make sure you visit <marks>.`
-	on complete
-		clear "fw located pirate fleet"
-		payment 80000
-		dialog `You report to Freya that you found a sizable pirate fleet in the Naper system, as well as spotting some pirates elsewhere. She thanks you, and pays you <payment>. "Thank you for your assistance," she says. "Again, I'll be in touch if we need you."`
 	on enter "Boral"
 		unmark "Boral"
 	on enter "Hintar"
 		unmark "Hintar"
-	on enter "Naper"
-		unmark "Naper"
-		set "fw located pirate fleet"
-		dialog `You have located the pirate fleet. Time to head back to <planet> to report to Freya what you found.`
 	on enter "Orvala"
 		unmark "Orvala"
+	on enter "Naper"
+		unmark "Boral"
+		unmark "Hintar"
+		unmark "Naper"
+		unmark "Orvala"
+		set "fw located pirate fleet"
+		dialog `You have located the pirate fleet. Time to head back to <planet> to report to Freya what you found.`
+	on visit
+		dialog `You have reached <planet>, but you haven't located the pirate fleet yet! Better depart and make sure you visit <marks>.`
+	to complete
+		has "fw located pirate fleet"
+	on complete
+		clear "fw located pirate fleet"
+		payment 80000
+		dialog `You report to Freya that you found a sizable pirate fleet in the Naper system, as well as spotting some pirates elsewhere. She thanks you, and pays you <payment>. "Thank you for your assistance," she says. "Again, I'll be in touch if we need you."`
 
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #8422 

## Summary
Currently, Pact Recon 3 is only finished when you visit every system. However, with a637e1e4c9b78029f4567f7b0b80c74e5f0d2807, you can use marks to only require visiting certain systems. This PR modifies Pact Recon 3 so that entering the system with the pirate fleet gives you a popup and allows you to go to the destination to complete the mission without having to visit the other systems.

## Screenshots
![image](https://github.com/endless-sky/endless-sky/assets/109186806/17be1416-fcd0-4e7c-bbaf-421fce70cf46)

## Testing Done
- Systems without the pirate fleet getting unmarked as you visit them
- All systems unmarking when you visited the system with the fleet
- The on visit message mentioning the four systems that the pirate fleet could be in for searching the wrong system
- The mission tick lighting up when finding the fleet
- The mission subsequently completing once you land at the destination without checking any of the other systems
- Unmarking systems for this mission doesn’t interfere with other missions

## Save File
This save file can be used to test these changes: [Test Pilot~Pact Recon.txt](https://github.com/endless-sky/endless-sky/files/15367234/Test.Pilot.Pact.Recon.txt)