### PR TITLE
Don't recalculate escort's distance maps every step when jumping.

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1897,7 +1897,8 @@ void AI::MoveEscort(Ship &ship, Command &command) const
 	// If the parent is in-system and planning to jump, non-staying escorts should follow suit.
 	else if(parent.Commands().Has(Command::JUMP) && parent.GetTargetSystem() && !isStaying)
 	{
-		SelectRoute(ship, parent.GetTargetSystem());
+		if(parent.GetTargetSystem() != ship.GetTargetSystem())
+			SelectRoute(ship, parent.GetTargetSystem());
 
 		if(ship.GetTargetSystem())
 		{


### PR DESCRIPTION
This PR addresses the bug/feature described in issue #9316

## Summary
Checks that the target system of an escort is not the same as as the target system of the flagship, skipping recomputing a distance map every frame (very expensive).

## Performance Impact
Improves performance, for once
