### PR TITLE
fix(style): Fix function spacing in the source files

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2009,6 +2009,7 @@ bool AI::CanRefuel(const Ship &ship, const StellarObject *target)
 }
 
 
+
 // Set the ship's target system or planet in order to reach the
 // next desired system. Will target a landable planet to refuel.
 // If the ship is an escort it will only use routes known to the player.
@@ -3775,6 +3776,7 @@ double AI::RendezvousTime(const Point &p, const Point &v, double vp)
 
 	return numeric_limits<double>::quiet_NaN();
 }
+
 
 
 // Searches every asteroid within the ship scan limit and returns either the

--- a/source/Color.cpp
+++ b/source/Color.cpp
@@ -111,6 +111,8 @@ Color Color::Additive(float alpha) const
 	return result;
 }
 
+
+
 Color Color::Combine(float a1, Color c1, float a2, Color c2)
 {
 	return Color(

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -88,6 +88,7 @@ namespace {
 }
 
 
+
 Dialog::Dialog(function<void()> okFunction, const string &message, Truncate truncate, bool canCancel, bool okIsActive)
 	: voidFun(okFunction)
 {

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -568,7 +568,6 @@ void Files::CreateFolder(const std::string &path)
 
 
 
-
 // Open this user's plugins directory in their native file explorer.
 void Files::OpenUserPluginFolder()
 {

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -133,7 +133,6 @@ bool Hardpoint::IsTurret() const
 
 
 
-
 bool Hardpoint::IsParallel() const
 {
 	return isParallel;

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -113,7 +113,6 @@ int Hazard::RandomDuration() const
 
 
 
-
 // Generates a random double between the minimum and maximum strength of this hazard.
 double Hazard::RandomStrength() const
 {

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -732,7 +732,6 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 
 
 
-
 // Members of the PointerElement class:
 
 // Constructor.

--- a/source/Personality.cpp
+++ b/source/Personality.cpp
@@ -225,7 +225,6 @@ bool Personality::IsDaring() const
 
 
 
-
 bool Personality::IsFrugal() const
 {
 	return flags.test(FRUGAL);

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -633,7 +633,6 @@ const string &Preferences::AutoFireSetting()
 
 
 
-
 void Preferences::ToggleBoarding()
 {
 	int targetIndex = boardingIndex + 1;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2375,6 +2375,7 @@ int Ship::CustomSwizzle() const
 }
 
 
+
 // Check if the ship is thrusting. If so, the engine sound should be played.
 bool Ship::IsThrusting() const
 {

--- a/source/ShipEvent.cpp
+++ b/source/ShipEvent.cpp
@@ -69,7 +69,6 @@ const Government *ShipEvent::TargetGovernment() const
 
 
 
-
 int ShipEvent::Type() const
 {
 	return type;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -606,7 +606,6 @@ const Government *System::GetGovernment() const
 
 
 
-
 // Get the name of the ambient audio to play in this system.
 const string &System::MusicName() const
 {

--- a/source/Wormhole.cpp
+++ b/source/Wormhole.cpp
@@ -206,7 +206,6 @@ const System &Wormhole::WormholeSource(const System &to) const
 
 
 
-
 const System &Wormhole::WormholeDestination(const System &from) const
 {
 	auto it = links.find(&from);


### PR DESCRIPTION
**Style fix**

This PR fixes some cases where functions had more or less than 3 empty lines between them.

## Summary
According to the style guide, we should use exactly three empty lines as the separator.

I did not fix test functions, functions within namespace blocks, nor within special preprocessor directives.

## Testing Done
I tested that the game still compiles.