### PR TITLE
Properly set camera position when leaving planet

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -245,7 +245,7 @@ namespace {
 	const double CAMERA_POSITION_CENTERING = 0.01;
 
 	pair<Point, Point> NewCenter(const Point &oldCenter, const Point &oldCenterVelocity,
-		const Point &baseCenter, const Point &baseVelocity)
+		const Point &baseCenter, const Point &baseVelocity, const double influence, bool killVelocity)
 	{
 		if(Preferences::CameraAcceleration() == Preferences::CameraAccel::OFF)
 			return make_pair(baseCenter, baseVelocity);
@@ -257,10 +257,13 @@ namespace {
 
 		const Point newAbsVelocity = absoluteOldCenterVelocity.Lerp(baseVelocity, CAMERA_VELOCITY_TRACKING);
 
-		const Point newCenter = (oldCenter + newAbsVelocity).Lerp(baseCenter, CAMERA_POSITION_CENTERING);
+		Point newCenter = (oldCenter + newAbsVelocity).Lerp(baseCenter, CAMERA_POSITION_CENTERING);
 
 		// Flip the velocity back over the baseVelocity
-		const Point newVelocity = baseVelocity.Lerp(newAbsVelocity, cameraAccelMultiplier);
+		Point newVelocity = baseVelocity.Lerp(newAbsVelocity, cameraAccelMultiplier);
+		
+		newCenter = newCenter.Lerp(baseCenter, pow(influence, .5));
+		newVelocity = killVelocity ? baseVelocity : newVelocity.Lerp(baseVelocity, pow(influence, .5));
 
 		return make_pair(newCenter, newVelocity);
 	}
@@ -414,6 +417,9 @@ void Engine::Place()
 	// that all special ships have been repositioned.
 	ships.splice(ships.end(), newShips);
 
+	center = flagship->Center();
+	centerVelocity = flagship->Velocity();
+
 	player.SetPlanet(nullptr);
 }
 
@@ -526,19 +532,13 @@ void Engine::Step(bool isActive)
 	}
 	else if(flagship)
 	{
-		const auto newCamera = NewCenter(center, centerVelocity,
-			flagship->Center(), flagship->Velocity());
+		if(isActive) {
+			const auto [newCenter, newCenterVelocity] = NewCenter(center, centerVelocity,
+				flagship->Center(), flagship->Velocity(), flagship->GetHyperspacePercentage() / 100.,
+				flagship->IsHyperspacing());
 
-		if(flagship->IsHyperspacing())
-		{
-			hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
-			center = newCamera.first.Lerp(flagship->Center(), pow(hyperspacePercentage, .5));
-			centerVelocity = flagship->Velocity();
-		}
-		else if(isActive)
-		{
-			center = newCamera.first;
-			centerVelocity = newCamera.second;
+			center = newCenter;
+			centerVelocity = newCenterVelocity;
 		}
 
 		if(doEnterLabels)
@@ -1592,22 +1592,11 @@ void Engine::CalculateStep()
 	Point newCenterVelocity;
 	if(flagship)
 	{
-		const auto newCamera = NewCenter(center, centerVelocity,
-			flagship->Center(), flagship->Velocity());
-
-		if(flagship->IsHyperspacing())
-		{
-			hyperspacePercentage =
-				flagship->GetHyperspacePercentage() / 100.;
-			newCenter = newCamera.first.Lerp(
-				flagship->Center(), pow(hyperspacePercentage, .5));
-			newCenterVelocity = flagship->Velocity();
-		}
-		else
-		{
-			newCenter = newCamera.first;
-			newCenterVelocity = newCamera.second;
-		}
+		const auto [newCameraCenter, newCameraVelocity] = NewCenter(center, centerVelocity,
+			flagship->Center(), flagship->Velocity(), flagship ->GetHyperspacePercentage() / 100.,
+			flagship->IsHyperspacing());
+		newCenter = newCameraCenter;
+		newCenterVelocity = newCameraVelocity;
 	}
 	draw[currentCalcBuffer].SetCenter(newCenter, newCenterVelocity);
 	batchDraw[currentCalcBuffer].SetCenter(newCenter);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -245,7 +245,7 @@ namespace {
 	const double CAMERA_POSITION_CENTERING = 0.01;
 
 	pair<Point, Point> NewCenter(const Point &oldCenter, const Point &oldCenterVelocity,
-		const Point &baseCenter, const Point &baseVelocity, const double influence, bool killVelocity)
+		const Point &baseCenter, const Point &baseVelocity, const double influence, const bool killVelocity)
 	{
 		if(Preferences::CameraAcceleration() == Preferences::CameraAccel::OFF)
 			return make_pair(baseCenter, baseVelocity);
@@ -1594,7 +1594,7 @@ void Engine::CalculateStep()
 	if(flagship)
 	{
 		const auto [newCameraCenter, newCameraVelocity] = NewCenter(center, centerVelocity,
-			flagship->Center(), flagship->Velocity(), flagship ->GetHyperspacePercentage() / 100.,
+			flagship->Center(), flagship->Velocity(), flagship->GetHyperspacePercentage() / 100.,
 			flagship->IsHyperspacing());
 		newCenter = newCameraCenter;
 		newCenterVelocity = newCameraVelocity;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -261,7 +261,7 @@ namespace {
 
 		// Flip the velocity back over the baseVelocity
 		Point newVelocity = baseVelocity.Lerp(newAbsVelocity, cameraAccelMultiplier);
-		
+
 		newCenter = newCenter.Lerp(baseCenter, pow(influence, .5));
 		newVelocity = killVelocity ? baseVelocity : newVelocity.Lerp(baseVelocity, pow(influence, .5));
 
@@ -532,7 +532,8 @@ void Engine::Step(bool isActive)
 	}
 	else if(flagship)
 	{
-		if(isActive) {
+		if(isActive)
+		{
 			const auto [newCenter, newCenterVelocity] = NewCenter(center, centerVelocity,
 				flagship->Center(), flagship->Velocity(), flagship->GetHyperspacePercentage() / 100.,
 				flagship->IsHyperspacing());


### PR DESCRIPTION
Fixes #10082, and deduplicates some code.

Works by setting camera position on `EnterSystem()` _after_ the initial ship positions are set, which was default-initialized to (0, 0) when buying ships before.