### PR TITLE
fix(content): Remove an empty log from Adelita

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7406,7 +7406,6 @@ mission "Adelita 5"
 	on complete
 		payment 220000
 		log `Helped the underground journalism collective "Adelita" gather video evidence of Syndicate participation in the slave trade while escaping from pirates.`
-		log ``
 		conversation
 			`Ale, River, and Bunker look glad to be back on <planet>. "Being there in person was bad enough," Ale grumbles as she looks through a stack of folders on her datapad. "Now we have to watch it over and over again to edit it into something presentable."`
 			`	As they are leaving, Ale hands you a stack of credit chips totaling <payment>. "There's a bonus in there for you. We really couldn't have done it without you," she tells you with a bittersweet smile. "Of course, you'll be one of the first to know when it's done."`


### PR DESCRIPTION
## Summary
I noticed a ` log `` ` in the Adelita missions that snuck in. Remove it.
