### PR TITLE
(fix)content: Fix sentence fragment in Stormhold description

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -4296,7 +4296,7 @@ planet Stonebreak
 planet Stormhold
 	attributes core "core pirate" forest frontier pirate
 	landscape land/fog11
-	description `A cold planet, with dense, foggy atmosphere. As with many pirate outposts, Stormhold is home to an unknown number of villages and hidden outposts, each controlled by a different pirate faction. It is also said that some of the most dangerous fugitives in the galaxy live deep in the forests of this planet, escaping detection by living underground or by avoiding the use of electronic devices.`
+	description `Stormhold is a cold planet, with a dense, foggy atmosphere. As with many pirate outposts, Stormhold is home to an unknown number of villages and hidden outposts, each controlled by a different pirate faction. It is also said that some of the most dangerous fugitives in the galaxy live deep in the forests of this planet, escaping detection by living underground or by avoiding the use of electronic devices.`
 	spaceport `The spaceport is a large town, with a population of roughly thirty thousand. People of all races and cultures mingle freely, while keeping a wary eye open for off-worlders who may be Republic agents in disguise.`
 	outfitter "Basic Outfits"
 	outfitter "Ammo North"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Fixes an awkward sentence fragment in the Stormhold planet description.

## Screenshots
Before
![Screenshot_20240523_161638](https://github.com/endless-sky/endless-sky/assets/65418682/b70621e5-48fc-4f30-ab74-7075e92df091)

After
![Screenshot_20240523_171613](https://github.com/endless-sky/endless-sky/assets/65418682/815fb184-7eef-47ee-a63a-84ad93161d73)

## Testing Done
See above.

## Save File
[Balance Tester.txt](https://github.com/endless-sky/endless-sky/files/15424851/Balance.Tester.txt)
