### PR TITLE
fix(ci): Add missing codespell excludes for the new version

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -100,3 +100,5 @@ planet Independance
 	description `Independance, originally named for a document of emancipation for an ancient nation on old Earth, became of interest to the Confederated Councils when they began to consider plans for a defense against an invasion. One such plan involved deploying "cloud bunkers" into the gas giants of the Outer Rim from which an uprising could be staged against a foreign occupier. Independance, given its fitting name and position near Alvorada, was chosen as the testing site for this project.`
 	description `	Of the few prototype bunkers that were deployed, none ever survived the surface of Independance; the Councils simply didn't have the technology for such an ambitious project. The official who proposed the plan was shortly shuffled out of the Politburo, and what remained of the bunkers were left quietly in the depths of the gas giant.`
 	object Independance
+		"Mian"
+		"i' amazin"          # is amazing (mispronounced)


### PR DESCRIPTION
**CI/CD/Testing**

Codespell had an update, and is now detecting lines that were previously fine. This is causing the CI to fail on unrelated pull requests.

## Summary
I fixed the issue by excluding the relevant lines from codespell.

## Testing Done
The CI should pass here.