### PR TITLE
feat(enhancement): Allow specifying multiple options for music

### DIFF
--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -100,7 +100,7 @@ private:
 	int64_t fine = 0;
 	std::vector<Debt> debt;
 
-	std::optional<std::string> music;
+	std::optional<std::vector<std::string>> music;
 
 	std::set<const System *> mark;
 	std::set<const System *> unmark;

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -177,7 +177,7 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes)
 		else if(key == "landscape")
 			landscape = SpriteSet::Get(value);
 		else if(key == "music")
-			music = value;
+			music = vector(node.Tokens().begin() + 1, node.Tokens().end());
 		else if(key == "description" || key == "spaceport")
 		{
 			const bool isDescription = key == "description";
@@ -364,9 +364,12 @@ const Sprite *Planet::Landscape() const
 
 
 // Get the name of the ambient audio to play on this planet.
+// If there are multiple options available, returns a random one.
 const string &Planet::MusicName() const
 {
-	return music;
+	if(music.size() == 1)
+		return music[0];
+	return music[Random::Int(music.size())];
 }
 
 

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -73,6 +73,7 @@ public:
 	// Get the landscape sprite.
 	const Sprite *Landscape() const;
 	// Get the name of the ambient audio to play on this planet.
+	// If there are multiple options available, returns a random one.
 	const std::string &MusicName() const;
 
 	// Get the list of "attributes" of the planet.
@@ -162,7 +163,7 @@ private:
 	std::string description;
 	Port port;
 	const Sprite *landscape = nullptr;
-	std::string music;
+	std::vector<std::string> music = std::vector<std::string>(1);
 
 	std::set<std::string> attributes;
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -366,7 +366,10 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		else if(key == "government")
 			government = GameData::Governments().Get(value);
 		else if(key == "music")
-			music = value;
+		{
+			if(hasValue)
+				music = vector(node.Tokens().begin() + 1, node.Tokens().end());
+		}
 		else if(key == "habitable")
 			habitable = child.Value(valueIndex);
 		else if(key == "jump range")
@@ -594,9 +597,12 @@ const Government *System::GetGovernment() const
 
 
 // Get the name of the ambient audio to play in this system.
+// If there are multiple options available, returns a random one.
 const string &System::MusicName() const
 {
-	return music;
+	if(music.size() == 1)
+		return music[0];
+	return music[Random::Int(music.size())];
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -85,6 +85,7 @@ public:
 	// Get this system's government.
 	const Government *GetGovernment() const;
 	// Get the name of the ambient audio to play in this system.
+	// If there are multiple options available, returns a random one.
 	const std::string &MusicName() const;
 
 	// Get the list of "attributes" of the planet.
@@ -208,7 +209,7 @@ private:
 	std::string name;
 	Point position;
 	const Government *government = nullptr;
-	std::string music;
+	std::vector<std::string> music = std::vector<std::string>(1);
 
 	// All possible hyperspace links to other systems.
 	std::set<const System *> links;


### PR DESCRIPTION
**Feature**

This PR adds support for specifying multiple audio files in `music` nodes.

## Summary
Planets, systems and game actions can now parse `music` tokens with more than one value. In these cases, a random audio source is chosen for playback each time. Due to how `mute` works internally (by attempting to play a file with an empty name) it is now also possible to have a random chance to not play audio on systems and planets.

`System::MusicName` and  `Planet::MusicName` now returns a random element to reflect this change.

## Usage examples
This can be used to make ambient sounds less repetitive.

## Testing Done
I tested that multiple values can be parsed, and can all be selected for playback, and that mute still works.

## Save File
This save file can be used to test these changes:
[Test.Pilot.txt](https://github.com/endless-sky/endless-sky/files/15442720/Test.Pilot.txt)