### PR TITLE
fix: steam workflow is missing libmad0-dev library

### DIFF
--- a/changelog
+++ b/changelog
@@ -196,7 +196,7 @@ version 0.10.7
     * Simplified CMake build on Linux and MacOS. (@quyykk)
     * Run CI workflows when their configuration file is changed. (@tibetiroka)
     * Updated codespell check exclusion list. (@tibetiroka)
-    * Update steam workflow to include necessary development libraries (@MCOfficer)
+    * Update Steam workflow to include necessary development libraries. (@MCOfficer)
 
 Version 0.10.6
   * Bug fixes:

--- a/changelog
+++ b/changelog
@@ -196,7 +196,7 @@ version 0.10.7
     * Simplified CMake build on Linux and MacOS. (@quyykk)
     * Run CI workflows when their configuration file is changed. (@tibetiroka)
     * Updated codespell check exclusion list. (@tibetiroka)
-    * Update Steam workflow to include necessary development libraries. (@MCOfficer)
+    * Updated Steam workflow to include necessary development libraries. (@MCOfficer)
 
 Version 0.10.6
   * Bug fixes:

--- a/changelog
+++ b/changelog
@@ -196,6 +196,7 @@ version 0.10.7
     * Simplified CMake build on Linux and MacOS. (@quyykk)
     * Run CI workflows when their configuration file is changed. (@tibetiroka)
     * Updated codespell check exclusion list. (@tibetiroka)
+    * Update steam workflow to include necessary development libraries (@MCOfficer)
 
 Version 0.10.6
   * Bug fixes:

--- a/io.github.endless_sky.endless_sky.appdata.xml
+++ b/io.github.endless_sky.endless_sky.appdata.xml
@@ -79,7 +79,7 @@
           <li>The firing arc for a turret hardpoint can now be limited.</li>
         </ul>
         <p>You can find out more in the changelog.</p>
-        <p>A special thanks to the 41 people who contributed to this release!</p>
+        <p>A special thanks to the 42 people who contributed to this release!</p>
       </description>
       <url>https://github.com/endless-sky/endless-sky/blob/v0.10.7/changelog</url>
     </release>

--- a/steam/docker-compose.yml
+++ b/steam/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - '/bin/bash'
       - '-c'
       - |
+        apt-get -y update && apt-get -y install libmad0-dev
         mkdir -p build/steam-x64
         cd build/steam-x64
         cmake ../../ -GNinja -DES_STEAM=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=linux-x64-release-static
@@ -24,6 +25,7 @@ services:
       - '/bin/bash'
       - '-c'
       - |
+        apt-get -y update && apt-get -y install libmad0-dev
         mkdir -p build/steam-x86
         cd build/steam-x86
         cmake ../../ -GNinja -DES_STEAM=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-m32 -DVCPKG_TARGET_TRIPLET=linux-x86-release-static


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature introduced in issue #9945

## Summary

#9945 changed the linux build from vcpkg to system libraries, which works well on our normal workflows. However, the steam workflow runs in a steam-sdk container, which seems to be missing libmad0-dev.