### PR TITLE
Always run Steam workflow if it is dispatched

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -8,13 +8,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changed:
-    uses: ./.github/workflows/compute-changes.yml
-
   build_linux:
     name: Linux
-    needs: changed
-    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.integration_tests == 'true' || needs.changed.outputs.cmake_files == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/changelog
+++ b/changelog
@@ -197,6 +197,7 @@ version 0.10.7
     * Run CI workflows when their configuration file is changed. (@tibetiroka)
     * Updated codespell check exclusion list. (@tibetiroka)
     * Updated Steam workflow to include necessary development libraries. (@MCOfficer)
+    * The Steam workflow now always runs build steps when it is dispatched, regardless of file changes. (@warp-core)
 
 Version 0.10.6
   * Bug fixes:


### PR DESCRIPTION
**CI/CD/Testing**

## Summary
Currently, the Steam workflow is only triggered by "workflow_dispatch" events. This means it only runs when someone tells it to run.
However, the build job within the workflow only conditionally runs when certain files are changed.
This is a problem when, for example, only the configuration for the workflow itself is changed and you want to rerun it. You tell it to run, but it'll bail out after calculating the changes because none of the required things have changed.
Instead of modifying the condition to also check if the workflow configuration has changed, this PR simply removes the conditional check. If I dispatch the workflow, I want it to run, regardless of what has changed. And, this way, there's less maintenance.
