### PR TITLE
fix(content): Typo in new mereti missions

### DIFF
--- a/data/wanderer/wanderer missions.txt
+++ b/data/wanderer/wanderer missions.txt
@@ -152,7 +152,7 @@ mission "Wanderers: Mereti: The Plant 5"
 				"Strong Wind"
 
 event "mereti visiting eneremprukt"
-	system eneremprukt
+	system Eneremprukt
 		fleet "Small Kor Mereti" 800
 
 event "field of mereti plants"


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug I noticed because the game gave me a warning

## Summary
Due to capitalization, the event "mereti visiting eneremprukt" wasn't working

## Save File
This is my save, which has the issue
[Eebop Masch~~previous-1.txt](https://github.com/endless-sky/endless-sky/files/15449356/Eebop.Masch.previous-1.txt)

