### PR TITLE
feat(balance): Divide `relative heat damage` by 1.5, for consistency with #9616

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -16,7 +16,7 @@ hazard "Ember Waste Base Heat"
 	"strength" 0.25 1.75
 	"system-wide"
 	weapon
-		"relative heat damage" 0.00035
+		"relative heat damage" 0.000233
 
 hazard "Ember Waste Base Storm"
 	"duration" 300 1500


### PR DESCRIPTION
**Balance**
oops

## Summary
Rescales `relative heat damage` everywhere I'm aware of it being used, to take into account masses being on average 1.5 times higher and heat dissipations being on average 1.5 times lower.
Because `relative heat damage` scales off heat capacity, not maximum heat, #9616 has indirectly made the heat of the Ember Waste somewhat more powerful than it was intended to be.
This change, which should have been part of #9616 to begin with, fixes that.

