### PR TITLE
Add action to deploy wiki updates

### DIFF
--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -32,13 +32,19 @@ jobs:
           if [[ $(git diff --cached --raw) ]]; then
             echo "changes=yes" >> "$GITHUB_OUTPUT"
           fi
+      - name: Get latest commit hash
+        if: ${{ steps.check-diff.outputs.changes == 'yes' }}
+        id: latest-commit
+        run: |
+          cd endless-sky-wiki
+          echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Commit changes
         if: ${{ steps.check-diff.outputs.changes == 'yes' }}
         run: |
           cd endless-sky.wiki
           git config --local user.name "GitHub Actions"
           git config --local user.email "actions@github.com"
-          git commit -m "Synchronize with endless-sky-wiki" -m "Triggered by ${{ github.actor }}"
+          git commit -m "Synchronize with endless-sky-wiki" -m "Latest commit: ${{ steps.latest-commit.outputs.hash }}" -m "Triggered by ${{ github.actor }}"
       - name: Push changes
         if: ${{ steps.check-diff.outputs.changes == 'yes' }}
         env:

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -35,7 +35,7 @@ jobs:
           cd endless-sky.wiki
           git config --local user.name "GitHub Actions"
           git config --local user.email "actions@github.com"
-          git commit -m "Update" -m "Triggered by ${{ github.actor }}"
+          git commit -m "Synchronize with endless-sky-wiki" -m "Triggered by ${{ github.actor }}"
       - name: Push changes
         if: ${{ steps.check-diff.outputs.changes == 'yes' }}
         env:

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -1,6 +1,8 @@
 name: Wiki CD
 
 on:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -22,7 +22,7 @@ jobs:
           git clone "https://github.com/endless-sky/endless-sky-wiki.git"
       - name: Checkout wiki
         run: git clone "https://github.com/${{ github.repository }}.wiki.git"
-      - name: Synchronise files
+      - name: Synchronize files
         run: rsync --delete -rvh -e .git endless-sky-wiki/wiki/* endless-sky.wiki/
       - name: Check for changes
         id: check-diff

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -13,6 +13,7 @@ jobs:
   cd_wiki:
     name: Wiki deployment
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'endless-sky/endless-sky' && github.ref == 'refs/heads/master' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -10,7 +10,7 @@ jobs:
 
   cd_wiki:
     name: Wiki deployment
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -44,7 +44,7 @@ jobs:
           cd endless-sky.wiki
           git config --local user.name "GitHub Actions"
           git config --local user.email "actions@github.com"
-          git commit -m "Synchronize with endless-sky-wiki" -m "Latest commit: ${{ steps.latest-commit.outputs.hash }}" -m "Triggered by ${{ github.actor }}"
+          git commit -m "Synchronize with endless-sky-wiki" -m "Latest commit: endless-sky/endless-sky-wiki@${{ steps.latest-commit.outputs.hash }}" -m "Triggered by ${{ github.actor }}"
       - name: Push changes
         if: ${{ steps.check-diff.outputs.changes == 'yes' }}
         env:

--- a/.github/workflows/cd_wiki.yaml
+++ b/.github/workflows/cd_wiki.yaml
@@ -1,0 +1,46 @@
+name: Wiki CD
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: 'wiki-cd'
+
+jobs:
+
+  cd_wiki:
+    name: Wiki deployment
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout endless-sky-wiki repository
+        run: |
+          git clone "https://github.com/endless-sky/endless-sky-wiki.git"
+      - name: Checkout wiki
+        run: git clone "https://github.com/${{ github.repository }}.wiki.git"
+      - name: Synchronise files
+        run: rsync --delete -rvh -e .git endless-sky-wiki/wiki/* endless-sky.wiki/
+      - name: Check for changes
+        id: check-diff
+        run: |
+          cd endless-sky.wiki
+          git add .
+          if [[ $(git diff --cached --raw) ]]; then
+            echo "changes=yes" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit changes
+        if: ${{ steps.check-diff.outputs.changes == 'yes' }}
+        run: |
+          cd endless-sky.wiki
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "actions@github.com"
+          git commit -m "Update" -m "Triggered by ${{ github.actor }}"
+      - name: Push changes
+        if: ${{ steps.check-diff.outputs.changes == 'yes' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd endless-sky.wiki
+          git remote set-url origin "https://github-actions:${{ env.GH_TOKEN }}@github.com/${{ github.repository }}.wiki.git"
+          git push origin


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug/feature described in issue #9043

## Summary
Adds a GitHub Action that will copy changes in https://endless-sky/endless-sky-wiki to the [GitHub wiki for this repository](https://github.com/endless-sky/endless-sky/wiki).
It runs on workflow dispatch because there's no easy way to make it run when that repository has changes without personal access tokens which I have been told is not acceptable.

## Testing Done
I'll describe it later.
