### PR TITLE
Update issue and PR templates for new wiki repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Wiki (on GitHub)
+    url: https://github.com/endless-sky/endless-sky-wiki/issues/
+    about: Please report issues with the GitHub wiki here.
   - name: Endless Sky Mobile
     url: https://github.com/thewierdnut/endless-mobile/issues/
     about: Please report bugs any issues related to the mobile port here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,5 +35,8 @@ This save file can be used to test these changes:
  - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
  - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}
 
+## Wiki Update
+(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)
+
 ## Performance Impact
 {{If this PR changed code, describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed.}}


### PR DESCRIPTION
**Documentation**

## Summary
Updates the issue template to direct users to https://github.com/endless-sky/endless-sky-wiki/issues for issues about the issue.
Updates the PR template to inform users that they should open a PR to https://github.com/endless-sky/endless-sky-wiki if updating the wiki alongside their PR is appropriate, and that a link to that PR should be included.

## Testing Done
No.
