### PR TITLE
Typo fix in "archaeology missions.txt"

### DIFF
--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -1574,7 +1574,7 @@ mission "Sheragi Archaeology: The Emerald Sword 3"
 				`	"Did that happen with the last one?"`
 					goto last
 			
-			`	Your questions is met with a chorus of "No, I'm fine," "All good over here," and various other affirmations of safety from the crew.`
+			`	Your question is met with a chorus of "No, I'm fine," "All good over here," and various other affirmations of safety from the crew.`
 				goto desyoend
 			
 			label last


### PR DESCRIPTION
**Bug fix (typo)**

This PR addresses the bug/feature described in issue #10118

## Summary
Erroneous plural fixed in Emerald Sword 3 mission, after the black box explodes (label explodes) in the visiting Desyo branch.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
N/A

## Save File
N/A

## Artwork Checklist
N/A

## Performance Impact
N/A
