### PR TITLE
Detect and move past the UTF8 byte order mark (BOM) at the beginning of a data file

### DIFF
--- a/source/DataFile.cpp
+++ b/source/DataFile.cpp
@@ -112,7 +112,7 @@ void DataFile::LoadData(const string &data)
 
 	size_t pos = 0;
 	// If the first character is the UTF8 byte order mark (BOM), skip it.
-	if(Utf8::IsBOM(Utf8::DecodeCodePoint(data, pos)))
+	if(!Utf8::IsBOM(Utf8::DecodeCodePoint(data, pos)))
 		pos = 0;
 
 	while(pos < end)

--- a/source/DataFile.cpp
+++ b/source/DataFile.cpp
@@ -112,8 +112,7 @@ void DataFile::LoadData(const string &data)
 
 	size_t pos = 0;
 	// If the first character is the UTF8 byte order mark (BOM), skip it.
-	char32_t firstChar = Utf8::DecodeCodePoint(data, pos);
-	if(firstChar != 0x0000FEFF)
+	if(Utf8::DecodeCodePoint(data, pos) != 0x0000FEFF)
 		pos = 0;
 
 	while(pos < end)

--- a/source/DataFile.cpp
+++ b/source/DataFile.cpp
@@ -109,7 +109,14 @@ void DataFile::LoadData(const string &data)
 	size_t lineNumber = 0;
 
 	size_t end = data.length();
-	for(size_t pos = 0; pos < end; )
+
+	size_t pos = 0;
+	// If the first character is the UTF8 byte order mark (BOM), skip it.
+	char32_t firstChar = Utf8::DecodeCodePoint(data, pos);
+	if(firstChar != 0x0000FEFF)
+		pos = 0;
+
+	while(pos < end)
 	{
 		++lineNumber;
 		size_t tokenPos = pos;

--- a/source/DataFile.cpp
+++ b/source/DataFile.cpp
@@ -112,7 +112,7 @@ void DataFile::LoadData(const string &data)
 
 	size_t pos = 0;
 	// If the first character is the UTF8 byte order mark (BOM), skip it.
-	if(Utf8::DecodeCodePoint(data, pos) != 0x0000FEFF)
+	if(Utf8::IsBOM(Utf8::DecodeCodePoint(data, pos)))
 		pos = 0;
 
 	while(pos < end)

--- a/source/text/Utf8.cpp
+++ b/source/text/Utf8.cpp
@@ -23,8 +23,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
-
-
 namespace {
 	constexpr char32_t BOM = 0x0000FEFF;
 }

--- a/source/text/Utf8.cpp
+++ b/source/text/Utf8.cpp
@@ -23,6 +23,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
+
+
+namespace {
+	static constexpr char32_t BOM = 0x0000FEFF;
+}
+
+
+
 namespace Utf8 {
 #if defined(_WIN32)
 	wstring ToUTF16(const string &input, bool isPath)
@@ -57,6 +65,14 @@ namespace Utf8 {
 		return result;
 	}
 #endif
+
+
+
+	// Check if this character is the byte order mark (BOM) sequence.
+	bool IsBOM(char32_t c)
+	{
+		return c == BOM;
+	}
 
 
 

--- a/source/text/Utf8.cpp
+++ b/source/text/Utf8.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 
 namespace {
-	static constexpr char32_t BOM = 0x0000FEFF;
+	constexpr char32_t BOM = 0x0000FEFF;
 }
 
 

--- a/source/text/Utf8.h
+++ b/source/text/Utf8.h
@@ -25,6 +25,9 @@ namespace Utf8 {
 	std::string ToUTF8(const wchar_t *str);
 #endif
 
+	// Check if this character is the byte order mark (BOM) sequence.
+	bool IsBOM(char32_t c);
+
 	// Skip to the next unicode code point after pos in utf8.
 	// Return string::npos when there are no more code points.
 	std::size_t NextCodePoint(const std::string &str, std::size_t pos);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described reported on Discord: https://discord.com/channels/251118043411775489/285540320823869441/1245161589779468340

## Summary
Some text editors ~~notepad~~ will save a byte order mark (BOM) sequence at the beginning of a UTF8 encoded text file, to indicate that it is UTF8.
Currently, Endless Sky doesn't know what that is, it just looks like another character to it.
This results in the first token it reads in the example text files being `ï»¿#`. This is the three bytes of the BOM plus the hash character to denote the comment. But, this isn't parsed as a comment. So, UniverseObjects checks it against all the expected root nodes, doesn't find a match and calls `DataNode::PrintTrace` on it.
During this step, the first byte is passed to `std::isspace`. In the implementation used by clang, this results in a static assertion failing because it is not happy about being given a character with a negative value, as this byte has.
The gcc implementation at least doesn't give up, but it still prints errors about an unrecognised root object, referring to a comment line preceded by a character your text editor probably won't render:
`L1:   ﻿# Copyright (c) 2016 Iaz Poolar;`

This PR adds a check when beginning to parse a data file for the BOM sequence, and moves past it before proceeding with normal parsing operations.

## Testing Done
Load [UrsaPolaris](https://github.com/LocalGod79/UrsaPolaris).
