### PR TITLE
Don't do bad things when user tries to sort an empty ship list

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -818,6 +818,9 @@ void PlayerInfoPanel::SortShips(InfoPanelState::ShipComparator *shipComparator)
 	if(panelState.CurrentSort() == shipComparator)
 		shipComparator = GetReverseCompareFrom(*shipComparator);
 
+	if(panelState.Ships().empty())
+		return;
+
 	// Save selected ships to preserve selection after sort.
 	multiset<shared_ptr<Ship>, InfoPanelState::ShipComparator *> selectedShips(shipComparator);
 	shared_ptr<Ship> lastSelected = panelState.SelectedIndex() == -1

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -814,12 +814,12 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 // Sorts the player's fleet given a comparator function (based on column).
 void PlayerInfoPanel::SortShips(InfoPanelState::ShipComparator *shipComparator)
 {
+	if(panelState.Ships().empty())
+		return;
+
 	// Clicking on a sort column twice reverses the comparison.
 	if(panelState.CurrentSort() == shipComparator)
 		shipComparator = GetReverseCompareFrom(*shipComparator);
-
-	if(panelState.Ships().empty())
-		return;
 
 	// Save selected ships to preserve selection after sort.
 	multiset<shared_ptr<Ship>, InfoPanelState::ShipComparator *> selectedShips(shipComparator);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10126

## Summary
Currently, the game calls `std::stable_sort` on an invalid range if the list of ships is empty and user tries to have it sorted in the player info panel.
This causes bad things (usually a crash).
This PR fixes it by exiting the ship sorting method early if the list is empty, because there's nothing (good) left to do.

## Testing Done
Launch the game.
Start a new pilot.
Don't buy a ship.
Leave the shipyard.
Open the player info panel.
Click one of the column headings to sort the (empty) list.

Without this change, you're likely to see a crash (at least, when built with clang, I didn't test a gcc implementation).
With this change, nothing happens (there's nothing to do).
