### PR TITLE
fix(mechanics): Properly reset player flagship after death

### DIFF
--- a/source/AmmoDisplay.cpp
+++ b/source/AmmoDisplay.cpp
@@ -38,6 +38,7 @@ AmmoDisplay::AmmoDisplay(PlayerInfo &player)
 }
 
 
+
 void AmmoDisplay::Reset()
 {
 	ammo.clear();

--- a/source/AmmoDisplay.cpp
+++ b/source/AmmoDisplay.cpp
@@ -38,10 +38,17 @@ AmmoDisplay::AmmoDisplay(PlayerInfo &player)
 }
 
 
+void AmmoDisplay::Reset()
+{
+	ammo.clear();
+}
+
+
+
 
 void AmmoDisplay::Update(const Ship &flagship)
 {
-	ammo.clear();
+	Reset();
 	for(const auto &it : flagship.Weapons())
 	{
 		const Outfit *secWeapon = it.GetOutfit();

--- a/source/AmmoDisplay.cpp
+++ b/source/AmmoDisplay.cpp
@@ -45,7 +45,6 @@ void AmmoDisplay::Reset()
 
 
 
-
 void AmmoDisplay::Update(const Ship &flagship)
 {
 	Reset();

--- a/source/AmmoDisplay.h
+++ b/source/AmmoDisplay.h
@@ -33,6 +33,7 @@ class Ship;
 class AmmoDisplay {
 public:
 	explicit AmmoDisplay(PlayerInfo &player);
+	void Reset();
 	void Update(const Ship &flagship);
 	void Draw(const Rectangle &ammoBox, const Point &iconDimensions) const;
 	bool Click(const Point &clickPoint, bool control);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -687,6 +687,8 @@ void Engine::Step(bool isActive)
 	// Update the player's ammo amounts.
 	if(flagship)
 		ammoDisplay.Update(*flagship);
+	else
+		ammoDisplay.Reset();
 
 	// Display escort information for all ships of the "Escort" government,
 	// and all ships with the "escort" personality, except for fighters that

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -73,6 +73,7 @@ void MainPanel::Step()
 
 	if(player.IsDead())
 		show = Command::NONE;
+
 	// Display any requested panels.
 	if(show.Has(Command::MAP))
 	{
@@ -207,6 +208,7 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 {
 	if(player.IsDead())
 		return true;
+
 	if(command.Has(Command::MAP | Command::INFO | Command::MESSAGE_LOG | Command::HAIL | Command::HELP))
 		show = command;
 	else if(command.Has(Command::TURRET_TRACKING))

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -205,6 +205,8 @@ Engine &MainPanel::GetEngine()
 // Only override the ones you need; the default action is to return false.
 bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
+	if(player.IsDead())
+		return true;
 	if(command.Has(Command::MAP | Command::INFO | Command::MESSAGE_LOG | Command::HAIL | Command::HELP))
 		show = command;
 	else if(command.Has(Command::TURRET_TRACKING))

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -71,6 +71,7 @@ void MainPanel::Step()
 	// checks only already-drawn panels.
 	bool isActive = GetUI()->IsTop(this);
 
+	// If the player is dead, don't show anything.
 	if(player.IsDead())
 		show = Command::NONE;
 

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -71,6 +71,8 @@ void MainPanel::Step()
 	// checks only already-drawn panels.
 	bool isActive = GetUI()->IsTop(this);
 
+	if(player.IsDead())
+		show = Command::NONE;
 	// Display any requested panels.
 	if(show.Has(Command::MAP))
 	{

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -75,6 +75,7 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 
 void PlanetPanel::Step()
 {
+	// If the player is dead, pop the planet panel.
 	if(player.IsDead())
 	{
 		player.SetPlanet(nullptr);

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -103,7 +103,10 @@ void PlanetPanel::Step()
 void PlanetPanel::Draw()
 {
 	if(player.IsDead())
+	{
+		GetUI()->Pop(this);
 		return;
+	}
 
 	Information info;
 	info.SetSprite("land", planet.Landscape());
@@ -155,7 +158,7 @@ void PlanetPanel::Draw()
 bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
 	if(player.IsDead())
-		return false;
+		return true;
 
 	Panel *oldPanel = selectedPanel;
 	const Ship *flagship = player.Flagship();

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -75,6 +75,13 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 
 void PlanetPanel::Step()
 {
+	if(player.IsDead())
+	{
+		player.SetPlanet(nullptr);
+		GetUI()->PopThrough(this);
+		return;
+	}
+
 	// If the previous mission callback resulted in a "launch", take off now.
 	const Ship *flagship = player.Flagship();
 	if(flagship && flagship->CanBeFlagship() && (player.ShouldLaunch() || requestedLaunch))
@@ -102,12 +109,6 @@ void PlanetPanel::Step()
 
 void PlanetPanel::Draw()
 {
-	if(player.IsDead())
-	{
-		GetUI()->Pop(this);
-		return;
-	}
-
 	Information info;
 	info.SetSprite("land", planet.Landscape());
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -154,6 +154,9 @@ void PlanetPanel::Draw()
 // Only override the ones you need; the default action is to return false.
 bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
+	if(player.IsDead())
+		return false;
+
 	Panel *oldPanel = selectedPanel;
 	const Ship *flagship = player.Flagship();
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -646,6 +646,7 @@ void PlayerInfo::Die(int response, const shared_ptr<Ship> &capturer)
 		if(it != ships.end())
 			ships.erase(it);
 	}
+
 	flagship.reset();
 }
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -646,6 +646,7 @@ void PlayerInfo::Die(int response, const shared_ptr<Ship> &capturer)
 		if(it != ships.end())
 			ships.erase(it);
 	}
+	flagship.reset();
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10125 

## Summary
Resetting the player flagship seems to fix most issues, except:
 - the ammo counter is still visible (but cannot be interacted with)
 - the trading panel is still available

## Testing Done
Tested with a mission that kills the player on a planet. Needs testing with mid-flight death.