### PR TITLE
fix(bug): invalid pointer dereference on sorting without ship selected

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -842,6 +842,9 @@ void PlayerInfoPanel::SortShips(InfoPanelState::ShipComparator *shipComparator)
 		shipComparator
 	);
 
+	// Ships are now sorted.
+	panelState.SetCurrentSort(shipComparator);
+
 	// Load the same selected ships from before the sort.
 	auto it = selectedShips.begin();
 	for(size_t i = 0; i < panelState.Ships().size(); ++i)
@@ -856,9 +859,6 @@ void PlayerInfoPanel::SortShips(InfoPanelState::ShipComparator *shipComparator)
 			if(it == selectedShips.end())
 				break;
 		}
-
-	// Ships are now sorted.
-	panelState.SetCurrentSort(shipComparator);
 }
 
 

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -846,6 +846,8 @@ void PlayerInfoPanel::SortShips(InfoPanelState::ShipComparator *shipComparator)
 	panelState.SetCurrentSort(shipComparator);
 
 	// Load the same selected ships from before the sort.
+	if(selectedShips.empty())
+		return;
 	auto it = selectedShips.begin();
 	for(size_t i = 0; i < panelState.Ships().size(); ++i)
 		if(panelState.Ships()[i] == *it)


### PR DESCRIPTION
**Bug fix**

## Summary
When sorting ships, the game makes a list of what ships are selected before sorting so it can reselect the new indices of those ships afterwards.
If there are no ships selected, it will dereference the `std::multiset::end()` iterator, because this is what is returned by `std::multiset::begin()` for an empty container.
When built with gcc, this is apparently not an issue. The game will continue.
When built with clang, though, this results in a crash.

This PR fixes this by checking if the container of selected ships is empty and then not attempting to dereference any of its iterators.

## Testing Done
Build with clang.
Try sorting ships without first selecting a ship.
Without this PR, crash.
With this PR, no crash.
