### PR TITLE
Fix(bug): std::isspace negative signed char on clang

### DIFF
--- a/source/DataNode.cpp
+++ b/source/DataNode.cpp
@@ -307,7 +307,7 @@ int DataNode::PrintTrace(const string &message) const
 	{
 		if(&token != &tokens.front())
 			line += ' ';
-		bool hasSpace = any_of(token.begin(), token.end(), [](char c) { return isspace(c); });
+		bool hasSpace = any_of(token.begin(), token.end(), [](unsigned char c) { return isspace(c); });
 		bool hasQuote = any_of(token.begin(), token.end(), [](char c) { return (c == '"'); });
 		if(hasSpace)
 			line += hasQuote ? '`' : '"';

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -130,7 +130,7 @@ void DataWriter::WriteToken(const char *a)
 void DataWriter::WriteToken(const string &a)
 {
 	// Figure out what kind of quotation marks need to be used for this string.
-	bool hasSpace = any_of(a.begin(), a.end(), [](char c) { return isspace(c); });
+	bool hasSpace = any_of(a.begin(), a.end(), [](unsigned char c) { return isspace(c); });
 	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
 	// If the token is an empty string, it needs to be wrapped in quotes as if it had a space.
 	hasSpace |= a.empty();

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -58,7 +58,7 @@ namespace {
 		string message;
 		if(isSingle)
 		{
-			char c = tolower(nameWas.front());
+			char c = tolower(static_cast<unsigned char>(nameWas.front()));
 			bool isVowel = (c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u');
 			message = (isVowel ? "An " : "A ");
 		}

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -559,7 +559,7 @@ string Format::Capitalize(const string &str)
 	bool first = true;
 	for(char &c : result)
 	{
-		if(isspace(c))
+		if(isspace(static_cast<unsigned char>(c)))
 			first = true;
 		else
 		{

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -719,6 +719,6 @@ string Format::ExpandConditions(const string &source, const ConditionGetter &get
 int Format::Search(const string &str, const string &sub)
 {
 	auto it = search(str.begin(), str.end(), sub.begin(), sub.end(),
-		[](char a, char b) { return toupper(a) == toupper(b); });
+		[](unsigned char a, unsigned char b) { return toupper(a) == toupper(b); });
 	return (it == str.end() ? -1 : it - str.begin());
 }

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -577,7 +577,7 @@ string Format::LowerCase(const string &str)
 {
 	string result = str;
 	for(char &c : result)
-		c = tolower(c);
+		c = tolower(static_cast<unsigned char>(c));
 	return result;
 }
 

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -563,8 +563,8 @@ string Format::Capitalize(const string &str)
 			first = true;
 		else
 		{
-			if(first && islower(c))
-				c = toupper(c);
+			if(first && islower(static_cast<unsigned char>(c)))
+				c = toupper(static_cast<unsigned char>(c));
 			first = false;
 		}
 	}


### PR DESCRIPTION
**Bug fix**

## Summary
Functions from the standard library header <cctype>, such as `std::isspace`, `std::islower`, and `std::toupper` have undefined behaviour if the value of the argument cannot be represented as `unsigned char` and is not equal to `EOF` (usually -1).
Source: https://en.cppreference.com/w/cpp/string/byte/islower
In the Microsoft implementation we use with clang, the undefined behaviour is the failure of a debug assertion.
This can be seen when loading [Ursa Polaris](https://github.com/LocalGod79/UrsaPolaris) with a binary built with clang in the Debug configuration.

This PR makes the recommended change of `static_cast<unsigned char>`ing the arguments passed to these functions.

## Testing Done
Build with clang in the Debug configuration.
Install the [Ursa Polaris](https://github.com/LocalGod79/UrsaPolaris) plugin.
Launch the game.
Without this PR, failed debug assertion.
With this PR, no issue.
