### PR TITLE
Feat(spoiler-avoidance): Hide cloaking control key until you know about

### DIFF
--- a/data/global listeners.txt
+++ b/data/global listeners.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 by RisingLeaf(https://github.com/RisingLeaf)
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+mission "Unlock Cloaking Key"
+	invisible
+	landing
+	to offer
+		and
+			not "global: found cloaking"
+			or
+				has "flagship attribute: cloak"
+				has "outfit (all): Cloaking Device"
+	on offer
+		set "global: found cloaking"
+		fail

--- a/data/global listeners.txt
+++ b/data/global listeners.txt
@@ -15,11 +15,10 @@ mission "Unlock Cloaking Key"
 	invisible
 	landing
 	to offer
-		and
-			not "global: found cloaking"
-			or
-				has "flagship attribute: cloak"
-				has "outfit (all): Cloaking Device"
+		not "global: found cloaking"
+		or
+			has "ship attribute: cloak"
+			has "outfit (all): Cloaking Device"
 	on offer
 		set "global: found cloaking"
 		fail

--- a/data/global listeners.txt
+++ b/data/global listeners.txt
@@ -15,7 +15,6 @@ mission "Unlock Cloaking Key"
 	invisible
 	landing
 	to offer
-		not "global: found cloaking"
 		or
 			has "ship attribute: cloak"
 			has "outfit (all): Cloaking Device"

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3480,11 +3480,11 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto shipAttributeFun = [this](const string &name) -> int64_t
 	{
 		auto attrib = name.substr(strlen("ship attribute: "));
+		int64_t sum = 0;
 		for(const shared_ptr<Ship> &ship : ships)
-			if(ship->Attributes().Get(attrib))
-				return 1;
+			sum += ship->Attributes().Get(attrib);
 
-		return 0;
+		return sum;
 	};
 	shipAttributeProvider.SetGetFunction(shipAttributeFun);
 	shipAttributeProvider.SetHasFunction(shipAttributeFun);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3475,6 +3475,20 @@ void PlayerInfo::RegisterDerivedConditions()
 		return retVal;
 	});
 
+	// Check if an attribute is present in fleet.
+	auto &&shipAttributeProvider = conditions.GetProviderPrefixed("ship attribute: ");
+	auto shipAttributeFun = [this](const string &name) -> int64_t
+	{
+		auto attrib = name.substr(strlen("ship attribute: "));
+		for(const shared_ptr<Ship> &ship : ships)
+			if(ship->Attributes().Get(attrib))
+				return 1;
+
+		return 0;
+	};
+	shipAttributeProvider.SetGetFunction(shipAttributeFun);
+	shipAttributeProvider.SetHasFunction(shipAttributeFun);
+
 	// The total number of ships the player has active and present.
 	auto &&totalPresentShipsProvider = conditions.GetProviderNamed("total ships");
 	totalPresentShipsProvider.SetGetFunction([this](const string &name) -> int64_t

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -586,8 +586,7 @@ void PreferencesPanel::DrawControls()
 
 			zones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), command);
 
-			const auto it = UNLOCKABLE_CONTROLS.find(command);
-			if(it != UNLOCKABLE_CONTROLS.end() && !GameData::GlobalConditions().Has(it->second))
+			if(UNLOCKABLE_CONTROLS.count(command) && !GameData::GlobalConditions().Has(it->second))
 				table.Draw("unknown command", medium);
 			else
 				table.Draw(command.Description(), medium);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -586,7 +586,8 @@ void PreferencesPanel::DrawControls()
 
 			zones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), command);
 
-			if(UNLOCKABLE_CONTROLS.count(command) && !GameData::GlobalConditions().Has(it->second))
+			auto it = UNLOCKABLE_CONTROLS.find(command);
+			if(it != UNLOCKABLE_CONTROLS.end() && !GameData::GlobalConditions().Has(it->second))
 				table.Draw("unknown command", medium);
 			else
 				table.Draw(command.Description(), medium);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/alignment.hpp"
 #include "Audio.h"
 #include "Color.h"
+#include "ConditionsStore.h"
 #include "Dialog.h"
 #include "Files.h"
 #include "FillShader.h"
@@ -80,6 +81,10 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
+
+	const map<Command, string> UNLOCKABLE_CONTROLS = {
+		{Command::CLOAK, "found cloaking"}
+	};
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;
@@ -581,7 +586,11 @@ void PreferencesPanel::DrawControls()
 
 			zones.emplace_back(table.GetCenterPoint(), table.GetRowSize(), command);
 
-			table.Draw(command.Description(), medium);
+			const auto it = UNLOCKABLE_CONTROLS.find(command);
+			if(it != UNLOCKABLE_CONTROLS.end() && !GameData::GlobalConditions().Has(it->second))
+				table.Draw("unknown command", medium);
+			else
+				table.Draw(command.Description(), medium);
 			table.Draw(command.KeyName(), isEditing ? bright : medium);
 		}
 	}


### PR DESCRIPTION
## Summary
Hides the cloaking control setting until you found a cloaking device or your flagship has the cloaking attribute.
Also lays some groundwork for other such listeners.

## Screenshots
might send one tomorrow


## Testing Done
Yes

