### PR TITLE
Tell me what kind of ship I just lost.

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1191,7 +1191,8 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 	if(event.TargetGovernment()->IsPlayer() && !hasFailed)
 	{
 		bool failed = false;
-		string message = "Your ship \"" + event.Target()->Name() + "\" has been ";
+		string message = "Your " + event.Target()->DisplayModelName() +
+			" \"" + event.Target()->Name() + "\" has been ";
 		if(event.Type() & ShipEvent::DESTROY)
 		{
 			// Destroyed ships carrying mission cargo result in failed missions.
@@ -1202,7 +1203,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 			for(const auto &it : event.Target()->Cargo().PassengerList())
 				failed |= (it.first == this && it.second);
 			if(failed)
-				message += "lost. ";
+				message += "destroyed. ";
 		}
 		else if(event.Type() & ShipEvent::BOARD)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3728,7 +3728,7 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 	if(explosionCount == explosionTotal || forget)
 	{
 		if(IsYours() && Preferences::Has("Extra fleet status messages"))
-			Messages::Add("Your ship \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
+			Messages::Add("Your " + DisplayModelName() + " \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
 
 		if(!forget)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3728,7 +3728,8 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 	if(explosionCount == explosionTotal || forget)
 	{
 		if(IsYours() && Preferences::Has("Extra fleet status messages"))
-			Messages::Add("Your " + DisplayModelName() + " \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
+			Messages::Add("Your " + DisplayModelName() +
+				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
 
 		if(!forget)
 		{


### PR DESCRIPTION
**Feature**
Add the ship model in "ship destroyed" logs.

## Summary
I want to know what kind of ship I just lost. If it was a Scrapper, I don't care, if it was a heavy warship, I need to reload my save.

I also changed the mission failed version to use "destroyed" instead of "lost" so that they match (and because 'lost' is ambiguous in English — did it just fly to the wrong system?)

## Screenshots
No before screenshot. All orange messages just said "Your ship ..."
<img width="1312" alt="Screenshot 2024-06-02 at 16 13 29" src="https://github.com/endless-sky/endless-sky/assets/206120/d0528720-6d90-4232-b861-c5b598870047">

## Testing Done
I flew around and got shot a lot.

## Save File
Any save with a fleet will do. I don't exactly have a handy one since I had to fly a lot to get to systems where my fleet would die. Let me know if I should make one specificly for this.

## Performance Impact
N/A