### PR TITLE
Sort salaries and tributes in descending order.

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -59,7 +59,7 @@ namespace {
 
 		if(otherCount > 0 && maxCount > 0)
 		{
-			list[maxCount - 1].second = "(" + to_string(otherCount + 1) + " Others)";
+			list[maxCount - 1].second = "(" + to_string(otherCount + 1) + " others)";
 			while(otherCount--)
 			{
 				list[maxCount - 1].first += list.back().first;
@@ -664,13 +664,13 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 	vector<pair<int64_t, string>> salary;
 	for(const auto &it : player.Accounts().SalariesIncome())
 		salary.emplace_back(it.second, it.first);
-	sort(salary.begin(), salary.end());
+	sort(salary.begin(), salary.end(), std::greater<>());
 	DrawList(salary, table, "salary:", 4);
 
 	vector<pair<int64_t, string>> tribute;
 	for(const auto &it : player.GetTribute())
 		tribute.emplace_back(it.second, it.first->TrueName());
-	sort(tribute.begin(), tribute.end());
+	sort(tribute.begin(), tribute.end(), std::greater<>());
 	DrawList(tribute, table, "tribute:", 4);
 
 	int maxRows = static_cast<int>(250. - 30. - table.GetPoint().Y()) / 20;


### PR DESCRIPTION
# Enhancement

## Summary
Show most important (greatest value) salaries and tributes at the top of the list in the player dialog.

## Screenshots
Before:
<img width="1312" alt="Screenshot 2024-06-02 at 18 24 35" src="https://github.com/endless-sky/endless-sky/assets/206120/78fe6b8f-6aa9-4d56-868f-695ca420ef89">
After:
<img width="1312" alt="Screenshot 2024-06-02 at 18 24 03" src="https://github.com/endless-sky/endless-sky/assets/206120/16f94f9a-5f64-4b6b-98e3-c56f4fdb2c4e">


## Testing Done
Nearly zero. I don't even have multiple salaries at the moment.


## Save File
Someone else's save would probably be better for this as I am still at the beginning of the game.


## Performance Impact
N/A