### PR TITLE
Slow down fleet scrolling by fifty percent.

### DIFF
--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -887,7 +887,8 @@ bool PlayerInfoPanel::Hover(const Point &point)
 
 bool PlayerInfoPanel::Scroll(double /* dx */, double dy)
 {
-	return Scroll(dy * -.1 * Preferences::ScrollSpeed());
+	// maps pref. of 20, 40, or 60 "pixels" to 1, 2, or 3 table rows
+	return Scroll(dy * -.05 * Preferences::ScrollSpeed());
 }
 
 


### PR DESCRIPTION
# Enhancement

## Summary
I was struggling to keep track of where a ship jumped to with just a single rotational click of my mouse's scroll wheel. I went into the code to figure out how to make the table scroll one line at a time and discovered there was a ScrollSpeed preference which I didn't know about. I eventually found it (second last item on second page of second tab!) and that it toggled between three values of 20, 40 and 60, which I presume to be pixels of scrollage for a normal scroll buffer. The default is 60! I would think new users should have it set to 20, at least until smooth (animated) scrolling is implemented. The current code maps this pref to 2, 4 or 6 table rows by multiplying by 0.1, however due to the nature of the table, and the number of scroll events (some of which are compound) a scroll wheel or track pad send in one swipe, I felt moving by 1, 2, or 3 rows per event provided a better user experience. A fast swipe can still send you hundreds of rows down the table.

## Screenshots
Cannot be seen in static screen shot.

## Testing Done
Experimented with all three preference settings using both a trackpad and a mouse scroll wheel.

## Save File
[fleet-scroll.txt](https://github.com/user-attachments/files/15526387/fleet-scroll.txt)
Testing with bigger fleet lists and other input devices would be appreciated.

## Performance Impact
N/A