### PR TITLE
fix(typo): `Quargs'` -> `Quarg's` in human hails

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -2029,9 +2029,9 @@ phrase "friendly civilian"
 		" and "
 	word
 		"witnessed a Quarg Wardragon jump in with one of their jump drives?"
-		"looked over one of the Quargs' sleek Skylarks?"
+		"looked over one of the Quarg's sleek Skylarks?"
 		"seen a Quarg Skylark up close?"
-		"seen the Quargs' Skylances in action?"
+		"seen the Quarg's Skylances in action?"
 		"seen how the Quarg decimate pirates with their Skylances?"
 		"seen how powerful those Quarg Skylances are?"
 	word


### PR DESCRIPTION
**Typo fix**

This PR fixes a minor typo in human hails.

## Summary
Somewhat counter-intuitively, the species name Quarg is always used in a singular fashion. This means that the possessive form is `Quarg's`, not `Quargs'`. This form is already used in some places, such as various Coalition and Quarg missions.