### PR TITLE
fix(content): Give hai festival jobs a deadline

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -227,7 +227,11 @@ mission "Hai Festival [1]"
 	passengers 10 20
 	cargo "party supplies" 1 2
 	to offer
-		month == 3
+		or
+			month == 3
+			and
+				month == 2
+				day >= 24
 		random < 60
 		"days until year end" > 289
 	to fail
@@ -257,7 +261,11 @@ mission "Hai Festival [2]"
 	passengers 10 20
 	cargo "party supplies" 1 2
 	to offer
-		month == 3
+		or
+			month == 3
+			and
+				month == 2
+				day >= 24
 		random < 60
 		"days until year end" > 289
 	to fail
@@ -287,7 +295,11 @@ mission "Hai Festival [3]"
 	passengers 10 20
 	cargo "party supplies" 1 2
 	to offer
-		month == 3
+		or
+			month == 3
+			and
+				month == 2
+				day >= 24
 		random < 60
 		"days until year end" > 289
 	to fail

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -222,7 +222,7 @@ mission "Hai Festival [1]"
 	name "Festival at <planet>"
 	job
 	repeat
-	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> Hai will pay you <payment> for you to transport them and their <tons> of supplies to <planet>."
+	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> Hai will pay you <payment> for you to transport them and their <tons> of supplies to <planet> by <date>."
 	deadline 0 2
 	passengers 10 20
 	cargo "party supplies" 1 2
@@ -256,7 +256,7 @@ mission "Hai Festival [2]"
 	name "Festival at <planet>"
 	job
 	repeat
-	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> humans will pay you <payment> for you to transport them and their <tons> of supplies to <planet>."
+	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> humans will pay you <payment> for you to transport them and their <tons> of supplies to <planet> by <date>."
 	deadline 0 2
 	passengers 10 20
 	cargo "party supplies" 1 2
@@ -290,7 +290,7 @@ mission "Hai Festival [3]"
 	name "Festival at <planet>"
 	job
 	repeat
-	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> Hai and humans will pay you <payment> for you to transport them and their <tons> of supplies to <planet>."
+	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> Hai and humans will pay you <payment> for you to transport them and their <tons> of supplies to <planet> by <date>."
 	deadline 0 2
 	passengers 10 20
 	cargo "party supplies" 1 2

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -223,11 +223,15 @@ mission "Hai Festival [1]"
 	job
 	repeat
 	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> Hai will pay you <payment> for you to transport them and their <tons> of supplies to <planet>."
+	deadline 0 2
 	passengers 10 20
 	cargo "party supplies" 1 2
 	to offer
 		month == 3
 		random < 60
+		"days until year end" > 289
+	to fail
+		month >= 4
 	source
 		government "Hai"
 	destination
@@ -249,11 +253,15 @@ mission "Hai Festival [2]"
 	job
 	repeat
 	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> humans will pay you <payment> for you to transport them and their <tons> of supplies to <planet>."
+	deadline 0 2
 	passengers 10 20
 	cargo "party supplies" 1 2
 	to offer
 		month == 3
 		random < 60
+		"days until year end" > 289
+	to fail
+		month >= 4
 	source
 		government "Hai"
 	destination
@@ -275,11 +283,15 @@ mission "Hai Festival [3]"
 	job
 	repeat
 	description "For a month each year, the Hai have a huge holiday festival. This group of <bunks> Hai and humans will pay you <payment> for you to transport them and their <tons> of supplies to <planet>."
+	deadline 0 2
 	passengers 10 20
 	cargo "party supplies" 1 2
 	to offer
 		month == 3
 		random < 60
+		"days until year end" > 289
+	to fail
+		month >= 4
 	source
 		government "Hai"
 	destination

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -231,7 +231,7 @@ mission "Hai Festival [1]"
 			month == 3
 			and
 				month == 2
-				day >= 24
+				day >= 27
 		random < 60
 		"days until year end" > 289
 	to fail
@@ -265,7 +265,7 @@ mission "Hai Festival [2]"
 			month == 3
 			and
 				month == 2
-				day >= 24
+				day >= 27
 		random < 60
 		"days until year end" > 289
 	to fail
@@ -299,7 +299,7 @@ mission "Hai Festival [3]"
 			month == 3
 			and
 				month == 2
-				day >= 24
+				day >= 27
 		random < 60
 		"days until year end" > 289
 	to fail

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -228,12 +228,13 @@ mission "Hai Festival [1]"
 	cargo "party supplies" 1 2
 	to offer
 		or
-			month == 3
+			and
+				month == 3
+				day <= 17
 			and
 				month == 2
 				day >= 27
 		random < 60
-		"days until year end" > 289
 	to fail
 		month >= 4
 	source
@@ -262,12 +263,13 @@ mission "Hai Festival [2]"
 	cargo "party supplies" 1 2
 	to offer
 		or
-			month == 3
+			and
+				month == 3
+				day <= 17
 			and
 				month == 2
 				day >= 27
 		random < 60
-		"days until year end" > 289
 	to fail
 		month >= 4
 	source
@@ -296,12 +298,13 @@ mission "Hai Festival [3]"
 	cargo "party supplies" 1 2
 	to offer
 		or
-			month == 3
+			and
+				month == 3
+				day <= 17
 			and
 				month == 2
 				day >= 27
 		random < 60
-		"days until year end" > 289
 	to fail
 		month >= 4
 	source


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10141

## Summary
The Hai Festival jobs do not have a deadline and can still offer even if it would be impossible to deliver the passengers until after the deadline. This PR adds a deadline, makes it so the mission can only offer if it is always possible to complete, and makes it fail after the end of the month.

EDIT: It can now also offer on February 27 or Februrary 28 as it takes at least two days to reach the destination, one to depart, and at least one to jump.

## Screenshots
![image](https://github.com/endless-sky/endless-sky/assets/109186806/f557d47d-3be7-4659-b324-2d8915b21115)

## Testing Done
Tested that the mission offered

## Save File
This save file can be used to test these changes: [Test Pilot~Festival.txt](https://github.com/user-attachments/files/15526771/Test.Pilot.Festival.txt)