### PR TITLE
Provide more user settings for scrolling speed.

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -357,9 +357,9 @@ bool PreferencesPanel::Scroll(double dx, double dy)
 		{
 			int speed = Preferences::ScrollSpeed();
 			if(dy < 0.)
-				speed = max(20, speed - 20);
+				speed = max(10, speed - 10);
 			else
-				speed = min(60, speed + 20);
+				speed = min(60, speed + 10);
 			Preferences::SetScrollSpeed(speed);
 		}
 		return true;
@@ -1231,10 +1231,10 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 	}
 	else if(str == SCROLL_SPEED)
 	{
-		// Toggle between three different speeds.
-		int speed = Preferences::ScrollSpeed() + 20;
+		// Toggle between six different speeds.
+		int speed = Preferences::ScrollSpeed() + 10;
 		if(speed > 60)
-			speed = 20;
+			speed = 10;
 		Preferences::SetScrollSpeed(speed);
 	}
 	else if(str == DATE_FORMAT)


### PR DESCRIPTION
# Enhancement
Provide finer grained user settings for scrolling speed.

## Summary
In order to be able to scroll the fleet list in the player info panel one line at a time, I would like to be able to set my scroll speed preference to "10". This change allows users to maintain their existing preference but provide more choices in the UI, in the range 10 to 60 going up in incrememnts of 10.

## Screenshots
After:
<img width="1312" alt="Screenshot 2024-06-02 at 21 45 29" src="https://github.com/endless-sky/endless-sky/assets/206120/57809b26-b419-4549-a59f-46634a068c9f">

## Testing Done
I manually tested clicking to advance the preference (which loops around from 60 back to 10) and hover-scrolling over it, which is bounded at 10 and 60.
I checked the effects of the 10 setting in the player info panel fleet list with 177 ships, and in the shipyard and outfitter panels with the same, on both the left (new ship and outfit) and right (owned ship) sides.

## Save File
It is a user preference.

## Wiki Update
I did a repo search and browsed the wiki but didn't see a page discussion available user settings.

## Performance Impact
N/A