### PR TITLE
Colour-code profitable commodities on the map screen.

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -164,6 +164,12 @@ color "planet target pointer restricted" .8 .8 .3 0.
 color "planet target pointer hostile" .85 .3 .2 0.
 color "planet target pointer dominated" 1. 1. 1. 0.
 
+# Colors used for commodity prices.
+color "profitable" 0. .5 0. 0.
+color "profitable selected" .2 .8 .2 0.
+color "unprofitable" .6 .2 .2 0.
+color "unprofitable selected" 1. .1 .1 0.
+
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.
 color "warning back" .21 .18 .08 1.

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -674,6 +674,10 @@ void MapDetailPanel::DrawInfo()
 {
 	const Color &dim = *GameData::Colors().Get("dim");
 	const Color &medium = *GameData::Colors().Get("medium");
+	const Color &profitable = *GameData::Colors().Get("profitable");
+	const Color &profitable_selected = *GameData::Colors().Get("profitable selected");
+	const Color &unprofitable = *GameData::Colors().Get("unprofitable");
+	const Color &unprofitable_selected = *GameData::Colors().Get("unprofitable selected");
 
 	const Color &back = *GameData::Colors().Get("map side panel background");
 
@@ -781,7 +785,7 @@ void MapDetailPanel::DrawInfo()
 		bool isSelected = false;
 		if(static_cast<unsigned>(this->commodity) < GameData::Commodities().size())
 			isSelected = (&commodity == &GameData::Commodities()[this->commodity]);
-		const Color &color = isSelected ? medium : dim;
+		Color color = isSelected ? medium : dim;
 
 		font.Draw(commodity.name, uiPoint, color);
 
@@ -800,11 +804,16 @@ void MapDetailPanel::DrawInfo()
 			else
 			{
 				value -= localValue;
-				price += "(";
 				if(value > 0)
+				{
 					price += '+';
+					color = isSelected ? profitable_selected : profitable;
+				}
+				else if(value < 0)
+				{
+					color = isSelected ? unprofitable_selected : unprofitable;
+				}
 				price += to_string(value);
-				price += ")";
 			}
 		}
 		else
@@ -814,7 +823,7 @@ void MapDetailPanel::DrawInfo()
 		font.Draw({price, alignRight}, uiPoint, color);
 
 		if(isSelected)
-			PointerShader::Draw(uiPoint + Point(0., 7.), Point(1., 0.), 10.f, 10.f, 0.f, color);
+			PointerShader::Draw(uiPoint + Point(0., 7.), Point(1., 0.), 10.f, 10.f, 0.f, medium);
 
 		uiPoint.Y() += 20.;
 	}


### PR DESCRIPTION
# Enhancement

## Summary
Colour-code the commodity prices on the map screen with a simple positive/negative difference. At present, the only difference between making a big profit and a big loss is the vertical stroke on the + character, which is hard for me to spot vs. the - character!

Also, this removes the parentheses, becase in finance this means that a number is negative. Looking down the list for the first time made me think everything was negative.

## Screenshots
Before:
<img width="1312" alt="Screenshot 2024-06-03 at 15 55 00" src="https://github.com/endless-sky/endless-sky/assets/206120/3ff693a3-43ad-45a3-ab25-83d8c742603b">
After:
<img width="1312" alt="Screenshot 2024-06-03 at 15 56 03" src="https://github.com/endless-sky/endless-sky/assets/206120/e078d1d9-24e5-4a96-9641-42be74f9075a">

## Testing Done
I did a fair bit of experimenting with various colours to see which ones felt as bright as the dim/medium colours used for the text on the left. I didn't want to make the whole row red or green.
I also accounted for the case where the difference is zero (see screenshots).

## Save File
Any save file will do.

## Wiki Update
(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)

## Performance Impact
N/A