### PR TITLE
Create a 'list of strings' node type in the UI.

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1276,6 +1276,16 @@ interface "trade"
 
 
 interface "bank"
+	strings "income"
+		""
+		"Your Salary Income"
+		"Your Tribute Income"
+		"Your Salary and Tribute Income"
+		"Your Return on Assets Income"
+		"Your Salary and Return on Assets Income"
+		"Your Tribute and Return on Assets Income"
+		"Your Salary, Tribute, and Returns Income"
+
 	box "content"
 		from -310 78 to 190 355
 

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -212,11 +212,10 @@ void BankPanel::Draw()
 		// Your daily income offsets expenses.
 		totalPayment -= salariesIncome + tributeIncome + b.assetsReturns;
 
-		static const string LABEL[] = {"", "Your Salary Income", "Your Tribute Income", "Your Salary and Tribute Income",
-			"Your Return on Assets Income", "Your Salary and Return on Assets Income",
-			"Your Tribute and Return on Assets Income", "Your Salary, Tribute, and Returns Income" };
+		const Interface *bankUi = GameData::Interfaces().Get("bank");
+		const vector<std::string> labels = bankUi->GetStrings("income");
 		const auto incomeLayout = Layout(310, Truncate::BACK);
-		table.DrawCustom({LABEL[(salariesIncome != 0) + 2 * (tributeIncome != 0) + 4 * (b.assetsReturns != 0)],
+		table.DrawCustom({labels[(salariesIncome != 0) + 2 * (tributeIncome != 0) + 4 * (b.assetsReturns != 0)],
 			incomeLayout});
 		// For crew salaries, only the "payment" field needs to be shown.
 		table.Advance(3);

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -86,6 +86,7 @@ void Interface::Load(const DataNode &node)
 	points.clear();
 	values.clear();
 	lists.clear();
+	strings.clear();
 
 	// First, figure out the anchor point of this interface.
 	Point anchor = ParseAlignment(node, 2);
@@ -109,6 +110,12 @@ void Interface::Load(const DataNode &node)
 			auto &list = lists[child.Token(1)];
 			for(const auto &grand : child)
 				list.emplace_back(grand.Value(0));
+		}
+		else if(child.Token(0) == "strings" && child.Size() >= 2)
+		{
+			auto &list = strings[child.Token(1)];
+			for(const auto &grand : child)
+				list.emplace_back(grand.Token(0));
 		}
 		else if(child.Token(0) == "visible" || child.Token(0) == "active")
 		{
@@ -196,12 +203,22 @@ double Interface::GetValue(const string &name) const
 
 
 
-// Get a named list.
+// Get a named list of values.
 const vector<double> &Interface::GetList(const string &name) const
 {
 	static vector<double> EMPTY;
 	auto it = lists.find(name);
 	return (it == lists.end() ? EMPTY : it->second);
+}
+
+
+
+// Get a named list of strings.
+const vector<std::string> &Interface::GetStrings(const string &name) const
+{
+	static vector<std::string> EMPTY;
+	auto it = strings.find(name);
+	return (it == strings.end() ? EMPTY : it->second);
 }
 
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -56,6 +56,7 @@ public:
 
 	// Get a named list.
 	const std::vector<double> &GetList(const std::string &name) const;
+	const std::vector<std::string> &GetStrings(const std::string &name) const;
 
 
 private:
@@ -246,6 +247,7 @@ private:
 	std::map<std::string, Element> points;
 	std::map<std::string, double> values;
 	std::map<std::string, std::vector<double>> lists;
+	std::map<std::string, std::vector<std::string>> strings;
 };
 
 


### PR DESCRIPTION
# Enhancement

## Summary
Create a new node type for interfaces.txt called "strings" which contains a list of strings to use in the interface.

## Screenshots
No visual difference.

## Usage examples
Example incuded in PR from Bank:
```
interface "bank"
	strings "income"
		""
		"Your Salary Income"
		"Your Tribute Income"
		"Your Salary and Tribute Income"
		"Your Return on Assets Income"
		"Your Salary and Return on Assets Income"
		"Your Tribute and Return on Assets Income"
		"Your Salary, Tribute, and Returns Income"
```

## Testing Done
It compiles. I only checked on one Hai planet with my current character, who has 'salary and tribute'.

## Save File
Land on any planet with a bank, using a variety of characters who have different levels of income.

## Wiki Update
A Wiki update will be required will be forthcoming if this change is generally approved of.

## Performance Impact
N/A