### PR TITLE
fix(mechanics): Don't reset player flagship after death

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -646,8 +646,6 @@ void PlayerInfo::Die(int response, const shared_ptr<Ship> &capturer)
 		if(it != ships.end())
 			ships.erase(it);
 	}
-
-	flagship.reset();
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR fixes #10161

## Summary
One of the changes introduced in #10128 apparently broke natural death, because a new flagship can get assigned to the player after one blows up.

Apparently, even without resetting the flagship, the other changes introduced in #10128 fix that issue, so the problematic code can be removed.

## Testing Done
I tested that `die` still works, and the flagship doesn't get reassigned after exploding.

## Save File
See the attached issues.