### PR TITLE
Smooth map zoom

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1430,6 +1430,8 @@ interface "map buttons (small screen)" bottom right
 interface "map"
 	value "max zoom" 2
 	value "min zoom" -2
+	value "labels" -1
+	value "large labels" 1.5
 
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -137,6 +137,8 @@ namespace {
 	const int HOVER_TIME = 60;
 	// Length in frames of the recentering animation.
 	const int RECENTER_TIME = 20;
+	// Length in frames of the zooming animation.
+	const int ZOOM_TIME = 10;
 
 	bool HasMultipleLandablePlanets(const System &system)
 	{
@@ -270,6 +272,10 @@ MapPanel::MapPanel(PlayerInfo &player, int commodity, const System *special)
 
 void MapPanel::Step()
 {
+	const double targetZoom = player.MapZoom();
+	if(zoom != targetZoom)
+		zoom += (targetZoom - zoom) / ZOOM_TIME;
+
 	if(recentering > 0)
 	{
 		double step = (recentering - .5) / RECENTER_TIME;
@@ -880,7 +886,7 @@ void MapPanel::Find(const string &name)
 
 double MapPanel::Zoom() const
 {
-	return pow(1.5, player.MapZoom());
+	return pow(1.5, zoom);
 }
 
 

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -140,6 +140,7 @@ protected:
 	int recentering = 0;
 	int commodity;
 	int step = 0;
+	double zoom;
 	std::string buttonCondition;
 
 	// Distance from the screen center to the nearest owned system,

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -140,7 +140,7 @@ protected:
 	int recentering = 0;
 	int commodity;
 	int step = 0;
-	double zoom;
+	double zoom = 0.;
 	std::string buttonCondition;
 
 	// Distance from the screen center to the nearest owned system,


### PR DESCRIPTION
# Enhancement

## Summary
Smoothly zooms the map when the user changes the zoom level.

## Screenshots
Behaviour is an animation.

## Testing Done
I was not able to get a "large label" value of 2 to work as expected. I think the pow() function is not producing comparable floating point values, so I set it to use large labels above a zoom level of 1.5

## Save File
Any saved game will do.

## Wiki Update
I don't think the new values need a Wiki entry. I might be wrong.

## Performance Impact
Computes a new Color on the stack for every system being rendered. Was unnoticable during testing but I have a powerful laptop.