### PR TITLE
Earlier destroyed log

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1191,8 +1191,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 	if(event.TargetGovernment()->IsPlayer() && !hasFailed)
 	{
 		bool failed = false;
-		string message = "Your " + event.Target()->DisplayModelName() +
-			" \"" + event.Target()->Name() + "\" has been ";
+		string message = "";
 		if(event.Type() & ShipEvent::DESTROY)
 		{
 			// Destroyed ships carrying mission cargo result in failed missions.
@@ -1202,8 +1201,6 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 			// If any mission passengers were present, this mission is failed.
 			for(const auto &it : event.Target()->Cargo().PassengerList())
 				failed |= (it.first == this && it.second);
-			if(failed)
-				message += "destroyed. ";
 		}
 		else if(event.Type() & ShipEvent::BOARD)
 		{
@@ -1211,7 +1208,8 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 			for(const auto &it : event.Actor()->Cargo().MissionCargo())
 				failed |= (it.first == this);
 			if(failed)
-				message += "plundered. ";
+				message += "Your " + event.Target()->DisplayModelName() +
+			" \"" + event.Target()->Name() + "\" has been plundered. ";
 		}
 
 		if(failed)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1191,7 +1191,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 	if(event.TargetGovernment()->IsPlayer() && !hasFailed)
 	{
 		bool failed = false;
-		string message = "";
+		string message;
 		if(event.Type() & ShipEvent::DESTROY)
 		{
 			// Destroyed ships carrying mission cargo result in failed missions.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1208,8 +1208,8 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 			for(const auto &it : event.Actor()->Cargo().MissionCargo())
 				failed |= (it.first == this);
 			if(failed)
-				message += "Your " + event.Target()->DisplayModelName() +
-			" \"" + event.Target()->Name() + "\" has been plundered. ";
+				message = "Your " + event.Target()->DisplayModelName() +
+					" \"" + event.Target()->Name() + "\" has been plundered. ";
 		}
 
 		if(failed)

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -515,7 +515,8 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, const Mission *
 
 	// Check if the success status has changed. If so, display a message.
 	if(isVisible && !alreadyFailed && HasFailed())
-		Messages::Add("Mission failed.", Messages::Importance::Highest);
+		Messages::Add("Mission failed" + (caller ? ": \"" + caller->Name() + "\"" : "") + ".",
+			Messages::Importance::Highest);
 	else if(ui && !alreadySucceeded && HasSucceeded(player.GetSystem(), false))
 	{
 		// If "completing" this NPC displays a conversation, reference

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3063,7 +3063,13 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 		hullDelay = max(hullDelay, static_cast<int>(attributes.Get("disabled repair delay")));
 	}
 	if(!wasDestroyed && IsDestroyed())
+	{
 		type |= ShipEvent::DESTROY;
+
+		if(IsYours() && Preferences::Has("Extra fleet status messages"))
+			Messages::Add("Your " + DisplayModelName() +
+				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
+	}
 
 	// Inflicted heat damage may also disable a ship, but does not trigger a "DISABLE" event.
 	if(heat > MaximumHeat())
@@ -3730,10 +3736,6 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 	// Once we've created enough little explosions, die.
 	if(explosionCount == explosionTotal || forget)
 	{
-		if(IsYours() && Preferences::Has("Extra fleet status messages"))
-			Messages::Add("Your " + DisplayModelName() +
-				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
-
 		if(!forget)
 		{
 			const Effect *effect = GameData::Effects().Get("smoke");


### PR DESCRIPTION
# Bug fix & Enhancement

## Summary
Currently, when an escort is destroyed, you only get a log message after all the explosions have finished. This may be after you have landed or jumped out of the system, in which case the ship is still destroyed but no log message appears!

After moving the log message to the first frame where the escort is irrevokably destroyed, I realised that the same "ship destroyed" log was being sent for every affected mission, at the point the ship starts exploding, and then again once the ship concludes exploding. I replaced this with just one message at the start.

## Screenshots
Before:
<img width="1312" alt="Screenshot 2024-06-06 at 08 47 35" src="https://github.com/endless-sky/endless-sky/assets/206120/163a5e92-a53e-4559-a134-18f53d280573">

After:
<img width="1312" alt="Screenshot 2024-06-06 at 08 35 53" src="https://github.com/endless-sky/endless-sky/assets/206120/e7776f7a-39c9-4976-9017-ca9707ed7911">


## Usage examples
N/A

## Testing Done
A lot of departing from planets using the attached save, and getting shot at.

## Save File
This save file can be used to test these changes:
[Mission Failed.txt](https://github.com/user-attachments/files/15612308/Mission.Failed.txt)
Just let the pirates kill your escorts. You might want to move the Nest to the edge of the system.


## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A