### PR TITLE
Fix battery only warning

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1302,7 +1302,7 @@ vector<string> Ship::FlightCheck() const
 			checks.emplace_back("afterburner only?");
 		if(!thrust && !afterburner)
 			checks.emplace_back("reverse only?");
-		if(!generation && !solar && !consuming)
+		if(energy <= battery)
 			checks.emplace_back("battery only?");
 		if(energy < thrustEnergy)
 			checks.emplace_back("limited thrust?");


### PR DESCRIPTION
# Bug fix

While investigating #10172 I discovered the "battery only?" warning never shows up for the affected ship, which will be how I got in to this situation in the first place.

## Summary
When a ship with "energy consumption" has no "energy generation", the check for `!generation` fails because the value is negative. We need to check if all sources of energy combined are not positive.

## Screenshots
No before image possible.
After:
<img width="1266" alt="Screenshot 2024-06-07 at 20 06 51" src="https://github.com/endless-sky/endless-sky/assets/206120/0429750e-1638-4b7d-8bef-274bb6041fbc">

## Testing Done
Just tested with one ship that only had a battery and nothing else.

## Save File
Any save file will do. Remove your energy generation, fuel converters, and solar power. Add some batteries.

## Wiki Update
N/A

## Performance Impact
N/A