### PR TITLE
Warn if the cooling efficiency is below 50%

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1189,7 +1189,7 @@ tip "no bays?"
 	`There are insufficient bays available to carry this ship. If it took off, it would be unable to leave this star system.`
 
 tip "inefficient cooling?"
-	`This ship has inefficient cooling. Remove some outfit expansions to improve efficiency.`
+	`This ship has inefficient cooling. Removing some outfits that have the "cooling inefficiency" property will alleviate this.`
 
 tip "insufficient energy to fire?"
 	`This ship has insufficient energy storage to fire an installed weapon.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1188,6 +1188,9 @@ tip "no fuel?"
 tip "no bays?"
 	`There are insufficient bays available to carry this ship. If it took off, it would be unable to leave this star system.`
 
+tip "inefficient cooling?"
+	`This ship has inefficient cooling. Remove some outfit expansions to improve efficiency.`
+
 tip "insufficient energy to fire?"
 	`This ship has insufficient energy storage to fire an installed weapon.`
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1325,6 +1325,10 @@ vector<string> Ship::FlightCheck() const
 				checks.emplace_back("insufficient energy to fire?");
 				break;
 			}
+		if(CoolingEfficiency() < .5)
+		{
+			checks.emplace_back("inefficient cooling?");
+		}
 	}
 
 	return checks;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1326,9 +1326,7 @@ vector<string> Ship::FlightCheck() const
 				break;
 			}
 		if(CoolingEfficiency() < .5)
-		{
 			checks.emplace_back("inefficient cooling?");
-		}
 	}
 
 	return checks;


### PR DESCRIPTION
# Enhancement

## Summary
Adds one more preflight warning for when you have too many outfit expansions.

## Screenshots
Before:
<img width="1312" alt="Screenshot 2024-06-08 at 15 51 44" src="https://github.com/endless-sky/endless-sky/assets/206120/4e1e6aff-9569-432e-8cc9-0b8d440e7c48">
After:
<img width="1312" alt="Screenshot 2024-06-08 at 15 51 51" src="https://github.com/endless-sky/endless-sky/assets/206120/4be65fa6-b900-4185-9ff4-6fa3d7337954">
Subsequent:
<img width="1312" alt="Screenshot 2024-06-08 at 15 51 58" src="https://github.com/endless-sky/endless-sky/assets/206120/9b9dc46f-d859-4d81-8d02-aa674da4825b">

## Testing Done
Minimal, enough to get he screenshots. I didn't try to take off.

## Save File
Get a cargo vessel. Buy a lot of outfit expansions to test.
Add a lot of cooling. It should have near-zero effect for put an additional Liquid Helium Cooler once you have enough Outfit Expansions.
The idea is that you can remove both the expansions and the unnecessary cooling and improve the kit-out of the ship.

## Wiki Update
Don't think it needs one.

## Performance Impact
N/A
