### PR TITLE
Move sell outfits btn

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1253,24 +1253,30 @@ interface "trade"
 
 	active if "can buy"
 	sprite "ui/dialog cancel"
-		center 40 355
+		center 60 355
 	button u "B_uy All"
-		center 40 355
+		center 60 355
 		dimensions 70 30
-	
-	sprite "ui/wide button"
-		center 130 355
-	
+
+	sprite "ui/dialog cancel"
+		center 140 355
 	active if "can sell"
-	visible if "!can sell outfits"
 	button e "S_ell All"
-		center 130 355
+		center 140 355
+		dimensions 70 30
+
+	sprite "ui/wide button"
+		center -150 355
+	active if "can sell minerals"
+	button n "Sell Mi_nerals"
+		center -150 355
 		dimensions 90 30
-	
+
+	sprite "ui/wide button"
+		center -250 355
 	active if "can sell outfits"
-	visible if "can sell outfits"
-	button e "S_ell Outfits"
-		center 130 355
+	button f "Sell Out_fits"
+		center -250 355
 		dimensions 90 30
 
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -199,7 +199,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 	// Don't show the "in stock" amount if the outfit has an unlimited stock or
 	// if it is not something that you can buy.
 	int stock = 0;
-	if(!outfitter.Has(outfit) && outfit->Get("installable") >= 0.)
+	if(!outfitter.Has(outfit) && (outfit->Get("installable") >= 0. || outfit->Get("minable") >= 0.))
 		stock = max(0, player.Stock(outfit));
 	int cargo = player.Cargo().Get(outfit);
 	int storage = player.Storage().Get(outfit);

--- a/source/TradingPanel.h
+++ b/source/TradingPanel.h
@@ -51,10 +51,6 @@ private:
 	const System &system;
 	const int COMMODITY_COUNT;
 
-	// Remember whether the "sell all" button will sell all outfits, or sell
-	// everything except outfits.
-	bool sellOutfits = false;
-
 	// Keep track of how much we sold and how much profit was made.
 	int tonsSold = 0;
 	int64_t profit = 0;


### PR DESCRIPTION
# Feature, Bug fixes, & Enhancements

## Summary
Split 'Sell Outfits' button away from 'Sell All'.

* Add new Sell Outfits button in trade panel (f or Shift + O).
* Add new Sell Minerals button in trade panel (n or Shift + M).
* Sell All button no longer sells minerals. I didn't expect it to do this and I must have lost LOTS of minerals this way — I am trying to do a Hai mission, jumping from system to system and doing trades along the way, and my minerals kept disappearing. I thought this was some other unrelated bug!
* Make Sell All button shorter.
* Display "in stock" in outfitter when you sell minerals, instead of "(not sold here)" — you can buy them back so they are in stock.

## Screenshots
forthcoming...

## Usage examples
N/A

## Testing Done
Buying and selling of commodities, outfits and minerals.

## Save File
forthcoming...

## Artwork Checklist
N/A

## Wiki Update
May need one. Will update PR if it does.

## Performance Impact
N/A