### PR TITLE
feat(enhancement): Assist recharging batteries

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -61,10 +61,20 @@ namespace {
 		return cancelers;
 	}
 
-	bool IsStranded(const Ship &ship)
+	bool NeedsFuel(const Ship &ship)
 	{
 		return ship.GetSystem() && !ship.IsEnteringHyperspace() && !ship.GetSystem()->HasFuelFor(ship)
-			&& ship.NeedsFuel();
+				&& ship.NeedsFuel();
+	}
+
+	bool NeedsEnergy(const Ship &ship)
+	{
+		return ship.GetSystem() && !ship.IsEnteringHyperspace() && ship.NeedsEnergy();
+	}
+
+	bool IsStranded(const Ship &ship)
+	{
+		return NeedsFuel(ship) || NeedsEnergy(ship);
 	}
 
 	bool CanBoard(const Ship &ship, const Ship &target)
@@ -777,7 +787,7 @@ void AI::Step(Command &activeCommands)
 			if(shipToAssist->IsDestroyed() || shipToAssist->GetSystem() != it->GetSystem()
 					|| shipToAssist->IsLanding() || shipToAssist->IsHyperspacing()
 					|| shipToAssist->GetGovernment()->IsEnemy(gov)
-					|| (!shipToAssist->IsDisabled() && !shipToAssist->NeedsFuel()))
+					|| (!shipToAssist->IsDisabled() && !shipToAssist->NeedsFuel() && !shipToAssist->NeedsEnergy()))
 			{
 				shipToAssist.reset();
 				it->SetShipToAssist(nullptr);
@@ -810,7 +820,7 @@ void AI::Step(Command &activeCommands)
 
 		// Stranded ships that have a helper need to stop and be assisted.
 		bool strandedWithHelper = isStranded &&
-			(HasHelper(*it, isStranded) || it->GetPersonality().IsDerelict() || it->IsYours());
+			(HasHelper(*it, NeedsFuel(*it), NeedsEnergy(*it)) || it->GetPersonality().IsDerelict() || it->IsYours());
 
 		// Behave in accordance with personality traits.
 		if(isPresent && personality.IsSwarming() && !strandedWithHelper)
@@ -1165,7 +1175,9 @@ bool AI::CanPursue(const Ship &ship, const Ship &target) const
 // Check if the ship is being helped, and if not, ask for help.
 void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 {
-	if(HasHelper(ship, isStranded))
+	bool needsFuel = NeedsFuel(ship);
+	bool needsEnergy = NeedsEnergy(ship);
+	if(HasHelper(ship, needsFuel, needsEnergy))
 		isStranded = true;
 	else if(!Random::Int(30))
 	{
@@ -1215,7 +1227,7 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 			}
 
 			// Check if this ship is physically able to help.
-			if(!CanHelp(ship, *helper, isStranded))
+			if(!CanHelp(ship, *helper, needsFuel, needsEnergy))
 				continue;
 
 			// Prefer fast ships over slow ones.
@@ -1239,7 +1251,7 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 
 
 // Determine if the selected ship is physically able to render assistance.
-bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel) const
+bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel, const bool needsEnergy) const
 {
 	// A ship being assisted cannot assist.
 	if(helperList.find(&helper) != helperList.end())
@@ -1256,8 +1268,8 @@ bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel) con
 			|| (ship.IsDisabled() && helper.GetGovernment() != ship.GetGovernment()))
 		return false;
 
-	// If the helper has insufficient fuel, it cannot help this ship unless this ship is also disabled.
-	if(!ship.IsDisabled() && needsFuel && !helper.CanRefuel(ship))
+	// If the helper has insufficient fuel or energy, it cannot help this ship unless this ship is also disabled.
+	if(!ship.IsDisabled() && ((needsFuel && !helper.CanRefuel(ship)) || (needsEnergy && !helper.CanGiveEnergy(ship))))
 		return false;
 
 	return true;
@@ -1265,13 +1277,13 @@ bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel) con
 
 
 
-bool AI::HasHelper(const Ship &ship, const bool needsFuel)
+bool AI::HasHelper(const Ship &ship, const bool needsFuel, const bool needsEnergy)
 {
 	// Do we have an existing ship that was asked to assist?
 	if(helperList.find(&ship) != helperList.end())
 	{
 		shared_ptr<Ship> helper = helperList[&ship].lock();
-		if(helper && helper->GetShipToAssist().get() == &ship && CanHelp(ship, *helper, needsFuel))
+		if(helper && helper->GetShipToAssist().get() == &ship && CanHelp(ship, *helper, needsFuel, needsEnergy))
 			return true;
 		else
 			helperList.erase(&ship);

--- a/source/AI.h
+++ b/source/AI.h
@@ -89,8 +89,8 @@ private:
 	bool CanPursue(const Ship &ship, const Ship &target) const;
 	// Disabled or stranded ships coordinate with other ships to get assistance.
 	void AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship);
-	bool CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel) const;
-	bool HasHelper(const Ship &ship, const bool needsFuel);
+	bool CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel, const bool needsEnergy) const;
+	bool HasHelper(const Ship &ship, const bool needsFuel, const bool needsEnergy);
 	// Pick a new target for the given ship.
 	std::shared_ptr<Ship> FindTarget(const Ship &ship) const;
 	std::shared_ptr<Ship> FindNonHostileTarget(const Ship &ship) const;

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -81,11 +81,16 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 	{
 		// Is the player in any need of assistance?
 		const Ship *flagship = player.Flagship();
-		// Check if the player is out of fuel.
+		// Check if the player is out of fuel or energy.
 		if(flagship->NeedsFuel(false))
 		{
 			playerNeedsHelp = true;
 			canGiveFuel = ship->CanRefuel(*flagship) && canAssistPlayer;
+		}
+		if(flagship->NeedsEnergy())
+		{
+			playerNeedsHelp = true;
+			canGiveEnergy = ship->CanGiveEnergy(*flagship) && canAssistPlayer;
 		}
 		// Check if the player is disabled.
 		if(flagship->IsDisabled())
@@ -112,6 +117,8 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 				helpOffer += "give you some fuel?";
 			else if(canRepair)
 				helpOffer += "patch you up?";
+			else if(canGiveEnergy)
+				helpOffer += "recharge you?";
 			SetMessage(helpOffer);
 		}
 		else if(playerNeedsHelp && !canAssistPlayer)
@@ -320,15 +327,27 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		{
 			if(ship->GetPersonality().IsSurveillance())
 				SetMessage("Sorry, I'm too busy to help you right now.");
-			else if(canGiveFuel || canRepair)
+			else if(canGiveFuel || canRepair || canGiveEnergy)
 			{
 				ship->SetShipToAssist(player.FlagshipPtr());
 				SetMessage("Hang on, we'll be there in a minute.");
 			}
-			else if(ship->Fuel())
-				SetMessage("Sorry, but if we give you fuel we won't have enough to make it to the next system.");
-			else
-				SetMessage("Sorry, we don't have any fuel.");
+			else if(player.Flagship()->NeedsFuel(false))
+			{
+				if(ship->Fuel())
+					SetMessage("Sorry, but if we give you fuel we won't have enough to make it to the next system.");
+				else
+					SetMessage("Sorry, we don't have any fuel.");
+			}
+			else if(player.Flagship()->NeedsEnergy())
+			{
+				if(ship->Energy())
+					SetMessage("Sorry, but if we give you energy we won't have enough for our ship.");
+				else
+					SetMessage("Sorry, we don't have any energy.");
+			}
+			else // shouldn't happen
+				SetMessage("Sorry, we are unable to assist you.");
 		}
 		else
 		{

--- a/source/HailPanel.h
+++ b/source/HailPanel.h
@@ -72,6 +72,7 @@ private:
 	bool playerNeedsHelp = false;
 	bool canAssistPlayer = true;
 	bool canGiveFuel = false;
+	bool canGiveEnergy = false;
 	bool canRepair = false;
 	bool hasLanguage = true;
 	bool requestedToBribeShip = false;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1781,10 +1781,11 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 			TransferFuel(victim->JumpFuelMissing(), victim.get());
 		}
 		// Transfer some energy, if needed.
-		if(victim->Attributes().Get("energy capacity") > 0 && victim->energy < 200)
+		if(victim->Attributes().Get("energy capacity") > 0 && victim->energy < 200.)
 		{
 			helped = true;
-			TransferEnergy(max(200., victim->Attributes().Get("energy capacity") * 0.2), victim.get());
+			double toGive = max(attributes.Get("energy capacity") * 0.1, victim->Attributes().Get("energy capacity") * 0.2);
+			TransferEnergy(max(200., toGive), victim.get());
 		}
 		if(helped)
 		{
@@ -2537,7 +2538,7 @@ bool Ship::CanRefuel(const Ship &other) const
 
 bool Ship::CanGiveEnergy(const Ship &other) const
 {
-	double toGive = max(200., other.attributes.Get("energy capacity") * 0.2);
+	double toGive = min(other.attributes.Get("energy capacity"), max(200., other.attributes.Get("energy capacity") * 0.2));
 	return energy >= 2 * toGive;
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2811,8 +2811,8 @@ bool Ship::NeedsFuel(bool followParent) const
 
 bool Ship::NeedsEnergy() const
 {
-	return Attributes().Get("energy capacity") && !energy && !Attributes().Get("energy generation")
-			&& !Attributes().Get("fuel energy") && !Attributes().Get("solar collection");
+	return attributes.Get("energy capacity") && !energy && !attributes.Get("energy generation")
+			&& !attributes.Get("fuel energy") && !attributes.Get("solar collection");
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2537,7 +2537,7 @@ bool Ship::CanRefuel(const Ship &other) const
 
 bool Ship::CanGiveEnergy(const Ship &other) const
 {
-	double toGive = max(200., other.attributes.Get("energy capacity"));
+	double toGive = max(200., other.attributes.Get("energy capacity") * 0.2);
 	return attributes.Get("energy capacity") >= 2 * toGive;
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2538,7 +2538,7 @@ bool Ship::CanRefuel(const Ship &other) const
 bool Ship::CanGiveEnergy(const Ship &other) const
 {
 	double toGive = max(200., other.attributes.Get("energy capacity") * 0.2);
-	return attributes.Get("energy capacity") >= 2 * toGive;
+	return energy >= 2 * toGive;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -311,8 +311,12 @@ public:
 	void Recharge(int rechargeType = Port::RechargeType::All, bool hireCrew = true);
 	// Check if this ship is able to give the given ship enough fuel to jump.
 	bool CanRefuel(const Ship &other) const;
+	// Check if this ship can transfer sufficient energy to the other ship.
+	bool CanGiveEnergy(const Ship &other) const;
 	// Give the other ship enough fuel for it to jump.
 	double TransferFuel(double amount, Ship *to);
+	// Give the other ship some energy.
+	double TransferEnergy(double amount, Ship *to);
 	// Mark this ship as property of the given ship. Returns the number of crew transferred from the capturer.
 	int WasCaptured(const std::shared_ptr<Ship> &capturer);
 	// Clear all orders and targets this ship has (after capture or transfer of control).
@@ -353,6 +357,8 @@ public:
 	// If followParent is false, this ship will not follow the parent.
 	int JumpsRemaining(bool followParent = true) const;
 	bool NeedsFuel(bool followParent = true) const;
+	// Checks whether this ship needs energy to function.
+	bool NeedsEnergy() const;
 	// Get the amount of fuel missing for the next jump (smart refueling)
 	double JumpFuelMissing() const;
 	// Get the heat level at idle.


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #4065.

## Summary
Enables helping ships that don't have any energy left in their batteries, and cannot generate any for themselves. Also adds support for stealing energy from boarded ships.

## Usage examples
Battery-only builds will benefit from this.

## Testing Done
I tested that:
 - you can ask for help when out of energy (no energy, no generators, but having some energy capacity)
 - ships will recharge you when docking
 - ships will take energy from hostile ships when boarding

## Wiki Update
N/A

## Performance Impact
N/A
