### PR TITLE
Help balance the Mind battle

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -753,8 +753,8 @@ mission "Wanderers: Kor Efret 3"
 			names "kor mereti"
 			variant
 				"Model 512" 2
-				"Model 256" 4
-				"Model 128" 7
+				"Model 256" 3
+				"Model 128" 5
 		dialog `The Kor Mereti drones have been neutralized. You should land on the planet and reconnect with Rek and the Korath engineers.`
 	npc
 		government "Kor Efret"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -753,8 +753,8 @@ mission "Wanderers: Kor Efret 3"
 			names "kor mereti"
 			variant
 				"Model 512" 2
-				"Model 256" 3
-				"Model 128" 5
+				"Model 256" 4
+				"Model 128" 7
 		dialog `The Kor Mereti drones have been neutralized. You should land on the planet and reconnect with Rek and the Korath engineers.`
 	npc
 		government "Kor Efret"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -1002,8 +1002,8 @@ mission "Wanderers: Mind Escorts"
 		fleet
 			names "wanderer"
 			variant
-				"Hurricane" 3
-				"Derecho" 4
+				"Hurricane" 2
+				"Derecho" 3
 				"Tempest" 5
 
 mission "Wanderers: Mind 4"
@@ -1130,7 +1130,7 @@ mission "Wanderers: Mind 6"
 				"Model 128" 4
 				"Model 64" 5
 				"Model 32" 7
-				"Model 16" 10
+				"Model 16" 12
 		dialog `The last of the hostile Kor Mereti drones are destroyed; the remaining drones are not attacking the Wanderers. It is not entirely clear what has happened, but hopefully the Wanderers back on <planet> will have gained some information through the backdoor connection to their AI.`
 	npc
 		government "Kor Mereti"
@@ -1138,11 +1138,10 @@ mission "Wanderers: Mind 6"
 		fleet
 			names "kor mereti"
 			variant
-				"Model 512" 1
-				"Model 256" 2
-				"Model 128" 3
-				"Model 64" 4
-				"Model 32" 7
+				"Model 256" 1
+				"Model 128" 2
+				"Model 64" 3
+				"Model 32" 5
 				"Model 16" 10
 	on visit
 		dialog `You've landed on <planet>, but there are still hostile Kor Mereti drones in the Chimitarp system. Better depart and make sure they've been taken care of.`

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -1002,9 +1002,9 @@ mission "Wanderers: Mind Escorts"
 		fleet
 			names "wanderer"
 			variant
-				"Hurricane" 2
-				"Derecho" 3
-				"Tempest" 4
+				"Hurricane" 3
+				"Derecho" 4
+				"Tempest" 5
 
 mission "Wanderers: Mind 4"
 	landing
@@ -1127,10 +1127,10 @@ mission "Wanderers: Mind 6"
 			variant
 				"Model 512" 3
 				"Model 256" 4
-				"Model 128" 5
-				"Model 64" 6
-				"Model 32" 8
-				"Model 16" 12
+				"Model 128" 4
+				"Model 64" 5
+				"Model 32" 7
+				"Model 16" 10
 		dialog `The last of the hostile Kor Mereti drones are destroyed; the remaining drones are not attacking the Wanderers. It is not entirely clear what has happened, but hopefully the Wanderers back on <planet> will have gained some information through the backdoor connection to their AI.`
 	npc
 		government "Kor Mereti"
@@ -1138,11 +1138,12 @@ mission "Wanderers: Mind 6"
 		fleet
 			names "kor mereti"
 			variant
-				"Model 256" 1
-				"Model 128" 2
-				"Model 64" 3
-				"Model 32" 5
-				"Model 16" 8
+				"Model 512" 1
+				"Model 256" 2
+				"Model 128" 3
+				"Model 64" 4
+				"Model 32" 7
+				"Model 16" 10
 	on visit
 		dialog `You've landed on <planet>, but there are still hostile Kor Mereti drones in the Chimitarp system. Better depart and make sure they've been taken care of.`
 

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -1139,7 +1139,7 @@ mission "Wanderers: Mind 6"
 			names "kor mereti"
 			variant
 				"Model 256" 1
-				"Model 128" 2
+				"Model 128" 1
 				"Model 64" 3
 				"Model 32" 5
 				"Model 16" 10


### PR DESCRIPTION
# **Balance**

This PR addresses the problem described in issue #7896. 

## Summary


In `Wanderers: Mind Escorts`, I added one Tempest.

In `Wanderers: Mind 6`, I took away from the hostile Mereti fleet one 128, one 64, and one 32. 

In `Wanderers: Mind 6`, I also added to the friendly fleet two 16s, but took away a 128. 

## Screenshots
None

## Usage examples
N/A

## Testing Done
None

## Save File
This save file can be used to test these changes:
[Melchior.Jack.txt](https://github.com/user-attachments/files/15845773/Melchior.Jack.txt). Courtesy of the issue. 

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Fewer mines. 