### PR TITLE
fix(mechanics): Fix crash when calculating sprite outline

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1115,11 +1115,10 @@ void Engine::Draw() const
 
 	for(const auto &outline : outlines)
 	{
-		if(outline.sprite)
-		{
-			Point size(outline.sprite->Width(), outline.sprite->Height());
-			OutlineShader::Draw(outline.sprite, outline.position, size, outline.color, outline.unit, outline.frame);
-		}
+		if(!outline.sprite)
+			continue;
+		Point size(outline.sprite->Width(), outline.sprite->Height());
+		OutlineShader::Draw(outline.sprite, outline.position, size, outline.color, outline.unit, outline.frame);
 	}
 
 	if(flash)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1115,8 +1115,11 @@ void Engine::Draw() const
 
 	for(const auto &outline : outlines)
 	{
-		Point size(outline.sprite->Width(), outline.sprite->Height());
-		OutlineShader::Draw(outline.sprite, outline.position, size, outline.color, outline.unit, outline.frame);
+		if(outline.sprite)
+		{
+			Point size(outline.sprite->Width(), outline.sprite->Height());
+			OutlineShader::Draw(outline.sprite, outline.position, size, outline.color, outline.unit, outline.frame);
+		}
 	}
 
 	if(flash)


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug introduced by #9642

## Summary
If a ship has no sprite, then the size of the sprite cannot be calculated. This causes a nullpointer dereference when the outlines are drawn.

## Testing Done
I tested that the game no longer crashes after this change

## Save File
N/A

## Performance Impact
N/A