### PR TITLE
Shop parked indicator

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -792,7 +792,7 @@ void ShopPanel::DrawShipsSidebar()
 			PointerShader::Draw(Point(point.X() - static_cast<int>(ICON_TILE / 3), point.Y()),
 				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
 
-		if (ship->IsParked())
+		if(ship->IsParked())
 		{
 			static const Point CORNER = .35 * Point(ICON_TILE, ICON_TILE);
 			FillShader::Fill(point + CORNER, Point(6., 6.), dark);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -791,6 +791,10 @@ void ShopPanel::DrawShipsSidebar()
 			PointerShader::Draw(Point(point.X() - static_cast<int>(ICON_TILE / 3), point.Y()),
 				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
 
+		if (ship->IsParked())
+			FillShader::Fill(point + .35 * Point(ICON_TILE, -ICON_TILE),
+				Point(5., 5.), Color(.7f, .7f, .7f, 1.f));
+
 		point.X() += ICON_TILE;
 	}
 	point.Y() += ICON_TILE;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -796,7 +796,7 @@ void ShopPanel::DrawShipsSidebar()
 		{
 			static const Point CORNER = .35 * Point(ICON_TILE, ICON_TILE);
 			FillShader::Fill(point + CORNER, Point(6., 6.), dark);
-			FillShader::Fill(point + CORNER, Point(4., 4.), bright);
+			FillShader::Fill(point + CORNER, Point(4., 4.), isSelected ? bright : medium);
 		}
 
 		point.X() += ICON_TILE;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -792,8 +792,11 @@ void ShopPanel::DrawShipsSidebar()
 				Point(1., 0.), 14.f, 12.f, 0., Color(.9f, .9f, .9f, .2f));
 
 		if (ship->IsParked())
-			FillShader::Fill(point + .35 * Point(ICON_TILE, -ICON_TILE),
-				Point(5., 5.), Color(.7f, .7f, .7f, 1.f));
+		{
+			static const Point CORNER = .35 * Point(ICON_TILE, ICON_TILE);
+			FillShader::Fill(point + CORNER, Point(6., 6.), Color(0.f, 0.f, 0.f, 1.f));
+			FillShader::Fill(point + CORNER, Point(4., 4.), Color(.7f, .7f, .7f, 1.f));
+		}
 
 		point.X() += ICON_TILE;
 	}

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -692,6 +692,7 @@ const Outfit *ShopPanel::Zone::GetOutfit() const
 void ShopPanel::DrawShipsSidebar()
 {
 	const Font &font = FontSet::Get(14);
+	const Color &dark = *GameData::Colors().Get("dark");
 	const Color &medium = *GameData::Colors().Get("medium");
 	const Color &bright = *GameData::Colors().Get("bright");
 
@@ -794,8 +795,8 @@ void ShopPanel::DrawShipsSidebar()
 		if (ship->IsParked())
 		{
 			static const Point CORNER = .35 * Point(ICON_TILE, ICON_TILE);
-			FillShader::Fill(point + CORNER, Point(6., 6.), Color(0.f, 0.f, 0.f, 1.f));
-			FillShader::Fill(point + CORNER, Point(4., 4.), Color(.7f, .7f, .7f, 1.f));
+			FillShader::Fill(point + CORNER, Point(6., 6.), dark);
+			FillShader::Fill(point + CORNER, Point(4., 4.), bright);
 		}
 
 		point.X() += ICON_TILE;


### PR DESCRIPTION
# Feature

## Summary
I might as well do this now too.
Adds a ship "parked" indicator to the shop panel. It lives in the bottom-right corner of the ship tile because that is where the warning/error indicator is, and you can't have that if the ship is parked, leaving the other three corners available for things like hotkey assignments (coming one day).

The design is a small square, chosen because it is language-neutral, which a blue parking "P" roadsign is not, and because it looks like the stop button on a cassette recorder. An argument could be made for using an octogon (universal shape for road Stop signs), but that is harder to implement than just `FillShader::Fill()`)

## Screenshots
<img width="1312" alt="Screenshot 2024-06-12 at 09 02 17" src="https://github.com/endless-sky/endless-sky/assets/206120/bf8bb26f-fea8-4f07-a467-b9a8010dbc8d">

## Testing Done
Extensive.

## Save File
Any multi-ship save file will do.
Testing of flagship-only fleets can be done with a new game or by leaving your fleet parked elsewhere.

## Wiki Update
A wiki update might be necessary to explain this (at least until there is a "Park"/"Unpark" button in the shop UI).

## Performance Impact
N/A