### PR TITLE
Add parked label to the ship tooltip.

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -11,6 +11,10 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
+# Fleet management:
+tip "parked"
+	` (parked)`
+
 # Outfit and ship attributes:
 tip "acceleration:"
 	`How quickly this ship gains speed. The higher a ship's mass (including the mass of any cargo or fighters it is carrying), the slower it accelerates.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -13,7 +13,7 @@
 
 # Fleet management:
 tip "parked"
-	` (parked)`
+	`(parked)`
 
 # Outfit and ship attributes:
 tip "acceleration:"

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -14,7 +14,6 @@
 # Fleet management:
 tip "parked"
 	`(parked)`
-
 # Outfit and ship attributes:
 tip "acceleration:"
 	`How quickly this ship gains speed. The higher a ship's mass (including the mass of any cargo or fighters it is carrying), the slower it accelerates.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -14,6 +14,9 @@
 # Fleet management:
 tip "parked"
 	`(parked)`
+
+
+
 # Outfit and ship attributes:
 tip "acceleration:"
 	`How quickly this ship gains speed. The higher a ship's mass (including the mass of any cargo or fighters it is carrying), the slower it accelerates.`

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -773,7 +773,7 @@ void ShopPanel::DrawShipsSidebar()
 
 		if(mouse.Y() < Screen::Bottom() - BUTTON_HEIGHT && shipZones.back().Contains(mouse))
 		{
-			shipName = ship->Name() + (ship->IsParked() ? GameData::Tooltip("parked") : "");
+			shipName = ship->Name() + (ship->IsParked() ? "\n" + GameData::Tooltip("parked") : "");
 			hoverPoint = shipZones.back().TopLeft();
 		}
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -773,7 +773,7 @@ void ShopPanel::DrawShipsSidebar()
 
 		if(mouse.Y() < Screen::Bottom() - BUTTON_HEIGHT && shipZones.back().Contains(mouse))
 		{
-			shipName = ship->Name();
+			shipName = ship->Name() + (ship->IsParked() ? GameData::Tooltip("parked") : "");
 			hoverPoint = shipZones.back().TopLeft();
 		}
 


### PR DESCRIPTION
# Feature

## Summary
add a second line with "(parked)" to the tooltips of any parked ship in the shop fleet panel.

## Screenshots
<img width="1312" alt="Screenshot 2024-06-12 at 13 53 02" src="https://github.com/endless-sky/endless-sky/assets/206120/268ec205-a2e3-43ba-9eaf-8549dea0bb32">

## Testing Done
See screenshot. That was it.

## Save File
Park any ship and hover it in the shop panel.

## Wiki Update
N/A

## Performance Impact
N/A