### PR TITLE
fix: Work around macos crash on Steam

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -333,6 +333,12 @@ void GameData::Preload(TaskQueue &queue, const Sprite *sprite)
 	while(pit != preloaded.end())
 	{
 		++pit->second;
+		#ifdef __APPLE__
+		// When using Steam on macOS the glDeleteTextures call segfaults when erasing old textures.
+		// We can work around it by not unloading the textures.
+		// TODO: fix the underlying OpenGL issue
+		++pit;
+		#else
 		if(pit->second >= 20)
 		{
 			// Unloading needs to be queued on the main thread.
@@ -341,6 +347,7 @@ void GameData::Preload(TaskQueue &queue, const Sprite *sprite)
 		}
 		else
 			++pit;
+		#endif
 	}
 
 	// Now, load all the files for this sprite.


### PR DESCRIPTION
**Bug fix**

This PR "addresses" the bug reported on [discord](https://discord.com/channels/251118043411775489/536900466655887360/1244878592438177832)

## Summary
Disables the sprite unloading code that was causing the crash on mac. According to quyykk, the code was broken for the last seven years before he fixed it, so this is just restoring the previous behaviour.

## Testing Done
I don't have any apples.