### PR TITLE
Move stars back a bit from planets/moons using a parallax effect.

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1341,6 +1341,9 @@ tip "Draw starfield"
 tip "Parallax background"
 	`Add parallax to objects in the background (haze and starfield). If set to fancy, create three layers of parallax. If set to fast, create one layer of parallax.`
 
+tip "System parallax"
+	`Add parallax to any stars and nebulae within the system.`
+
 tip "Show hyperspace flash"
 	`Create a white flash when hyperspacing between systems.`
 

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -52,6 +52,12 @@ Body::Body(const Body &sprite, Point position, Point velocity, Angle facing, dou
 
 
 
+Body::~Body()
+{
+}
+
+
+
 // Check that this Body has a sprite and that the sprite has at least one frame.
 bool Body::HasSprite() const
 {
@@ -183,6 +189,13 @@ double Body::Zoom() const
 double Body::Scale() const
 {
 	return static_cast<double>(scale);
+}
+
+
+
+double Body::Parallax() const
+{
+	return 1.;
 }
 
 

--- a/source/Body.h
+++ b/source/Body.h
@@ -38,6 +38,7 @@ public:
 	Body() = default;
 	Body(const Sprite *sprite, Point position, Point velocity = Point(), Angle facing = Angle(), double zoom = 1.);
 	Body(const Body &sprite, Point position, Point velocity = Point(), Angle facing = Angle(), double zoom = 1.);
+	virtual ~Body();
 
 	// Check that this Body has a sprite and that the sprite has at least one frame.
 	bool HasSprite() const;
@@ -62,6 +63,7 @@ public:
 	Point Unit() const;
 	double Zoom() const;
 	double Scale() const;
+	virtual double Parallax() const;
 
 	// Check if this object is marked for removal from the game.
 	bool ShouldBeRemoved() const;

--- a/source/DrawList.cpp
+++ b/source/DrawList.cpp
@@ -56,7 +56,7 @@ bool DrawList::Add(const Body &body, double cloak)
 
 bool DrawList::Add(const Body &body, Point position, double cloak)
 {
-	position -= center;
+	position = position - center * body.Parallax();
 	Point blur = body.Velocity() - centerVelocity;
 	if(Cull(body, position, blur))
 		return false;
@@ -69,7 +69,7 @@ bool DrawList::Add(const Body &body, Point position, double cloak)
 
 bool DrawList::AddUnblurred(const Body &body)
 {
-	Point position = body.Position() - center;
+	Point position = body.Position() - center * body.Parallax();
 	Point blur;
 	if(Cull(body, position, blur))
 		return false;
@@ -82,7 +82,7 @@ bool DrawList::AddUnblurred(const Body &body)
 
 bool DrawList::AddSwizzled(const Body &body, int swizzle, double cloak)
 {
-	Point position = body.Position() - center;
+	Point position = body.Position() - center * body.Parallax();
 	Point blur = body.Velocity() - centerVelocity;
 	if(Cull(body, position, blur))
 		return false;

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -133,9 +133,12 @@ namespace {
 	const vector<string> FLOTSAM_SETTINGS = {"off", "on", "flagship only", "escorts only"};
 	int flotsamIndex = 1;
 
+	const vector<string> SYSTEM_PARALLAX_SETTINGS = {"off", "on"};
+	bool systemParallax = false;
+
 	// Enable "fast" parallax by default. "fancy" is too GPU heavy, especially for low-end hardware.
-	const vector<string> PARALLAX_SETTINGS = {"off", "fancy", "fast"};
-	int parallaxIndex = 2;
+	const vector<string> BACKGROUND_PARALLAX_SETTINGS = {"off", "fancy", "fast"};
+	int backgroundParallaxIndex = 2;
 
 	const vector<string> EXTENDED_JUMP_EFFECT_SETTINGS = {"off", "medium", "heavy"};
 	int extendedJumpEffectIndex = 0;
@@ -208,8 +211,10 @@ void Preferences::Load()
 			autoAimIndex = max<int>(0, min<int>(node.Value(1), AUTO_AIM_SETTINGS.size() - 1));
 		else if(node.Token(0) == "Automatic firing")
 			autoFireIndex = max<int>(0, min<int>(node.Value(1), AUTO_FIRE_SETTINGS.size() - 1));
+		else if(node.Token(0) == "System parallax")
+			systemParallax = !!node.Value(1);
 		else if(node.Token(0) == "Parallax background")
-			parallaxIndex = max<int>(0, min<int>(node.Value(1), PARALLAX_SETTINGS.size() - 1));
+			backgroundParallaxIndex = max<int>(0, min<int>(node.Value(1), BACKGROUND_PARALLAX_SETTINGS.size() - 1));
 		else if(node.Token(0) == "Extended jump effects")
 			extendedJumpEffectIndex = max<int>(0, min<int>(node.Value(1), EXTENDED_JUMP_EFFECT_SETTINGS.size() - 1));
 		else if(node.Token(0) == "fullscreen")
@@ -280,7 +285,8 @@ void Preferences::Save()
 	out.Write("Show neutral overlays", statusOverlaySettings[OverlayType::NEUTRAL].ToInt());
 	out.Write("Automatic aiming", autoAimIndex);
 	out.Write("Automatic firing", autoFireIndex);
-	out.Write("Parallax background", parallaxIndex);
+	out.Write("System parallax", systemParallax);
+	out.Write("Parallax background", backgroundParallaxIndex);
 	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
 	out.Write("previous saves", previousSaveCount);
@@ -427,27 +433,49 @@ const vector<double> &Preferences::Zooms()
 
 
 
-// Starfield parallax.
-void Preferences::ToggleParallax()
+// Parallax of stars and nebulae within the system.
+void Preferences::ToggleSystemParallax()
 {
-	int targetIndex = parallaxIndex + 1;
-	if(targetIndex == static_cast<int>(PARALLAX_SETTINGS.size()))
+	systemParallax = !systemParallax;
+}
+
+
+
+bool Preferences::GetSystemParallax()
+{
+	return systemParallax;
+}
+
+
+
+const string &Preferences::SystemParallaxSetting()
+{
+	return SYSTEM_PARALLAX_SETTINGS[systemParallax];
+}
+
+
+
+// Starfield parallax.
+void Preferences::ToggleBackgroundParallax()
+{
+	int targetIndex = backgroundParallaxIndex + 1;
+	if(targetIndex == static_cast<int>(BACKGROUND_PARALLAX_SETTINGS.size()))
 		targetIndex = 0;
-	parallaxIndex = targetIndex;
+	backgroundParallaxIndex = targetIndex;
 }
 
 
 
 Preferences::BackgroundParallax Preferences::GetBackgroundParallax()
 {
-	return static_cast<BackgroundParallax>(parallaxIndex);
+	return static_cast<BackgroundParallax>(backgroundParallaxIndex);
 }
 
 
 
-const string &Preferences::ParallaxSetting()
+const string &Preferences::BackgroundParallaxSetting()
 {
-	return PARALLAX_SETTINGS[parallaxIndex];
+	return BACKGROUND_PARALLAX_SETTINGS[backgroundParallaxIndex];
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -159,10 +159,15 @@ public:
 	static AutoFire GetAutoFire();
 	static const std::string &AutoFireSetting();
 
+	// System parallax setting, either "on", or "off".
+	static void ToggleSystemParallax();
+	static bool GetSystemParallax();
+	static const std::string &SystemParallaxSetting();
+
 	// Background parallax setting, either "fast", "fancy", or "off".
-	static void ToggleParallax();
+	static void ToggleBackgroundParallax();
 	static BackgroundParallax GetBackgroundParallax();
-	static const std::string &ParallaxSetting();
+	static const std::string &BackgroundParallaxSetting();
 
 	// Extended jump effects setting, either "off", "medium", or "heavy".
 	static void ToggleExtendedJumpEffects();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -76,6 +76,7 @@ namespace {
 	const string DATE_FORMAT = "Date format";
 	const string BOARDING_PRIORITY = "Boarding target priority";
 	const string TARGET_ASTEROIDS_BASED_ON = "Target asteroid based on";
+	const string SYSTEM_PARALLAX = "System parallax";
 	const string BACKGROUND_PARALLAX = "Parallax background";
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
@@ -643,6 +644,7 @@ void PreferencesPanel::DrawSettings()
 		"Reduce large graphics",
 		"Draw background haze",
 		"Draw starfield",
+		SYSTEM_PARALLAX,
 		BACKGROUND_PARALLAX,
 		"Show hyperspace flash",
 		EXTENDED_JUMP_EFFECTS,
@@ -850,9 +852,14 @@ void PreferencesPanel::DrawSettings()
 			isOn = true;
 			text = Preferences::Has(TARGET_ASTEROIDS_BASED_ON) ? "proximity" : "value";
 		}
+		else if(setting == SYSTEM_PARALLAX)
+		{
+			text = Preferences::SystemParallaxSetting();
+			isOn = text != "off";
+		}
 		else if(setting == BACKGROUND_PARALLAX)
 		{
-			text = Preferences::ParallaxSetting();
+			text = Preferences::BackgroundParallaxSetting();
 			isOn = text != "off";
 		}
 		else if(setting == EXTENDED_JUMP_EFFECTS)
@@ -1183,8 +1190,10 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 	}
 	else if(str == BOARDING_PRIORITY)
 		Preferences::ToggleBoarding();
+	else if(str == SYSTEM_PARALLAX)
+		Preferences::ToggleSystemParallax();
 	else if(str == BACKGROUND_PARALLAX)
-		Preferences::ToggleParallax();
+		Preferences::ToggleBackgroundParallax();
 	else if(str == EXTENDED_JUMP_EFFECTS)
 		Preferences::ToggleExtendedJumpEffects();
 	else if(str == VIEW_ZOOM_FACTOR)

--- a/source/StellarObject.cpp
+++ b/source/StellarObject.cpp
@@ -97,7 +97,7 @@ const string &StellarObject::LandingMessage() const
 // Get the color to be used for displaying this object.
 int StellarObject::RadarType(const Ship *ship) const
 {
-	if(IsStar())
+	if(isStar)
 		return Radar::STAR;
 	else if(!planet || !planet->IsAccessible(ship))
 		return Radar::INACTIVE;
@@ -151,6 +151,13 @@ int StellarObject::Parent() const
 double StellarObject::Distance() const
 {
 	return distance;
+}
+
+
+
+double StellarObject::Parallax() const
+{
+	return isStar ? .7 : 1.;
 }
 
 

--- a/source/StellarObject.cpp
+++ b/source/StellarObject.cpp
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Government.h"
 #include "Planet.h"
 #include "Politics.h"
+#include "Preferences.h"
 #include "Radar.h"
 
 #include <algorithm>
@@ -157,7 +158,7 @@ double StellarObject::Distance() const
 
 double StellarObject::Parallax() const
 {
-	return isStar ? .7 : 1.;
+	return (isStar && Preferences::GetSystemParallax()) ? .7 : 1.;
 }
 
 

--- a/source/StellarObject.h
+++ b/source/StellarObject.h
@@ -72,6 +72,7 @@ public:
 	const std::vector<RandomEvent<Hazard>> &Hazards() const;
 	// Find out how far this object is from its parent.
 	double Distance() const;
+	virtual double Parallax() const override;
 
 
 private:


### PR DESCRIPTION
# Feature

## Summary
Push stars back from the ships/planets/moons using a parallax effect.
This deliberatly does not alter the radar or the Orbits pane of the Map Detail Panel, as both of those are supposed ot look like 2D projections, the main view is meant to look more 3D.

This assumes that StellarObjects with `isStar == true` can not be targetted. The targeting graphic does not factor target parallax into account (yet?).

If a StellarObjects with `isStar == true` can be landed on somewhere in the game, the ring label showing name and government will need to factor in parallax too.

Since the player is always at (0,0) landing on a star (if even possible) should be unaffected.

## Screenshots
Needs to be played around with to appreciate. It looks cool in systems with puffy stars, lots of planets/moons, and haze.

Here are two with the player moved a little.

<img width="1312" alt="Screenshot 2024-06-14 at 11 30 19" src="https://github.com/endless-sky/endless-sky/assets/206120/eaec992b-da41-49dd-bc66-856fb308b2e9">
<img width="1312" alt="Screenshot 2024-06-14 at 11 30 27" src="https://github.com/endless-sky/endless-sky/assets/206120/afc428bc-3e60-4d09-8f0a-51daeb91aaa5">


## Testing Done
I tried the values .2, .5, .7, .8 and .9 in the systems Girtab, Saquergen, and Alphecca. I liked .7 best, especially the way it interacts with the haze layer in Saquergen.

## Save File
Any save will do

## Wiki Update
N/A

## Performance Impact
This adds one vtable function lookup & call, one branch prediction, and one floating-point multiplication to the insertion of every Body to a DrawList. I saw no change in performance at all. It does not increase heap size of the Body object with any additional member variables (i.e. all stars are drawn at the same parallax, but maybe we want to change that one day).