### PR TITLE
Fix steam linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 cmake_dependent_option(ES_GLES "Build the game with OpenGL ES" OFF UNIX OFF)
 cmake_dependent_option(ES_STEAM "Build the game for the Steam Linux runtime" OFF UNIX OFF)
-cmake_dependent_option(ES_USE_SYSTEM_LIBRARIES "Use system libraries instead of the vcpkg ones." ON APPLE OFF)
+cmake_dependent_option(ES_USE_SYSTEM_LIBRARIES "Use system libraries instead of the vcpkg ones." ON "APPLE OR ES_STEAM" OFF)
 cmake_dependent_option(ES_CREATE_BUNDLE "Create a Bundle instead of an executable. Not suitable for development purposes." OFF APPLE OFF)
 
 # Support Debug and Release configurations.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16...3.29)
 
 include(CMakeDependentOption)
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT ES_STEAM)
 	option(ES_USE_VCPKG "Use vcpkg to get dependencies." OFF)
 else()
 	option(ES_USE_VCPKG "Use vcpkg to get dependencies." ON)

--- a/steam/docker-compose.yml
+++ b/steam/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - '/bin/bash'
       - '-c'
       - |
-        apt-get -y update && apt-get -y install libmad0-dev
         mkdir -p build/steam-x64
         cd build/steam-x64
         cmake ../../ -GNinja -DES_STEAM=ON -DCMAKE_BUILD_TYPE=Release -DVCPKG_TARGET_TRIPLET=linux-x64-release-static
@@ -25,7 +24,6 @@ services:
       - '/bin/bash'
       - '-c'
       - |
-        apt-get -y update && apt-get -y install libmad0-dev
         mkdir -p build/steam-x86
         cd build/steam-x86
         cmake ../../ -GNinja -DES_STEAM=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-m32 -DVCPKG_TARGET_TRIPLET=linux-x86-release-static


### PR DESCRIPTION
**Bug fix**

## Summary
The Steam runtime does not provide libmad. This means we need to acquire it via vcpkg and statically link it. We should also use system libraries where possible for this build.
A previous change disabled these things so the build for the Steam runtim was not working.
This PR re-enables them so the Steam Linux build now works correctly.

## Testing Done
Built in the Steam Linux runtime with:
```bash
cd steam
docker-compose run steam-x64
```
Then tried running the result in the Steam Linux runtime:
```bash
cd build/steam-x64
docker run --rm -it -v ".:/pwd" registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest /pwd/endless-sky
```
(Both starting in the root directory of the repository.)
Without this change, it fails the run because it cannot find libmad.
With this change, it fails to run because it can't find hte resource directory, which is expected.
