### PR TITLE
fix(conditions): Remove unused Has functionality

### DIFF
--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -167,14 +167,14 @@ namespace {
 				value = static_cast<int64_t>(DataNode::Value(str));
 			else
 			{
-				const auto temp = created.HasGet(str);
-				if(temp.first)
-					value = temp.second;
+				const auto temp = created.Get(str);
+				if(temp)
+					value = temp;
 				else
 				{
-					const auto perm = conditions.HasGet(str);
-					if(perm.first)
-						value = perm.second;
+					const auto perm = conditions.Get(str);
+					if(perm)
+						value = perm;
 				}
 			}
 			result.emplace_back(value);

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -40,13 +40,6 @@ void ConditionsStore::DerivedProvider::SetGetFunction(function<int64_t(const str
 
 
 
-void ConditionsStore::DerivedProvider::SetHasFunction(function<bool(const string &)> newHasFun)
-{
-	hasFunction = std::move(newHasFun);
-}
-
-
-
 void ConditionsStore::DerivedProvider::SetSetFunction(function<bool(const string &, int64_t)> newSetFun)
 {
 	setFunction = std::move(newSetFun);
@@ -212,41 +205,6 @@ int64_t ConditionsStore::Get(const string &name) const
 		return ce->value;
 
 	return ce->provider->getFunction(name);
-}
-
-
-
-bool ConditionsStore::Has(const string &name) const
-{
-	const ConditionEntry *ce = GetEntry(name);
-	if(!ce)
-		return false;
-
-	if(!ce->provider)
-		return true;
-
-	return ce->provider->hasFunction(name);
-}
-
-
-
-// Returns a pair where the boolean indicates if the game has this condition set,
-// and an int64_t which contains the value if the condition was set.
-pair<bool, int64_t> ConditionsStore::HasGet(const string &name) const
-{
-	const ConditionEntry *ce = GetEntry(name);
-	if(!ce)
-		return make_pair(false, 0);
-
-	if(!ce->provider)
-		return make_pair(true, ce->value);
-
-	bool has = ce->provider->hasFunction(name);
-	int64_t val = 0;
-	if(has)
-		val = ce->provider->getFunction(name);
-
-	return make_pair(has, val);
 }
 
 

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -52,7 +52,6 @@ public:
 	public:
 		// Functions to set the lambda functions for accessing the conditions.
 		void SetGetFunction(std::function<int64_t(const std::string &)> newGetFun);
-		void SetHasFunction(std::function<bool(const std::string &)> newHasFun);
 		void SetSetFunction(std::function<bool(const std::string &, int64_t)> newSetFun);
 		void SetEraseFunction(std::function<bool(const std::string &)> newEraseFun);
 
@@ -69,7 +68,6 @@ public:
 		// Lambda functions for accessing the derived conditions, with some sensible
 		// default implementations;
 		std::function<int64_t(const std::string &)> getFunction = [](const std::string &name) { return 0; };
-		std::function<bool(const std::string &)> hasFunction = [](const std::string &name) { return true; };
 		std::function<bool(const std::string &, int64_t)> setFunction = [](const std::string &name, int64_t value) {
 			return false; };
 		std::function<bool(const std::string &)> eraseFunction = [](const std::string &name) { return false; };
@@ -116,8 +114,6 @@ public:
 	// Retrieve a "condition" flag from this store (directly or from the
 	// connected provider).
 	int64_t Get(const std::string &name) const;
-	bool Has(const std::string &name) const;
-	std::pair<bool, int64_t> HasGet(const std::string &name) const;
 
 	// Add a value to a condition, set a value for a condition or erase a
 	// condition completely. Returns true on success, false on failure.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3205,7 +3205,6 @@ void PlayerInfo::RegisterDerivedConditions()
 			return 0;
 		return it->second;
 	};
-	salaryIncomeProvider.SetHasFunction(salaryIncomeHasGetFun);
 	salaryIncomeProvider.SetGetFunction(salaryIncomeHasGetFun);
 	salaryIncomeProvider.SetSetFunction([this](const string &name, int64_t value) -> bool
 	{
@@ -3231,7 +3230,6 @@ void PlayerInfo::RegisterDerivedConditions()
 
 		return it->second;
 	};
-	tributeProvider.SetHasFunction(tributeHasGetFun);
 	tributeProvider.SetGetFunction(tributeHasGetFun);
 	tributeProvider.SetSetFunction([this](const string &name, int64_t value) -> bool {
 		return SetTribute(name.substr(strlen("tribute: ")), value);
@@ -3241,9 +3239,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	});
 
 	auto &&licenseProvider = conditions.GetProviderPrefixed("license: ");
-	licenseProvider.SetHasFunction([this](const string &name) -> bool {
-		return HasLicense(name.substr(strlen("license: ")));
-	});
 	licenseProvider.SetGetFunction([this](const string &name) -> int64_t {
 		return HasLicense(name.substr(strlen("license: ")));
 	});
@@ -3283,7 +3278,6 @@ void PlayerInfo::RegisterDerivedConditions()
 			return false;
 		return name == "flagship model: " + flagship->TrueModelName();
 	};
-	flagshipModelProvider.SetHasFunction(flagshipModelFun);
 	flagshipModelProvider.SetGetFunction(flagshipModelFun);
 
 	auto &&flagshipDisabledProvider = conditions.GetProviderNamed("flagship disabled");
@@ -3291,7 +3285,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		return flagship && flagship->IsDisabled();
 	};
-	flagshipDisabledProvider.SetHasFunction(flagshipDisabledFun);
 	flagshipDisabledProvider.SetGetFunction(flagshipDisabledFun);
 
 	auto flagshipAttributeHelper = [](const Ship *flagship, const string &attribute, bool base) -> int64_t
@@ -3313,7 +3306,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagshipAttributeHelper(this->Flagship(), name.substr(strlen("flagship base attribute: ")), true);
 	};
 	flagshipBaseAttributeProvider.SetGetFunction(flagshipBaseAttributeFun);
-	flagshipBaseAttributeProvider.SetHasFunction(flagshipBaseAttributeFun);
 
 	auto &&flagshipAttributeProvider = conditions.GetProviderPrefixed("flagship attribute: ");
 	auto flagshipAttributeFun = [this, flagshipAttributeHelper](const string &name) -> int64_t
@@ -3321,7 +3313,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagshipAttributeHelper(this->Flagship(), name.substr(strlen("flagship attribute: ")), false);
 	};
 	flagshipAttributeProvider.SetGetFunction(flagshipAttributeFun);
-	flagshipAttributeProvider.SetHasFunction(flagshipAttributeFun);
 
 	auto &&flagshipBaysProvider = conditions.GetProviderPrefixed("flagship bays: ");
 	auto flagshipBaysFun = [this](const string &name) -> int64_t
@@ -3332,14 +3323,12 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagship->BaysTotal(name.substr(strlen("flagship bays: ")));
 	};
 	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);
-	flagshipBaysProvider.SetHasFunction(flagshipBaysFun);
 
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{
 		return name == "name: " + firstName + " " + lastName;
 	};
-	playerNameProvider.SetHasFunction(playerNameFun);
 	playerNameProvider.SetGetFunction(playerNameFun);
 
 	auto &&playerNameFirstProvider = conditions.GetProviderPrefixed("first name: ");
@@ -3347,7 +3336,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		return name == "first name: " + firstName;
 	};
-	playerNameFirstProvider.SetHasFunction(playerNameFirstFun);
 	playerNameFirstProvider.SetGetFunction(playerNameFirstFun);
 
 	auto &&playerNameLastProvider = conditions.GetProviderPrefixed("last name: ");
@@ -3355,7 +3343,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		return name == "last name: " + lastName;
 	};
-	playerNameLastProvider.SetHasFunction(playerNameLastFun);
 	playerNameLastProvider.SetGetFunction(playerNameLastFun);
 
 
@@ -3398,7 +3385,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return round((1. - safeChance) * 1000.);
 	};
 	systemAttractionProvider.SetGetFunction(systemAttractionFun);
-	systemAttractionProvider.SetHasFunction(systemAttractionFun);
 
 	// Special conditions for cargo and passenger space.
 	// If boarding a ship, missions should not consider the space available
@@ -3715,7 +3701,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		return name == "entered system by: " + EntryToString(entry);
 	};
-	systemEntryProvider.SetHasFunction(systemEntryFun);
 	systemEntryProvider.SetGetFunction(systemEntryFun);
 
 	// This condition corresponds to the last system the flagship was in.
@@ -3726,7 +3711,6 @@ void PlayerInfo::RegisterDerivedConditions()
 			return false;
 		return name == "previous system: " + previousSystem->Name();
 	};
-	previousSystemProvider.SetHasFunction(previousSystemFun);
 	previousSystemProvider.SetGetFunction(previousSystemFun);
 
 	// Conditions to determine if flagship is in a system and on a planet.
@@ -3737,7 +3721,6 @@ void PlayerInfo::RegisterDerivedConditions()
 			return false;
 		return name == "flagship system: " + flagship->GetSystem()->Name();
 	};
-	flagshipSystemProvider.SetHasFunction(flagshipSystemFun);
 	flagshipSystemProvider.SetGetFunction(flagshipSystemFun);
 
 	auto &&flagshipLandedProvider = conditions.GetProviderNamed("flagship landed");
@@ -3745,7 +3728,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		return (flagship && flagship->GetPlanet());
 	};
-	flagshipLandedProvider.SetHasFunction(flagshipLandedFun);
 	flagshipLandedProvider.SetGetFunction(flagshipLandedFun);
 
 	auto &&flagshipPlanetProvider = conditions.GetProviderPrefixed("flagship planet: ");
@@ -3755,7 +3737,6 @@ void PlayerInfo::RegisterDerivedConditions()
 			return false;
 		return name == "flagship planet: " + flagship->GetPlanet()->TrueName();
 	};
-	flagshipPlanetProvider.SetHasFunction(flagshipPlanetFun);
 	flagshipPlanetProvider.SetGetFunction(flagshipPlanetFun);
 
 	auto &&flagshipPlanetAttributesProvider = conditions.GetProviderPrefixed("flagship planet attribute: ");
@@ -3767,7 +3748,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagship->GetPlanet()->Attributes().count(attribute);
 	};
 	flagshipPlanetAttributesProvider.SetGetFunction(flagshipPlanetAttributesFun);
-	flagshipPlanetAttributesProvider.SetHasFunction(flagshipPlanetAttributesFun);
 
 	// Read only exploration conditions.
 	auto &&visitedPlanetProvider = conditions.GetProviderPrefixed("visited planet: ");
@@ -3777,7 +3757,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return planet ? HasVisited(*planet) : false;
 	};
 	visitedPlanetProvider.SetGetFunction(visitedPlanetFun);
-	visitedPlanetProvider.SetHasFunction(visitedPlanetFun);
 
 	auto &&visitedSystemProvider = conditions.GetProviderPrefixed("visited system: ");
 	auto visitedSystemFun = [this](const string &name) -> bool
@@ -3786,7 +3765,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return system ? HasVisited(*system) : false;
 	};
 	visitedSystemProvider.SetGetFunction(visitedSystemFun);
-	visitedSystemProvider.SetHasFunction(visitedSystemFun);
 
 	auto &&landingAccessProvider = conditions.GetProviderPrefixed("landing access: ");
 	auto landingAccessFun = [this](const string &name) -> bool
@@ -3795,7 +3773,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return (planet && flagship) ? planet->CanLand(*flagship) : false;
 	};
 	landingAccessProvider.SetGetFunction(landingAccessFun);
-	landingAccessProvider.SetHasFunction(landingAccessFun);
 
 	auto &&pluginProvider = conditions.GetProviderPrefixed("installed plugin: ");
 	auto pluginFun = [](const string &name) -> bool
@@ -3803,7 +3780,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		const Plugin *plugin = Plugins::Get().Find(name.substr(strlen("installed plugin: ")));
 		return plugin ? plugin->IsValid() && plugin->enabled : false;
 	};
-	pluginProvider.SetHasFunction(pluginFun);
 	pluginProvider.SetGetFunction(pluginFun);
 
 	auto &&destroyedPersonProvider = conditions.GetProviderPrefixed("person destroyed: ");
@@ -3813,7 +3789,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return person ? person->IsDestroyed() : false;
 	};
 	destroyedPersonProvider.SetGetFunction(destroyedPersonFun);
-	destroyedPersonProvider.SetHasFunction(destroyedPersonFun);
 
 	// Read-only navigation conditions.
 	auto HyperspaceTravelDays = [](const System *origin, const System *destination) -> int
@@ -3840,7 +3815,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return HyperspaceTravelDays(this->GetSystem(), system);
 	};
 	hyperjumpsToSystemProvider.SetGetFunction(hyperjumpsToSystemFun);
-	hyperjumpsToSystemProvider.SetHasFunction(hyperjumpsToSystemFun);
 
 	auto &&hyperjumpsToPlanetProvider = conditions.GetProviderPrefixed("hyperjumps to planet: ");
 	auto hyperjumpsToPlanetFun = [this, HyperspaceTravelDays](const string &name) -> int
@@ -3862,16 +3836,10 @@ void PlayerInfo::RegisterDerivedConditions()
 		return HyperspaceTravelDays(this->GetSystem(), system);
 	};
 	hyperjumpsToPlanetProvider.SetGetFunction(hyperjumpsToPlanetFun);
-	hyperjumpsToPlanetProvider.SetHasFunction(hyperjumpsToPlanetFun);
 
 	// Read/write government reputation conditions.
 	// The erase function is still default (since we cannot erase government conditions).
 	auto &&reputationProvider = conditions.GetProviderPrefixed("reputation: ");
-	reputationProvider.SetHasFunction([](const string &name) -> bool
-	{
-		string govName = name.substr(strlen("reputation: "));
-		return GameData::Governments().Has(govName);
-	});
 	reputationProvider.SetGetFunction([](const string &name) -> int64_t
 	{
 		string govName = name.substr(strlen("reputation: "));
@@ -3908,16 +3876,10 @@ void PlayerInfo::RegisterDerivedConditions()
 			return 0;
 		return Random::Int(value);
 	};
-	randomRollProvider.SetHasFunction(randomRollFun);
 	randomRollProvider.SetGetFunction(randomRollFun);
 
 	// Global conditions setters and getters:
 	auto &&globalProvider = conditions.GetProviderPrefixed("global: ");
-	globalProvider.SetHasFunction([](const string &name) -> bool
-	{
-		string condition = name.substr(strlen("global: "));
-		return GameData::GlobalConditions().Has(condition);
-	});
 	globalProvider.SetGetFunction([](const string &name) -> int64_t
 	{
 		string condition = name.substr(strlen("global: "));

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -606,8 +606,8 @@ void Test::Fail(const TestContext &context, const PlayerInfo &player, const stri
 	string conditions;
 	for(const auto &it : RelevantConditions())
 	{
-		const auto &val = player.Conditions().HasGet(it);
-		conditions += "Condition: \"" + it + "\" = " + (val.first ? to_string(val.second) : "(not set)") + "\n";
+		const auto &val = player.Conditions().Get(it);
+		conditions += "Condition: \"" + it + "\" = " + to_string(val) + "\n";
 	}
 
 	if(!conditions.empty())

--- a/tests/unit/src/test_conditionSet.cpp
+++ b/tests/unit/src/test_conditionSet.cpp
@@ -176,7 +176,7 @@ SCENARIO( "Applying changes to conditions", "[ConditionSet][Usage]" ) {
 		THEN( "the condition list is updated via Apply" ) {
 			applySet.Apply(store);
 			REQUIRE_FALSE( store.PrimariesSize() == 0 );
-			REQUIRE( store.Has("year") );
+			REQUIRE( store.Get("year") );
 			CHECK( store["year"] == 3013 );
 		}
 	}


### PR DESCRIPTION
**Bug fix**

This PR removes unused functionality that was accidentally introduced as part of #5017 (in PR #5244)

## Summary
The keyword `has` for conditions is defined as "is not zero", which means that actual presence of conditions is never visibile outside the codebase. It also means that conditions which are zero don't need to be written at saving, which we actually also don't do.

The DerivedConditionsProviders however had extensive support for "Has" for conditions, while this support was never used. Removing this "Has" support makes the codebase quite a bit simpler.

There were 3 locations within the codebase that used Has to check if a condition was existing, but all those locations were easily re-implemented by Get, since they used a default value of 0 when the condition was not present (which is exactly what Get also does).

## Screenshots
N/A

## Usage examples
N/A (This pr removes unused functionality)

## Testing Done
This code is tested by unit-tests, and the integration tests also test large parts of the affected codebase.

## Save File
N/A (This affects unused core conditions functionality.)

## Artwork Checklist

## Wiki Update
The wiki is already correct in describing what the `has` keyword does.

## Performance Impact
No impact expected.