### PR TITLE
Nerve Gas for Marauders & Some Pirates

### DIFF
--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -302,7 +302,6 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 		"Large Radar Jammer"
 		"Outfits Expansion" 4
 		"Laser Rifle" 80
-
 		"Security Station" 3
 		
 		"A860 Atomic Thruster"

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -73,6 +73,7 @@ ship "Marauder Arrow" "Marauder Arrow (Engines)"
 		"Supercapacitor" 2
 		"D14-RN Shield Generator"
 		"Laser Rifle" 5
+		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
@@ -259,7 +260,7 @@ ship "Marauder Falcon"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"Laser Rifle" 80
-		"Nerve Gas" 10
+		"Nerve Gas" 15
 		"Security Station"
 		
 		"A520 Atomic Thruster"
@@ -301,7 +302,7 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 		"Large Radar Jammer"
 		"Outfits Expansion" 4
 		"Laser Rifle" 80
-		"Nerve Gas" 9
+
 		"Security Station" 3
 		
 		"A860 Atomic Thruster"
@@ -339,7 +340,7 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"Laser Rifle" 80
-		"Nerve Gas" 12
+		"Nerve Gas" 20
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -397,7 +398,7 @@ ship "Marauder Firebird"
 		"Liquid Helium Cooler"
 		"Outfits Expansion"
 		"Laser Rifle" 25
-		"Nerve Gas" 6
+		"Nerve Gas" 29
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -437,7 +438,7 @@ ship "Marauder Firebird" "Marauder Firebird (Engines)"
 		"Outfits Expansion"
 		"Security Station"
 		"Laser Rifle" 24
-		"Nerve Gas" 5
+		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -465,7 +466,7 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 		"Outfits Expansion"
 		"Security Station"
 		"Laser Rifle" 24
-		"Nerve Gas" 8
+		"Nerve Gas" 13
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -518,7 +519,7 @@ ship "Marauder Leviathan"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
-		"Nerve Gas" 9
+		"Nerve Gas" 15
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -593,7 +594,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
-		"Nerve Gas" 11
+		"Nerve Gas" 48
 
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -648,7 +649,7 @@ ship "Marauder Manta"
 		"Liquid Nitrogen Cooler"
 		"Security Station" 3
 		"Laser Rifle" 8
-		"Nerve Gas" 2
+		"Nerve Gas" 4
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -686,7 +687,6 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 		"D14-RN Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 11
-		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -724,7 +724,7 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 		"D14-RN Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 11
-		"Nerve Gas" 3
+		"Nerve Gas" 2
 		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
@@ -813,6 +813,7 @@ ship "Marauder Quicksilver" "Marauder Quicksilver (Engines)"
 		"Liquid Nitrogen Cooler"
 		"Security Station" 2
 		"Laser Rifle" 5
+		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A375 Atomic Steering"
@@ -943,7 +944,7 @@ ship "Marauder Raven"
 		"Volcano Afterburner"
 		"Hyperdrive"
 		"Laser Rifle" 14
-		"Nerve Gas"
+		"Nerve Gas" 3
 	
 	engine -9.5 63
 	engine 9.5 63
@@ -1008,7 +1009,7 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Laser Rifle" 14
-		"Nerve Gas" 2
+		"Nerve Gas" 5
 	
 	gun -13.5 -35.5
 	gun 13.5 -35.5
@@ -1053,7 +1054,7 @@ ship "Marauder Splinter"
 		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 22
-		"Nerve Gas"
+		"Nerve Gas" 2
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -1091,7 +1092,6 @@ ship "Marauder Splinter" "Marauder Splinter (Engines)"
 		"Water Coolant System"
 		"Security Station"
 		"Laser Rifle" 21
-		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -1122,7 +1122,7 @@ ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 		"Liquid Nitrogen Cooler"
 		"Security Station" 2
 		"Laser Rifle" 20
-		"Nerve Gas" 2
+		"Nerve Gas" 4
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -259,6 +259,7 @@ ship "Marauder Falcon"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"Laser Rifle" 80
+		"Nerve Gas" 10
 		"Security Station"
 		
 		"A520 Atomic Thruster"
@@ -300,6 +301,7 @@ ship "Marauder Falcon" "Marauder Falcon (Engines)"
 		"Large Radar Jammer"
 		"Outfits Expansion" 4
 		"Laser Rifle" 80
+		"Nerve Gas" 9
 		"Security Station" 3
 		
 		"A860 Atomic Thruster"
@@ -337,6 +339,7 @@ ship "Marauder Falcon" "Marauder Falcon (Weapons)"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
 		"Laser Rifle" 80
+		"Nerve Gas" 12
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -394,6 +397,7 @@ ship "Marauder Firebird"
 		"Liquid Helium Cooler"
 		"Outfits Expansion"
 		"Laser Rifle" 25
+		"Nerve Gas" 6
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -433,6 +437,7 @@ ship "Marauder Firebird" "Marauder Firebird (Engines)"
 		"Outfits Expansion"
 		"Security Station"
 		"Laser Rifle" 24
+		"Nerve Gas" 5
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -460,6 +465,7 @@ ship "Marauder Firebird" "Marauder Firebird (Weapons)"
 		"Outfits Expansion"
 		"Security Station"
 		"Laser Rifle" 24
+		"Nerve Gas" 8
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -512,6 +518,7 @@ ship "Marauder Leviathan"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
+		"Nerve Gas" 9
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -555,6 +562,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
+		"Nerve Gas" 8
 		
 		"A520 Atomic Thruster"
 		"A865 Atomic Steering"
@@ -585,6 +593,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Weapons)"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
 		"Laser Rifle" 69
+		"Nerve Gas" 11
 
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -639,6 +648,7 @@ ship "Marauder Manta"
 		"Liquid Nitrogen Cooler"
 		"Security Station" 3
 		"Laser Rifle" 8
+		"Nerve Gas" 2
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -676,6 +686,7 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 		"D14-RN Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 11
+		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -713,6 +724,7 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 		"D14-RN Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 11
+		"Nerve Gas" 3
 		
 		"A250 Atomic Thruster"
 		"A375 Atomic Steering"
@@ -931,6 +943,7 @@ ship "Marauder Raven"
 		"Volcano Afterburner"
 		"Hyperdrive"
 		"Laser Rifle" 14
+		"Nerve Gas"
 	
 	engine -9.5 63
 	engine 9.5 63
@@ -966,6 +979,7 @@ ship "Marauder Raven" "Marauder Raven (Engines)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Laser Rifle" 14
+		"Nerve Gas"
 	
 	engine -10.5 63.5
 	engine 10.5 63.5
@@ -994,6 +1008,7 @@ ship "Marauder Raven" "Marauder Raven (Weapons)"
 		"A375 Atomic Steering"
 		"Hyperdrive"
 		"Laser Rifle" 14
+		"Nerve Gas" 2
 	
 	gun -13.5 -35.5
 	gun 13.5 -35.5
@@ -1038,6 +1053,7 @@ ship "Marauder Splinter"
 		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 22
+		"Nerve Gas"
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -1075,6 +1091,7 @@ ship "Marauder Splinter" "Marauder Splinter (Engines)"
 		"Water Coolant System"
 		"Security Station"
 		"Laser Rifle" 21
+		"Nerve Gas"
 		
 		"A370 Atomic Thruster"
 		"A525 Atomic Steering"
@@ -1105,6 +1122,7 @@ ship "Marauder Splinter" "Marauder Splinter (Weapons)"
 		"Liquid Nitrogen Cooler"
 		"Security Station" 2
 		"Laser Rifle" 20
+		"Nerve Gas" 2
 		
 		"A250 Atomic Thruster"
 		"A525 Atomic Steering"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2754,7 +2754,6 @@ ship "Modified Argosy"
 		"Small Radar Jammer"
 		"Brig"
 		"Laser Rifle" 12
-		"Nerve Gas"
 		
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -840,6 +840,7 @@ ship "Bulwark"
 		"Water Coolant System"
 		"Tactical Scanner"
 		"Laser Rifle" 19
+		"Nerve Gas" 3
 		
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
@@ -2752,7 +2753,8 @@ ship "Modified Argosy"
 		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		"Brig"
-		"Laser Rifle" 2
+		"Laser Rifle" 12
+		"Nerve Gas"
 		
 		"Greyhound Plasma Thruster"
 		"X3200 Ion Steering"
@@ -3935,6 +3937,7 @@ ship "Valkyrie"
 		"D67-TM Shield Generator"
 		"Large Radar Jammer"
 		"Laser Rifle" 18
+		"Nerve Gas" 3
 		
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"


### PR DESCRIPTION
**Feature**


This PR addresses the bug/feature described in issues #10204 and #2218.

## Summary
I added Nerve Gas (sorry for the capitalization) to three especially pirate ships. I can remove it from the Modified Argosy if people want, because that is a bit iffy. I’m also requesting a review from @Amazinite before this gets merged. 
Important to note is that the Nighthawk also has Nerve Gas, which I did _not_ add. 

## Screenshots
None. 

## Usage examples
N/A

## Testing Done
No. 

## Save File
This save file can be used to test these changes:
None. Start a World Forge or Omnis game with this PR installed and buy a ship. 

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A