### PR TITLE
fix(typo, issuetracker): Remove typo in the New Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Please report issues with the GitHub wiki here.
   - name: Endless Sky Mobile
     url: https://github.com/thewierdnut/endless-mobile/issues/
-    about: Please report bugs any issues related to the mobile port here.
+    about: Please report any issues related to the mobile port here.


### PR DESCRIPTION
**.github fix**

This PR addresses the bug/feature described in issue
None. 

## Summary
I removed a word in the new issue template. 

## Screenshots
Not really. 

## Usage examples
N/A

## Testing Done
It’s a one word change and isn’t in-game. 

## Save File
This save file can be used to test these changes:
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A