### PR TITLE
UI: Harvesting message includes fleet remaining free space

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2445,7 +2445,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 
 	int free = collector->Cargo().Free();
 	int total = 0;
-	for(const shared_ptr <Ship> &ship: player.Ships())
+	for(const shared_ptr <Ship> &ship : player.Ships())
 		if(!ship->IsParked() && ship->GetSystem() == player.GetSystem())
 			total += ship->Cargo().Free();
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2441,19 +2441,20 @@ void Engine::DoCollection(Flotsam &flotsam)
 	}
 
 	// Unless something went wrong while forming the message, display it.
-	if(message.empty()) return;
+	if(message.empty())
+		return;
 
 	int free = collector->Cargo().Free();
 	int total = 0;
-	for(const shared_ptr <Ship> &ship : player.Ships())
+	for(const shared_ptr<Ship> &ship : player.Ships())
 		if(!ship->IsParked() && ship->GetSystem() == player.GetSystem())
 			total += ship->Cargo().Free();
 
+	message += " (" + Format::CargoString(free, "free space") + " remaining";
 	if(free == total)
-		message += " (" + Format::CargoString(free, "free space") + " remaining.)";
+		message += ".)";
 	else
-		message += " (" + Format::CargoString(free, "free space") + " remaining, "
-				+ Format::MassString(total) + " in fleet.)";
+		message += ", " + Format::MassString(total) + " in fleet.)";
 	Messages::Add(message, Messages::Importance::High);
 }
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2441,12 +2441,20 @@ void Engine::DoCollection(Flotsam &flotsam)
 	}
 
 	// Unless something went wrong while forming the message, display it.
-	if(!message.empty())
-	{
-		int free = collector->Cargo().Free();
+	if(message.empty()) return;
+
+	int free = collector->Cargo().Free();
+	int total = 0;
+	for(const shared_ptr <Ship> &ship: player.Ships())
+		if(!ship->IsParked() && ship->GetSystem() == player.GetSystem())
+			total += ship->Cargo().Free();
+
+	if(free == total)
 		message += " (" + Format::CargoString(free, "free space") + " remaining.)";
-		Messages::Add(message, Messages::Importance::High);
-	}
+	else
+		message += " (" + Format::CargoString(free, "free space") + " remaining, "
+				+ Format::MassString(total) + " in fleet.)";
+	Messages::Add(message, Messages::Importance::High);
 }
 
 


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #10228

## Summary
As the issue suggested - my skills are very limited, but finding the message was trivial, and adapting the "which ships should I count" loop from Engine::Place seemed straightforward too.

## Screenshots
<details>

Sorry for the size... Also not vanilla rules, plugins active. But for a simple message...

![image](https://github.com/endless-sky/endless-sky/assets/63000004/6f316eb1-bad0-47a4-83d6-201d2d16db53)

</details>

## Testing Done
Took screenshot. :zany_face: 
Actually, with my mods I can generate way more flotsam in a very short time than one can in vanilla, so it got some stress test.

## Save File
May add one later, or on request - should be vanilla and not require any plugin

## Performance Impact
A loop to get a total is more expensive than the one method call this message had before, but -as mentioned- my tests suggest that has little impact, especially as this does not repeat per frame, it's only once per flotsam?