### PR TITLE
feat(enhancement): `<model>` replacement for model name of the flagship

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -73,9 +73,15 @@ ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &con
 	subs["<first>"] = player.FirstName();
 	subs["<last>"] = player.LastName();
 	if(ship)
+	{
 		subs["<ship>"] = ship->Name();
+		subs["<model>"] = ship->DisplayModelName();
+	}
 	else if(player.Flagship())
+	{
 		subs["<ship>"] = player.Flagship()->Name();
+		subs["<model>"] = player.Flagship()->DisplayModelName();
+	}
 
 	// Start a PlayerInfo transaction to prevent saves during the conversation
 	// from recording partial results.

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -990,7 +990,10 @@ string Mission::BlockedMessage(const PlayerInfo &player)
 	subs["<first>"] = player.FirstName();
 	subs["<last>"] = player.LastName();
 	if(flagship)
+	{
 		subs["<ship>"] = flagship->Name();
+		subs["<model>"] = flagship->DisplayModelName();
+	}
 
 	const auto &playerConditions = player.Conditions();
 	subs["<conditions>"] = toAccept.Test(playerConditions) ? "meet" : "do not meet";

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -330,8 +330,12 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const Mission *caller, const 
 		GameData::GetTextReplacements().Substitutions(subs, player.Conditions());
 		subs["<first>"] = player.FirstName();
 		subs["<last>"] = player.LastName();
-		if(player.Flagship())
-			subs["<ship>"] = player.Flagship()->Name();
+		const Ship *flagship = player.Flagship();
+		if(flagship)
+		{
+			subs["<ship>"] = flagship->Name();
+			subs["<model>"] = flagship->DisplayModelName();
+		}
 		string text = Format::Replace(dialogText, subs);
 
 		// Don't push the dialog text if this is a visit action on a nonunique

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2321,8 +2321,12 @@ map<string, string> PlayerInfo::GetSubstitutions() const
 
 	subs["<first>"] = FirstName();
 	subs["<last>"] = LastName();
-	if(Flagship())
-		subs["<ship>"] = Flagship()->Name();
+	const Ship *flag = Flagship();
+	if(flag)
+	{
+		subs["<ship>"] = flag->Name();
+		subs["<model>"] = flag->DisplayModelName();
+	}
 
 	subs["<system>"] = GetSystem()->Name();
 	subs["<date>"] = GetDate().ToString();
@@ -4143,8 +4147,12 @@ void PlayerInfo::StepMissions(UI *ui)
 		{"<first>", firstName},
 		{"<last>", lastName}
 	};
-	if(Flagship())
-		substitutions["<ship>"] = Flagship()->Name();
+	const Ship *flag = Flagship();
+	if(flag)
+	{
+		substitutions["<ship>"] = flag->Name();
+		substitutions["<model>"] = flag->DisplayModelName();
+	}
 
 	auto mit = missions.begin();
 	while(mit != missions.end())

--- a/source/TextReplacements.cpp
+++ b/source/TextReplacements.cpp
@@ -31,7 +31,7 @@ void TextReplacements::Load(const DataNode &node)
 	// Check for reserved keys. Only some hardcoded replacement keys are
 	// reserved, as these ones are done on the fly after all other replacements
 	// have been done.
-	const set<string> reserved = {"<first>", "<last>", "<ship>"};
+	const set<string> reserved = {"<first>", "<last>", "<ship>", "<model>"};
 
 	for(const DataNode &child : node)
 	{

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -540,6 +540,7 @@ Conversation LoadConversation()
 		{"<passengers>", "[your passengers]"},
 		{"<planet>", "[Planet]"},
 		{"<ship>", "[Ship]"},
+		{"<model>", "[Ship Model]"},
 		{"<system>", "[Star]"},
 		{"<tons>", "[N tons]"}
 	};


### PR DESCRIPTION
**Feature**

resolves #5366

## Summary
Added a `<model>` text replacement (expanded to the display model name of the flagship), which should work in the same places as the `<ship>` replacement.

## Testing Done
Tested with this mission:
```
mission "model replacement test"
	job
	name "Model replacement test"
	destination "Earth"
	on accept
		conversation
			"<model>"
```

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/14

## Performance Impact
N/A
