### PR TITLE
Micro-optimisations.

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -352,10 +352,10 @@ void Body::Turn(double amount)
 		return;
 
 	auto RotatePointAroundOrigin = [](Point &toRotate, double radians) -> Point {
-		float si = sin(radians);
-		float co = cos(radians);
-		float newX = toRotate.X() * co - toRotate.Y() * si;
-		float newY = toRotate.X() * si + toRotate.Y() * co;
+		double si = sin(radians);
+		double co = cos(radians);
+		double newX = toRotate.X() * co - toRotate.Y() * si;
+		double newY = toRotate.X() * si + toRotate.Y() * co;
 		return Point(newX, newY);
 	};
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1032,7 +1032,7 @@ void Engine::Step(bool isActive)
 void Engine::Go()
 {
 	++step;
-	currentCalcBuffer = currentCalcBuffer ? 0 : 1;
+	currentCalcBuffer = (!currentCalcBuffer) & 1;
 	queue.Run([this] { CalculateStep(); });
 }
 


### PR DESCRIPTION
# Performance

## Summary
Two tiny optimisations that were bugging me.

## Testing Done
I checked the buffers still draw. I did not check for a ship that doesn't rotate around the centre.

## Performance Impact
Doing a couple of double-precision operations with values already in the registers is a lot more efficient than converting a double to a float and back again several times.
The other change eliminates a branch prediction.