### PR TITLE
feat(ui): Display a placeholder text when the message log is empty

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1573,6 +1573,11 @@ interface "info panel"
 interface "message log"
 	value "width" 570
 
+	visible if "empty"
+	label "(The message log is empty.)"
+		from 300 0 left
+		color medium
+
 
 
 interface "hail panel"

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -22,6 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Font.h"
 #include "text/FontSet.h"
 #include "GameData.h"
+#include "Information.h"
 #include "Interface.h"
 #include "Preferences.h"
 #include "Screen.h"
@@ -41,7 +42,8 @@ namespace {
 
 
 MessageLogPanel::MessageLogPanel()
-	: messages(Messages::GetLog()), width(GameData::Interfaces().Get("message log")->GetValue("width"))
+	: messages(Messages::GetLog()),
+	interface(GameData::Interfaces().Get("message log")), width(interface->GetValue("width"))
 {
 	SetInterruptible(false);
 }
@@ -61,6 +63,14 @@ void MessageLogPanel::Draw()
 		backColor);
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + width);
+
+	Information info;
+	if(messages.empty())
+	{
+		info.SetCondition("empty");
+		interface->Draw(info, nullptr);
+		return;
+	}
 
 	const Font &font = FontSet::Get(14);
 

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -43,7 +43,7 @@ namespace {
 
 MessageLogPanel::MessageLogPanel()
 	: messages(Messages::GetLog()),
-	interface(GameData::Interfaces().Get("message log")), width(interface->GetValue("width"))
+	interf(GameData::Interfaces().Get("message log")), width(interf->GetValue("width"))
 {
 	SetInterruptible(false);
 }
@@ -68,7 +68,7 @@ void MessageLogPanel::Draw()
 	if(messages.empty())
 	{
 		info.SetCondition("empty");
-		interface->Draw(info, nullptr);
+		interf->Draw(info, nullptr);
 		return;
 	}
 

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -42,8 +42,7 @@ namespace {
 
 
 MessageLogPanel::MessageLogPanel()
-	: messages(Messages::GetLog()),
-	interf(GameData::Interfaces().Get("message log")), width(interf->GetValue("width"))
+	: messages(Messages::GetLog()), width(GameData::Interfaces().Get("message log")->GetValue("width"))
 {
 	SetInterruptible(false);
 }
@@ -68,7 +67,7 @@ void MessageLogPanel::Draw()
 	if(messages.empty())
 	{
 		info.SetCondition("empty");
-		interf->Draw(info, nullptr);
+		GameData::Interfaces().Get("message log")->Draw(info, nullptr);
 		return;
 	}
 

--- a/source/MessageLogPanel.h
+++ b/source/MessageLogPanel.h
@@ -43,7 +43,6 @@ protected:
 private:
 	const std::deque<std::pair<std::string, Messages::Importance>> &messages;
 
-	const Interface *interf;
 	const double width;
 	// Current scroll:
 	double scroll = 0.;

--- a/source/MessageLogPanel.h
+++ b/source/MessageLogPanel.h
@@ -20,8 +20,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Messages.h"
 
-class Interface;
-
 
 
 // User interface panel that displays the message log.

--- a/source/MessageLogPanel.h
+++ b/source/MessageLogPanel.h
@@ -20,6 +20,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Messages.h"
 
+class Interface;
+
 
 
 // User interface panel that displays the message log.
@@ -41,6 +43,7 @@ protected:
 private:
 	const std::deque<std::pair<std::string, Messages::Importance>> &messages;
 
+	const Interface *interface;
 	const double width;
 	// Current scroll:
 	double scroll = 0.;

--- a/source/MessageLogPanel.h
+++ b/source/MessageLogPanel.h
@@ -43,7 +43,7 @@ protected:
 private:
 	const std::deque<std::pair<std::string, Messages::Importance>> &messages;
 
-	const Interface *interface;
+	const Interface *interf;
 	const double width;
 	// Current scroll:
 	double scroll = 0.;


### PR DESCRIPTION
**Feature**

resolves #9999

## Summary
Added a centered text (defined in the interface) saying that the message log is empty.

## Screenshots
<details>
<summary>Screenshot</summary>

![log_empty](https://github.com/endless-sky/endless-sky/assets/108272452/e79b8462-f8d0-4ccc-9702-83ab0819267c)

</details>

## Testing Done
yes™

## Performance Impact
N/A
