### PR TITLE
fix(typo): Consistent Excavator naming

### DIFF
--- a/data/gegno/gegno outfits.txt
+++ b/data/gegno/gegno outfits.txt
@@ -819,7 +819,7 @@ outfit "Excavator"
 		"minable damage" 104
 		"prospecting" 145
 		"hit force" -6
-	description `Excavator Drills are large drills designed by the Gegno that rip materials out of asteroids in an efficient manner. These types of drill systems are only found on ships specifically designed around them as they require substantial infrastructure to be functional.`
+	description `Excavators are large drills designed by the Gegno that rip materials out of asteroids in an efficient manner. These types of drill systems are only found on ships specifically designed around them as they require substantial infrastructure to be functional.`
 
 effect "excavate"
 	sprite "effect/smoke"


### PR DESCRIPTION
**Bug fix**


This PR addresses the bug/feature described in issue #10138.

## Summary
I made the Gegno Excavator be consistently named by removing one word. 

## Alternative Approaches
Break save file compatibility and call the outfit Excavator Drill instead. 

## Screenshots
None. 

## Usage examples
N/A

## Testing Done
No, but it is a one word change. 

## Save File
This save file can be used to test these changes:
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
