### PR TITLE
feat(enhancement): Custom scan sounds

### DIFF
--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -262,6 +262,10 @@ void Outfit::Load(const DataNode &node)
 			++jumpInSounds[Audio::Get(child.Token(1))];
 		else if(child.Token(0) == "jump out sound" && child.Size() >= 2)
 			++jumpOutSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "cargo scan sound" && child.Size() >= 2)
+			++cargoScanSounds[Audio::Get(child.Token(1))];
+		else if(child.Token(0) == "outfit scan sound" && child.Size() >= 2)
+			++outfitScanSounds[Audio::Get(child.Token(1))];
 		else if(child.Token(0) == "flotsam sprite" && child.Size() >= 2)
 			flotsamSprite = SpriteSet::Get(child.Token(1));
 		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
@@ -545,6 +549,8 @@ void Outfit::Add(const Outfit &other, int count)
 	MergeMaps(jumpSounds, other.jumpSounds, count);
 	MergeMaps(jumpInSounds, other.jumpInSounds, count);
 	MergeMaps(jumpOutSounds, other.jumpOutSounds, count);
+	MergeMaps(cargoScanSounds, other.cargoScanSounds, count);
+	MergeMaps(outfitScanSounds, other.outfitScanSounds, count);
 }
 
 
@@ -662,6 +668,20 @@ const map<const Sound *, int> &Outfit::JumpInSounds() const
 const map<const Sound *, int> &Outfit::JumpOutSounds() const
 {
 	return jumpOutSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::CargoScanSounds() const
+{
+	return cargoScanSounds;
+}
+
+
+
+const map<const Sound *, int> &Outfit::OutfitScanSounds() const
+{
+	return outfitScanSounds;
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -99,6 +99,9 @@ public:
 	const std::map<const Sound *, int> &JumpSounds() const;
 	const std::map<const Sound *, int> &JumpInSounds() const;
 	const std::map<const Sound *, int> &JumpOutSounds() const;
+	// Get this outfit's scan sounds, if any.
+	const std::map<const Sound *, int> &CargoScanSounds() const;
+	const std::map<const Sound *, int> &OutfitScanSounds() const;
 	// Get the sprite this outfit uses when dumped into space.
 	const Sprite *FlotsamSprite() const;
 
@@ -143,6 +146,8 @@ private:
 	std::map<const Sound *, int> jumpSounds;
 	std::map<const Sound *, int> jumpInSounds;
 	std::map<const Sound *, int> jumpOutSounds;
+	std::map<const Sound *, int> cargoScanSounds;
+	std::map<const Sound *, int> outfitScanSounds;
 	const Sprite *flotsamSprite = nullptr;
 };
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1863,8 +1863,8 @@ int Ship::Scan(const PlayerInfo &player)
 
 	// Check if either scanner has finished scanning.
 	bool startedScanning = false;
-	int activeScanning = 0;
-	int result = 0;
+	int activeScanning = ShipEvent::NONE;
+ 	int result = ShipEvent::NONE;
 	auto doScan = [&distanceSquared, &startedScanning, &activeScanning, &result]
 			(double &elapsed, const double speed, const double scannerRangeSquared,
 					const double depth, const int event)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -990,6 +990,12 @@ void Ship::Save(DataWriter &out) const
 			for(const auto &it : baseAttributes.HyperOutSounds())
 				for(int i = 0; i < it.second; ++i)
 					out.Write("hyperdrive out sound", it.first->Name());
+			for(const auto &it : baseAttributes.CargoScanSounds())
+				for(int i = 0; i < it.second; ++i)
+					out.Write("cargo scan sound", it.first->Name());
+			for(const auto &it : baseAttributes.OutfitScanSounds())
+				for(int i = 0; i < it.second; ++i)
+					out.Write("outfit scan sound", it.first->Name());
 			for(const auto &it : baseAttributes.Attributes())
 				if(it.second)
 					out.Write(it.first, it.second);
@@ -1857,7 +1863,7 @@ int Ship::Scan(const PlayerInfo &player)
 
 	// Check if either scanner has finished scanning.
 	bool startedScanning = false;
-	bool activeScanning = false;
+	int activeScanning = 0;
 	int result = 0;
 	auto doScan = [&distanceSquared, &startedScanning, &activeScanning, &result]
 			(double &elapsed, const double speed, const double scannerRangeSquared,
@@ -1870,7 +1876,7 @@ int Ship::Scan(const PlayerInfo &player)
 			return;
 
 		startedScanning |= !elapsed;
-		activeScanning = true;
+		activeScanning |= event;
 
 		// Total scan time is:
 		// Proportional to e^(0.5 * (distance / range)^2),
@@ -1903,8 +1909,21 @@ int Ship::Scan(const PlayerInfo &player)
 	doScan(outfitScan, outfitSpeed, outfitDistanceSquared, outfits, ShipEvent::SCAN_OUTFITS);
 
 	// Play the scanning sound if the actor or the target is the player's ship.
-	if(isYours || (target->isYours && activeScanning))
-		Audio::Play(Audio::Get("scan"), Position());
+	auto playScanSounds = [](const map<const Sound *, int> &sounds, Point &position)
+	{
+		if(sounds.empty())
+			Audio::Play(Audio::Get("scan"), position);
+		else
+			for(const auto &sound : sounds)
+				Audio::Play(sound.first, position);
+	};
+	if(isYours || (target->isYours))
+	{
+		if(activeScanning & ShipEvent::SCAN_CARGO)
+			playScanSounds(attributes.CargoScanSounds(), position);
+		if(activeScanning & ShipEvent::SCAN_OUTFITS)
+			playScanSounds(attributes.OutfitScanSounds(), position);
+	}
 
 	bool isImportant = false;
 	if(target->isYours)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1864,7 +1864,7 @@ int Ship::Scan(const PlayerInfo &player)
 	// Check if either scanner has finished scanning.
 	bool startedScanning = false;
 	int activeScanning = ShipEvent::NONE;
- 	int result = ShipEvent::NONE;
+	int result = ShipEvent::NONE;
 	auto doScan = [&distanceSquared, &startedScanning, &activeScanning, &result]
 			(double &elapsed, const double speed, const double scannerRangeSquared,
 					const double depth, const int event)


### PR DESCRIPTION
**Feature**

## Summary
You can now set custom sounds for cargo and outfit scanners. They're played when you scan a ship, or when someone scans your ship. If there's no custom sound set, the default one is used, for two reasons: to prevent situations where someone forgets to add a sound and there's no audible warning that the player's ship is being scanned, and to provide some backward compatibility.

There are no data changes in this PR.

## Testing Done
I've done some in-flight testing with custom outfits.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/15

## Performance Impact
N/A
