### PR TITLE
Cargo for unique missions loaded onto the flagship when possible

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1865,11 +1865,18 @@ const CargoHold &PlayerInfo::DistributeCargo()
 			}
 			else
 			{
-				// Your flagship takes first priority for passengers but last for cargo.
+				// Your flagship takes first priority for passengers but last for cargo from
+				// non-unique missions.
 				desiredCrew = ship->Crew();
 				ship->Cargo().SetBunks(ship->Attributes().Get("bunks") - desiredCrew);
 				for(const auto &it : cargo.PassengerList())
 					cargo.TransferPassengers(it.first, it.second, ship->Cargo());
+				// Load unique mission cargo onto the flagship.
+				for(const auto &it : cargo.MissionCargo())
+				{
+					if(it.first->IsUnique())
+						cargo.Transfer(it.first, it.second, ship->Cargo());
+				}
 			}
 		}
 	// Load up your flagship last, so that it will have space free for any


### PR DESCRIPTION
**Bug fix**

This PR addresses the problem described in issues #10241 and #6444 and #9464.

## Summary
When distributing cargo on takeoff, the game now places cargo for missions marked as unique onto your flagship, where possible.

## Screenshots
![wrongmind](https://github.com/endless-sky/endless-sky/assets/898230/acd3eff5-8e65-403a-92e3-82fe4aa877d8)

*Before change: Plot-critical Artificial Mind is loaded onto a random Tubfalet escort.*

![rightmind](https://github.com/endless-sky/endless-sky/assets/898230/aa6453ae-0b72-4d8b-938c-8d228589a766)

*After change: Artificial Mind is now on flagship, along with the four Wanderer passengers from the same mission.*

## Testing Done
* Taking off with escorts at the start of the "Install the Mind" Wanderer mission now stores the mind in the flagship cargo hold.
* Taking off with escorts at the start of a random rush delivery mission still stores the cargo in the escort cargo hold.
* Integration tests pass.
* Code style tests pass.

## Save File
These save files can be used to test these changes:

* Install the Mind save: [Vladimir Zarkonnen~3036-11-14-installthemind.txt](https://github.com/user-attachments/files/15911370/Vladimir.Zarkonnen.3036-11-14-installthemind.txt)
* Rush delivery save: [Cargo Test.txt](https://github.com/user-attachments/files/15911368/Cargo.Test.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A