### PR TITLE
bugfix: Fix `flagship only` flotsam collection

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2403,7 +2403,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 			return;
 		if(collector == player.Flagship() && flotsamSetting == Preferences::FlotsamCollection::ESCORT)
 			return;
-		if(flotsamSetting == Preferences::FlotsamCollection::FLAGSHIP)
+		if(collector != player.Flagship() && flotsamSetting == Preferences::FlotsamCollection::FLAGSHIP)
 			return;
 	}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2085,7 +2085,7 @@ Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 			return pullVector;
 		if(!GetParent() && flotsamSetting == Preferences::FlotsamCollection::ESCORT)
 			return pullVector;
-		if(flotsamSetting == Preferences::FlotsamCollection::FLAGSHIP)
+		if(GetParent() && flotsamSetting == Preferences::FlotsamCollection::FLAGSHIP)
 			return pullVector;
 	}
 


### PR DESCRIPTION
**Bug fix**

This PR fixes `flagship only` flotsam collection, which didn't actually enable the flagship to collect flotsam.

## Summary
It only checked if the preference was set, without checking whether it was your flagship picking up flotsam.

## Usage examples
Flotsam collection?

## Testing Done
I tested that the flagship can now collect flotsam with this preference, and escorts can't.