### PR TITLE
fix(mechanics): Escorts stop following orders after the flagship dies

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1550,9 +1550,12 @@ bool AI::FollowOrders(Ship &ship, Command &command) const
 
 	int type = it->second.type;
 
+	// Ships without an (alive) parent don't follow orders.
+	shared_ptr<Ship> parent = ship.GetParent();
+	if(!parent)
+		return false;
 	// If your parent is jumping or absent, that overrides your orders unless
 	// your orders are to hold position.
-	shared_ptr<Ship> parent = ship.GetParent();
 	if(parent && type != Orders::HOLD_POSITION && type != Orders::HOLD_ACTIVE && type != Orders::MOVE_TO)
 	{
 		if(parent->GetSystem() != ship.GetSystem())


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported in https://github.com/endless-sky/endless-sky/pull/10039#issuecomment-2180264491

## Summary
Escort ships were still following (GATHER) orders after the flagship died. This PR fixes that by checking for ships with orders if they have a parent.

## Testing Done
Tested dying with an active gather command, before and after this fix. The escorts were no longer gathering after dying after this fix.

## Save File
N/A, any save file with a flagship, escorts and hostiles that can kill the player will do. (Using a weak ship without shield generators helps in dying faster.)

## Performance Impact
This only affects player ships with active orders, little to no impact expected.