### PR TITLE
Only compute derived attributes when a ship changes configuration, not on every frame.

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1191,9 +1191,6 @@ tip "no bays?"
 tip "insufficient energy to fire?"
 	`This ship has insufficient energy storage to fire an installed weapon.`
 
-tip "under 20s of battery?"
-	`This ship has less than 20 seconds of combat battery power.`
-
 
 
 # Boolean attributes:

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1191,6 +1191,9 @@ tip "no bays?"
 tip "insufficient energy to fire?"
 	`This ship has insufficient energy storage to fire an installed weapon.`
 
+tip "under 20s of battery?"
+	`This ship has less than 20 seconds of combat battery power.`
+
 
 
 # Boolean attributes:

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -900,50 +900,42 @@ void Ship::FinishLoading(bool isNewInstance)
 			targetSystem = nullptr;
 		}
 	}
-
-	RecomputeDerivedAttributes();
 }
 
 
 
-void Ship::RecomputeDerivedAttributes()
+double Ship::GetAttribute(string name) const
 {
 	double shieldRegen = (attributes.Get("shield generation")
 		+ attributes.Get("delayed shield generation"))
 		* (1. + attributes.Get("shield generation multiplier"));
 	bool hasShieldRegen = shieldRegen > 0.;
-	derivedAttributes["shield regen"] = shieldRegen;
 
 	double hullRepair = (attributes.Get("hull repair rate")
 		+ attributes.Get("delayed hull repair rate"))
 		* (1. + attributes.Get("hull repair multiplier"));
 	bool hasHullRepair = hullRepair > 0.;
-	derivedAttributes["hull repair"] = hullRepair;
 
 	const double idleEnergyPerFrame = attributes.Get("energy generation")
 		+ attributes.Get("solar collection")
 		+ attributes.Get("fuel energy")
 		- attributes.Get("energy consumption")
 		- attributes.Get("cooling energy");
-	derivedAttributes["idle energy per frame"] = idleEnergyPerFrame;
 
 	const double idleHeatPerFrame = attributes.Get("heat generation")
 		+ attributes.Get("solar heat")
 		+ attributes.Get("fuel heat")
 		- CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling"));
-	derivedAttributes["idle heat per frame"] = idleHeatPerFrame;
 
 	const double movingEnergyPerFrame =
 		max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
 		+ attributes.Get("turning energy")
 		+ attributes.Get("afterburner energy");
-	derivedAttributes["moving energy per frame"] = movingEnergyPerFrame;
 
 	const double movingHeatPerFrame =
 		max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
 		+ attributes.Get("turning heat")
 		+ attributes.Get("afterburner heat");
-	derivedAttributes["moving heat per frame"] = movingHeatPerFrame;
 
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
@@ -953,47 +945,73 @@ void Ship::RecomputeDerivedAttributes()
 			firingEnergy += it.second * it.first->FiringEnergy() / it.first->Reload();
 			firingHeat += it.second * it.first->FiringHeat() / it.first->Reload();
 		}
-	derivedAttributes["firing energy"] = firingEnergy;
-	derivedAttributes["firing heat"] = firingHeat;
 
 	double shieldEnergy = hasShieldRegen ? (attributes.Get("shield energy")
 		+ attributes.Get("delayed shield energy"))
 		* (1. + attributes.Get("shield energy multiplier")) : 0.;
-	derivedAttributes["total shield energy cost"] = shieldEnergy;
 	double hullEnergy = hasHullRepair ? (attributes.Get("hull energy")
 		+ attributes.Get("delayed hull energy"))
 		* (1. + attributes.Get("hull energy multiplier")) : 0.;
-	derivedAttributes["total hull energy cost"] = hullEnergy;
-	derivedAttributes["total shield & hull energy cost"] = (shieldEnergy + hullEnergy);
 
 	double shieldHeat = hasShieldRegen ? (attributes.Get("shield heat")
 		+ attributes.Get("delayed shield heat"))
 		* (1. + attributes.Get("shield heat multiplier")) : 0.;
-	derivedAttributes["total shield heat cost"] = shieldHeat;
 	double hullHeat = hasHullRepair ? (attributes.Get("hull heat")
 		+ attributes.Get("delayed hull heat"))
 		* (1. + attributes.Get("hull heat multiplier")) : 0.;
-	derivedAttributes["total hull heat cost"] = hullHeat;
-	derivedAttributes["total shield & hull heat cost"] = (shieldHeat + hullHeat);
 
 	const double overallEnergy = idleEnergyPerFrame
 		- movingEnergyPerFrame
 		- firingEnergy
 		- shieldEnergy
 		- hullEnergy;
-	derivedAttributes["net energy"] = overallEnergy;
 
 	const double overallHeat = idleHeatPerFrame
 		+ movingHeatPerFrame
 		+ firingHeat
 		+ shieldHeat
 		+ hullHeat;
-	derivedAttributes["net heat"] = overallHeat;
-
 	const double maxEnergy = attributes.Get("energy capacity");
 	const double maxHeat = HeatDissipation() * MaximumHeat();
-	derivedAttributes["max energy"] = maxEnergy;
-	derivedAttributes["max heat"] = maxHeat;
+
+	if(name == "shield regen")
+		return shieldRegen;
+	else if(name == "hull repair")
+		return hullRepair;
+	else if(name == "idle energy per frame")
+		return idleEnergyPerFrame;
+	else if(name == "idle heat per frame")
+		return idleHeatPerFrame;
+	else if(name == "moving energy per frame")
+		return movingEnergyPerFrame;
+	else if(name == "moving heat per frame")
+		return movingHeatPerFrame;
+	else if(name == "firing energy")
+		return firingEnergy;
+	else if(name == "firing heat")
+		return firingHeat;
+	else if(name == "total shield energy cost")
+		return shieldEnergy;
+	else if(name == "total hull energy cost")
+		return hullEnergy;
+	else if(name == "total shield & hull energy cost")
+		return (shieldEnergy + hullEnergy);
+	else if(name == "total shield heat cost")
+		return shieldHeat;
+	else if(name == "total hull heat cost")
+		return hullHeat;
+	else if(name == "total shield & hull heat cost")
+		return (shieldHeat + hullHeat);
+	else if(name == "net energy")
+		return overallEnergy;
+	else if(name == "net heat")
+		return overallHeat;
+	else if(name == "max energy")
+		return maxEnergy;
+	else if(name == "max heat")
+		return maxHeat;
+
+	return attributes.Get(name);
 }
 
 
@@ -3460,13 +3478,6 @@ const Outfit &Ship::BaseAttributes() const
 
 
 
-const Dictionary &Ship::DerivedAttributes() const
-{
-	return derivedAttributes;
-}
-
-
-
 // Get outfit information.
 const map<const Outfit *, int> &Ship::Outfits() const
 {
@@ -3527,8 +3538,6 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		// Non-player ships will recalibrate before they jump.
 		else if(isYours)
 			navigation.Recalibrate(*this);
-
-		RecomputeDerivedAttributes();
 	}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -908,94 +908,92 @@ void Ship::FinishLoading(bool isNewInstance)
 
 void Ship::RecomputeDerivedAttributes()
 {
-	{
-		double shieldRegen = (attributes.Get("shield generation")
-			+ attributes.Get("delayed shield generation"))
-			* (1. + attributes.Get("shield generation multiplier"));
-		bool hasShieldRegen = shieldRegen > 0.;
-		derivedAttributes["shield regen"] = shieldRegen;
+	double shieldRegen = (attributes.Get("shield generation")
+		+ attributes.Get("delayed shield generation"))
+		* (1. + attributes.Get("shield generation multiplier"));
+	bool hasShieldRegen = shieldRegen > 0.;
+	derivedAttributes["shield regen"] = shieldRegen;
 
-		double hullRepair = (attributes.Get("hull repair rate")
-			+ attributes.Get("delayed hull repair rate"))
-			* (1. + attributes.Get("hull repair multiplier"));
-		bool hasHullRepair = hullRepair > 0.;
-		derivedAttributes["hull repair"] = hullRepair;
+	double hullRepair = (attributes.Get("hull repair rate")
+		+ attributes.Get("delayed hull repair rate"))
+		* (1. + attributes.Get("hull repair multiplier"));
+	bool hasHullRepair = hullRepair > 0.;
+	derivedAttributes["hull repair"] = hullRepair;
 
-		const double idleEnergyPerFrame = attributes.Get("energy generation")
-			+ attributes.Get("solar collection")
-			+ attributes.Get("fuel energy")
-			- attributes.Get("energy consumption")
-			- attributes.Get("cooling energy");
-		derivedAttributes["idle energy per frame"] = idleEnergyPerFrame;
+	const double idleEnergyPerFrame = attributes.Get("energy generation")
+		+ attributes.Get("solar collection")
+		+ attributes.Get("fuel energy")
+		- attributes.Get("energy consumption")
+		- attributes.Get("cooling energy");
+	derivedAttributes["idle energy per frame"] = idleEnergyPerFrame;
 
-		const double idleHeatPerFrame = attributes.Get("heat generation")
-			+ attributes.Get("solar heat")
-			+ attributes.Get("fuel heat")
-			- CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling"));
-		derivedAttributes["idle heat per frame"] = idleHeatPerFrame;
+	const double idleHeatPerFrame = attributes.Get("heat generation")
+		+ attributes.Get("solar heat")
+		+ attributes.Get("fuel heat")
+		- CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling"));
+	derivedAttributes["idle heat per frame"] = idleHeatPerFrame;
 
-		const double movingEnergyPerFrame =
-			max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
-			+ attributes.Get("turning energy")
-			+ attributes.Get("afterburner energy");
-		derivedAttributes["moving energy per frame"] = movingEnergyPerFrame;
+	const double movingEnergyPerFrame =
+		max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
+		+ attributes.Get("turning energy")
+		+ attributes.Get("afterburner energy");
+	derivedAttributes["moving energy per frame"] = movingEnergyPerFrame;
 
-		const double movingHeatPerFrame =
-			max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
-			+ attributes.Get("turning heat")
-			+ attributes.Get("afterburner heat");
-		derivedAttributes["moving heat per frame"] = movingHeatPerFrame;
+	const double movingHeatPerFrame =
+		max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
+		+ attributes.Get("turning heat")
+		+ attributes.Get("afterburner heat");
+	derivedAttributes["moving heat per frame"] = movingHeatPerFrame;
 
-		double firingEnergy = 0.;
-		double firingHeat = 0.;
-		for(const auto &it : outfits)
-			if(it.first->IsWeapon() && it.first->Reload())
-			{
-				firingEnergy += it.second * it.first->FiringEnergy() / it.first->Reload();
-				firingHeat += it.second * it.first->FiringHeat() / it.first->Reload();
-			}
-		derivedAttributes["firing energy"] = firingEnergy;
-		derivedAttributes["firing heat"] = firingHeat;
+	double firingEnergy = 0.;
+	double firingHeat = 0.;
+	for(const auto &it : outfits)
+		if(it.first->IsWeapon() && it.first->Reload())
+		{
+			firingEnergy += it.second * it.first->FiringEnergy() / it.first->Reload();
+			firingHeat += it.second * it.first->FiringHeat() / it.first->Reload();
+		}
+	derivedAttributes["firing energy"] = firingEnergy;
+	derivedAttributes["firing heat"] = firingHeat;
 
-		double shieldEnergy = hasShieldRegen ? (attributes.Get("shield energy")
-			+ attributes.Get("delayed shield energy"))
-			* (1. + attributes.Get("shield energy multiplier")) : 0.;
-		derivedAttributes["total shield energy cost"] = shieldEnergy;
-		double hullEnergy = hasHullRepair ? (attributes.Get("hull energy")
-			+ attributes.Get("delayed hull energy"))
-			* (1. + attributes.Get("hull energy multiplier")) : 0.;
-		derivedAttributes["total hull energy cost"] = hullEnergy;
-		derivedAttributes["total shield & hull energy cost"] = (shieldEnergy + hullEnergy);
+	double shieldEnergy = hasShieldRegen ? (attributes.Get("shield energy")
+		+ attributes.Get("delayed shield energy"))
+		* (1. + attributes.Get("shield energy multiplier")) : 0.;
+	derivedAttributes["total shield energy cost"] = shieldEnergy;
+	double hullEnergy = hasHullRepair ? (attributes.Get("hull energy")
+		+ attributes.Get("delayed hull energy"))
+		* (1. + attributes.Get("hull energy multiplier")) : 0.;
+	derivedAttributes["total hull energy cost"] = hullEnergy;
+	derivedAttributes["total shield & hull energy cost"] = (shieldEnergy + hullEnergy);
 
-		double shieldHeat = hasShieldRegen ? (attributes.Get("shield heat")
-			+ attributes.Get("delayed shield heat"))
-			* (1. + attributes.Get("shield heat multiplier")) : 0.;
-		derivedAttributes["total shield heat cost"] = shieldHeat;
-		double hullHeat = hasHullRepair ? (attributes.Get("hull heat")
-			+ attributes.Get("delayed hull heat"))
-			* (1. + attributes.Get("hull heat multiplier")) : 0.;
-		derivedAttributes["total hull heat cost"] = hullHeat;
-		derivedAttributes["total shield & hull heat cost"] = (shieldHeat + hullHeat);
+	double shieldHeat = hasShieldRegen ? (attributes.Get("shield heat")
+		+ attributes.Get("delayed shield heat"))
+		* (1. + attributes.Get("shield heat multiplier")) : 0.;
+	derivedAttributes["total shield heat cost"] = shieldHeat;
+	double hullHeat = hasHullRepair ? (attributes.Get("hull heat")
+		+ attributes.Get("delayed hull heat"))
+		* (1. + attributes.Get("hull heat multiplier")) : 0.;
+	derivedAttributes["total hull heat cost"] = hullHeat;
+	derivedAttributes["total shield & hull heat cost"] = (shieldHeat + hullHeat);
 
-		const double overallEnergy = idleEnergyPerFrame
-			- movingEnergyPerFrame
-			- firingEnergy
-			- shieldEnergy
-			- hullEnergy;
-		derivedAttributes["net energy"] = overallEnergy;
+	const double overallEnergy = idleEnergyPerFrame
+		- movingEnergyPerFrame
+		- firingEnergy
+		- shieldEnergy
+		- hullEnergy;
+	derivedAttributes["net energy"] = overallEnergy;
 
-		const double overallHeat = idleHeatPerFrame
-			+ movingHeatPerFrame
-			+ firingHeat
-			+ shieldHeat
-			+ hullHeat;
-		derivedAttributes["net heat"] = overallHeat;
+	const double overallHeat = idleHeatPerFrame
+		+ movingHeatPerFrame
+		+ firingHeat
+		+ shieldHeat
+		+ hullHeat;
+	derivedAttributes["net heat"] = overallHeat;
 
-		const double maxEnergy = attributes.Get("energy capacity");
-		const double maxHeat = HeatDissipation() * MaximumHeat();
-		derivedAttributes["max energy"] = maxEnergy;
-		derivedAttributes["max heat"] = maxHeat;
-	}
+	const double maxEnergy = attributes.Get("energy capacity");
+	const double maxHeat = HeatDissipation() * MaximumHeat();
+	derivedAttributes["max energy"] = maxEnergy;
+	derivedAttributes["max heat"] = maxHeat;
 }
 
 
@@ -1421,8 +1419,6 @@ vector<string> Ship::FlightCheck() const
 				checks.emplace_back("insufficient energy to fire?");
 				break;
 			}
-		if(-20. * 60. * derivedAttributes.Get("net energy") > battery)
-			checks.emplace_back("under 20s of battery?");
 	}
 
 	return checks;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -900,6 +900,102 @@ void Ship::FinishLoading(bool isNewInstance)
 			targetSystem = nullptr;
 		}
 	}
+
+	RecomputeDerivedAttributes();
+}
+
+
+
+void Ship::RecomputeDerivedAttributes()
+{
+	{
+		double shieldRegen = (attributes.Get("shield generation")
+			+ attributes.Get("delayed shield generation"))
+			* (1. + attributes.Get("shield generation multiplier"));
+		bool hasShieldRegen = shieldRegen > 0.;
+		derivedAttributes["shield regen"] = shieldRegen;
+
+		double hullRepair = (attributes.Get("hull repair rate")
+			+ attributes.Get("delayed hull repair rate"))
+			* (1. + attributes.Get("hull repair multiplier"));
+		bool hasHullRepair = hullRepair > 0.;
+		derivedAttributes["hull repair"] = hullRepair;
+
+		const double idleEnergyPerFrame = attributes.Get("energy generation")
+			+ attributes.Get("solar collection")
+			+ attributes.Get("fuel energy")
+			- attributes.Get("energy consumption")
+			- attributes.Get("cooling energy");
+		derivedAttributes["idle energy per frame"] = idleEnergyPerFrame;
+
+		const double idleHeatPerFrame = attributes.Get("heat generation")
+			+ attributes.Get("solar heat")
+			+ attributes.Get("fuel heat")
+			- CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling"));
+		derivedAttributes["idle heat per frame"] = idleHeatPerFrame;
+
+		const double movingEnergyPerFrame =
+			max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
+			+ attributes.Get("turning energy")
+			+ attributes.Get("afterburner energy");
+		derivedAttributes["moving energy per frame"] = movingEnergyPerFrame;
+
+		const double movingHeatPerFrame =
+			max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
+			+ attributes.Get("turning heat")
+			+ attributes.Get("afterburner heat");
+		derivedAttributes["moving heat per frame"] = movingHeatPerFrame;
+
+		double firingEnergy = 0.;
+		double firingHeat = 0.;
+		for(const auto &it : outfits)
+			if(it.first->IsWeapon() && it.first->Reload())
+			{
+				firingEnergy += it.second * it.first->FiringEnergy() / it.first->Reload();
+				firingHeat += it.second * it.first->FiringHeat() / it.first->Reload();
+			}
+		derivedAttributes["firing energy"] = firingEnergy;
+		derivedAttributes["firing heat"] = firingHeat;
+
+		double shieldEnergy = hasShieldRegen ? (attributes.Get("shield energy")
+			+ attributes.Get("delayed shield energy"))
+			* (1. + attributes.Get("shield energy multiplier")) : 0.;
+		derivedAttributes["total shield energy cost"] = shieldEnergy;
+		double hullEnergy = hasHullRepair ? (attributes.Get("hull energy")
+			+ attributes.Get("delayed hull energy"))
+			* (1. + attributes.Get("hull energy multiplier")) : 0.;
+		derivedAttributes["total hull energy cost"] = hullEnergy;
+		derivedAttributes["total shield & hull energy cost"] = (shieldEnergy + hullEnergy);
+
+		double shieldHeat = hasShieldRegen ? (attributes.Get("shield heat")
+			+ attributes.Get("delayed shield heat"))
+			* (1. + attributes.Get("shield heat multiplier")) : 0.;
+		derivedAttributes["total shield heat cost"] = shieldHeat;
+		double hullHeat = hasHullRepair ? (attributes.Get("hull heat")
+			+ attributes.Get("delayed hull heat"))
+			* (1. + attributes.Get("hull heat multiplier")) : 0.;
+		derivedAttributes["total hull heat cost"] = hullHeat;
+		derivedAttributes["total shield & hull heat cost"] = (shieldHeat + hullHeat);
+
+		const double overallEnergy = idleEnergyPerFrame
+			- movingEnergyPerFrame
+			- firingEnergy
+			- shieldEnergy
+			- hullEnergy;
+		derivedAttributes["net energy"] = overallEnergy;
+
+		const double overallHeat = idleHeatPerFrame
+			+ movingHeatPerFrame
+			+ firingHeat
+			+ shieldHeat
+			+ hullHeat;
+		derivedAttributes["net heat"] = overallHeat;
+
+		const double maxEnergy = attributes.Get("energy capacity");
+		const double maxHeat = HeatDissipation() * MaximumHeat();
+		derivedAttributes["max energy"] = maxEnergy;
+		derivedAttributes["max heat"] = maxHeat;
+	}
 }
 
 
@@ -1325,6 +1421,8 @@ vector<string> Ship::FlightCheck() const
 				checks.emplace_back("insufficient energy to fire?");
 				break;
 			}
+		if(-20. * 60. * derivedAttributes.Get("net energy") > battery)
+			checks.emplace_back("under 20s of battery?");
 	}
 
 	return checks;
@@ -3366,6 +3464,13 @@ const Outfit &Ship::BaseAttributes() const
 
 
 
+const Dictionary &Ship::DerivedAttributes() const
+{
+	return derivedAttributes;
+}
+
+
+
 // Get outfit information.
 const map<const Outfit *, int> &Ship::Outfits() const
 {
@@ -3426,6 +3531,8 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		// Non-player ships will recalibrate before they jump.
 		else if(isYours)
 			navigation.Recalibrate(*this);
+
+		RecomputeDerivedAttributes();
 	}
 }
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -432,6 +432,8 @@ public:
 	const Outfit &Attributes() const;
 	// Get the attributes of this ship chassis before any outfits were added.
 	const Outfit &BaseAttributes() const;
+	// Get the computed attributes of this ship.
+	const Dictionary &DerivedAttributes() const;
 	// Get the list of all outfits installed in this ship.
 	const std::map<const Outfit *, int> &Outfits() const;
 	// Find out how many outfits of the given type this ship contains.
@@ -490,6 +492,8 @@ public:
 
 
 private:
+	void RecomputeDerivedAttributes();
+
 	// Various steps of Ship::Move:
 
 	// Check if this ship has been in a different system from the player for so
@@ -604,6 +608,7 @@ private:
 	// Installed outfits, cargo, etc.:
 	Outfit attributes;
 	Outfit baseAttributes;
+	Dictionary derivedAttributes;
 	bool addAttributes = false;
 	const Outfit *explosionWeapon = nullptr;
 	std::map<const Outfit *, int> outfits;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -429,11 +429,10 @@ public:
 	void Jettison(const Outfit *outfit, int count, bool wasAppeasing = false);
 
 	// Get the current attributes of this ship.
+	double GetAttribute(std::string name) const;
 	const Outfit &Attributes() const;
 	// Get the attributes of this ship chassis before any outfits were added.
 	const Outfit &BaseAttributes() const;
-	// Get the computed attributes of this ship.
-	const Dictionary &DerivedAttributes() const;
 	// Get the list of all outfits installed in this ship.
 	const std::map<const Outfit *, int> &Outfits() const;
 	// Find out how many outfits of the given type this ship contains.
@@ -492,8 +491,6 @@ public:
 
 
 private:
-	void RecomputeDerivedAttributes();
-
 	// Various steps of Ship::Move:
 
 	// Check if this ship has been in a different system from the player for so
@@ -608,7 +605,6 @@ private:
 	// Installed outfits, cargo, etc.:
 	Outfit attributes;
 	Outfit baseAttributes;
-	Dictionary derivedAttributes;
 	bool addAttributes = false;
 	const Outfit *explosionWeapon = nullptr;
 	std::map<const Outfit *, int> outfits;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -160,7 +160,6 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributesHeight += 20;
 
 	const Outfit &attributes = ship.Attributes();
-	const Dictionary &derived = ship.DerivedAttributes();
 
 	if(!ship.IsYours())
 		for(const string &license : attributes.Licenses())
@@ -194,7 +193,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
-	double shieldRegen = derived.Get("shield regen");
+	double shieldRegen = ship.GetAttribute("shield regen");
 	bool hasShieldRegen = shieldRegen > 0.;
 	if(hasShieldRegen)
 	{
@@ -208,7 +207,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		attributeValues.push_back(Format::Number(ship.MaxShields()));
 	}
 	attributesHeight += 20;
-	double hullRepair = derived.Get("hull repair");
+	double hullRepair = ship.GetAttribute("hull repair");
 	bool hasHullRepair = hullRepair > 0.;
 	if(hasHullRepair)
 	{
@@ -332,54 +331,54 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	// Skip a spacer and the table header.
 	attributesHeight += 30;
 
-	const double idleEnergyPerFrame = derived.Get("idle energy per frame");
-	const double idleHeatPerFrame = derived.Get("idle heat per frame");
+	const double idleEnergyPerFrame = ship.GetAttribute("idle energy per frame");
+	const double idleHeatPerFrame = ship.GetAttribute("idle heat per frame");
 	tableLabels.push_back("idle:");
 	energyTable.push_back(Format::Number(60. * idleEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * idleHeatPerFrame));
 
 	// Add energy and heat while moving to the table.
 	attributesHeight += 20;
-	const double movingEnergyPerFrame = derived.Get("moving energy per frame");
-	const double movingHeatPerFrame = derived.Get("moving heat per frame");
+	const double movingEnergyPerFrame = ship.GetAttribute("moving energy per frame");
+	const double movingHeatPerFrame = ship.GetAttribute("moving heat per frame");
 	tableLabels.push_back("moving:");
 	energyTable.push_back(Format::Number(-60. * movingEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * movingHeatPerFrame));
 
 	// Add energy and heat while firing to the table.
 	attributesHeight += 20;
-	const double firingEnergy = derived.Get("firing energy");
-	const double firingHeat = derived.Get("firing heat");
+	const double firingEnergy = ship.GetAttribute("firing energy");
+	const double firingHeat = ship.GetAttribute("firing heat");
 	tableLabels.push_back("firing:");
 	energyTable.push_back(Format::Number(-60. * firingEnergy));
 	heatTable.push_back(Format::Number(60. * firingHeat));
 
 	// Add energy and heat when doing shield and hull repair to the table.
 	attributesHeight += 20;
-	double shieldEnergy = derived.Get("total shield energy cost");
-	double hullEnergy = derived.Get("total hull energy cost");
-	double shieldHeat = derived.Get("total shield heat cost");
-	double hullHeat = derived.Get("total hull heat cost");
+	double shieldEnergy = ship.GetAttribute("total shield energy cost");
+	double hullEnergy = ship.GetAttribute("total hull energy cost");
+	double shieldHeat = ship.GetAttribute("total shield heat cost");
+	double hullHeat = ship.GetAttribute("total hull heat cost");
 	bool hasShieldRepairCost = shieldEnergy || shieldHeat;
 	bool hasHullRepairCost = hullEnergy || hullHeat;
 	tableLabels.push_back((hasShieldRepairCost && hasHullRepairCost) ? "shields / hull:" :
 		hasHullRepairCost ? "repairing hull:" : "charging shields:");
-	energyTable.push_back(Format::Number(-60. * derived.Get("total shield & hull energy cost")));
-	heatTable.push_back(Format::Number(60. * derived.Get("total shield & hull heat cost")));
+	energyTable.push_back(Format::Number(-60. * ship.GetAttribute("total shield & hull energy cost")));
+	heatTable.push_back(Format::Number(60. * ship.GetAttribute("total shield & hull heat cost")));
 
 	if(scrollingPanel)
 	{
 		// Add up the maximum possible changes and add the total to the table.
 		attributesHeight += 20;
 		tableLabels.push_back("net change:");
-		energyTable.push_back(Format::Number(60. * derived.Get("net energy")));
-		heatTable.push_back(Format::Number(60. * derived.Get("net heat")));
+		energyTable.push_back(Format::Number(60. * ship.GetAttribute("net energy")));
+		heatTable.push_back(Format::Number(60. * ship.GetAttribute("net heat")));
 	}
 
 	// Add maximum values of energy and heat to the table.
 	attributesHeight += 20;
-	const double maxEnergy = derived.Get("max energy");
-	const double maxHeat = derived.Get("max heat");
+	const double maxEnergy = ship.GetAttribute("max energy");
+	const double maxHeat = ship.GetAttribute("max heat");
 	tableLabels.push_back("max:");
 	energyTable.push_back(Format::Number(maxEnergy));
 	heatTable.push_back(Format::Number(60. * maxHeat));


### PR DESCRIPTION
# Performance enhancement


I thought this had already been in PR for a week but aparently I only [posted it on Discord](https://discord.com/channels/251118043411775489/285540320823869441/1250913097540046888).

## Summary
Stop re-computing some things that don't change every frame. Used for the ship info tables in the outfitter, shipyard, and ship info panel.

## Screenshots
No visual difference.

## Testing Done
I have been using it for two weeks and have not noticed anything wrong. I rely on this information hourly. My main concern is that there is some case I have missed where attributes can change but I haven't covered. I just realised, for example, that I have not bought a new ship since introducing this change locally.

## Save File
Any save will do.

## Wiki Update
N/A

## Performance Impact
Should improve things significanly but I have no means to measure this.
