### PR TITLE
refactor(code): Small DataWriter refactor

### DIFF
--- a/source/DataNode.cpp
+++ b/source/DataNode.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "DataNode.h"
 
+#include "DataWriter.h"
 #include "Logger.h"
 
 #include <algorithm>
@@ -89,6 +90,14 @@ int DataNode::Size() const noexcept
 const vector<string> &DataNode::Tokens() const noexcept
 {
 	return tokens;
+}
+
+
+
+// Add tokens to the node.
+void DataNode::AddToken(const std::string &token)
+{
+	tokens.emplace_back(token);
 }
 
 
@@ -262,6 +271,14 @@ bool DataNode::IsBool(const string &token)
 
 
 
+// Add a new child. The child's parent must be this node.
+void DataNode::AddChild(const DataNode &child)
+{
+	children.emplace_back(child);
+}
+
+
+
 // Check if this node has any children.
 bool DataNode::HasChildren() const noexcept
 {
@@ -307,13 +324,7 @@ int DataNode::PrintTrace(const string &message) const
 	{
 		if(&token != &tokens.front())
 			line += ' ';
-		bool hasSpace = any_of(token.begin(), token.end(), [](unsigned char c) { return isspace(c); });
-		bool hasQuote = any_of(token.begin(), token.end(), [](char c) { return (c == '"'); });
-		if(hasSpace)
-			line += hasQuote ? '`' : '"';
-		line += token;
-		if(hasSpace)
-			line += hasQuote ? '`' : '"';
+		line += DataWriter::Quote(token);
 	}
 	Logger::LogError(line);
 

--- a/source/DataNode.h
+++ b/source/DataNode.h
@@ -44,6 +44,8 @@ public:
 	int Size() const noexcept;
 	// Get all the tokens in this node as an iterable vector.
 	const std::vector<std::string> &Tokens() const noexcept;
+	// Add tokens to the node.
+	void AddToken(const std::string &token);
 	// Get the token at the given index. No bounds checking is done internally.
 	// DataFile loading guarantees index 0 always exists.
 	const std::string &Token(int index) const;
@@ -64,6 +66,8 @@ public:
 	bool IsBool(int index) const;
 	static bool IsBool(const std::string &token);
 
+	// Add a new child. The child's parent must be this node.
+	void AddChild(const DataNode &child);
 	// Check if this node has any children. If so, the iterator functions below
 	// can be used to access them.
 	bool HasChildren() const noexcept;

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -63,6 +63,14 @@ void DataWriter::SaveToPath(const std::string &filepath)
 
 
 
+// Get the contents as a string.
+string DataWriter::SaveToString()
+{
+	return out.str();
+}
+
+
+
 // Write a DataNode with all its children.
 void DataWriter::Write(const DataNode &node)
 {
@@ -113,7 +121,7 @@ void DataWriter::EndChild()
 // Write a comment line, at the current indentation level.
 void DataWriter::WriteComment(const string &str)
 {
-	out << indent << "# " << str << '\n';
+	out << *before << "# " << str << '\n';
 }
 
 
@@ -129,21 +137,29 @@ void DataWriter::WriteToken(const char *a)
 // Write a token, given as a string object.
 void DataWriter::WriteToken(const string &a)
 {
-	// Figure out what kind of quotation marks need to be used for this string.
-	bool hasSpace = any_of(a.begin(), a.end(), [](unsigned char c) { return isspace(c); });
-	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
-	// If the token is an empty string, it needs to be wrapped in quotes as if it had a space.
-	hasSpace |= a.empty();
-	// Write the token, enclosed in quotes if necessary.
 	out << *before;
-	if(hasQuote)
-		out << '`' << a << '`';
-	else if(hasSpace)
-		out << '"' << a << '"';
-	else
-		out << a;
+	out << Quote(a);
 
 	// The next token written will not be the first one on this line, so it only
 	// needs to have a single space before it.
 	before = &space;
+}
+
+
+
+string DataWriter::Quote(const std::string &a)
+{
+	// Figure out what kind of quotation marks need to be used for this string.
+	bool hasSpace = any_of(a.begin(), a.end(), [](unsigned char c) { return isspace(c); });
+	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
+	bool hasBacktick = any_of(a.begin(), a.end(), [](char c) { return (c == '`'); });
+	// If the token is an empty string, it needs to be wrapped in quotes as if it had a space.
+	hasSpace |= a.empty();
+
+	if(hasQuote)
+		return '`' + a + '`';
+	else if(hasSpace || hasBacktick)
+		return '"' + a + '"';
+	else
+		return a;
 }

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -121,7 +121,8 @@ void DataWriter::EndChild()
 // Write a comment line, at the current indentation level.
 void DataWriter::WriteComment(const string &str)
 {
-	out << *before << "# " << str << '\n';
+	out << *before << "# " << str;
+	Write();
 }
 
 

--- a/source/DataWriter.h
+++ b/source/DataWriter.h
@@ -47,6 +47,8 @@ public:
 
 	// Save the contents to a file.
 	void SaveToPath(const std::string &path);
+	// Get the contents as a string.
+	std::string SaveToString();
 
 	// The Write() function can take any number of arguments. Each argument is
 	// converted to a token. Arguments may be strings or numeric values.
@@ -74,6 +76,9 @@ public:
 	// Write a token of any arithmetic type.
 	template <class A>
 	void WriteToken(const A &a);
+
+	// Enclose a string in the correct quotation marks.
+	static std::string Quote(const std::string &text);
 
 
 private:

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "DataFile.h"
 #include "DataNode.h"
+#include "DataWriter.h"
 #include "GameData.h"
 #include "GameEvent.h"
 #include "LocationFilter.h"
@@ -51,7 +52,7 @@ namespace {
 	void PrintItemSales(const Set<Type> &items, const Set<Sale<Type>> &sales,
 		const string &itemNoun, const string &saleNoun)
 	{
-		cout << itemNoun << ',' << saleNoun << '\n';
+		cout << DataWriter::Quote(itemNoun) << ',' << DataWriter::Quote(saleNoun) << '\n';
 		map<string, set<string>> itemSales;
 		for(auto &saleIt : sales)
 			for(auto &itemIt : saleIt.second)
@@ -60,9 +61,9 @@ namespace {
 		{
 			if(itemIt.first != ObjectName(itemIt.second))
 				continue;
-			cout << '"' << itemIt.first << '"';
+			cout << DataWriter::Quote(itemIt.first);
 			for(auto &saleName : itemSales[itemIt.first])
-				cout << ',' << '"' << saleName << '"';
+				cout << ',' << DataWriter::Quote(saleName);
 			cout << '\n';
 		}
 	}
@@ -72,13 +73,13 @@ namespace {
 	template <class Type>
 	void PrintSales(const Set<Sale<Type>> &sales, const string &saleNoun, const string &itemNoun)
 	{
-		cout << saleNoun << ';' << itemNoun << '\n';
+		cout << DataWriter::Quote(saleNoun) << ';' << DataWriter::Quote(itemNoun) << '\n';
 		for(auto &saleIt : sales)
 		{
-			cout << '"' << saleIt.first << '"';
+			cout << DataWriter::Quote(saleIt.first);
 			int index = 0;
 			for(auto &item : saleIt.second)
-				cout << (index++ ? ';' : ',') << '"' << ObjectName(*item) << '"';
+				cout << (index++ ? ';' : ',') <<DataWriter::Quote(ObjectName(*item));
 			cout << '\n';
 		}
 	}
@@ -86,13 +87,11 @@ namespace {
 
 	// Take a Set and print a list of the names (keys) it contains.
 	template <class Type>
-	void PrintObjectList(const Set<Type> &objects, bool withQuotes, const string &name)
+	void PrintObjectList(const Set<Type> &objects, const string &name)
 	{
-		cout << name << '\n';
-		const string start = withQuotes ? "\"" : "";
-		const string end = withQuotes ? "\"\n" : "\n";
+		cout << DataWriter::Quote(name) << '\n';
 		for(const auto &it : objects)
-			cout << start << it.first << end;
+			cout << DataWriter::Quote(it.first) << endl;
 	}
 
 	// Takes a Set of objects and prints the key for each, followed by a list of its attributes.
@@ -100,14 +99,14 @@ namespace {
 	template <class Type>
 	void PrintObjectAttributes(const Set<Type> &objects, const string &name)
 	{
-		cout << name << ',' << "attributes" << '\n';
+		cout << DataWriter::Quote(name) << ',' << DataWriter::Quote("attributes") << '\n';
 		for(auto &it : objects)
 		{
-			cout << '"' << it.first << '"';
+			cout << DataWriter::Quote(it.first);
 			const Type &object = it.second;
 			int index = 0;
 			for(const string &attribute : object.Attributes())
-				cout << (index++ ? ';' : ',') << '"' << attribute << '"';
+				cout << (index++ ? ';' : ',') << DataWriter::Quote(attribute);
 			cout << '\n';
 		}
 	}
@@ -117,7 +116,7 @@ namespace {
 	template <class Type>
 	void PrintObjectsByAttribute(const Set<Type> &objects, const string &name)
 	{
-		cout << "attribute" << ',' << name << '\n';
+		cout << DataWriter::Quote("attribute") << ',' << DataWriter::Quote(name) << '\n';
 		set<string> attributes;
 		for(auto &it : objects)
 		{
@@ -127,13 +126,13 @@ namespace {
 		}
 		for(const string &attribute : attributes)
 		{
-			cout << '"' << attribute << '"';
+			cout << DataWriter::Quote(attribute);
 			int index = 0;
 			for(auto &it : objects)
 			{
 				const Type &object = it.second;
 				if(object.Attributes().count(attribute))
-					cout << (index++ ? ';' : ',') << '"' << it.first << '"';
+					cout << (index++ ? ';' : ',') << DataWriter::Quote(it.first);
 			}
 			cout << '\n';
 		}
@@ -144,11 +143,13 @@ namespace {
 	{
 		auto PrintBaseShipStats = []() -> void
 		{
-			cout << "model" << ',' << "category" << ',' << "chassis cost" << ',' << "loaded cost" << ',' << "shields" << ','
-				<< "hull" << ',' << "mass" << ',' << "drag" << ',' << "heat dissipation" << ','
-				<< "required crew" << ',' << "bunks" << ',' << "cargo space" << ',' << "fuel" << ','
-				<< "outfit space" << ',' << "weapon capacity" << ',' << "engine capacity" << ',' << "gun mounts" << ','
-				<< "turret mounts" << ',' << "fighter bays" << ',' << "drone bays" << '\n';
+			cout << "model" << ',' << "category" << ',' << DataWriter::Quote("chassis cost") << ','
+				<< DataWriter::Quote("loaded cost") << ',' << "shields" << ',' << "hull" << ',' << "mass" << ',' << "drag" << ','
+				<< DataWriter::Quote("heat dissipation") << ',' << DataWriter::Quote("required crew") << ',' << "bunks" << ','
+				<< DataWriter::Quote("cargo space") << ',' << "fuel" << ',' << DataWriter::Quote("outfit space") << ','
+				<< DataWriter::Quote("weapon capacity") << ',' << DataWriter::Quote("engine capacity") << ','
+				<< DataWriter::Quote("gun mounts") << ',' << DataWriter::Quote("turret mounts") << ','
+				<< DataWriter::Quote("fighter bays") << ',' << DataWriter::Quote("drone bays") << '\n';
 
 			for(auto &it : GameData::Ships())
 			{
@@ -157,10 +158,10 @@ namespace {
 					continue;
 
 				const Ship &ship = it.second;
-				cout << '"' << it.first << '"' << ',';
+				cout << DataWriter::Quote(it.first) << ',';
 
 				const Outfit &attributes = ship.BaseAttributes();
-				cout << '"' << attributes.Category() << '"' << ',';
+				cout << DataWriter::Quote(attributes.Category()) << ',';
 				cout << ship.ChassisCost() << ',';
 				cout << ship.Cost() << ',';
 
@@ -198,14 +199,15 @@ namespace {
 
 		auto PrintLoadedShipStats = [](bool variants) -> void
 		{
-			cout << "model" << ',' << "category" << ',' << "cost" << ',' << "shields" << ','
-				<< "hull" << ',' << "mass" << ',' << "required crew" << ',' << "bunks" << ','
-				<< "cargo space" << ',' << "fuel" << ',' << "outfit space" << ',' << "weapon capacity" << ','
-				<< "engine capacity" << ',' << "speed" << ',' << "accel" << ',' << "turn" << ','
-				<< "energy generation" << ',' << "max energy usage" << ',' << "energy capacity" << ','
-				<< "idle/max heat" << ',' << "max heat generation" << ',' << "max heat dissipation" << ','
-				<< "gun mounts" << ',' << "turret mounts" << ',' << "fighter bays" << ','
-				<< "drone bays" << ',' << "deterrence" << '\n';
+			cout << "model" << ',' << "category" << ',' << "cost" << ',' << "shields" << ',' << "hull" << ',' << "mass" << ','
+				<< DataWriter::Quote("required crew") << ',' << "bunks" << ',' << DataWriter::Quote("cargo space") << ','
+				<< "fuel" << ',' << DataWriter::Quote("outfit space") << ',' << DataWriter::Quote("weapon capacity") << ','
+				<< DataWriter::Quote("engine capacity") << ',' << "speed" << ',' << "accel" << ',' << "turn" << ','
+				<< DataWriter::Quote("energy generation") << ',' << DataWriter::Quote("max energy usage") << ','
+				<< DataWriter::Quote("energy capacity") << ',' << DataWriter::Quote("idle/max heat") << ','
+				<< DataWriter::Quote("max heat generation") << ',' << DataWriter::Quote("max heat dissipation") << ','
+				<< DataWriter::Quote("gun mounts") << ',' << DataWriter::Quote("turret mounts") << ','
+				<< DataWriter::Quote("fighter bays") << ',' << DataWriter::Quote("drone bays") << ',' << "deterrence" << '\n';
 
 			for(auto &it : GameData::Ships())
 			{
@@ -214,10 +216,10 @@ namespace {
 					continue;
 
 				const Ship &ship = it.second;
-				cout << '"' << it.first << '"' << ',';
+				cout << DataWriter::Quote(it.first) << ',';
 
 				const Outfit &attributes = ship.Attributes();
-				cout << '"' << attributes.Category() << '"' << ',';
+				cout << DataWriter::Quote(attributes.Category()) << ',';
 				cout << ship.Cost() << ',';
 
 				auto mass = attributes.Mass() ? attributes.Mass() : 1.;
@@ -310,7 +312,7 @@ namespace {
 				if(it.second.TrueModelName() != it.first && !variants)
 					continue;
 
-				cout << "\"" << it.first << "\"\n";
+				cout << DataWriter::Quote(it.first) << "\n";
 			}
 		};
 
@@ -346,14 +348,15 @@ namespace {
 	{
 		auto PrintWeaponStats = []() -> void
 		{
-			cout << "name" << ',' << "category" << ',' << "cost" << ',' << "space" << ',' << "range" << ','
-				<< "reload" << ',' << "burst count" << ',' << "burst reload" << ',' << "lifetime" << ','
-				<< "shots/second" << ',' << "energy/shot" << ',' << "heat/shot" << ',' << "recoil/shot" << ','
-				<< "energy/s" << ',' << "heat/s" << ',' << "recoil/s" << ',' << "shield/s" << ','
-				<< "discharge/s" << ',' << "hull/s" << ',' << "corrosion/s" << ',' << "heat dmg/s" << ','
-				<< "burn dmg/s" << ',' << "energy dmg/s" << ',' << "ion dmg/s" << ',' << "scrambling dmg/s" << ','
-				<< "slow dmg/s" << ',' << "disruption dmg/s" << ',' << "piercing" << ',' << "fuel dmg/s" << ','
-				<< "leak dmg/s" << ',' << "push/s" << ',' << "homing" << ',' << "strength" << ','
+			cout << "name" << ',' << "category" << ',' << "cost" << ',' << "space" << ',' << "range" << ',' << "reload" << ','
+				<< DataWriter::Quote("burst count") << ',' << DataWriter::Quote("burst reload") << ',' << "lifetime" << ','
+				<< "shots/second" << ',' << "energy/shot" << ',' << "heat/shot" << ',' << "recoil/shot" << ',' << "energy/s" << ','
+				<< "heat/s" << ',' << "recoil/s" << ',' << "shield/s" << ',' << "discharge/s" << ',' << "hull/s" << ','
+				<< "corrosion/s" << ',' << "heat dmg/s" << ',' << DataWriter::Quote("burn dmg/s") << ','
+				<< DataWriter::Quote("energy dmg/s") << ',' << DataWriter::Quote("ion dmg/s") << ','
+				<< DataWriter::Quote("scrambling dmg/s") << ',' << DataWriter::Quote("slow dmg/s") << ','
+				<< DataWriter::Quote("disruption dmg/s") << ',' << "piercing" << ',' << DataWriter::Quote("fuel dmg/s") << ','
+				<< DataWriter::Quote("leak dmg/s") << ',' << "push/s" << ',' << "homing" << ',' << "strength" << ','
 				<< "deterrence" << '\n';
 
 			for(auto &it : GameData::Outfits())
@@ -363,8 +366,8 @@ namespace {
 					continue;
 
 				const Outfit &outfit = it.second;
-				cout << '"' << it.first << '"' << ',';
-				cout << '"' << outfit.Category() << '"' << ',';
+				cout << DataWriter::Quote(it.first)<< ',';
+				cout << DataWriter::Quote(outfit.Category()) << ',';
 				cout << outfit.Cost() << ',';
 				cout << -outfit.Get("weapon capacity") << ',';
 
@@ -436,12 +439,13 @@ namespace {
 
 		auto PrintEngineStats = []() -> void
 		{
-			cout << "name" << ',' << "cost" << ',' << "mass" << ',' << "outfit space" << ','
-				<< "engine capacity" << ',' << "thrust/s" << ',' << "thrust energy/s" << ','
-				<< "thrust heat/s" << ',' << "turn/s" << ',' << "turn energy/s" << ','
-				<< "turn heat/s" << ',' << "reverse thrust/s" << ',' << "reverse energy/s" << ','
-				<< "reverse heat/s" << ',' << "afterburner thrust/s" << ',' << "afterburner energy/s" << ','
-				<< "afterburner heat/s" << ',' << "afterburner fuel/s" << '\n';
+			cout << "name" << ',' << "cost" << ',' << "mass" << ',' << DataWriter::Quote("outfit space") << ','
+				<< DataWriter::Quote("engine capacity") << ',' << "thrust/s" << ',' << DataWriter::Quote("thrust energy/s") << ','
+				<< DataWriter::Quote("thrust heat/s") << ',' << "turn/s" << ',' << DataWriter::Quote("turn energy/s") << ','
+				<< DataWriter::Quote("turn heat/s") << ',' << DataWriter::Quote("reverse thrust/s") << ','
+				<< DataWriter::Quote("reverse energy/s") << ',' << DataWriter::Quote("reverse heat/s") << ','
+				<< DataWriter::Quote("afterburner thrust/s") << ',' << DataWriter::Quote("afterburner energy/s") << ','
+				<< DataWriter::Quote("afterburner heat/s") << ',' << DataWriter::Quote("afterburner fuel/s") << '\n';
 
 			for(auto &it : GameData::Outfits())
 			{
@@ -450,7 +454,7 @@ namespace {
 					continue;
 
 				const Outfit &outfit = it.second;
-				cout << '"' << it.first << '"' << ',';
+				cout << DataWriter::Quote(it.first) << ',';
 				cout << outfit.Cost() << ',';
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
@@ -475,8 +479,9 @@ namespace {
 
 		auto PrintPowerStats = []() -> void
 		{
-			cout << "name" << ',' << "cost" << ',' << "mass" << ',' << "outfit space" << ','
-				<< "energy generation" << ',' << "heat generation" << ',' << "energy capacity" << '\n';
+			cout << "name" << ',' << "cost" << ',' << "mass" << ',' << DataWriter::Quote("outfit space") << ','
+				<< DataWriter::Quote("energy generation") << ',' << DataWriter::Quote("heat generation") << ','
+				<< DataWriter::Quote("energy capacity") << '\n';
 
 			for(auto &it : GameData::Outfits())
 			{
@@ -485,7 +490,7 @@ namespace {
 					continue;
 
 				const Outfit &outfit = it.second;
-				cout << '"' << it.first << '"' << ',';
+				cout << DataWriter::Quote(it.first) << ',';
 				cout << outfit.Cost() << ',';
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
@@ -509,14 +514,14 @@ namespace {
 
 			cout << "name" << ',' << "category" << ',' << "cost" << ',' << "mass";
 			for(const auto &attribute : attributes)
-				cout << ',' << '"' << attribute << '"';
+				cout << ',' << DataWriter::Quote(attribute);
 			cout << '\n';
 
 			for(auto &it : GameData::Outfits())
 			{
 				const Outfit &outfit = it.second;
-				cout << '"' << outfit.TrueName() << '"' << ',';
-				cout << '"' << outfit.Category() << '"' << ',';
+				cout << DataWriter::Quote(outfit.TrueName()) << ',';
+				cout << DataWriter::Quote(outfit.Category()) << ',';
 				cout << outfit.Cost() << ',';
 				cout << outfit.Mass();
 				for(const auto &attribute : attributes)
@@ -557,7 +562,7 @@ namespace {
 		else if(all)
 			PrintOutfitsAllStats();
 		else
-			PrintObjectList(GameData::Outfits(), true, "outfit");
+			PrintObjectList(GameData::Outfits(), "outfit");
 	}
 
 	void Sales(const char *const *argv)
@@ -625,7 +630,7 @@ namespace {
 		else if(attributes)
 			PrintObjectAttributes(GameData::Planets(), "planet");
 		if(!(descriptions || attributes))
-			PrintObjectList(GameData::Planets(), false, "planet");
+			PrintObjectList(GameData::Planets(), "planet");
 	}
 
 	void Systems(const char *const *argv)
@@ -646,7 +651,7 @@ namespace {
 		else if(attributes)
 			PrintObjectAttributes(GameData::Systems(), "system");
 		else
-			PrintObjectList(GameData::Systems(), false, "system");
+			PrintObjectList(GameData::Systems(), "system");
 	}
 
 	void LocationFilterMatches(const char *const *argv)

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -79,7 +79,7 @@ namespace {
 			cout << DataWriter::Quote(saleIt.first);
 			int index = 0;
 			for(auto &item : saleIt.second)
-				cout << (index++ ? ';' : ',') <<DataWriter::Quote(ObjectName(*item));
+				cout << (index++ ? ';' : ',') << DataWriter::Quote(ObjectName(*item));
 			cout << '\n';
 		}
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(EndlessSkyTests PRIVATE
 	unit/src/test_conditionsStore.cpp
 	unit/src/test_datafile.cpp
 	unit/src/test_datanode.cpp
+	unit/src/test_datawriter.cpp
 	unit/src/test_dictionary.cpp
 	unit/src/test_distance_calculation_settings.cpp
 	unit/src/test_esuuid.cpp

--- a/tests/unit/src/test_datawriter.cpp
+++ b/tests/unit/src/test_datawriter.cpp
@@ -99,7 +99,7 @@ R"(first
 		# comment
 		"after comment"
 	"second after"
-)" );
+)");
 		}
 		THEN( "writing an inline comment is possible" ) {
 			writer.WriteToken("begin");
@@ -112,7 +112,7 @@ R"(first
 		third
 		begin # comment
 	"second after"
-)" );
+)");
 		}
 	}
 }

--- a/tests/unit/src/test_datawriter.cpp
+++ b/tests/unit/src/test_datawriter.cpp
@@ -1,0 +1,154 @@
+/* test_datawriter.cpp
+Copyright (c) 2024 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "es-test.hpp"
+
+// Include only the tested class's header.
+#include "../../../source/DataWriter.h"
+
+// ... and any system includes needed for the test file.
+#include "../../../source/DataNode.h"
+
+namespace { // test namespace
+
+// #region mock data
+// #endregion mock data
+
+
+
+// #region unit tests
+TEST_CASE( "DataWriter::Quote", "[datawriter][quote]" ) {
+	CHECK( DataWriter::Quote("") == "\"\"" );
+	CHECK( DataWriter::Quote(" ") == "\" \"" );
+	CHECK( DataWriter::Quote("a") == "a" );
+	CHECK( DataWriter::Quote("multiple spaces here ") == "\"multiple spaces here \"" );
+	CHECK( DataWriter::Quote("\"") == "`\"`" );
+	CHECK( DataWriter::Quote("quote and\" space ") == "`quote and\" space `" );
+	CHECK( DataWriter::Quote("`") == "\"`\"" );
+	CHECK( DataWriter::Quote("long ` text") == "\"long ` text\"" );
+}
+
+TEST_CASE( "DataWriter::WriteComment", "[datawriter][writecomment]" ) {
+	DataWriter writer;
+	GIVEN( "an empty DataWriter" ) {
+		THEN( "writing a comment is possible" ) {
+			writer.WriteComment("hello");
+			CHECK( writer.SaveToString() == "# hello\n" );
+		}
+	}
+	GIVEN( "a DataWriter with a partial line" ) {
+		writer.WriteToken("hello there");
+		THEN( "writing a comment is possible" ) {
+			writer.WriteComment("comment");
+			CHECK( writer.SaveToString() == "\"hello there\" # comment\n" );
+		}
+	}
+	GIVEN( "a DataWriter with multiple lines" ) {
+		writer.Write("hello", "there");
+		THEN( "writing a comment is possible" ) {
+			writer.WriteComment("comment");
+			CHECK( writer.SaveToString() == "hello there\n# comment\n" );
+		}
+	}
+	GIVEN( "a DataWriter with indentation" ) {
+		writer.Write("hello");
+		writer.BeginChild();
+		THEN( "writing a comment is possible" ) {
+			writer.Write("there");
+			writer.WriteComment("comment");
+			writer.EndChild();
+			CHECK( writer.SaveToString() == "hello\n\tthere\n\t# comment\n" );
+		}
+		THEN( "writing an inline comment is possible" ) {
+			writer.WriteToken("there");
+			writer.WriteComment("comment");
+			writer.EndChild();
+			CHECK( writer.SaveToString() == "hello\n\tthere # comment\n" );
+		}
+	}
+}
+
+TEST_CASE( "DataWriter::WriteSorted", "[datawriter][writesorted]" ) {
+	GIVEN( "a DataWriter" ) {
+		DataWriter writer;
+		std::map<const std::string *, double> data;
+		using InnerType = std::pair<const std::string * const, double>;
+		const auto &sortF = [&](const InnerType *a, const InnerType *b) {return a->second < b->second;};
+		const auto &writeF = [&](const InnerType &it){writer.Write(*it.first);};
+		AND_GIVEN( "no data" ) {
+			THEN( "sorting is possible" ) {
+				WriteSorted(data, sortF, writeF);
+				CHECK( writer.SaveToString() == "" );
+			}
+		}
+		AND_GIVEN( "a single data point" ) {
+			std::string buffer = "1";
+			data.emplace(&buffer, 8);
+			THEN( "sorting is possible" ) {
+				WriteSorted(data, sortF, writeF);
+				CHECK( writer.SaveToString() == "1\n" );
+			}
+		}
+		AND_GIVEN( "multiple data points" ) {
+			std::string buffer[] = {"1", "6", "3", "4", "5", "2"};
+			double nums[] = {1, 6, 3, 4, 5, 2};
+			for(int i = 0; i < 6; i++)
+				data.emplace(buffer + i, nums[i]);
+
+			THEN( "sorting is possible" ) {
+				WriteSorted(data, sortF, writeF);
+				CHECK( writer.SaveToString() == "1\n2\n3\n4\n5\n6\n" );
+			}
+		}
+	}
+}
+
+TEST_CASE( "DataWriter::Write", "[datawriter][write]" ) {
+	GIVEN( "a DataWriter" ) {
+		DataWriter writer;
+		DataNode node;
+		AND_GIVEN( "a single-level node" ) {
+			node.AddToken("first");
+			node.AddToken("line");
+			THEN( "the node can be written" ) {
+				writer.Write(node);
+				CHECK( writer.SaveToString() == "first line\n" );
+			}
+		}
+		AND_GIVEN( "a multi-level node" ) {
+			node.AddToken("first");
+			node.AddToken("line");
+			DataNode child(&node);
+			child.AddToken("second");
+			child.AddToken("line");
+			DataNode child2(&node);
+			child2.AddToken("third");
+			DataNode child3(&child);
+			child3.AddToken("inner");
+			child.AddChild(child3);
+			node.AddChild(child);
+			node.AddChild(child2);
+			THEN( "the node can be written" ) {
+				writer.Write(node);
+				CHECK( writer.SaveToString() == "first line\n\tsecond line\n\t\tinner\n\tthird\n" );
+			}
+		}
+	}
+}
+// #endregion unit tests
+
+
+
+} // test namespace

--- a/tests/unit/src/test_datawriter.cpp
+++ b/tests/unit/src/test_datawriter.cpp
@@ -52,7 +52,8 @@ TEST_CASE( "DataWriter::WriteComment", "[datawriter][writecomment]" ) {
 		writer.WriteToken("hello there");
 		THEN( "writing a comment is possible" ) {
 			writer.WriteComment("comment");
-			CHECK( writer.SaveToString() == "\"hello there\" # comment\n" );
+			writer.Write("next line");
+			CHECK( writer.SaveToString() == "\"hello there\" # comment\n\"next line\"\n" );
 		}
 	}
 	GIVEN( "a DataWriter with multiple lines" ) {
@@ -68,14 +69,50 @@ TEST_CASE( "DataWriter::WriteComment", "[datawriter][writecomment]" ) {
 		THEN( "writing a comment is possible" ) {
 			writer.Write("there");
 			writer.WriteComment("comment");
+			writer.Write("after comment");
 			writer.EndChild();
-			CHECK( writer.SaveToString() == "hello\n\tthere\n\t# comment\n" );
+			writer.Write("outer");
+			CHECK( writer.SaveToString() == "hello\n\tthere\n\t# comment\n\t\"after comment\"\nouter\n" );
 		}
 		THEN( "writing an inline comment is possible" ) {
 			writer.WriteToken("there");
 			writer.WriteComment("comment");
 			writer.EndChild();
 			CHECK( writer.SaveToString() == "hello\n\tthere # comment\n" );
+		}
+	}
+	GIVEN( "a DataWriter with multiple levels of indentation" ) {
+		writer.Write("first");
+		writer.BeginChild();
+		writer.Write("second");
+		writer.BeginChild();
+		writer.Write("third");
+		THEN( "writing a comment is possible" ) {
+			writer.WriteComment("comment");
+			writer.Write("after comment");
+			writer.EndChild();
+			writer.Write("second after");
+			CHECK( writer.SaveToString() ==
+R"(first
+	second
+		third
+		# comment
+		"after comment"
+	"second after"
+)" );
+		}
+		THEN( "writing an inline comment is possible" ) {
+			writer.WriteToken("begin");
+			writer.WriteComment("comment");
+			writer.EndChild();
+			writer.Write("second after");
+			CHECK( writer.SaveToString() ==
+R"(first
+	second
+		third
+		begin # comment
+	"second after"
+)" );
 		}
 	}
 }


### PR DESCRIPTION
**Refactor**

This PR refactors DataWriter to enable unit testing and safe PrintData output parsing.

## Summary
Exposes the quotation logic in DataWriter, removing the need for the re-implemented version in DataNode.

Adds a SaveToString() function to DataWriter for unit tests, and some modifier functions to DataNode.

Fixes the long-standing bug of PrintData not quoting its output properly.

Adds some new unit tests.

## Usage examples
Unit tests and PrintData. Also useful for future work with somewhat complicated data writing semantics, such as #9114 (which could get more unit tests with this refactor).

## Testing Done
The new tests run. PrintData seems to work.