### PR TITLE
feat(status-messages): Always show destroyed escorts, flotsam collect only if enabled

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1402,7 +1402,7 @@ tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
 tip "Extra fleet status messages"
-	`Display extra status messages about escorts in your fleet, such as when they are destroyed or scanned.`
+	`Display extra status messages about escorts in your fleet, such as when they collect flotsam or are under-crewed.`
 
 tip "Control ship with mouse"
 	`If active, your flagship will always turn toward your mouse. For activating mouse turning on a key press, see the "Mouse turning (hold)" control.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1402,7 +1402,7 @@ tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
 tip "Extra fleet status messages"
-	`Display extra status messages about escorts in your fleet, such as when they collect flotsam or are under-crewed.`
+	`Display extra status messages about escorts in your fleet, such as when they are under-crewed or collect flotsam.`
 
 tip "Control ship with mouse"
 	`If active, your flagship will always turn toward your mouse. For activating mouse turning on a key press, see the "Mouse turning (hold)" control.`

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2396,28 +2396,30 @@ void Engine::DoCollection(Flotsam &flotsam)
 	}
 
 	// Checks for player FlotsamCollection setting
+	bool collectorIsFlagship = collector == player.Flagship();
 	if(collector->IsYours())
 	{
 		const auto flotsamSetting = Preferences::GetFlotsamCollection();
 		if(flotsamSetting == Preferences::FlotsamCollection::OFF)
 			return;
-		if(collector == player.Flagship() && flotsamSetting == Preferences::FlotsamCollection::ESCORT)
+		if(collectorIsFlagship && flotsamSetting == Preferences::FlotsamCollection::ESCORT)
 			return;
-		if(collector != player.Flagship() && flotsamSetting == Preferences::FlotsamCollection::FLAGSHIP)
+		if(!collectorIsFlagship && flotsamSetting == Preferences::FlotsamCollection::FLAGSHIP)
 			return;
 	}
 
 	// Transfer cargo from the flotsam to the collector ship.
 	int amount = flotsam.TransferTo(collector);
+
 	// If the collector is not one of the player's ships, we can bail out now.
 	if(!collector->IsYours())
 		return;
 
-	if(collector->GetParent() && !Preferences::Has("Extra fleet status messages"))
+	if(!collectorIsFlagship && !Preferences::Has("Extra fleet status messages"))
 		return;
 
 	// One of your ships picked up this flotsam. Describe who it was.
-	string name = (!collector->GetParent() ? "You" :
+	string name = (collectorIsFlagship ? "You" :
 			"Your " + collector->Noun() + " \"" + collector->Name() + "\"") + " picked up ";
 	// Describe what they collected from this flotsam.
 	string commodity;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2413,6 +2413,9 @@ void Engine::DoCollection(Flotsam &flotsam)
 	if(!collector->IsYours())
 		return;
 
+	if(collector->GetParent() && !Preferences::Has("Extra fleet status messages"))
+		return;
+
 	// One of your ships picked up this flotsam. Describe who it was.
 	string name = (!collector->GetParent() ? "You" :
 			"Your " + collector->Noun() + " \"" + collector->Name() + "\"") + " picked up ";

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4482,13 +4482,13 @@ void Ship::StepPilot()
 	else if(requiredCrew && static_cast<int>(Random::Int(requiredCrew)) >= Crew())
 	{
 		pilotError = 30;
-		if(isYours || (personality.IsEscort() && Preferences::Has("Extra fleet status messages")))
+		if(isYours || personality.IsEscort())
 		{
-			if(parent.lock())
-				Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."
-					, Messages::Importance::Low);
-			else
+			if(!parent.lock())
 				Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it."
+					, Messages::Importance::Low);
+			else if(Preferences::Has("Extra fleet status messages"))
+				Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."
 					, Messages::Importance::Low);
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3066,7 +3066,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 	{
 		type |= ShipEvent::DESTROY;
 
-		if(IsYours() && Preferences::Has("Extra fleet status messages"))
+		if(IsYours())
 			Messages::Add("Your " + DisplayModelName() +
 				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
 	}


### PR DESCRIPTION
# Feature

## Summary
Change the "Extra fleet status messages" preference to suppress lower priority fleet messages, not higher priority ones. Specificly, always show 'destroyed' messages and conditionally show 'collected flotsam' and 'escort under-crewed' messages. Mission and player-owned escorts now behave the same, per the preference. Update the tooltip accordingly. Nota bene: there never was a message saying your escort had been scanned, despite what the tooltip had said.

## Screenshots
Not a visual change.

## Testing Done
Repeated with preference on/off:
* Ordered escort to it's inevitable doom, message always showed.
* Collected flotsam with flagship, message always showed.
* Collected flotsam with escort, message showed conditionally.
* Captured ship with too few crew to transfer a full compliment, message shows for both flagship and escort with preference on, just flagship with preference off.

## Save File
Available on request. Any save with escorts will do.

## Wiki Update
Not sure if one is needed.

## Performance Impact
Negligible. Should improve performance when preference is off as fewer messages will be logged. No change when on.