### PR TITLE
Feature: Display total credit gain/loss from automatic income and payments

### DIFF
--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -17,7 +17,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "DataNode.h"
 #include "DataWriter.h"
-#include "PlayerInfo.h"
 #include "text/Format.h"
 
 #include <algorithm>

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "DataNode.h"
 #include "DataWriter.h"
+#include "PlayerInfo.h"
 #include "text/Format.h"
 
 #include <algorithm>
@@ -271,6 +272,12 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	if(debtPaid)
 		typesPaid["debt"] = debtPaid;
 
+	totalPreviousPayment = 0;
+	for (const auto& paid : typesPaid)
+	{
+		totalPreviousPayment += paid.second;
+	}
+
 	// If you made payments of three or more types, the punctuation needs to
 	// include commas, so just handle that separately here.
 	if(typesPaid.size() >= 3)
@@ -456,7 +463,11 @@ int64_t Account::TotalDebt(const string &type) const
 	return total;
 }
 
-
+// Get how many credits the player paid
+int64_t Account::TotalLastPayment() const
+{
+	return totalPreviousPayment;
+}
 
 // Extrapolate from the player's current net worth history to determine how much
 // their net worth is expected to change over the course of the next year.

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -272,7 +272,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 		typesPaid["debt"] = debtPaid;
 
 	totalPreviousPayment = 0;
-	for( const auto& paid : typesPaid)
+	for(const auto &paid : typesPaid)
 	{
 		totalPreviousPayment += paid.second;
 	}

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -462,11 +462,13 @@ int64_t Account::TotalDebt(const string &type) const
 	return total;
 }
 
+
 // Get how many credits the player paid
 int64_t Account::TotalPreviousPayment() const
 {
 	return totalPreviousPayment;
 }
+
 
 // Extrapolate from the player's current net worth history to determine how much
 // their net worth is expected to change over the course of the next year.

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -272,7 +272,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 		typesPaid["debt"] = debtPaid;
 
 	totalPreviousPayment = 0;
-	for (const auto& paid : typesPaid)
+	for( const auto& paid : typesPaid)
 	{
 		totalPreviousPayment += paid.second;
 	}

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -273,9 +273,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 
 	totalPreviousPayment = 0;
 	for(const auto &paid : typesPaid)
-	{
 		totalPreviousPayment += paid.second;
-	}
 
 	// If you made payments of three or more types, the punctuation needs to
 	// include commas, so just handle that separately here.
@@ -463,11 +461,13 @@ int64_t Account::TotalDebt(const string &type) const
 }
 
 
-// Get how many credits the player paid
+
+// Get how many credits the player paid.
 int64_t Account::TotalPreviousPayment() const
 {
 	return totalPreviousPayment;
 }
+
 
 
 // Extrapolate from the player's current net worth history to determine how much

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -463,7 +463,7 @@ int64_t Account::TotalDebt(const string &type) const
 }
 
 // Get how many credits the player paid
-int64_t Account::TotalLastPayment() const
+int64_t Account::TotalPreviousPayment() const
 {
 	return totalPreviousPayment;
 }

--- a/source/Account.h
+++ b/source/Account.h
@@ -75,6 +75,7 @@ public:
 	// Get how many credits the player paid
 	int64_t TotalPreviousPayment() const;
 
+
 private:
 	int64_t YearlyRevenue() const;
 

--- a/source/Account.h
+++ b/source/Account.h
@@ -82,8 +82,6 @@ private:
 
 private:
 	int64_t credits = 0;
-	// Keep track of how much was paid by the player.
-	int64_t totalPreviousPayment = 0;
 	// Regular income from salaries paid to the player.
 	std::map<std::string, int64_t> salariesIncome;
 	// If back salaries and maintenance cannot be paid, they pile up rather
@@ -92,6 +90,8 @@ private:
 	int64_t maintenanceDue = 0;
 	// Your credit score determines the interest rate on your mortgages.
 	int creditScore = 400;
+	// Keep track of how much was paid by the player.
+	int64_t totalPreviousPayment = 0;
 
 	std::vector<Mortgage> mortgages;
 

--- a/source/Account.h
+++ b/source/Account.h
@@ -72,7 +72,7 @@ public:
 	// mortgages if a blank string is provided.
 	int64_t TotalDebt(const std::string &type = "") const;
 
-	// Get how many credits the player paid
+	// Get how many credits the player paid.
 	int64_t TotalPreviousPayment() const;
 
 

--- a/source/Account.h
+++ b/source/Account.h
@@ -73,7 +73,7 @@ public:
 	int64_t TotalDebt(const std::string &type = "") const;
 
 	// Get how many credits the player paid
-	int64_t TotalLastPayment() const;
+	int64_t TotalPreviousPayment() const;
 
 private:
 	int64_t YearlyRevenue() const;

--- a/source/Account.h
+++ b/source/Account.h
@@ -72,6 +72,8 @@ public:
 	// mortgages if a blank string is provided.
 	int64_t TotalDebt(const std::string &type = "") const;
 
+	// Get how many credits the player paid
+	int64_t TotalLastPayment() const;
 
 private:
 	int64_t YearlyRevenue() const;
@@ -79,6 +81,8 @@ private:
 
 private:
 	int64_t credits = 0;
+	// Keep track of how much was paid by the player.
+	int64_t totalPreviousPayment = 0;
 	// Regular income from salaries paid to the player.
 	std::map<std::string, int64_t> salariesIncome;
 	// If back salaries and maintenance cannot be paid, they pile up rather

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -785,7 +785,8 @@ void PlayerInfo::IncrementDate()
 		Messages::Add(message, Messages::Importance::High);
 
 	// Tell the player the total gain/loss of credits automatically paid.
-	Messages::Add("For a total change of " + Format::CreditString(salariesIncome + tributeIncome - accounts.TotalLastPayment()) + ".", Messages::Importance::High);
+	Messages::Add("For a total change of " + Format::CreditString(salariesIncome + tributeIncome - accounts.TotalLastPayment()) + ".",
+		Messages::Importance::High);
 
 	// Reset the reload counters for all your ships.
 	for(const shared_ptr<Ship> &ship : ships)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -785,7 +785,8 @@ void PlayerInfo::IncrementDate()
 		Messages::Add(message, Messages::Importance::High);
 
 	// Tell the player the total gain/loss of credits automatically paid.
-	Messages::Add("For a total change of " + Format::CreditString(salariesIncome + tributeIncome - accounts.TotalLastPayment()) + ".",
+	Messages::Add("For a total change of " +
+		Format::CreditString(salariesIncome + tributeIncome - accounts.TotalLastPayment()) + ".",
 		Messages::Importance::High);
 
 	// Reset the reload counters for all your ships.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -784,6 +784,9 @@ void PlayerInfo::IncrementDate()
 	if(!message.empty())
 		Messages::Add(message, Messages::Importance::High);
 
+	// Tell the player the total gain/loss of credits automatically paid.
+	Messages::Add("For a total change of " + Format::CreditString(salariesIncome + tributeIncome - accounts.TotalLastPayment()) + ".", Messages::Importance::High);
+
 	// Reset the reload counters for all your ships.
 	for(const shared_ptr<Ship> &ship : ships)
 		ship->GetArmament().ReloadAll();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -786,7 +786,7 @@ void PlayerInfo::IncrementDate()
 
 	// Tell the player the total gain/loss of credits automatically paid.
 	Messages::Add("For a total change of " +
-		Format::CreditString(salariesIncome + tributeIncome - accounts.TotalLastPayment()) + ".",
+		Format::CreditString(salariesIncome + tributeIncome - accounts.TotalPreviousPayment()) + ".",
 		Messages::Importance::High);
 
 	// Reset the reload counters for all your ships.


### PR DESCRIPTION
**Feature**


Resolves #2945

## Summary
When ever a day passes you are told money made from selling things, tribute, salary, etc, and credits lost from crew salary, morgages, etc.; now this also displays a sum total of all

I am not married to the wording 

## Screenshots

![Screenshot_2024-07-1T23:46:18-EDT](https://github.com/endless-sky/endless-sky/assets/20733061/c6d9c3ec-b02a-41db-9fc4-40a7744da7f8)
![Screenshot_2024-07-1T23:46:48-EDT](https://github.com/endless-sky/endless-sky/assets/20733061/8f61fbbd-4e87-4120-9dc7-88ad0d6c97e7)

## Usage examples
n/a

## Testing Done
Tried various combinations of all the ways to automatically gain/lose credits per day, all displayed correctly

## Save File
n/a

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
n/a 
