### PR TITLE
Standardize newlines in news across all files

### DIFF
--- a/data/coalition/coalition news.txt
+++ b/data/coalition/coalition news.txt
@@ -27,6 +27,7 @@ news "heliarch news"
 			"During one of the more busy hours on the spaceport, the news details the crimes of a recently arrested terrorist group: arson, kidnapping, theft of government equipment, possession of weapons, conspiring against the Coalition, attacking both government and civilian properties, subversion... The list goes on for a few more minutes."
 			`After the latest report on how the Heliarchs arrested some terrorists on a nearby world, the news shows various short clips with the same message, asking the public to "stay vigilant" and report any and all suspicious activity.`
 
+
 news "heliarch propaganda"
 	location
 		government "Coalition" "Heliarch"
@@ -39,6 +40,7 @@ news "heliarch propaganda"
 			"A local screen shows a stressed Saryd working at a computer late at night. The door creaks, and she looks back to find her children peeking. She puts them to sleep and then goes to bed herself. After waking up, she finds nobody around the house. She goes outside, seeing the children, along with their father, admiring the sun rising."
 			"After a government broadcast, a timelapse plays on a spaceport monitor, showcasing Ring of Friendship gaining more and more solar panels on its exterior over the centuries."
 			"During a break, a recruitment advertisement plays. A recruit of each species is shown putting on their brand new uniforms, then training on some sort of obstacle track, and then the view switches to troops marching in unison in the Academy of Cadets of Belug's Plunge."
+
 
 news "longcow rancher"
 	location
@@ -56,6 +58,7 @@ news "longcow rancher"
 			`"Fresh steak here! First leg steak, second leg steak... a discount for tenth leg steak there is!"`
 			"You see a rancher walk out of a shop with a trolley full of bells. You wonder if they are for multiple longcows, or just a particularly long one."
 
+
 news "kimek farmer"
 	location
 		government "Coalition"
@@ -71,6 +74,7 @@ news "kimek farmer"
 			`"Some fresh produce would you like, Captain? If purchase these, you do, teach you a family recipe I could. I'm sure that love it, a human would. Probably."`
 			"After noticing you looking at the produce, the farmer asks if you would like some free samples, before grabbing an entire box with various fruits and vegetables and handing it to you."
 			`Dozens of farmers in different stands call out to you as you walk by the spaceport, asking you to take a look at the special prices of today's "food expo." You later look into it, and turns out yesterday there also was an expo, as well as the day before that. Tomorrow's starts the moment today's ends.`
+
 
 news "heliarch agent"
 	location
@@ -94,6 +98,7 @@ news "heliarch agent"
 			`"A pilot, I once was. Learned from an older sibling, I did."`
 			`"Seen those charity workers in blue on some of our worlds, have you? Noble intentions they may have, but understand it I do not. Why trouble themselves with it when taking care of everyone, we already are?"`
 
+
 news "heliarch candidate"
 	location
 		government "Heliarch"
@@ -105,6 +110,7 @@ news "heliarch candidate"
 			`"Laws, history, theory, too much of it I have read, and still behind I am..."`
 			`"As part of my trials, read the works of consul Aulori, I had to. Exceeded my expectations, his books have."`
 			`"Meant to prove our dedication and show our potential, the trials we candidates go through are. Though difficult, we're sure to be apt to serve once passed, we have."`
+
 
 news "coalition ad"
 	location
@@ -118,6 +124,7 @@ news "coalition ad"
 			"A commercial for House Debdo plays on a local monitor, with various scenes of tourist spots being accompanied by an upbeat, serene jingle."
 			"An ad shows various graphs of what you guess are stock values. An Arach leg swipes the view, and the graphs begin fluctuating a lot more to one side. At the end, the logo of House Plumtab flashes on the screen."
 			"An ad for an energy drink is on display on a local shop. A Kimek is down on the ground in the middle of the streets, struggling to move, as a crowd gathers around them. When they get the drink, they jump up and bolt past the crowd, and then proceed to climb up a skyscraper. At the end a disclaimer advises against Saryds consuming the drink."
+
 
 news "arach tourist"
 	location
@@ -133,6 +140,7 @@ news "arach tourist"
 			`"Much better than I expected, the food here is. Still, beat longcow steak, nothing here does."`
 			`"That the streets here were too narrow for us Arachi, I had heard, but no problem so far I've had."`
 
+
 news "kimek tourist"
 	location
 		government "Coalition"
@@ -147,6 +155,7 @@ news "kimek tourist"
 			`"Asked me to bring them some gifts from my trip, my family has, but fit them all in my luggage I cannot, and only half of the gifts purchased I have!"`
 			`"From an arcology I am, so to me twice the vacation, a trip to a planet without them is."`
 
+
 news "saryd tourist"
 	location
 		government "Coalition"
@@ -160,6 +169,7 @@ news "saryd tourist"
 			`"From far away I've come, and for weeks sleeping in a ship I was. My first time traveling to another planet, it is, so not used to being so far from nature, I was. No idea how other Saryds make it as pilots, I have."`
 			`"Truly breathtaking, the sights of this world are. The cuisine, too, greatly enjoyed I have. If only the locals had a more civil sense of attire."`
 			`"Climb up walls, the denizens of this world can. Otherworldly it is, to see them do so in the distinct architecture of some buildings here."`
+
 
 news "coalition researcher"
 	location
@@ -178,6 +188,7 @@ news "coalition researcher"
 			`"A lecture in nanotechnology, I am here to present. Unclear on whether I would be teaching faculty or students, the invitation was."`
 			`"Earned a degree in xenobiology, I did some time ago. Under a top researcher in the field, I work now."`
 
+
 news "coalition researcher yottrite"
 	to show
 		has "Coalition Yottrite 9: done"
@@ -192,6 +203,7 @@ news "coalition researcher yottrite"
 			`"Seems that interesting findings, the research on yottrite has yielded. Proud of having helped us learn more, you should be."`
 			`"Now that more information on yottrite we have, wonder if House Ablomab will ask for samples to experiment on, I do."`
 			`"Kill for the papers on the yottrite research, I would, but still confidential the information is."`
+
 
 news "coalition ringworld worker"
 	location
@@ -215,6 +227,7 @@ news "coalition ringworld worker"
 			"A small section of the area is roped off. An Arach has removed a floor panel and is busy reconfiguring circuitry below."
 			`"Friend, please step aside." A Kimek gestures to a large cart filled with tools and equipment, and you move to let them pass.`
 
+
 news "coalition spaceport worker"
 	location
 		government "Coalition" "Heliarch"
@@ -226,6 +239,7 @@ news "coalition spaceport worker"
 			`"Since with captains of other species, we deal, translation boxes, we are issued. Simple tools for us, but too expensive for many to purchase, they are, so to enjoy the opportunity to use them, we try."`
 			`"Three different styles of ships, we deal with daily, so never on autopilot we can be, or else refuel one incorrectly, we might."`
 			`"Inspect every crate before it is put on a ship, the Heliarchs do. A tedious process, it is."`
+
 
 news "coalition merchant"
 	location
@@ -249,6 +263,7 @@ news "coalition merchant"
 			"The spacefarer is assisting the rest of their crew in unloading cargo from a ship."
 			`"Used to fly with me, my brother did, but now become a Heliarch, he has."`
 
+
 news "arach civilian"
 	location
 		government "Coalition"
@@ -263,6 +278,7 @@ news "arach civilian"
 			`"To Ring of Wisdom, a researcher friend of mine has gone. Always there, our wisest mingle, but remain here, few do. Difficult for us, sometimes it is."`
 			`"Always mixing up our Houses, Kimek and Saryd tourists are. Mind it, I do not, but angry, sometimes my friends get."`
 			`"Learnt my language, some Kimek friends have, but so fast they speak, that difficult to understand them, it is."`
+
 
 news "kimek civilian"
 	location
@@ -279,6 +295,7 @@ news "kimek civilian"
 			`"Tired of dealing with faulty translation boxes, my sister got, so learning to speak Arachi, she is."`
 			`"Much more reserved than us, the Saryds are. So long do they live for, that difficult to understand their habits, it can be."`
 
+
 news "saryd civilian"
 	location
 		government "Coalition"
@@ -294,6 +311,7 @@ news "saryd civilian"
 			`"Troubling it is, when their children, Kimek and Arach tourists bring. Climb up everywhere, they try."`
 			`"Travel to new places, I used to, but infinite, our planets are not, so seen them all by now I have."`
 
+
 news "coalition vendor"
 	location
 		government "Coalition"
@@ -308,6 +326,7 @@ news "coalition vendor"
 			`"Interested in these ringworld keychains, are you? For you, only 30 credits!"`
 			`"Caught your eye, this necklace has? Real hedgelion quills, these are. Great luck, they bring, for those generous enough to make a purchase."`
 			`"Arcology miniatures? Arachi armor replicas? Multipurpose gardening tools? For all of those and more, the best prices I have!"`
+
 
 news "coalition civilian expeditions past"
 	to show
@@ -330,6 +349,7 @@ news "coalition civilian expeditions past"
 			`"The one that helped that Heliarch inspector in her expedition, you are. A very strong ship, you must have, if made it back, you two did."`
 			`"Helped that Heliarch inspector come back from the outside, you have. Always thought that impossible, I did."`
 
+
 news "heliarch expeditions past"
 	to show
 		has "Coalition: Expeditions Past 10: done"
@@ -346,6 +366,7 @@ news "heliarch expeditions past"
 			`"Our thanks for helping inspector Sedlitaris, you have. Finally found their way back, the last expedition's reports have."`
 			`"The one who helped inspector Sedlitaris on her expedition you are, correct? Read her report on it, I have. Disconcerting, the fate of the last expedition is, but at least recovered their findings, we now have."`
 
+
 news "coalition games broadcast"
 	to show
 		month == 7
@@ -361,6 +382,7 @@ news "coalition games broadcast"
 			"Some Arachi attentively wait for a game to start. The screen shows the competitors, who are also Arachi, putting on various layers of plate armor. They then all move to a metal cable, just thick enough for them to be gripped with all legs. They then stay there. For many minutes. Until they start falling one by one. Exhilarating."
 			"During a break from the games, some analysts go over spreadsheets with the statistics for the competitors of the past few games. You can't read any of it, but passerby workers and captains stay a while to glance at the results."
 			"One of the competitors from the last game, still catching their breath from the event, is giving an interview and gulping down water every time the interviewer talks. Given their excitement, you figure they must've performed very well."
+
 
 news "coalition games people"
 	to show
@@ -385,6 +407,7 @@ news "coalition games people"
 			`"Watching the Coalition Games transmissions lately, I have been. Tried to become an athlete myself, I once did, but too rigorous, their training routine is! Made me appreciate the sports more, it has."`
 			`"Just arrived from my first live viewing of the Coalition Games, I have. An incredible experience, it was. Go again next year, I for sure will!"`
 
+
 news "coalition games planet heliarch"
 	to show
 		month == 7
@@ -399,6 +422,7 @@ news "coalition games planet heliarch"
 			"You spot a few agents on their lunch break inside a local restaurant. They seem to be enjoying the Coalition Games broadcast more than the meals themselves."
 			`"Heading to the Coalition Games, are you? If so, forgive us you must. Some trouble with organizing the crowds this morning, there was, so delayed by five minutes, the whole line is."`
 			`"A former athlete myself, I am. Earned my rank by winning in the Games, I did, so always eager to help organize the event, I am."`
+
 
 news "coalition games planet people"
 	to show
@@ -422,6 +446,7 @@ news "coalition games planet people"
 			`"Here for the Games too, are you? The largest event in all the Coalition, it is. Come here to watch every year, I do!"`
 			`"Come to watch a relative of mine compete, I have. Training hard for many years, they have been, so sure I am that do well, they will."`
 
+
 news "coalition games crowd"
 	to show
 		month == 7
@@ -435,6 +460,7 @@ news "coalition games crowd"
 			"The lines of people heading to the Coalition Games seem to have stopped moving abruptly. Upon further investigation, you see some young Kimek have fallen on their backs and are being helped back to their feet one by one by both Heliarch agents and others from the crowd."
 			"This is a particularly crowded part of the spaceport today. The lines of people waiting for admission into the Games have started crossing and looping in on themselves. Some even head inside shops and restaurants while others stretch into docking areas. Battalions of Heliarch agents work as hard as they can to bring everyone back into orderly lines."
 			"Several children coming to see the Coalition Games are running and playing simplified versions of the events, sporting different colors and assets for different games. Their parents struggle to get them to settle down while keeping their spots in the waiting lines."
+
 
 news "lunarium charity"
 	location
@@ -450,6 +476,7 @@ news "lunarium charity"
 			"The spaceport has a few flyers glued to the entrance walls. You ask one of the locals, and they tell you they're for promoting a charity organization."
 			"Coalition families have formed a line to a large cargo ship. Brought by their parents, the children are one by one giving away blankets, outdated electronics, and all sorts of toys, which are all carefully packed into cargo containers. It seems they are donating to a charity organization."
 			"Charity workers are meeting with a few wealthy-looking individuals in the spaceport. Apparently all the expenses of the endeavor are paid by donations, and they are trying to bring in some new patrons to expand the efforts."
+
 
 news "lunarium charity worker"
 	to show

--- a/data/hai/hai news.txt
+++ b/data/hai/hai news.txt
@@ -38,6 +38,7 @@ news "food in Hai space"
 		word
 			`"`
 
+
 news "trading in Hai space"
 	location
 		government "Hai"
@@ -89,6 +90,7 @@ news "science in Hai space"
 		word
 			`"`
 
+
 news "cute story in Hai space"
 	location
 		government "Hai"
@@ -112,6 +114,7 @@ news "cute story in Hai space"
 		word
 			`"`
 
+
 news "cute hai story in Hai space"
 	location
 		government "Hai"
@@ -133,6 +136,7 @@ news "cute hai story in Hai space"
 			"I love participating in the festivities and traditions that humans bring with them into Hai space. They are so diverse and interesting!"
 		word
 			`"`
+
 
 news "business owner in Hai space"
 	location
@@ -175,6 +179,7 @@ news "business owner in Hai space"
 		word
 			`"`
 
+
 news "there might be riots on allhome Hai"
 	location
 		government "Hai"
@@ -198,6 +203,7 @@ news "there might be riots on allhome Hai"
 		word
 			`"`
 
+
 news "there might be riots on allhome human"
 	location
 		government "Hai"
@@ -218,6 +224,7 @@ news "there might be riots on allhome human"
 			"I thought I'd escaped that wretched music the kids were listening to when I came here, but it seems like it's been following me all this time!"
 		word
 			`"`
+
 
 news "concerned merchant in Hai space"
 	location
@@ -242,6 +249,7 @@ news "concerned merchant in Hai space"
 		word
 			`"`
 
+
 news "concerned hai in Hai space"
 	location
 		government "Hai"
@@ -260,6 +268,7 @@ news "concerned hai in Hai space"
 			"I feel so terrible for the many humans that attempt to reach our worlds and are destroyed by the Unfettered humans that block their passage."
 		word
 			`"`
+
 
 news "human citizen in Hai space"
 	location
@@ -280,6 +289,7 @@ news "human citizen in Hai space"
 			"Living here rather than back on Prime has its pros and cons. I don't have to worry about pirates showing up anymore, but now I can't find a single store that sells the latest hologame consoles that I'm used to!"
 		word
 			`"`
+
 
 news "human reaction to Greenwater outfitter"
 	location
@@ -303,6 +313,7 @@ news "human reaction to Greenwater outfitter"
 		word
 			`"`
 
+
 news "businessperson in hai space"
 	location
 		government "Hai"
@@ -322,6 +333,7 @@ news "businessperson in hai space"
 			"It seems that no amount of persuasion can make merchants fly through the north just to get to Hai space. Probably doesn't help that the promise of 'large squirrel customers' isn't very believable."
 		word
 			`"`
+
 
 news "reformed pirate in Hai space"
 	location
@@ -357,6 +369,7 @@ news "reformed pirate in Hai space"
 		word
 			`"`
 
+
 news "human advertisement in Hai space"
 	location
 		government "Hai"
@@ -376,6 +389,7 @@ news "human advertisement in Hai space"
 		word
 			`"`
 
+
 news "hai advertisement in Hai space"
 	location
 		government "Hai"
@@ -394,6 +408,7 @@ news "hai advertisement in Hai space"
 			"If you crave bizarre cuisine from beyond the wormhole, you must try the food at Duality Diner, featuring human chef Dibani Wilczek and her excellent dishes like 'broccoli,' 'oranges,' and 'cereal'!"
 		word
 			`"`
+
 
 news "hai attacked by pirates"
 	location
@@ -415,6 +430,7 @@ news "hai attacked by pirates"
 			"No wonder you have so many pirates in your space, with those fragile freighters you have. So much cargo with so little protection is pure madness! That is why I love humans." 3
 		word
 			`"`
+
 
 news "hai joining unfettered"
 	location
@@ -439,6 +455,7 @@ news "hai joining unfettered"
 			"My music is not appreciated here. I guess I'll be going to Unfettered space to see how they like it. I heard their taste is more... developed." 2
 		word
 			`"`
+
 
 news "hai joining unfettered"
 	location
@@ -480,6 +497,7 @@ news "unfettered hai no dialog"
 			"At a booth, you see a Hai selling stolen ship weaponry for outrageous prices."
 			"At a booth, you see a Hai selling various types of unpleasant-smelling substances. Judging by the effects it has on those who consume them, you guess that they're some type of drug."
 
+
 news "unfettered hai no dialog group"
 	location
 		government "Hai (Unfettered)"
@@ -495,6 +513,7 @@ news "unfettered hai no dialog group"
 			"You hear yelling in the Hai language. When you turn around, you see that two Hai are facing off against each other, as onlookers egg them on. You turn away before it gets ugly."
 			"A group of small Hai children run around playing some sort of game. More concerning, however, is the fact that they are carrying weapons while doing so."
 			"A group of Hai are camped around a bonfire just outside the spaceport. They sing songs and dance around the fire in an energetic, almost maniacal way."
+
 
 news "unfettered hai dialog"
 	location
@@ -528,6 +547,7 @@ news "unfettered hai dialog"
 		word
 			`"`
 
+
 news "Unfettered Regret"
 	location
 		government "Hai (Unfettered)"
@@ -549,6 +569,7 @@ news "Unfettered Regret"
 			"My captain calls the food shipments we get from the Fettered 'tribute,' but anyone can see it's charity to keep us from starving." 2
 		word
 			`"`
+
 
 news "unfettered hai after wanderers invasion"
 	location
@@ -578,6 +599,7 @@ news "unfettered hai after wanderers invasion"
 			"The aliens to the north call themselves the Wanderers. Overgrown birds is more like it."
 		word
 			`"`
+
 
 news "unfettered hai after wanderers invasion regret"
 	location

--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -64,7 +64,6 @@ news "merchant anywhere"
 			`"`
 
 
-
 news "merchant in human space"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent" "Quarg"
@@ -171,6 +170,7 @@ news "farmer"
 		word
 			`"`
 
+
 news "sailor"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -221,7 +221,6 @@ news "textile worker"
 			`"`
 
 
-
 news "miner"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -244,7 +243,6 @@ news "miner"
 			"Mining really is something magical. Shovel goes in, money comes up!"
 		word
 			`"`
-
 
 
 news "factory worker"
@@ -272,7 +270,6 @@ news "factory worker"
 			"My boss is great. If we suffer, then he makes sure he takes the heat as well."
 		word
 			`"`
-
 
 
 news "street vendor"
@@ -303,7 +300,6 @@ news "street vendor"
 			`"`
 
 
-
 news "grifter"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -325,7 +321,6 @@ news "grifter"
 			"This laser razor never needs sharpening! Achieve a smoking hot look every time!"
 		word
 			`"`
-
 
 
 news "company psychologist"
@@ -350,7 +345,6 @@ news "company psychologist"
 			`"`
 
 
-
 news "genetic counselor"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -372,7 +366,6 @@ news "genetic counselor"
 			`"`
 
 
-
 news "parent"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -391,7 +384,6 @@ news "parent"
 			"Don't you hate it when parents only talk about their kids and nothing else? I really try to avoid that... although I do have really nice kids. Do you want to hear about them?"
 		word
 			`"`
-
 
 
 news "unemployed youth"
@@ -423,7 +415,6 @@ news "unemployed youth"
 			`"`
 
 
-
 news "union organizer"
 	location
 		government "Syndicate"
@@ -446,7 +437,6 @@ news "union organizer"
 			"Here's a tip to know if you're being treated unfairly: 'Someone assigns you work, gives you a pizza, and then goes home.' The pizza is worth less than your time, and both your time and the pizza are valued much less than they value their time."
 		word
 			`"`
-
 
 
 phrase "small trash item"
@@ -484,7 +474,6 @@ news "waste collector"
 			`"`
 
 
-
 news "dock worker"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -519,7 +508,6 @@ news "dock worker"
 			`"`
 
 
-
 news "housekeeper"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -539,7 +527,6 @@ news "housekeeper"
 			"I just got fired. The dog of one of the kids died and the missus asked me to fly to Earth and buy a new identical one. When I returned she was screaming that she didn't need two dead dogs."
 		word
 			`"`
-
 
 
 news "groundskeeper"
@@ -563,7 +550,6 @@ news "groundskeeper"
 			`"`
 
 
-
 news "hair stylist"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -582,7 +568,6 @@ news "hair stylist"
 			"A real challenge for my profession in this day and age is finding styles that work in both high and low gravity environments."
 		word
 			`"`
-
 
 
 news "tour guide"
@@ -614,7 +599,6 @@ news "tour guide"
 			`"`
 
 
-
 news "human resources worker"
 	location
 		government "Syndicate"
@@ -635,7 +619,6 @@ news "human resources worker"
 			"I should be dealing with employees that just hang around and don't do any useful work, but being here in the spaceport and talking to people like you is much more fun."
 		word
 			`"`
-
 
 
 news "loan officer"
@@ -662,7 +645,6 @@ news "loan officer"
 			`"`
 
 
-
 news "hyperspace relay engineer"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent" "Quarg"
@@ -683,7 +665,6 @@ news "hyperspace relay engineer"
 			`"Have you ever set up a TCP/IP connection from Bourne to a server on Farpoint? I have. It's a little slow, but it works!"`
 			`"Do you know the DRQ of the HSBE for the hyperlanes around here? You don't understand? Sorry, a hyperlane can be thought of as a corridor through space..." The engineer gives a long-winded and confusing explanation of hyperlanes.`
 			`"It might take hours to get a message a few systems away going through the hyperspace relays, but it sure beats taking multiple days to send a ship or multiple centuries to send a message at light speed."`
-
 
 
 news "hyperspace scientist"
@@ -710,7 +691,6 @@ news "hyperspace scientist"
 			`"`
 
 
-
 news "geological engineer"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -729,7 +709,6 @@ news "geological engineer"
 			"I can't believe how annoying it must've been in the distant past to be a geological engineer, with you on one side, the thing you're trying to study on the other, and 15 kilometers of solid rock in between. Thankfully, technology and scanners have marched on since then, and those depressing days are long gone."
 		word
 			`"`
-
 
 
 news "agricultural scientist"
@@ -762,7 +741,6 @@ phrase "athlete competition location"
 		"Shangri-La in the Polaris system"
 
 
-
 news "athlete"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -784,7 +762,6 @@ news "athlete"
 			"I once went to a sports event on Dancer in the Rastaban system, but never again! All activities were indoors because of the horrible weather the planet has."
 		word
 			`"`
-
 
 
 news "dentist"
@@ -809,7 +786,6 @@ news "dentist"
 			`"`
 
 
-
 news "epidemiologist in human space"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -827,7 +803,6 @@ news "epidemiologist in human space"
 			"Don't listen to those conspiracy theories that say you can catch awful viruses from the Quarg. Their physiology is so alien that we're immune to all their diseases."
 		word
 			`"`
-
 
 
 news "epidemiologist on quarg world"
@@ -849,7 +824,6 @@ news "epidemiologist on quarg world"
 			`"`
 
 
-
 news "economist"
 	location
 		government "Syndicate"
@@ -867,7 +841,6 @@ news "economist"
 			"An economy is almost like a living organism, and if you're able to grasp its intricacy and scope, it's actually a very beautiful thing."
 		word
 			`"`
-
 
 
 news "mechanic"
@@ -893,6 +866,7 @@ news "mechanic"
 			"If it ain't broken, then don't come to me."
 		word
 			`"`
+
 
 news "mechanic on frozen world"
 	location
@@ -938,7 +912,6 @@ news "ship salesperson"
 			`"`
 
 
-
 news "nuclear technician"
 	location
 		government "Syndicate"
@@ -961,7 +934,6 @@ news "nuclear technician"
 			`"`
 
 
-
 news "substance abuse counselor"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -980,7 +952,6 @@ news "substance abuse counselor"
 			"If someone ever offers you a drug running job, I beg you to deny it and direct them toward one of us. That person will thank you later."
 		word
 			`"`
-
 
 
 news "reporter"
@@ -1012,7 +983,6 @@ news "reporter"
 			`"`
 
 
-
 news "public relations worker"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent" "Quarg"
@@ -1032,7 +1002,6 @@ news "public relations worker"
 			"One of my clients crashed her shuttle into the Parliament building. Keeping that out of the news was horribly expensive, but it was still cheaper than the reputation hit if it were broadcast."
 		word
 			`"`
-
 
 
 news "museum curator"
@@ -1058,7 +1027,6 @@ news "museum curator"
 			`"`
 
 
-
 news "actor"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1079,7 +1047,6 @@ news "actor"
 			"Don't be fooled by my jovial appearance onstage. I take my work very seriously."
 		word
 			`"`
-
 
 
 news "musician"
@@ -1107,7 +1074,6 @@ news "musician"
 			`"`
 
 
-
 news "technical writer"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1129,7 +1095,6 @@ news "technical writer"
 			`"`
 
 
-
 news "dietitian"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1147,7 +1112,6 @@ news "dietitian"
 			"There are probably thousands of edible native plants on every world human beings have colonized, but people still prefer the plants we brought with us from ancient Earth."
 		word
 			`"`
-
 
 
 news "chef"
@@ -1178,7 +1142,6 @@ news "chef"
 			`"`
 
 
-
 news "insurance agent"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1200,7 +1163,6 @@ news "insurance agent"
 			"What keeps me up at night? Correlated risk."
 		word
 			`"`
-
 
 
 news "excavation specialist"
@@ -1227,7 +1189,6 @@ news "excavation specialist"
 			`"`
 
 
-
 news "chauffeur"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1250,7 +1211,6 @@ news "chauffeur"
 			"You're not in traffic, you're part of traffic."
 		word
 			`"`
-
 
 
 news "retiree"
@@ -1277,7 +1237,6 @@ news "retiree"
 			`"`
 
 
-
 news "financial analyst"
 	location
 		attributes "paradise" "near earth"
@@ -1301,7 +1260,6 @@ news "financial analyst"
 			"Nearly lost my shirt in the commodities market last week. If my boss ever found out, it'd be curtains for me!"
 		word
 			`"`
-
 
 
 news "syndicate manager"
@@ -1345,7 +1303,6 @@ news "syndicate manager"
 			`"`
 
 
-
 news "work coach"
 	location
 		government "Syndicate"
@@ -1362,7 +1319,6 @@ news "work coach"
 			"Working as the head of a company requires sound decision making abilities. Hiring an expensive consultant like me usually suggests a lack thereof, but I'm not complaining since I get paid well."
 		word
 			`"`
-
 
 
 news "scientist"
@@ -1385,7 +1341,6 @@ news "scientist"
 			"My research concerns force fields. No, not those kinds of force fields."
 		word
 			`"`
-
 
 
 news "student"
@@ -1414,7 +1369,6 @@ news "student"
 			`"`
 
 
-
 news "religious"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1441,7 +1395,6 @@ news "religious"
 			"Praise God! This day is a blessing."
 		word
 			`"`
-
 
 
 news "tourist"
@@ -1482,6 +1435,7 @@ news "tourist"
 		word
 			`"`
 
+
 news "tourist on frozen world"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Independent" "Neutral"
@@ -1502,6 +1456,7 @@ news "tourist on frozen world"
 		word
 			`"`
 
+
 news "protester"
 	location
 		government "Republic" "Free Worlds" "Syndicate"
@@ -1519,7 +1474,6 @@ news "protester"
 			"Give up your sinful life as spaceship captain and settle on this beautiful planet."
 		word
 			`"`
-
 
 
 news "diplomat"
@@ -1544,7 +1498,6 @@ news "diplomat"
 			`"`
 
 
-
 news "mercenary"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1566,7 +1519,6 @@ news "mercenary"
 			"As much as I'd like to dual-wield laser rifles, I'd probably just miss every shot."
 		word
 			`"`
-
 
 
 news "republic soldier"
@@ -1594,7 +1546,6 @@ news "republic soldier"
 			`"`
 
 
-
 news "lawyer"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -1614,7 +1565,6 @@ news "lawyer"
 			"I was involved in a case of an out-of-spec Syndicate nuclear reactor. Allegedly, the Syndicate threatened the inspector to prevent him from publishing his results, but he didn't give in."
 		word
 			`"`
-
 
 
 news "syndicate soldier"
@@ -1638,7 +1588,6 @@ news "syndicate soldier"
 			"If you ask me, I think that the Syndicate is far too soft on the pirates - almost as if they don't want to harm them more than they need to. Don't tell my employers that I said that, though."
 		word
 			`"`
-
 
 
 news "pirate"
@@ -1699,7 +1648,6 @@ news "pirate"
 			`"`
 
 
-
 news "merchant in pirate space"
 	location
 		government "Pirate"
@@ -1724,7 +1672,6 @@ news "merchant in pirate space"
 			"The optimist has the glass half full, the pessimist has the glass half empty, but here you are already lucky if the glass doesn't get shot, stolen, or broken before you take your first sip."
 		word
 			`"`
-
 
 
 news "farmer in pirate space"
@@ -1760,7 +1707,6 @@ news "farmer in pirate space"
 			`"`
 
 
-
 news "republic reporter in pirate space"
 	location
 		government "Pirate"
@@ -1782,7 +1728,6 @@ news "republic reporter in pirate space"
 			"Read my column on how to identify pirates in disguise! Or just look around this planet, that also works."
 		word
 			`"`
-
 
 
 news "conspiracy theorist"
@@ -1820,7 +1765,6 @@ news "conspiracy theorist"
 			`"`
 
 
-
 news "spaceport video advertisement"
 	location
 		government "Republic"
@@ -1833,7 +1777,6 @@ news "spaceport video advertisement"
 			"A video of fast spaceships racing around a three dimensional course in space is shown on the screen, interwoven with clips of very luxurious ships where people appear to be watching the race."
 			"An action-packed advertisement about joining the Navy is playing on the screen. It shows impressive video-fragments of carriers, gunships, dropships and heroic marines."
 			"Some video is showing Syndicate equipment. The video ends with the slogan, 'Just what's needed to get the job done.'"
-
 
 
 phrase "culinary venue"
@@ -1852,7 +1795,6 @@ phrase "restaurant names"
 		"civilian subphrase 4"
 		"civilian subphrase 5"
 		"civilian subphrase 10"
-
 
 
 news "syndicate pa system"
@@ -1877,11 +1819,11 @@ news "syndicate pa system"
 			`"`
 
 
-
 phrase "tourist names"
 	phrase
 		"male names"
 		"female names"
+
 
 phrase "platform number"
 	word
@@ -1925,6 +1867,8 @@ news "tourist pa system"
 			"Dear travelers: please take the time to adjust to normal gravity."
 		word
 			`"`
+
+
 phrase "pirate worlds"
 	word
 		"Albatross"
@@ -1940,6 +1884,7 @@ phrase "pirate worlds"
 		"Stormhold"
 		"Thule"
 		"Zenith"
+
 
 phrase "rnas travel advisory [1]"
 	word
@@ -1966,6 +1911,7 @@ phrase "rnas travel advisory [2]"
 		"to be extremely dangerous."
 		"to place Navy rescue personnel in unnecessary danger."
 
+
 phrase "rnas travel advisory [3]"
 	word
 		"Navigational hazard:"
@@ -1982,11 +1928,13 @@ phrase "rnas travel advisory [3]"
 	word
 		"."
 
+
 phrase "rnas travel advisory"
 	phrase
 		"rnas travel advisory [1]"
 		"rnas travel advisory [2]"
 		"rnas travel advisory [3]"
+
 
 phrase "rnas port emergency alert test"
 	word
@@ -2001,6 +1949,7 @@ phrase "rnas port emergency alert test"
 		"Fire. Evacuate immediately. Fire. Evacuate immediately. Fire. Evacuate immediately."
 		"Cryogenic fluid release. Evacuate immediately. Cryogenic fluid release. Evacuate immediately. Cryogenic fluid release. Evacuate immediately."
 		"Orbital bombardment. Evacuate immediately. Orbital bombardment. Evacuate immediately. Orbital bombardment. Evacuate immediately."
+
 
 news "republic navy advisory system"
 	location
@@ -2019,6 +1968,7 @@ news "republic navy advisory system"
 		word
 			`"`
 
+
 news "republic navy advisory system [wartime]"
 	location
 		government "Republic"
@@ -2036,6 +1986,7 @@ news "republic navy advisory system [wartime]"
 			"Attention: Dangerous combat conditions persist in the galactic South. Avoid all travel to affected systems unless strictly necessary."
 		word
 			`"`
+
 
 news "explorer on frozen world"
 	location
@@ -2076,12 +2027,14 @@ phrase "republic motto graffiti"
 		`Underneath are the words "POVERTY AMONG THE STARS."`
 		`Underneath are the words "PEACE AMONG THE PARADISE WORLDS."`
 
+
 phrase "deep motto graffiti"
 	word
 		`` 2
 		`Underneath are the words "Peace, Prosperity, Progress."` 2
 		`Underneath are the words "Power, Poverty, Pride."`
 		`Underneath are the words "Peace, Prosperity, Progress, for those who are born lucky."`
+
 
 news "republic navy advisory system [alphas]"
 	location
@@ -2099,6 +2052,8 @@ news "republic navy advisory system [alphas]"
 			"For your safety, do not attempt to apprehend an Alpha. Instead, contact Republic Navy personnel at once."
 		word
 			`"`
+
+
 news "safety posters"
 	location
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
@@ -2127,6 +2082,7 @@ news "safety posters"
 			"PROTECTIVE EQUIPMENT REQUIRED WITHIN HAZARD ZONE"
 		word
 			`"`
+
 
 news "graffiti on spaceport wall"
 	location

--- a/data/korath/korath news.txt
+++ b/data/korath/korath news.txt
@@ -29,6 +29,7 @@ news "kor efret merchant"
 			"One Korath seems to be auctioning off a strange device to a small crowd."
 			"You enter an unusually busy building and are greeted by a Korath who seems to work there. It's filled with monitors displaying natural flora and fauna. The Korath in here are captivated by them."
 
+
 news "kor efret worker"
 	location
 		government "Kor Efret"
@@ -43,6 +44,7 @@ news "kor efret worker"
 			"Two of the workers nearby are speaking to each other while gesturing to your ship. It looks like they aren't used to visitors here."
 			"A worker carries a crate containing several tools past you to several other Korath. They seem to be repairing an outfit - or maybe it's an air conditioning unit. You can't really tell."
 			"A Korath emerges from a nearby dilapidated building and begins sealing every possible entrance - windows, doors, large cracks - shut. It moves with such efficiency that you're sure it's done this plenty of times before."
+
 
 news "kor efret local"
 	location
@@ -60,6 +62,7 @@ news "kor efret local"
 			"A local Korath gestures toward a building you've never been inside before. Out of curiosity, you poke your head inside to see the reptilian aliens conversing and sharing drinks: it's a bar. Some things never change, no matter where you are in the galaxy."
 			"You pass by one of the abandoned buildings and hear a door open and close rapidly behind you. You turn back and see a Korath dressed in rags quickly walking the other direction."
 
+
 news "kor efret scientist"
 	location
 		government "Kor Efret"
@@ -74,7 +77,8 @@ news "kor efret scientist"
 		word
 			"A Kor Efret pushes a cart filled with strange chemicals and bits of technology past you."
 			"A Korath walks through the spaceport reading numbers off a device and inputting them onto another one. It looks like it's taking samples of the air quality."
-			
+
+
 news "kor efret station friendly"
 	location
 		government "Kor Efret"
@@ -90,7 +94,8 @@ news "kor efret station friendly"
 			"A Kor Efret near your ship is speaking with a worker, gradually increasing its volume until it's doing some strange mix of shouting and hissing. Suddenly, it turns and stalks away with its chest puffed out."
 			"A Korath is studying you intently from a distance. You guess it's never seen a human face to face before."
 			"A local greets you by holding its hands up with its palms facing toward you."
-			
+
+
 news "wanderer at kor efret spaceport"
 	to show
 		has "wanderers sestor done"

--- a/data/pug/pug news.txt
+++ b/data/pug/pug news.txt
@@ -59,6 +59,7 @@ news "artist on post-fw Deneb"
 		word
 			"!"
 
+
 news "tourist on post-fw Deneb"
 	location
 		government "Neutral"
@@ -112,6 +113,7 @@ news "tourist on post-fw Deneb"
 			"fascinating"
 		word
 			"!"
+
 
 news "conspiracy theorist on post-fw Deneb"
 	location
@@ -170,6 +172,7 @@ news "conspiracy theorist on post-fw Deneb"
 			"This is all just a stunt by the Republic and the Free Worlds"
 		word
 			"."
+
 
 news "reporter on post-fw Deneb"
 	location
@@ -230,6 +233,7 @@ news "reporter on post-fw Deneb"
 			"is going live in a minute"
 		word
 			"."
+
 
 news "merchant on post-fw Deneb"
 	location
@@ -296,6 +300,7 @@ news "merchant on post-fw Deneb"
 		word
 			"!"
 
+
 news "worker on pug-occupied planet after fw"
 	location
 		neighbor system "Deneb"
@@ -349,6 +354,7 @@ news "worker on pug-occupied planet after fw"
 			"we get these days"
 		word
 			"."
+
 
 news "pug on pug planets during fw"
 	location

--- a/data/quarg/quarg news.txt
+++ b/data/quarg/quarg news.txt
@@ -65,6 +65,7 @@ news "anonymous quarg"
 		word
 			`"`
 
+
 news "linguist on quarg planets in human and hai space"
 	location
 		government "Quarg"
@@ -166,6 +167,7 @@ news "linguist on quarg planets in human and hai space"
 		word
 			`"`
 
+
 news "tourist on quarg planets in human and hai space"
 	location
 		government "Quarg"
@@ -221,6 +223,7 @@ news "tourist on quarg planets in human and hai space"
 		word
 			`"`
 
+
 news "engineer on quarg planets in human space"
 	location
 		government "Quarg"
@@ -237,6 +240,7 @@ news "engineer on quarg planets in human space"
 			"I'm working on a new spaceship for the Tarazed Corporation. Every once in a while I come here to take some inspiration from these magnificent designs."
 		word
 			`"`
+
 
 news "merchant on quarg planets in human and hai space"
 	location
@@ -288,6 +292,7 @@ news "merchant on quarg planets in human and hai space"
 			"."
 		word
 			`"`
+
 
 news "merchant on quarg planets in human space"
 	location
@@ -357,6 +362,7 @@ news "merchant on quarg planets in human space"
 		word
 			`"`
 
+
 news "reporter on quarg planets in human space"
 	location
 		government "Quarg"
@@ -387,6 +393,7 @@ news "reporter on quarg planets in human space"
 			"Secrets Humanity Learned from the Quarg!"
 		word
 			`"`
+
 
 news "student on quarg planets"
 	location
@@ -443,6 +450,7 @@ news "student on quarg planets"
 		word
 			`"`
 
+
 news "quarg anywhere"
 	location
 		attributes "quarg" "human quarg" "hai quarg"
@@ -464,6 +472,7 @@ news "quarg anywhere"
 			`An older Quarg is playing with a much younger Quarg, young enough that it's still shorter than yourself. The strange game consists of passing to one another a jar with some slimy, metallic substance inside. Every time the jar is passed, the substance meshes itself into a different shape, sometimes into shapes you know not the meaning of.`
 			`Dozens of Quarg children are being led around by a handful of adults, as if on a school trip. When they notice you, they continue taking glances and talking among themselves. It seems they've never seen a human before.`
 
+
 news "ringworld quarg"
 	location
 		attributes "quarg"
@@ -477,6 +486,7 @@ news "ringworld quarg"
 			"ringworld quarg phrases" 8
 			"quarg poems on species" 1
 
+
 phrase "ringworld quarg phrases"
 	word
 		`You see a shorter, younger Quarg, likely a child in Quarg years, being shown around the ringworld by an adult. It seems like the parent is teaching the child about the ring.`
@@ -489,6 +499,7 @@ phrase "ringworld quarg phrases"
 		`Two Quarg ships land at the same time a few hangar bays away from one another. They open their hatches, and what must be the ships' entire crews come out. Without a hitch the crew of each ship boards the other's ship and depart.`
 		`The Quarg seem to have set up some form of festival in the ring: endless stands stretch out as far as you can see, all displaying variations of the same orange-like fruit, ranging from impossibly smooth to unbelievably wrinkled, and also from sizes as small as a pea to as large as a watermelon. You can't figure what quality they like best.`
 		`You see one Quarg turn a sharp corner in what's a haste by their standards. When you look into the corridor it went to, you see it's a dead end, with the Quarg having inexplicably vanished.`
+
 
 phrase "quarg poems on species"
 	word

--- a/data/remnant/remnant news.txt
+++ b/data/remnant/remnant news.txt
@@ -25,7 +25,6 @@ phrase "00-07"
 		"07"
 
 
-
 phrase "0-F"
 	word
 		"0"
@@ -46,14 +45,12 @@ phrase "0-F"
 		"F"
 
 
-
 phrase "00-1F"
 	word
 		"0"
 		"1"
 	phrase
 		"0-F"
-
 
 
 phrase "A group of"
@@ -75,7 +72,6 @@ phrase "A group of"
 		" of "
 
 
-
 phrase "Indeterminate"
 	word
 		"A few"
@@ -85,7 +81,6 @@ phrase "Indeterminate"
 		"Many"
 	word
 		" "
-
 
 
 phrase "Amount of Remnant"
@@ -212,7 +207,6 @@ news "remnant security advisory"
 			`"`
 
 
-
 news "remnant incomprehensible"
 	location
 		government "Remnant"
@@ -280,7 +274,6 @@ news "remnant incomprehensible"
 			"."
 
 
-
 news "remnant cafeteria"
 	location
 		government "Remnant"
@@ -308,7 +301,6 @@ news "remnant cafeteria"
 			"are examining holo projections over a large meal"
 		word
 			"."
-
 
 
 news "remnant comprehensible"

--- a/data/wanderer/wanderer news.txt
+++ b/data/wanderer/wanderer news.txt
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
+
+
 news "wanderer civilians, no dialog 1"
 	location
 		government "Wanderer"
@@ -23,6 +25,7 @@ news "wanderer civilians, no dialog 1"
 		word
 			"Outside the spaceport, you see someone performing maintenance on some sort of irrigation system. Once they get it working, it begins to water a field of plants."
 			"A dockworker unloads complex scientific equipment from a ship. More surprising, however, is the fact that they unload several bags of fertilizer from it as well."
+
 
 news "wanderer civilians no dialog 2"
 	location
@@ -36,6 +39,7 @@ news "wanderer civilians no dialog 2"
 			"A crowd has formed around an object. Upon closer inspection, it appears to be some sort of technological device."
 			"On a booth near the spaceport, a group is playing on objects that look vaguely like wooden flutes. Their music is quiet and lacks a discernible melody."
 
+
 news "wanderer civilians, no dialog 1, post language"
 	to show
 		has "language: Wanderer"
@@ -48,6 +52,7 @@ news "wanderer civilians, no dialog 1, post language"
 	message
 		word
 			"Many buildings near the spaceport have plants growing on their roofs. An indignant squawk draws your attention to a Wanderer as they rapidly flap away from an automated watering system dousing them where they stood."
+
 
 news "wanderer civilians no dialog 2, post language"
 	to show
@@ -65,6 +70,7 @@ news "wanderer civilians no dialog 2, post language"
 			"A group of Wanderer children appear to be playing a game similar to hopscotch, but instead of hopping they fly to their spots."
 			"Two Wanderers are at a table. They appear to be playing some sort of board game using shell pieces."
 			"A crowd of Wanderer children follow an adult through the spaceport. The adult talks to them as they follow, as the children take notes."
+
 
 news "Wanderers and Aliens"
 	to show
@@ -95,6 +101,7 @@ news "Wanderers and Aliens"
 		word
 			`"`
 
+
 news "Wanderer Linguistics 2"
 	to show
 		has "language: Wanderer"
@@ -114,6 +121,7 @@ news "Wanderer Linguistics 2"
 			"I went to a [prison, jail] where some Unfettered Hai were being held, in order to [study, apprehend] their language on a more [in-depth, detailed] level. It was hard to get [information, data] out of them, to say the least."
 		word
 			`"`
+
 
 news "Wanderer civilians, dialog"
 	to show
@@ -141,6 +149,7 @@ news "Wanderer civilians, dialog"
 		word
 			`"`
 
+
 news "Wanderer scientists"
 	to show
 		has "language: Wanderer"
@@ -165,6 +174,7 @@ news "Wanderer scientists"
 		word
 			`"`
 
+
 news "Wanderer oil safety"
 	to show
 		has "language: Wanderer"
@@ -184,6 +194,7 @@ news "Wanderer oil safety"
 		word
 			`"`
 
+
 news "Wanderer oil drilling"
 	to show
 		has "language: Wanderer"
@@ -202,6 +213,7 @@ news "Wanderer oil drilling"
 			"What I do is [unfortunate, regrettable], but we have no other [option, choice]."
 		word
 			`"`
+
 
 news "wanderer farmer"
 	to show
@@ -223,6 +235,7 @@ news "wanderer farmer"
 			"You must not [override, dismiss] the natural [rhythms? balance?] of the land you work on. Doing otherwise would cause [harm, destruction] to that which [feeds, nurtures] you."
 		word
 			`"`
+
 
 news "Wanderer soldier"
 	to show
@@ -249,6 +262,7 @@ news "Wanderer soldier"
 		word
 			`"`
 
+
 news "Wanderer engineer"
 	to show
 		has "Wanderers Solifuge Recon 2: offered"
@@ -270,6 +284,7 @@ news "Wanderer engineer"
 			"I create weapons of [destruction, annihilation] so that we may survive and go on to [create, rebirth]."
 		word
 			`"`
+
 
 news "Wanderers and the Eye"
 	to show
@@ -300,6 +315,7 @@ news "Wanderers and the Eye"
 		word
 			`"`
 
+
 news "Wanderers and Korath"
 	to show
 		has "wanderers sestor done"
@@ -325,6 +341,7 @@ news "Wanderers and Korath"
 			"I am [excited, overjoyed] to be part of [healing, renewing] the Korath worlds. We are once again [transforming, altering] the old into the new."
 		word
 			`"`
+
 
 news "Wanderer Linguistics"
 	to show


### PR DESCRIPTION
**Consistency**

This PR addresses the bug/feature described in issue #
None

## Summary
When I was looking at #10274, I was rather bothered by the inconsistency between lines.

So this standardizes the amount of newlines between pieces of news across all of the files. Two in between each item, and three at the top of each file.
We could also make it be one newline between items instead of two the way I have it.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
N/A

## Save File
This save file can be used to test these changes:
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A