### PR TITLE
Fix(Code): Fix assertion fails in TextArea::Hover

### DIFF
--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -170,7 +170,6 @@ void TextArea::Draw()
 
 bool TextArea::Click(int x, int y, int clicks)
 {
-	assert(buffer);
 	if(!buffer)
 		return false;
 	Rectangle bounds(position, {buffer->Width(), buffer->Height()});
@@ -204,7 +203,6 @@ bool TextArea::Release(int x, int y)
 
 bool TextArea::Hover(int x, int y)
 {
-	assert(buffer);
 	if(!buffer)
 		return false;
 	Rectangle bounds(position, {buffer->Width(), buffer->Height()});


### PR DESCRIPTION
# Bug Fix


This PR addresses the bug described in issue [#10299](https://github.com/endless-sky/endless-sky/issues/10299). This was caused by the textwrap support from [#9786](https://github.com/endless-sky/endless-sky/pull/9786)

## Summary
Hover already has code to just return false if there isn't a valid box, I just removed the check so that the code will do it.

## Testing Done
Game doesn't crash any more when moving mouse when a dialog pops up

## Save File
Do a mission and then move your mouse during the done dialog

## Performance Impact
Makes the code infinitesimally faster by removing a check 