### PR TITLE
fix(ui): Fix off-by-one error in dialog size calculation

### DIFF
--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -382,6 +382,8 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
+	// The text height is over-reported by 5 pixels, but setting the rectangle size to an odd number causes blur,
+	// so we only add 4 pixels to the height here.
 	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 4;
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -382,7 +382,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
-	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 1;
+	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 4;
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
 	text->SetRect(textRect);

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -382,8 +382,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
-	// The text height is over-reported by 6 pixels, but setting the rectangle size to an odd number causes blur,
-	// so we only add 4 pixels to the height here.
+	// The text height is over-reported by 6 pixels, so we add those pixels back.
 	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 6;
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -383,7 +383,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
 	// The text height was over-reported by 6 pixels, so we add those pixels back for consistency.
-	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 6;
+	textRectSize.Y() = 60 + height * 40 + 6 - 30 * (!isMission && (intFun || stringFun));
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
 	text->SetRect(textRect);

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -382,7 +382,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
-	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun));
+	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 1;
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
 	text->SetRect(textRect);

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -382,7 +382,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
-	// The text height is over-reported by 6 pixels, so we add those pixels back.
+	// The text height was over-reported by 6 pixels, so we add those pixels back for consistency.
 	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 6;
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -361,9 +361,9 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 
 	// The dialog with no extenders is 80 pixels tall. 10 pixels at the top and
 	// bottom are "padding," but text.Height() over-reports the height by about
-	// 5 pixels because it includes its own padding at the bottom. If there is a
+	// 6 pixels because it includes its own padding at the bottom. If there is a
 	// text input, we need another 20 pixels for it and 10 pixels padding.
-	height = 10 + (textRectSize.Y() - 5) + 10 + 30 * (!isMission && (intFun || stringFun));
+	height = 10 + (textRectSize.Y() - 6) + 10 + 30 * (!isMission && (intFun || stringFun));
 	// Determine how many 40-pixel extension panels we need.
 	if(height <= 80)
 		height = 0;
@@ -382,9 +382,9 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
-	// The text height is over-reported by 5 pixels, but setting the rectangle size to an odd number causes blur,
+	// The text height is over-reported by 6 pixels, but setting the rectangle size to an odd number causes blur,
 	// so we only add 4 pixels to the height here.
-	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 4;
+	textRectSize.Y() = 60 + height * 40 - 30 * (!isMission && (intFun || stringFun)) + 6;
 
 	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
 	text->SetRect(textRect);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature reported on [discord](https://discord.com/channels/251118043411775489/536900466655887360/1259648458764193822)

## Summary
Apparently, the scroll area's size was one pixel shorter than necessary. This caused dialog text to nearly always be scrollable, even when the dialog's size was large enough.

## Testing Done
I tested that simple dialogs no longer scroll. The mission panel seems to not have the same scrolling issue to begin with.