### PR TITLE
fix(typo): Fix the Small Turn Module's turn

### DIFF
--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -371,7 +371,7 @@ outfit "Small Steering Module"
 	"mass" 7
 	"outfit space" -7
 	"engine capacity" -7
-	"turn" 214.2
+	"turn" 268.2
 	"turning energy" 0.26
 	"turning heat" 1.8
 	"steering flare sprite" "effect/coalition flare/small"


### PR DESCRIPTION
**Fix**

This PR addresses the bug I just noticed

## Summary
Prior to the mass rebalance (#9616) the Small Turn Module had 178.8 turn. After the mass rebalance, it now has 214.2
However, 214.2 is not, in fact, 1.5 times 178.8
I don't recall whether I made a mistake typing it in, or used the wrong value somewhere else, but in any case the number is wrong, and this fixes it.
Oops.