### PR TITLE
style: added clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,72 @@
+Language: Cpp
+Standard: c++17
+LineEnding: LF
+UseTab: Always
+IndentWidth: 8
+IndentCaseLabels: true
+
+PackConstructorInitializers: NextLineOnly
+AlwaysBreakAfterReturnType: None
+PointerAlignment: Right
+FixNamespaceComments: false
+NamespaceIndentation: All
+
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpacesInAngles: Never
+
+# These can cause breaking changes if clang-format messed up
+QualifierAlignment: Left
+
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Always
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+
+BreakAfterAttributes: Leave
+BreakBeforeBinaryOperators: NonAssignment
+BreakConstructorInitializers: BeforeColon
+
+ColumnLimit: 120
+ReflowComments: false
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 3
+
+SortIncludes: CaseInsensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '<[:alnum:]+/[:alnum:]+>'
+    Priority:        2
+  - Regex:           '<[:alnum:]+>'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 Language: Cpp
-Standard: c++17
+Standard: c++20
 LineEnding: LF
 UseTab: Always
 IndentWidth: 8

--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,11 @@ Language: Cpp
 Standard: c++20
 LineEnding: LF
 UseTab: Always
+
 IndentWidth: 8
+ContinuationIndentWidth: 8
+ConstructorInitializerIndentWidth: 8
+
 IndentCaseLabels: true
 
 PackConstructorInitializers: NextLineOnly
@@ -10,25 +14,28 @@ AlwaysBreakAfterReturnType: None
 PointerAlignment: Right
 FixNamespaceComments: false
 NamespaceIndentation: All
+AlignAfterOpenBracket: DontAlign
+AccessModifierOffset: -8
+IndentAccessModifiers: false
 
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: true
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: Never
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpacesInAngles: Never
 
-# These can cause breaking changes if clang-format messed up
+# This can cause breaking changes if clang-format messed up
 QualifierAlignment: Left
 
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: None
 AllowShortLoopsOnASingleLine: false
@@ -48,7 +55,6 @@ BraceWrapping:
   BeforeLambdaBody: true
   BeforeWhile: false
   IndentBraces: false
-  SplitEmptyFunction: true
 
 BreakAfterAttributes: Leave
 BreakBeforeBinaryOperators: NonAssignment
@@ -63,10 +69,11 @@ MaxEmptyLinesToKeep: 3
 SortIncludes: CaseInsensitive
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '<[:alnum:]+/[:alnum:]+>'
+  - Regex:           '<[:alnum:]+/.*>'
     Priority:        2
+    SortPriority:    2
   - Regex:           '<[:alnum:]+>'
     Priority:        3
-  - Regex:           '.*'
+  - Regex:           '".*"'
     Priority:        1
 


### PR DESCRIPTION
**Styling and Formatting**

This PR attempts to continue #10122 (although with a somewhat different format) whilst being a lot more lax about it because it seems that formatting remains one of the more... untouched and frozen (dare I say, outdated) aspect of endless-sky.

## Summary

A `.clang-format` file is used by clang-format as a collection of option for formatting a file. Now, as of 2024 even in 19.0.0 clang-format and its options are not specific enough to adhere to the standards created by Michael Zahniser himself, mostly due to the 3, 2, and 1 blank line(s) rule. But, the good news is that clang-format is surprisingly decent.

## Testing Done

I have tried this on a few files (like AI.cpp), and to say the least clang-format is mildly successful at formatting them. There were changes, for better or worse, but it kept most of the preexisting formatting intact.

## Further Discussion

Now, here's the hard part that I can't just solve myself:

- Should clang-format be used as a regulative (every piece of code must conform) or assistive tool (just to help newer contributors and catch formatting mishaps)?
- Should we keep following a style guide that is as old as a 4th grader and still mentions SVN?
- Should I just format everything (like @Koranir did) and add it to this commit?