### PR TITLE
Fix spaceport on Esquiline

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -214,7 +214,7 @@ event "remnant: pantica void sprites"
 		add attributes remnant
 		remove attributes uninhabited
 		description `While Esquiline used to be simply another planet the Remnant harvested valuable resources from, the introduction of void sprites and the activation of their station has turned this world into a hidden research lab: The first human astrobiology station studying void sprites.`
-		add spaceport `Although the facilities here are basic, the Remnant cafeteria boasts a food dispenser that is available at any time, along with a mesmerizing view of the clouds outside. Occasionally a void sprite will pass in front of the window, much to the delight of everyone.`
+		spaceport `Although the facilities here are basic, the Remnant cafeteria boasts a food dispenser that is available at any time, along with a mesmerizing view of the clouds outside. Occasionally a void sprite will pass in front of the window, much to the delight of everyone.`
 
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10309.

## Summary
I removed an "add " from before the Esquiline "add spaceport" in remnant events.txt.
This fixes #10309.

## Screenshots
Before:
![Before](https://github.com/endless-sky/endless-sky/assets/145969603/6d7ca598-c2d2-4209-9634-0cb4d4ea7295)

After:
![After](https://github.com/endless-sky/endless-sky/assets/145969603/cdcdd49e-ef32-460b-863c-9a0c0b69f042)

## Usage examples
N/A

## Testing Done
Tried it with my save file. Seems to work.

## Save File
This save file can be used to test these changes:
Before:
[Asiah Racer Before.txt](https://github.com/user-attachments/files/16163019/Asiah.Racer.txt)
After:
[Asiah Racer After.txt](https://github.com/user-attachments/files/16163029/Asiah.Racer.After.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A