### PR TITLE
fix(mechanics): Correctly parse `add description/spaceport` text nodes

### DIFF
--- a/source/Paragraphs.cpp
+++ b/source/Paragraphs.cpp
@@ -28,7 +28,7 @@ void Paragraphs::Load(const DataNode &node)
 	for(const DataNode &child : node)
 		if(child.Size() == 2 && child.Token(0) == "to" && child.Token(1) == "display")
 		{
-			text.emplace_back(child, node.Token(1) + "\n");
+			text.emplace_back(child, node.Token(node.Size() - 1) + "\n");
 			return;
 		}
 	text.emplace_back(ConditionSet(), node.Token(node.Size() - 1) + "\n");

--- a/source/Paragraphs.cpp
+++ b/source/Paragraphs.cpp
@@ -31,7 +31,7 @@ void Paragraphs::Load(const DataNode &node)
 			text.emplace_back(child, node.Token(1) + "\n");
 			return;
 		}
-	text.emplace_back(ConditionSet(), node.Token(1) + "\n");
+	text.emplace_back(ConditionSet(), node.Token(node.Size() - 1) + "\n");
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in https://github.com/endless-sky/endless-sky/issues/10309#issuecomment-2220679738

## Summary
The text is always the last token, so just parse that.

## Testing Done
Warp's provided save now works, both with and without `add`.

## Save File
This save file can be used to test these changes:
[warp.core.add.descriptioin.tes.txt](https://github.com/user-attachments/files/16189347/warp.core.add.descriptioin.tes.txt)