### PR TITLE
fix(typo): Add missing period to cloaked afterburner description

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -229,7 +229,7 @@ namespace {
 		{"minable", "This item is mined from asteroids."},
 		{"atrocity", "This outfit is considered an atrocity."},
 		{"unique", "This item is unique."},
-		{"cloaked afterburner", "You may use your afterburner when cloaked"},
+		{"cloaked afterburner", "You may use your afterburner when cloaked."},
 		{"cloaked boarding", "You may board even when cloaked."},
 		{"cloaked communication", "You may make hails when cloaked."},
 		{"cloaked deployment", "You may deploy drones and fighters without revealing your location."},


### PR DESCRIPTION
**Typo fix**

This PR fixes a missing period.

## Summary
Every other boolean attribute had a period after its description, but it was missing from `cloaked afterburner`.

## Testing Done
N/A

## Performance Impact
N/A