### PR TITLE
feat(enhancement): Make ships snap to formation

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1793,14 +1793,10 @@ void AI::MoveInFormation(Ship &ship, Command &command)
 		if(abs(facingDeltaDegrees) > FACING_TOLERANCE_DEGREES)
 			command.SetTurn(facingDeltaDegrees);
 
-		// If the position and velocity matches, smoothly "snap" to position over multiple frames.
-		Point positionDelta = it->second.Position(&ship) - ship.Position();
-		Point snapMovement = positionDelta.LengthSquared() < 4. ? positionDelta : positionDelta.Unit() * 2;
-		ship.SetPosition(ship.Position() + snapMovement);
-
+		// If the position and velocity matches, smoothly match velocity over multiple frames.
 		Point velocityDelta = formationLead->Velocity() - ship.Velocity();
-		Point snapAcceleration = velocityDelta.LengthSquared() < 4. ? velocityDelta : velocityDelta.Unit() * 2;
-		if((ship.Velocity() + snapAcceleration).LengthSquared() <= ship.MaxVelocity())
+		Point snapAcceleration = velocityDelta.Length() < 0.001 ? velocityDelta : velocityDelta.Unit() * 0.001;
+		if((ship.Velocity() + snapAcceleration).Length() <= ship.MaxVelocity())
 			ship.SetVelocity(ship.Velocity() + snapAcceleration);
 	}
 }

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1792,6 +1792,16 @@ void AI::MoveInFormation(Ship &ship, Command &command)
 		double facingDeltaDegrees = (formationLead->Facing() - ship.Facing()).Degrees();
 		if(abs(facingDeltaDegrees) > FACING_TOLERANCE_DEGREES)
 			command.SetTurn(facingDeltaDegrees);
+
+		// If the position and velocity matches, smoothly "snap" to position over multiple frames.
+		Point positionDelta = it->second.Position(&ship) - ship.Position();
+		Point snapMovement = positionDelta.LengthSquared() < 4. ? positionDelta : positionDelta.Unit() * 2;
+		ship.SetPosition(ship.Position() + snapMovement);
+
+		Point velocityDelta = formationLead->Velocity() - ship.Velocity();
+		Point snapAcceleration = velocityDelta.LengthSquared() < 4. ? velocityDelta : velocityDelta.Unit() * 2;
+		if((ship.Velocity() + snapAcceleration).LengthSquared() <= ship.MaxVelocity())
+			ship.SetVelocity(ship.Velocity() + snapAcceleration);
 	}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1349,6 +1349,13 @@ void Ship::SetPosition(Point position)
 
 
 
+void Ship::SetVelocity(Point velocity)
+{
+	this->velocity = velocity;
+}
+
+
+
 // Instantiate a newly-created ship in-flight.
 void Ship::Place(Point position, Point velocity, Angle angle, bool isDeparting)
 {

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -174,6 +174,7 @@ public:
 	std::vector<std::string> FlightCheck() const;
 
 	void SetPosition(Point position);
+	void SetVelocity(Point velocity);
 	// When creating a new ship, you must set the following:
 	void Place(Point position = Point(), Point velocity = Point(), Angle angle = Angle(), bool isDeparting = true);
 	void SetName(const std::string &name);
@@ -300,7 +301,7 @@ public:
 	const std::vector<EnginePoint> &ReverseEnginePoints() const;
 	const std::vector<EnginePoint> &SteeringEnginePoints() const;
 
-	// Make a ship disabled or destroyed, or bring back a destroyed ship.
+	// Make a ship disabled or destroyed, orVelocity bring back a destroyed ship.
 	void Disable();
 	void Destroy();
 	void SelfDestruct();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -301,7 +301,7 @@ public:
 	const std::vector<EnginePoint> &ReverseEnginePoints() const;
 	const std::vector<EnginePoint> &SteeringEnginePoints() const;
 
-	// Make a ship disabled or destroyed, orVelocity bring back a destroyed ship.
+	// Make a ship disabled or destroyed, or bring back a destroyed ship.
 	void Disable();
 	void Destroy();
 	void SelfDestruct();


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #10285 (fixes #10285)

## Summary
Adds automatic snapping to the position and velocity of ships once they are in formation. The position is adjusted continuously over multiple frames to make it appear smooth.

## Testing Done
I tested that ships require far less corrections to stay in formation (none if the lead ship doesn't accelerate), and that major course changes by the lead ship still require the ships to manually move back to position.

## Performance Impact
Should be minimal.