### PR TITLE
Prevent weird side mission/FW plot crossover

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5927,6 +5927,9 @@ mission "Argosy Hijacking"
 	to offer
 		"combat rating" > 200
 		random < 5
+		or
+			has "main plot completed"
+			not "fw given jump drive"
 	on offer
 		conversation
 			`You're signing the standard Syndicate landing papers with an officer on <origin>. "Everything seems to be in order. And of course, we'll have your ship refueled promptly. Have a good day, Captain <last>." He nods his head at you and starts to move off towards the next ship.`


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
This side mission can currently trigger during the FW pug cutoff in reconciliation, i.e. on liberated Maker, which is disruptive in both lore and gameplay.  Seems unintended (and was quite jarring when it happened to me).

## Usage examples
There are multiple possible solutions to this, i.e. excluding specific planets, tracking specific mission states - but this way seems most future-proof, just blocking it during that segment.  This means if that section of the plot changes, i.e. new worlds/battles etc, this fix will still work.  If the entire section of the plot is removed, this will still work.  Prioritizing compatibility here.
Open to other approaches, of course, if anyone disagrees.