### PR TITLE
refactor: Replace unused sound maps with sets

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1489,13 +1489,13 @@ void Engine::CalculateStep()
 	if(!wasHyperspacing && flagship && flagship->IsEnteringHyperspace())
 	{
 		bool isJumping = flagship->IsUsingJumpDrive();
-		const map<const Sound *, int> &jumpSounds = isJumping
+		const set<const Sound *> &jumpSounds = isJumping
 			? flagship->Attributes().JumpSounds() : flagship->Attributes().HyperSounds();
 		if(jumpSounds.empty())
 			Audio::Play(Audio::Get(isJumping ? "jump drive" : "hyperdrive"));
 		else
 			for(const auto &sound : jumpSounds)
-				Audio::Play(sound.first);
+				Audio::Play(sound);
 	}
 	// Check if the flagship just entered a new system.
 	if(flagship && playerSystem != flagship->GetSystem())
@@ -1637,17 +1637,17 @@ void Engine::CalculateStep()
 				if(ship->IsThrusting() && !ship->EnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().FlareSounds())
-						Audio::Play(it.first, ship->Position());
+						Audio::Play(it, ship->Position());
 				}
 				else if(ship->IsReversing() && !ship->ReverseEnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().ReverseFlareSounds())
-						Audio::Play(it.first, ship->Position());
+						Audio::Play(it, ship->Position());
 				}
 				if(ship->IsSteering() && !ship->SteeringEnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().SteeringFlareSounds())
-						Audio::Play(it.first, ship->Position());
+						Audio::Play(it, ship->Position());
 				}
 			}
 			else
@@ -1660,17 +1660,17 @@ void Engine::CalculateStep()
 		if(flagship->IsThrusting() && !flagship->EnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().FlareSounds())
-				Audio::Play(it.first);
+				Audio::Play(it);
 		}
 		else if(flagship->IsReversing() && !flagship->ReverseEnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().ReverseFlareSounds())
-				Audio::Play(it.first);
+				Audio::Play(it);
 		}
 		if(flagship->IsSteering() && !flagship->SteeringEnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().SteeringFlareSounds())
-				Audio::Play(it.first);
+				Audio::Play(it);
 		}
 	}
 	// Draw the projectiles.
@@ -1736,25 +1736,25 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		// Did this ship just begin hyperspacing?
 		if(wasHere && !wasHyperspacing && ship->IsHyperspacing())
 		{
-			const map<const Sound *, int> &jumpSounds = isJump
+			const set<const Sound *> &jumpSounds = isJump
 				? ship->Attributes().JumpOutSounds() : ship->Attributes().HyperOutSounds();
 			if(jumpSounds.empty())
 				Audio::Play(Audio::Get(isJump ? "jump out" : "hyperdrive out"), position);
 			else
 				for(const auto &sound : jumpSounds)
-					Audio::Play(sound.first, position);
+					Audio::Play(sound, position);
 		}
 
 		// Did this ship just jump into the player's system?
 		if(!wasHere && flagship && ship->GetSystem() == flagship->GetSystem())
 		{
-			const map<const Sound *, int> &jumpSounds = isJump
+			const set<const Sound *> &jumpSounds = isJump
 				? ship->Attributes().JumpInSounds() : ship->Attributes().HyperInSounds();
 			if(jumpSounds.empty())
 				Audio::Play(Audio::Get(isJump ? "jump in" : "hyperdrive in"), position);
 			else
 				for(const auto &sound : jumpSounds)
-					Audio::Play(sound.first, position);
+					Audio::Play(sound, position);
 		}
 	}
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -189,19 +189,6 @@ namespace {
 		else
 			oit->second += count * it.second;
 	}
-
-	// Used to add the contents of one outfit's map to another, while also
-	// erasing any key with a value of zero.
-	template <class T>
-	void MergeMaps(map<const T *, int> &thisMap, const map<const T *, int> &otherMap, int count)
-	{
-		for(const auto &it : otherMap)
-		{
-			thisMap[it.first] += count * it.second;
-			if(thisMap[it.first] == 0)
-				thisMap.erase(it.first);
-		}
-	}
 }
 
 
@@ -241,31 +228,31 @@ void Outfit::Load(const DataNode &node)
 			steeringFlareSprites.back().first.LoadSprite(child);
 		}
 		else if(child.Token(0) == "flare sound" && child.Size() >= 2)
-			++flareSounds[Audio::Get(child.Token(1))];
+			flareSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "reverse flare sound" && child.Size() >= 2)
-			++reverseFlareSounds[Audio::Get(child.Token(1))];
+			reverseFlareSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "steering flare sound" && child.Size() >= 2)
-			++steeringFlareSounds[Audio::Get(child.Token(1))];
+			steeringFlareSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "afterburner effect" && child.Size() >= 2)
 			++afterburnerEffects[GameData::Effects().Get(child.Token(1))];
 		else if(child.Token(0) == "jump effect" && child.Size() >= 2)
 			++jumpEffects[GameData::Effects().Get(child.Token(1))];
 		else if(child.Token(0) == "hyperdrive sound" && child.Size() >= 2)
-			++hyperSounds[Audio::Get(child.Token(1))];
+			hyperSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "hyperdrive in sound" && child.Size() >= 2)
-			++hyperInSounds[Audio::Get(child.Token(1))];
+			hyperInSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "hyperdrive out sound" && child.Size() >= 2)
-			++hyperOutSounds[Audio::Get(child.Token(1))];
+			hyperOutSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "jump sound" && child.Size() >= 2)
-			++jumpSounds[Audio::Get(child.Token(1))];
+			jumpSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "jump in sound" && child.Size() >= 2)
-			++jumpInSounds[Audio::Get(child.Token(1))];
+			jumpInSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "jump out sound" && child.Size() >= 2)
-			++jumpOutSounds[Audio::Get(child.Token(1))];
+			jumpOutSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "cargo scan sound" && child.Size() >= 2)
-			++cargoScanSounds[Audio::Get(child.Token(1))];
+			cargoScanSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "outfit scan sound" && child.Size() >= 2)
-			++outfitScanSounds[Audio::Get(child.Token(1))];
+			outfitScanSounds.insert(Audio::Get(child.Token(1)));
 		else if(child.Token(0) == "flotsam sprite" && child.Size() >= 2)
 			flotsamSprite = SpriteSet::Get(child.Token(1));
 		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
@@ -538,19 +525,19 @@ void Outfit::Add(const Outfit &other, int count)
 		AddFlareSprites(reverseFlareSprites, it, count);
 	for(const auto &it : other.steeringFlareSprites)
 		AddFlareSprites(steeringFlareSprites, it, count);
-	MergeMaps(flareSounds, other.flareSounds, count);
-	MergeMaps(reverseFlareSounds, other.reverseFlareSounds, count);
-	MergeMaps(steeringFlareSounds, other.steeringFlareSounds, count);
-	MergeMaps(afterburnerEffects, other.afterburnerEffects, count);
-	MergeMaps(jumpEffects, other.jumpEffects, count);
-	MergeMaps(hyperSounds, other.hyperSounds, count);
-	MergeMaps(hyperInSounds, other.hyperInSounds, count);
-	MergeMaps(hyperOutSounds, other.hyperOutSounds, count);
-	MergeMaps(jumpSounds, other.jumpSounds, count);
-	MergeMaps(jumpInSounds, other.jumpInSounds, count);
-	MergeMaps(jumpOutSounds, other.jumpOutSounds, count);
-	MergeMaps(cargoScanSounds, other.cargoScanSounds, count);
-	MergeMaps(outfitScanSounds, other.outfitScanSounds, count);
+	flareSounds.insert(other.flareSounds.begin(), other.flareSounds.end());
+	reverseFlareSounds.insert(other.reverseFlareSounds.begin(), other.reverseFlareSounds.end());
+	steeringFlareSounds.insert(other.steeringFlareSounds.begin(), other.steeringFlareSounds.end());
+	afterburnerEffects.insert(other.afterburnerEffects.begin(), other.afterburnerEffects.end());
+	jumpEffects.insert(other.jumpEffects.begin(), other.jumpEffects.end());
+	hyperSounds.insert(other.hyperSounds.begin(), other.hyperSounds.end());
+	hyperInSounds.insert(other.hyperInSounds.begin(), other.hyperInSounds.end());
+	hyperOutSounds.insert(other.hyperOutSounds.begin(), other.hyperOutSounds.end());
+	jumpSounds.insert(other.jumpSounds.begin(), other.jumpSounds.end());
+	jumpInSounds.insert(other.jumpInSounds.begin(), other.jumpInSounds.end());
+	jumpOutSounds.insert(other.jumpOutSounds.begin(), other.jumpOutSounds.end());
+	cargoScanSounds.insert(other.cargoScanSounds.begin(), other.cargoScanSounds.end());
+	outfitScanSounds.insert(other.outfitScanSounds.begin(), other.outfitScanSounds.end());
 }
 
 
@@ -593,21 +580,21 @@ const vector<pair<Body, int>> &Outfit::SteeringFlareSprites() const
 
 
 
-const map<const Sound *, int> &Outfit::FlareSounds() const
+const set<const Sound *> &Outfit::FlareSounds() const
 {
 	return flareSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::ReverseFlareSounds() const
+const set<const Sound *> &Outfit::ReverseFlareSounds() const
 {
 	return reverseFlareSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::SteeringFlareSounds() const
+const set<const Sound *> &Outfit::SteeringFlareSounds() const
 {
 	return steeringFlareSounds;
 }
@@ -630,56 +617,56 @@ const map<const Effect *, int> &Outfit::JumpEffects() const
 
 
 
-const map<const Sound *, int> &Outfit::HyperSounds() const
+const set<const Sound *> &Outfit::HyperSounds() const
 {
 	return hyperSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::HyperInSounds() const
+const set<const Sound *> &Outfit::HyperInSounds() const
 {
 	return hyperInSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::HyperOutSounds() const
+const set<const Sound *> &Outfit::HyperOutSounds() const
 {
 	return hyperOutSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::JumpSounds() const
+const set<const Sound *> &Outfit::JumpSounds() const
 {
 	return jumpSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::JumpInSounds() const
+const set<const Sound *> &Outfit::JumpInSounds() const
 {
 	return jumpInSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::JumpOutSounds() const
+const set<const Sound *> &Outfit::JumpOutSounds() const
 {
 	return jumpOutSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::CargoScanSounds() const
+const set<const Sound *> &Outfit::CargoScanSounds() const
 {
 	return cargoScanSounds;
 }
 
 
 
-const map<const Sound *, int> &Outfit::OutfitScanSounds() const
+const set<const Sound *> &Outfit::OutfitScanSounds() const
 {
 	return outfitScanSounds;
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Dictionary.h"
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -86,22 +87,22 @@ public:
 	const std::vector<std::pair<Body, int>> &FlareSprites() const;
 	const std::vector<std::pair<Body, int>> &ReverseFlareSprites() const;
 	const std::vector<std::pair<Body, int>> &SteeringFlareSprites() const;
-	const std::map<const Sound *, int> &FlareSounds() const;
-	const std::map<const Sound *, int> &ReverseFlareSounds() const;
-	const std::map<const Sound *, int> &SteeringFlareSounds() const;
+	const std::set<const Sound *> &FlareSounds() const;
+	const std::set<const Sound *> &ReverseFlareSounds() const;
+	const std::set<const Sound *> &SteeringFlareSounds() const;
 	// Get the afterburner effect, if any.
 	const std::map<const Effect *, int> &AfterburnerEffects() const;
 	// Get this outfit's jump effects and sounds, if any.
 	const std::map<const Effect *, int> &JumpEffects() const;
-	const std::map<const Sound *, int> &HyperSounds() const;
-	const std::map<const Sound *, int> &HyperInSounds() const;
-	const std::map<const Sound *, int> &HyperOutSounds() const;
-	const std::map<const Sound *, int> &JumpSounds() const;
-	const std::map<const Sound *, int> &JumpInSounds() const;
-	const std::map<const Sound *, int> &JumpOutSounds() const;
+	const std::set<const Sound *> &HyperSounds() const;
+	const std::set<const Sound *> &HyperInSounds() const;
+	const std::set<const Sound *> &HyperOutSounds() const;
+	const std::set<const Sound *> &JumpSounds() const;
+	const std::set<const Sound *> &JumpInSounds() const;
+	const std::set<const Sound *> &JumpOutSounds() const;
 	// Get this outfit's scan sounds, if any.
-	const std::map<const Sound *, int> &CargoScanSounds() const;
-	const std::map<const Sound *, int> &OutfitScanSounds() const;
+	const std::set<const Sound *> &CargoScanSounds() const;
+	const std::set<const Sound *> &OutfitScanSounds() const;
 	// Get the sprite this outfit uses when dumped into space.
 	const Sprite *FlotsamSprite() const;
 
@@ -135,19 +136,19 @@ private:
 	std::vector<std::pair<Body, int>> flareSprites;
 	std::vector<std::pair<Body, int>> reverseFlareSprites;
 	std::vector<std::pair<Body, int>> steeringFlareSprites;
-	std::map<const Sound *, int> flareSounds;
-	std::map<const Sound *, int> reverseFlareSounds;
-	std::map<const Sound *, int> steeringFlareSounds;
+	std::set<const Sound *> flareSounds;
+	std::set<const Sound *> reverseFlareSounds;
+	std::set<const Sound *> steeringFlareSounds;
 	std::map<const Effect *, int> afterburnerEffects;
 	std::map<const Effect *, int> jumpEffects;
-	std::map<const Sound *, int> hyperSounds;
-	std::map<const Sound *, int> hyperInSounds;
-	std::map<const Sound *, int> hyperOutSounds;
-	std::map<const Sound *, int> jumpSounds;
-	std::map<const Sound *, int> jumpInSounds;
-	std::map<const Sound *, int> jumpOutSounds;
-	std::map<const Sound *, int> cargoScanSounds;
-	std::map<const Sound *, int> outfitScanSounds;
+	std::set<const Sound *> hyperSounds;
+	std::set<const Sound *> hyperInSounds;
+	std::set<const Sound *> hyperOutSounds;
+	std::set<const Sound *> jumpSounds;
+	std::set<const Sound *> jumpInSounds;
+	std::set<const Sound *> jumpOutSounds;
+	std::set<const Sound *> cargoScanSounds;
+	std::set<const Sound *> outfitScanSounds;
 	const Sprite *flotsamSprite = nullptr;
 };
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -955,20 +955,17 @@ void Ship::Save(DataWriter &out) const
 				for(int i = 0; i < it.second; ++i)
 					it.first.SaveSprite(out, "flare sprite");
 			for(const auto &it : baseAttributes.FlareSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("flare sound", it.first->Name());
+				out.Write("flare sound", it->Name());
 			for(const auto &it : baseAttributes.ReverseFlareSprites())
 				for(int i = 0; i < it.second; ++i)
 					it.first.SaveSprite(out, "reverse flare sprite");
 			for(const auto &it : baseAttributes.ReverseFlareSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("reverse flare sound", it.first->Name());
+				out.Write("reverse flare sound", it->Name());
 			for(const auto &it : baseAttributes.SteeringFlareSprites())
 				for(int i = 0; i < it.second; ++i)
 					it.first.SaveSprite(out, "steering flare sprite");
 			for(const auto &it : baseAttributes.SteeringFlareSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("steering flare sound", it.first->Name());
+				out.Write("steering flare sound", it->Name());
 			for(const auto &it : baseAttributes.AfterburnerEffects())
 				for(int i = 0; i < it.second; ++i)
 					out.Write("afterburner effect", it.first->Name());
@@ -976,29 +973,21 @@ void Ship::Save(DataWriter &out) const
 				for(int i = 0; i < it.second; ++i)
 					out.Write("jump effect", it.first->Name());
 			for(const auto &it : baseAttributes.JumpSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("jump sound", it.first->Name());
+				out.Write("jump sound", it->Name());
 			for(const auto &it : baseAttributes.JumpInSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("jump in sound", it.first->Name());
+				out.Write("jump in sound", it->Name());
 			for(const auto &it : baseAttributes.JumpOutSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("jump out sound", it.first->Name());
+				out.Write("jump out sound", it->Name());
 			for(const auto &it : baseAttributes.HyperSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("hyperdrive sound", it.first->Name());
+				out.Write("hyperdrive sound", it->Name());
 			for(const auto &it : baseAttributes.HyperInSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("hyperdrive in sound", it.first->Name());
+				out.Write("hyperdrive in sound", it->Name());
 			for(const auto &it : baseAttributes.HyperOutSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("hyperdrive out sound", it.first->Name());
+				out.Write("hyperdrive out sound", it->Name());
 			for(const auto &it : baseAttributes.CargoScanSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("cargo scan sound", it.first->Name());
+				out.Write("cargo scan sound", it->Name());
 			for(const auto &it : baseAttributes.OutfitScanSounds())
-				for(int i = 0; i < it.second; ++i)
-					out.Write("outfit scan sound", it.first->Name());
+				out.Write("outfit scan sound", it->Name());
 			for(const auto &it : baseAttributes.Attributes())
 				if(it.second)
 					out.Write(it.first, it.second);
@@ -1928,13 +1917,13 @@ int Ship::Scan(const PlayerInfo &player)
 	doScan(outfitScan, outfitSpeed, outfitDistanceSquared, outfits, ShipEvent::SCAN_OUTFITS);
 
 	// Play the scanning sound if the actor or the target is the player's ship.
-	auto playScanSounds = [](const map<const Sound *, int> &sounds, Point &position)
+	auto playScanSounds = [](const set<const Sound *> &sounds, Point &position)
 	{
 		if(sounds.empty())
 			Audio::Play(Audio::Get("scan"), position);
 		else
 			for(const auto &sound : sounds)
-				Audio::Play(sound.first, position);
+				Audio::Play(sound, position);
 	};
 	if(isYours || (target->isYours))
 	{


### PR DESCRIPTION
**Refactor**

## Summary
Various outfit sounds (for engines, hyperdrives and scanners) are internally mapped to ints to allow multiple instances of each sound (probably). The thing is, these numbers aren't used at all, so I changed all maps with outfit sounds to sets (considered using vectors, but sets are more convenient if we don't want duplicates).

## Testing Done
Did some basic testing: flying around, jumping (HD and JD), scanning.

## Performance Impact
N/A, I think
