### PR TITLE
fix(bug): Restore extended jump effects

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -536,7 +536,7 @@ void Engine::Step(bool isActive)
 		if(isActive)
 		{
 			const auto [newCenter, newCenterVelocity] = NewCenter(center, centerVelocity,
-				flagship->Center(), flagship->Velocity(), flagship->GetHyperspacePercentage() / 100.,
+				flagship->Center(), flagship->Velocity(), hyperspacePercentage,
 				flagship->IsHyperspacing());
 
 			center = newCenter;
@@ -1598,9 +1598,12 @@ void Engine::CalculateStep()
 	Point newCenterVelocity;
 	if(flagship)
 	{
+		bool isHyperspacing = flagship->IsHyperspacing();
+		if(isHyperspacing)
+			hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
 		const auto [newCameraCenter, newCameraVelocity] = NewCenter(center, centerVelocity,
-			flagship->Center(), flagship->Velocity(), flagship->GetHyperspacePercentage() / 100.,
-			flagship->IsHyperspacing());
+			flagship->Center(), flagship->Velocity(), hyperspacePercentage,
+			isHyperspacing);
 		newCenter = newCameraCenter;
 		newCenterVelocity = newCameraVelocity;
 	}

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -244,6 +244,7 @@ private:
 	std::vector<std::pair<const Outfit *, int>> ammo;
 	int jumpCount = 0;
 	const System *jumpInProgress[2] = {nullptr, nullptr};
+	// Flagship's hyperspace percentage converted to a [0, 1] double.
 	double hyperspacePercentage = 0.;
 
 	int step = 0;


### PR DESCRIPTION
**Bug fix**

## Summary
This PR brings back the ~~"kill your GPU" mode~~ extended jump effects that were effectively disabled because a variable that was supposed to store the hyperjump progress wasn't being set.

Also replaced some duplicate calculations with that variable and added a comment explaining that it's not really a percentage (should it be renamed then?).

## Testing Done
yes.

## Performance Impact
Huge, but disabled by default.
