### PR TITLE
fix(content): Tweaks to Incipias: Help the Stranded 1

### DIFF
--- a/data/incipias/incipias first contact.txt
+++ b/data/incipias/incipias first contact.txt
@@ -215,9 +215,9 @@ mission "Incipias: Help The Stranded 1"
 			choice
 				`	"I could help them."`
 					goto initiative
+				`	"How can you make such a cold-hearted decision?"`
 				`	"I understand. I'll leave them alone."`
 					goto declined
-				`	"How can you make such a cold-hearted decision?"`
 			`	"It is perhaps a laborious task for an adolescent species such as yourself to comprehend our ways, but we must place the continuation of species above the existence of individuals. If we reveal ourselves to them at this inopportune moment, the shock of such an advanced species appearing in their space will fan the flames of chaos."`
 			choice
 				`	"Then let me help them."`
@@ -237,6 +237,10 @@ mission "Incipias: Help The Stranded 1"
 				`	"If that's how I can help them, sure."`
 					goto yes
 				`	"Why do you not want me to give them my tech?"`
+					to display
+						not "tech dialog"
+			action
+				set "tech dialog"
 			`	"Halting the natural increase of a species is unpredictable at the best of times. Your species lacks the wisdom to understand this, as you are young, and have not seen what we have seen." The Quarg pauses for a moment, lost in thought. "The foreseeable risks of even letting you contact them are monumental, and not something you should consider trivial."`
 				goto choice
 			label yes
@@ -264,6 +268,7 @@ mission "Incipias: Help The Stranded 1"
 				`	"I want to help one of your stranded ships."`
 			`	Again a long pause. "Your intention-goals are welcome. Please dock to the capital-station." Along the message comes a small map of the station with the docking ports highlighted.`
 	on complete
+		clear "tech dialog"
 		conversation
 			`Thanks to the map, you are easily able to dock with the station. Your airlock opens and you enter an environment like nothing you've ever seen before. There are no hallways like you would see in a human space station - instead, tubes full of fog, some of which even ascend vertically, appear to be the only way of getting around. A crowd of beings gathered in front of your airlock, each flashing a multitude of colors. A group of five floats in front of the crowd, and the middle one starts pulsating in calm tones.`
 			`	"Welcome, outer-being, to our capital. We are the Incipias." It stops as if awaiting an answer.`


### PR DESCRIPTION
**Bug fix**

## Summary
In Help the Stranded 1, when you get the option to either say "If that's how I can help them, sure" or "Why do you not want me to give them my tech", the latter option jumps back to the choice label but currently has no conditions to clear it if you already chose it, meaning it can be repetitively clicked. 
![image](https://github.com/user-attachments/assets/b3022f47-b617-4e15-bcc9-a24d947a6c16)
This PR adds a condition to remove that option once you choose it so only the other option remains, and clears the condition after the mission.

On the side, I've elected to change the order of a previous choice, where one option is a decline of continuing the current Incipias content. I've moved that option down to the bottom instead of the middle since it immediately results in a decline.

## Save File
If a save file is necessary, I will make one; otherwise I've tested and ensured this works.