### PR TITLE
fix(docs): Add Catch2 dependency to the developer documentation

### DIFF
--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -59,7 +59,7 @@ In addition to the below dependencies, you will also need CMake 3.16 or newer, h
 <summary>DEB-based distros</summary>
 
 ```
-g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libopenal-dev libmad0-dev uuid-dev
+g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libopenal-dev libmad0-dev uuid-dev catch2
 ```
 
 </details>
@@ -68,7 +68,7 @@ g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev li
 <summary>RPM-based distros</summary>
 
 ```
-gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel openal-soft-devel libmad-devel libuuid-devel
+gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel openal-soft-devel libmad-devel libuuid-devel catch2-devel
 ```
 
 </details>

--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -25,6 +25,7 @@ Use your favorite package manager to install the following (version numbers may 
    - libopenal-dev
    - libmad0-dev
    - uuid-dev
+   - catch2
 
 ##### RPM-based distros:
    - gcc-c++
@@ -37,6 +38,7 @@ Use your favorite package manager to install the following (version numbers may 
    - openal-soft-devel
    - libmad-devel
    - libuuid-devel
+   - catch2-devel
 
 Then, from the project root folder, simply type:
 


### PR DESCRIPTION
**Documentation**

In the C++20 migration PR, Catch2 was removed from our tree and is now used as a standalone dependency. The documentation was not changed to address this change, however. Fixes #10360.

## Summary
Adds Catch2 as a dependency to the developer and cmake guides. I believe these are the only places where build instructions are stored currently.