### PR TITLE
refactor: Use various C++20 features

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3087,7 +3087,7 @@ void AI::DoMining(Ship &ship, Command &command)
 {
 	// This function is only called for ships that are in the player's system.
 	// Update the radius that the ship is searching for asteroids at.
-	bool isNew = !miningAngle.count(&ship);
+	bool isNew = !miningAngle.contains(&ship);
 	Angle &angle = miningAngle[&ship];
 	if(isNew)
 	{
@@ -3141,7 +3141,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command) const
 	shared_ptr<Flotsam> target = ship.GetTargetFlotsam();
 	// Don't try to chase flotsam that are already being pulled toward the ship by a tractor beam.
 	const set<const Flotsam *> &avoid = ship.GetTractorFlotsam();
-	if(target && (!ship.CanPickUp(*target) || avoid.count(target.get())))
+	if(target && (!ship.CanPickUp(*target) || avoid.contains(target.get())))
 	{
 		target.reset();
 		ship.SetTargetFlotsam(target);
@@ -3156,7 +3156,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command) const
 		double bestTime = 600.;
 		for(const shared_ptr<Flotsam> &it : flotsam)
 		{
-			if(!ship.CanPickUp(*it) || avoid.count(it.get()))
+			if(!ship.CanPickUp(*it) || avoid.contains(it.get()))
 				continue;
 			// Only pick up flotsam that is nearby and that you are facing toward. Player escorts should
 			// always attempt to pick up nearby flotsams when they are given a harvest order, and so ignore
@@ -3282,7 +3282,7 @@ bool AI::DoCloak(Ship &ship, Command &command)
 			// TODO: This could use an "Avoid" method, to account for other in-system hazards.
 			// Simple approximation: move equally away from both the system center and the
 			// nearest enemy, until the constrainment boundary is reached.
-			if(ship.GetPersonality().IsUnconstrained() || !fenceCount.count(&ship))
+			if(ship.GetPersonality().IsUnconstrained() || !fenceCount.contains(&ship))
 				safety = 2 * ship.Position().Unit() - nearestEnemy->Position().Unit();
 			else
 				safety = -ship.Position().Unit();
@@ -3408,7 +3408,7 @@ bool AI::DoSecretive(Ship &ship, Command &command)
 		if(distance < maxScanRange)
 		{
 			Point away;
-			if(ship.GetPersonality().IsUnconstrained() || !fenceCount.count(&ship))
+			if(ship.GetPersonality().IsUnconstrained() || !fenceCount.contains(&ship))
 				away = pos - scanningPos;
 			else
 				away = -pos;
@@ -4767,7 +4767,7 @@ void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const Syste
 				// "Know your enemies."
 				enemyStrength[gov.first] += enemy.second;
 				for(const auto &ally : strength)
-					if(ally.first->IsEnemy(enemy.first) && !allies.count(ally.first))
+					if(ally.first->IsEnemy(enemy.first) && !allies.contains(ally.first))
 					{
 						// "The enemy of my enemy is my friend."
 						allyStrength[gov.first] += ally.second;
@@ -4782,7 +4782,7 @@ void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const Syste
 		const Government *gov = it->GetGovernment();
 
 		// Check if this ship's government has the authority to enforce scans & fines in this system.
-		if(!scanPermissions.count(gov))
+		if(!scanPermissions.contains(gov))
 			scanPermissions.emplace(gov, gov && gov->CanEnforce(playerSystem));
 
 		// Only have ships update their strength estimate once per second on average.
@@ -4894,7 +4894,7 @@ void AI::IssueOrders(const Orders &newOrders, const string &description)
 				continue;
 
 			gaveOrder = true;
-			hasMismatch |= !orders.count(ship);
+			hasMismatch |= !orders.contains(ship);
 
 			Orders &existing = orders[ship];
 			existing.MergeOrders(newOrders, hasMismatch, alreadyHarvesting, orderOperation);

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -69,7 +69,7 @@ namespace {
 		static const set<string> comparison = {
 			"==", "!=", "<", ">", "<=", ">="
 		};
-		return comparison.count(op);
+		return comparison.contains(op);
 	}
 
 	bool IsAssignment(const string &op)
@@ -77,7 +77,7 @@ namespace {
 		static const set<string> assignment = {
 			"=", "+=", "-=", "*=", "/=", "<?=", ">?="
 		};
-		return assignment.count(op);
+		return assignment.contains(op);
 	}
 
 	bool IsSimple(const string &op)
@@ -85,7 +85,7 @@ namespace {
 		static const set<string> simple = {
 			"(", ")", "+", "-", "*", "/", "%"
 		};
-		return simple.count(op);
+		return simple.contains(op);
 	}
 
 	int Precedence(const string &op)
@@ -106,7 +106,7 @@ namespace {
 			"||", "&&", "&=", "|=", "<<", ">>"
 		};
 		for(const string &str : tokens)
-			if(invalids.count(str))
+			if(invalids.contains(str))
 				return true;
 		return false;
 	}

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -619,7 +619,7 @@ bool Conversation::HasDisplayRestriction(const DataNode &node)
 // Add a label, pointing to whatever node is created next.
 void Conversation::AddLabel(const string &label, const DataNode &node)
 {
-	if(labels.count(label))
+	if(labels.contains(label))
 	{
 		node.PrintTrace("Error: Conversation: label \"" + label + "\" is used more than once:");
 		return;

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -94,7 +94,7 @@ DistanceMap::DistanceMap(const Ship &ship, const System *destination, const Play
 // Find out if the given system is reachable.
 bool DistanceMap::HasRoute(const System *system) const
 {
-	return route.count(system);
+	return route.contains(system);
 }
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -100,14 +100,14 @@ namespace {
 		return Radar::UNFRIENDLY;
 	}
 
-	template <template<class> class Container, class Type>
-	void Prune(Container<Type> &objects)
+	template <template<class, class> class Container, class Type, class Alloc>
+	void Prune(Container<Type, Alloc> &objects)
 	{
 		erase_if(objects, &Type::ShouldBeRemoved);
 	}
 
-	template <template<class> class Container, template<class> class PtrType, class Inner>
-	void Prune(Container<PtrType<Inner>> &objects)
+	template <template<class, class> class Container, template<class> class PtrType, class Alloc, class Inner>
+	void Prune(Container<PtrType<Inner>, Alloc> &objects)
 	{
 		erase_if(objects, [&](const auto &ptr){return ptr->ShouldBeRemoved();});
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -100,8 +100,8 @@ namespace {
 		return Radar::UNFRIENDLY;
 	}
 
-	template <template<class, class> class Container, template<class> class PtrType, class Alloc, class Inner>
-	void Prune(Container<PtrType<Inner>, Alloc> &objects)
+	template <template<class, class> class Container, class Alloc, class Inner>
+	void Prune(Container<shared_ptr<Inner>, Alloc> &objects)
 	{
 		erase_if(objects, [&](const auto &ptr){return ptr->ShouldBeRemoved();});
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -107,9 +107,9 @@ namespace {
 	}
 
 	template <template<class, class> class Container, class Type, class Alloc>
-	enable_if_t<is_base_of_v<Body, Type> || is_base_of_v<Weather, Type>, void> Prune(Container<Type, Alloc> &objects)
+	void Prune(Container<Type, Alloc> &objects)
 	{
-		erase_if(objects, &Type::ShouldBeRemoved);
+		erase_if(objects, [](const auto &object){return object.ShouldBeRemoved();});
 	}
 
 	template <class Type>

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -100,16 +100,16 @@ namespace {
 		return Radar::UNFRIENDLY;
 	}
 
-	template <template<class, class> class Container, class Type, class Alloc>
-	void Prune(Container<Type, Alloc> &objects)
-	{
-		erase_if(objects, &Type::ShouldBeRemoved);
-	}
-
 	template <template<class, class> class Container, template<class> class PtrType, class Alloc, class Inner>
 	void Prune(Container<PtrType<Inner>, Alloc> &objects)
 	{
 		erase_if(objects, [&](const auto &ptr){return ptr->ShouldBeRemoved();});
+	}
+
+	template <template<class, class> class Container, class Type, class Alloc>
+	void Prune(Container<Type, Alloc> &objects)
+	{
+		erase_if(objects, &Type::ShouldBeRemoved);
 	}
 
 	template <class Type>

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -103,11 +103,11 @@ namespace {
 	template <template<class, class> class Container, class Alloc, class Inner>
 	void Prune(Container<shared_ptr<Inner>, Alloc> &objects)
 	{
-		erase_if(objects, [&](const auto &ptr){return ptr->ShouldBeRemoved();});
+		erase_if(objects, [](const auto &ptr){return ptr->ShouldBeRemoved();});
 	}
 
 	template <template<class, class> class Container, class Type, class Alloc>
-	void Prune(Container<Type, Alloc> &objects)
+	enable_if_t<is_base_of_v<Body, Type> || is_base_of_v<Weather, Type>, void> Prune(Container<Type, Alloc> &objects)
 	{
 		erase_if(objects, &Type::ShouldBeRemoved);
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -100,17 +100,10 @@ namespace {
 		return Radar::UNFRIENDLY;
 	}
 
-	template <template<class, class> class Container, class Alloc, class Inner>
-	void Prune(Container<shared_ptr<Inner>, Alloc> &objects)
-	{
-		erase_if(objects, [](const auto &ptr){return ptr->ShouldBeRemoved();});
-	}
-
-	template <template<class, class> class Container, class Type, class Alloc>
-	void Prune(Container<Type, Alloc> &objects)
-	{
-		erase_if(objects, [](const auto &object){return object.ShouldBeRemoved();});
-	}
+	constexpr auto PrunePointers = [](auto &objects) { erase_if(objects,
+			[](const auto &obj) { return obj->ShouldBeRemoved(); }); };
+	constexpr auto Prune = [](auto &objects) { erase_if(objects,
+			[](const auto &obj) { return obj.ShouldBeRemoved(); }); };
 
 	template <class Type>
 	void Append(vector<Type> &objects, vector<Type> &added)
@@ -1500,7 +1493,7 @@ void Engine::CalculateStep()
 		player.SetSystem(*playerSystem);
 		EnterSystem();
 	}
-	Prune(ships);
+	PrunePointers(ships);
 
 	// Move the asteroids. This must be done before collision detection. Minables
 	// may create visuals or flotsam.
@@ -1510,7 +1503,7 @@ void Engine::CalculateStep()
 	// checks if any ship has picked it up.
 	for(const shared_ptr<Flotsam> &it : flotsam)
 		it->Move(newVisuals);
-	Prune(flotsam);
+	PrunePointers(flotsam);
 
 	// Move the projectiles.
 	for(Projectile &projectile : projectiles)

--- a/source/EscortDisplay.cpp
+++ b/source/EscortDisplay.cpp
@@ -240,7 +240,7 @@ void EscortDisplay::MergeStacks(int maxHeight) const
 		int height = 0;
 		for(Icon &icon : icons)
 		{
-			if(!unstackable.count(icon.sprite) && (!cheapest || *cheapest < icon))
+			if(!unstackable.contains(icon.sprite) && (!cheapest || *cheapest < icon))
 				cheapest = &icon;
 
 			height += icon.Height();

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -435,7 +435,7 @@ const System *Fleet::Enter(const System &system, Ship &ship, const System *sourc
 		}
 	));
 
-	if(!canEnter || system.Links().empty() || (source && !system.Links().count(source)))
+	if(!canEnter || system.Links().empty() || (source && !system.Links().contains(source)))
 	{
 		Place(system, ship);
 		return &system;

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -422,7 +422,7 @@ void GameAction::Do(PlayerInfo &player, UI *ui, const Mission *caller) const
 		// mission as failed. It will not be removed from the player's mission
 		// list until it is safe to do so.
 		for(const Mission &mission : player.Missions())
-			if(fail.count(mission.Identifier()))
+			if(fail.contains(mission.Identifier()))
 				player.FailMission(mission);
 	}
 	if(failCaller && caller)

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -777,7 +777,7 @@ const vector<Trade::Commodity> &GameData::SpecialCommodities()
 // Custom messages to be shown when trying to land on certain stellar objects.
 bool GameData::HasLandingMessage(const Sprite *sprite)
 {
-	return objects.landingMessages.count(sprite);
+	return objects.landingMessages.contains(sprite);
 }
 
 

--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -48,7 +48,7 @@ map<string, set<string>> GameEvent::DeferredDefinitions(const list<DataNode> &ch
 	auto definitions = map<string, set<string>> {};
 
 	for(auto &&node : changes)
-		if(node.Size() >= 2 && node.HasChildren() && DEFINITION_NODES.count(node.Token(0)))
+		if(node.Size() >= 2 && node.HasChildren() && DEFINITION_NODES.contains(node.Token(0)))
 		{
 			const string &key = node.Token(0);
 			const string &name = node.Token(1);
@@ -116,7 +116,7 @@ void GameEvent::Load(const DataNode &node)
 			planetsToUnvisit.push_back(GameData::Planets().Get(child.Token(1)));
 		else if(key == "visit planet" && child.Size() >= 2)
 			planetsToVisit.push_back(GameData::Planets().Get(child.Token(1)));
-		else if(allowedChanges.count(key))
+		else if(allowedChanges.contains(key))
 			changes.push_back(child);
 		else
 			conditionsToApply.Add(child);
@@ -199,11 +199,11 @@ string GameEvent::IsValid() const
 
 	for(auto &&systems : {systemsToVisit, systemsToUnvisit})
 		for(auto &&system : systems)
-			if(!system->IsValid() && !deferred["system"].count(system->Name()))
+			if(!system->IsValid() && !deferred["system"].contains(system->Name()))
 				return "contains invalid system \"" + system->Name() + "\".";
 	for(auto &&planets : {planetsToVisit, planetsToUnvisit})
 		for(auto &&planet : planets)
-			if(!planet->IsValid() && !deferred["planet"].count(planet->TrueName()))
+			if(!planet->IsValid() && !deferred["planet"].contains(planet->TrueName()))
 				return "contains invalid planet \"" + planet->TrueName() + "\".";
 
 	return isDefined ? "" : "not defined";

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -132,7 +132,7 @@ void Government::Load(const DataNode &node)
 		bool removeAll = (remove && !hasValue);
 		// If this is the first entry for the given key, and we are not in "add"
 		// or "remove" mode, its previous value should be cleared.
-		bool overwriteAll = (!add && !remove && shouldOverwrite.count(key));
+		bool overwriteAll = (!add && !remove && shouldOverwrite.contains(key));
 
 		if(removeAll || overwriteAll)
 		{
@@ -490,7 +490,7 @@ double Government::PenaltyFor(int eventType, const Government *other) const
 		return PenaltyHelper(eventType, penaltyFor);
 
 	const int id = other->id;
-	const auto &penalties = useForeignPenaltiesFor.count(id) ? other->penaltyFor : penaltyFor;
+	const auto &penalties = useForeignPenaltiesFor.contains(id) ? other->penaltyFor : penaltyFor;
 
 	const auto it = customPenalties.find(id);
 	if(it == customPenalties.end())
@@ -522,7 +522,7 @@ double Government::GetFineFraction() const
 
 bool Government::Trusts(const Government *government) const
 {
-	return government == this || trusted.count(government);
+	return government == this || trusted.contains(government);
 }
 
 

--- a/source/Information.cpp
+++ b/source/Information.cpp
@@ -138,7 +138,7 @@ bool Information::HasCondition(const string &condition) const
 	if(condition.front() == '!')
 		return !HasCondition(condition.substr(1));
 
-	return conditions.count(condition);
+	return conditions.contains(condition);
 }
 
 

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -159,7 +159,7 @@ void Interface::Draw(const Information &info, Panel *panel) const
 // Check if a named point exists.
 bool Interface::HasPoint(const string &name) const
 {
-	return points.count(name);
+	return points.contains(name);
 }
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -215,7 +215,7 @@ void LoadPanel::Draw()
 	string hoverText;
 
 	// Draw the list of snapshots for the selected pilot.
-	if(!selectedPilot.empty() && files.count(selectedPilot))
+	if(!selectedPilot.empty() && files.contains(selectedPilot))
 	{
 		const Point topLeft = snapshotBox.TopLeft();
 		Point currentTopLeft = topLeft + Point(0, -centerScroll);

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -343,10 +343,10 @@ bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 	if(!shipCategory.empty())
 		return false;
 
-	if(!governments.empty() && !governments.count(planet->GetGovernment()))
+	if(!governments.empty() && !governments.contains(planet->GetGovernment()))
 		return false;
 
-	if(!planets.empty() && !planets.count(planet))
+	if(!planets.empty() && !planets.contains(planet))
 		return false;
 	for(const set<string> &attr : attributes)
 		if(!SetsIntersect(attr, planet->Attributes()))
@@ -382,12 +382,12 @@ bool LocationFilter::Matches(const System *system, const System *origin) const
 bool LocationFilter::Matches(const Ship &ship) const
 {
 	const System *origin = ship.GetSystem();
-	if(!systems.empty() && !systems.count(origin))
+	if(!systems.empty() && !systems.contains(origin))
 		return false;
-	if(!governments.empty() && !governments.count(ship.GetGovernment()))
+	if(!governments.empty() && !governments.contains(ship.GetGovernment()))
 		return false;
 
-	if(!shipCategory.empty() && !shipCategory.count(ship.Attributes().Category()))
+	if(!shipCategory.empty() && !shipCategory.contains(ship.Attributes().Category()))
 		return false;
 
 	if(!attributes.empty())
@@ -497,7 +497,7 @@ const Planet *LocationFilter::PickPlanet(const System *origin, bool hasClearance
 		if(planet.IsWormhole()
 				|| (requireSpaceport && !planet.GetPort().HasService(Port::ServicesType::OffersMissions))
 				|| (!hasClearance && !planet.CanLand()))
-			if(planets.empty() || !planets.count(&planet))
+			if(planets.empty() || !planets.contains(&planet))
 				continue;
 		if(Matches(&planet, origin))
 			options.push_back(&planet);
@@ -609,14 +609,14 @@ bool LocationFilter::Matches(const System *system, const System *origin, bool di
 {
 	if(!system || !system->IsValid())
 		return false;
-	if(!systems.empty() && !systems.count(system))
+	if(!systems.empty() && !systems.contains(system))
 		return false;
 
 	// Don't check these filters again if they were already checked as a part of
 	// checking if a planet matches.
 	if(!didPlanet)
 	{
-		if(!governments.empty() && !governments.count(system->GetGovernment()))
+		if(!governments.empty() && !governments.contains(system->GetGovernment()))
 			return false;
 
 		// This filter is being applied to a system, not a planet.

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -499,7 +499,7 @@ void MapDetailPanel::GeneratePlanetCards(const System &system)
 			// The same "planet" may appear multiple times in one system,
 			// providing multiple landing and departure points (e.g. ringworlds).
 			const Planet *planet = object.GetPlanet();
-			if(planet->IsWormhole() || !planet->IsAccessible(player.Flagship()) || shown.count(planet))
+			if(planet->IsWormhole() || !planet->IsAccessible(player.Flagship()) || shown.contains(planet))
 				continue;
 
 			planetCards.emplace_back(object, number, player.HasVisited(*planet));

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -278,7 +278,7 @@ void MapOutfitterPanel::Init()
 	for(auto &&it : GameData::Planets())
 		if(it.second.IsValid() && player.CanView(*it.second.GetSystem()))
 			for(const Outfit *outfit : it.second.Outfitter())
-				if(!seen.count(outfit))
+				if(!seen.contains(outfit))
 				{
 					catalog[outfit->Category()].push_back(outfit);
 					seen.insert(outfit);
@@ -288,7 +288,7 @@ void MapOutfitterPanel::Init()
 	for(const auto &it : player.PlanetaryStorage())
 		if(it.first->HasOutfitter())
 			for(const auto &oit : it.second.Outfits())
-				if(!seen.count(oit.first))
+				if(!seen.contains(oit.first))
 				{
 					catalog[oit.first->Category()].push_back(oit.first);
 					seen.insert(oit.first);
@@ -296,7 +296,7 @@ void MapOutfitterPanel::Init()
 
 	// Add all known minables.
 	for(const auto &it : player.Harvested())
-		if(!seen.count(it.second))
+		if(!seen.contains(it.second))
 		{
 			catalog[it.second->Category()].push_back(it.second);
 			seen.insert(it.second);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -429,7 +429,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 	Point center = .5 * (jump[0]->Position() + jump[1]->Position());
 	const Point &drawPos = GameData::Interfaces().Get("hud")->GetPoint("mini-map");
 	set<const System *> drawnSystems = { jump[0], jump[1] };
-	bool isLink = jump[0]->Links().count(jump[1]);
+	bool isLink = jump[0]->Links().contains(jump[1]);
 
 	const Set<Color> &colors = GameData::Colors();
 	const Color &currentColor = colors.Get("active mission")->Additive(alpha * 2.f);
@@ -465,7 +465,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 			Point unit = (from - to).Unit() * LINK_OFFSET;
 			LineShader::Draw(from - unit, to + unit, LINK_WIDTH, lineColor);
 
-			if(drawnSystems.count(link))
+			if(drawnSystems.contains(link))
 				continue;
 			drawnSystems.insert(link);
 
@@ -904,7 +904,7 @@ bool MapPanel::IsSatisfied(const PlayerInfo &player, const Mission &mission)
 bool MapPanel::GetTravelInfo(const System *previous, const System *next, const double jumpRange,
 	bool &isJump, bool &isWormhole, bool &isMappable, Color *wormholeColor) const
 {
-	const bool isHyper = previous->Links().count(next);
+	const bool isHyper = previous->Links().contains(next);
 	isWormhole = false;
 	isMappable = false;
 	// Short-circuit the loop for MissionPanel, which draws hyperlinks and wormholes the same.
@@ -925,7 +925,7 @@ bool MapPanel::GetTravelInfo(const System *previous, const System *next, const d
 					break;
 				}
 			}
-	isJump = !isHyper && !isWormhole && previous->JumpNeighbors(jumpRange).count(next);
+	isJump = !isHyper && !isWormhole && previous->JumpNeighbors(jumpRange).contains(next);
 	return isHyper || isWormhole || isJump;
 }
 

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -327,7 +327,7 @@ void MapSalesPanel::DrawInfo() const
 
 bool MapSalesPanel::DrawHeader(Point &corner, const string &category)
 {
-	bool hide = collapsed.count(category);
+	bool hide = collapsed.contains(category);
 	if(!hidPrevious)
 		corner.Y() += 50.;
 	hidPrevious = hide;
@@ -432,7 +432,7 @@ void MapSalesPanel::ScrollTo(int index)
 
 void MapSalesPanel::ClickCategory(const string &name)
 {
-	bool isHidden = collapsed.count(name);
+	bool isHidden = collapsed.contains(name);
 	if(SDL_GetModState() & KMOD_SHIFT)
 	{
 		// If the shift key is held down, hide or show all categories.

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -266,7 +266,7 @@ void MapShipyardPanel::Init()
 	for(const auto &it : GameData::Planets())
 		if(it.second.IsValid() && player.CanView(*it.second.GetSystem()))
 			for(const Ship *ship : it.second.Shipyard())
-				if(!seen.count(ship))
+				if(!seen.contains(ship))
 				{
 					catalog[ship->Attributes().Category()].push_back(ship);
 					seen.insert(ship);
@@ -278,7 +278,7 @@ void MapShipyardPanel::Init()
 		{
 			const Ship *model = GameData::Ships().Get(it->TrueModelName());
 			++parkedShips[it->GetSystem()][model];
-			if(!seen.count(model))
+			if(!seen.contains(model))
 			{
 				catalog[model->Attributes().Category()].push_back(model);
 				seen.insert(model);

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -472,10 +472,10 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			it.second.Save(out);
 		// Save any "on enter" actions that have not been performed.
 		for(const auto &it : onEnter)
-			if(!didEnter.count(&it.second))
+			if(!didEnter.contains(&it.second))
 				it.second.Save(out);
 		for(const MissionAction &action : genericOnEnter)
-			if(!didEnter.count(&action))
+			if(!didEnter.contains(&action))
 				action.Save(out);
 	}
 	out.EndChild();
@@ -760,7 +760,7 @@ bool Mission::HasClearance(const Planet *planet) const
 {
 	if(clearance.empty())
 		return false;
-	if(planet == destination || stopovers.count(planet) || visitedStopovers.count(planet))
+	if(planet == destination || stopovers.contains(planet) || visitedStopovers.contains(planet))
 		return true;
 	return (!clearanceFilter.IsEmpty() && clearanceFilter.Matches(planet));
 }
@@ -1156,7 +1156,7 @@ bool Mission::RequiresGiftedShip(const string &shipId) const
 			requiredActions.insert(Trigger::WAYPOINT);
 	}
 	for(const auto &it : actions)
-		if(requiredActions.count(it.first) && it.second.RequiresGiftedShip(shipId))
+		if(requiredActions.contains(it.first) && it.second.RequiresGiftedShip(shipId))
 			return true;
 
 	return false;
@@ -1620,7 +1620,7 @@ bool Mission::Enter(const System *system, PlayerInfo &player, UI *ui)
 {
 	const auto eit = onEnter.find(system);
 	const auto originalSize = didEnter.size();
-	if(eit != onEnter.end() && !didEnter.count(&eit->second) && eit->second.CanBeDone(player, IsFailed(player)))
+	if(eit != onEnter.end() && !didEnter.contains(&eit->second) && eit->second.CanBeDone(player, IsFailed(player)))
 	{
 		eit->second.Do(player, ui, this);
 		didEnter.insert(&eit->second);
@@ -1629,7 +1629,7 @@ bool Mission::Enter(const System *system, PlayerInfo &player, UI *ui)
 	// which may use a LocationFilter to govern which systems it can be performed in.
 	else
 		for(MissionAction &action : genericOnEnter)
-			if(!didEnter.count(&action) && action.CanBeDone(player, IsFailed(player)))
+			if(!didEnter.contains(&action) && action.CanBeDone(player, IsFailed(player)))
 			{
 				action.Do(player, ui, this);
 				didEnter.insert(&action);

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -69,7 +69,7 @@ namespace {
 		for(auto &&it : ship.Outfits())
 		{
 			const Outfit *outfit = it.first;
-			if(outfit->Ammo() && !outfit->IsWeapon() && !armed.count(outfit))
+			if(outfit->Ammo() && !outfit->IsWeapon() && !armed.contains(outfit))
 				toRefill.emplace(outfit->Ammo());
 		}
 		return toRefill;
@@ -255,7 +255,7 @@ double OutfitterPanel::DrawDetails(const Point &center)
 
 	if(selectedOutfit)
 	{
-		outfitInfo.Update(*selectedOutfit, player, CanSell(), collapsed.count(DESCRIPTION));
+		outfitInfo.Update(*selectedOutfit, player, CanSell(), collapsed.contains(DESCRIPTION));
 		selectedItem = selectedOutfit->DisplayName();
 
 		const Sprite *thumbnail = selectedOutfit->Thumbnail();
@@ -276,8 +276,7 @@ double OutfitterPanel::DrawDetails(const Point &center)
 
 		if(hasDescription)
 		{
-			// Maintenance note: This can be replaced with collapsed.contains() in C++20
-			if(!collapsed.count(DESCRIPTION))
+			if(!collapsed.contains(DESCRIPTION))
 			{
 				descriptionOffset = outfitInfo.DescriptionHeight();
 				outfitInfo.DrawDescription(startPoint);

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -92,7 +92,7 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes)
 		removeAll |= (!add && !remove && hasValue && value == "clear");
 		// If this is the first entry for the given key, and we are not in "add"
 		// or "remove" mode, its previous value should be cleared.
-		bool overwriteAll = (!add && !remove && !removeAll && shouldOverwrite.count(key));
+		bool overwriteAll = (!add && !remove && !removeAll && shouldOverwrite.contains(key));
 		// Clear the data of the given type.
 		if(removeAll || overwriteAll)
 		{
@@ -238,7 +238,7 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes)
 	// For reverse compatibility, if this planet has a spaceport but it was not custom loaded,
 	// and the planet has the "uninhabited" attribute, replace the spaceport with a special-case
 	// uninhabited spaceport.
-	if(attributes.count("uninhabited") && HasNamedPort() && !port.CustomLoaded())
+	if(attributes.contains("uninhabited") && HasNamedPort() && !port.CustomLoaded())
 		port.LoadUninhabitedSpaceport();
 
 	// Apply any auto-attributes to this planet depending on what it has.
@@ -284,7 +284,7 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes)
 	}
 
 	// Precalculate commonly used values that can only change due to Load().
-	inhabited = (HasServices() || requiredReputation || !defenseFleets.empty()) && !attributes.count("uninhabited");
+	inhabited = (HasServices() || requiredReputation || !defenseFleets.empty()) && !attributes.contains("uninhabited");
 	SetRequiredAttributes(Attributes(), requiredAttributes);
 }
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -354,7 +354,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 		};
 		for(const auto &result : flightChecks)
 			for(const auto &warning : result.second)
-				if(jumpWarnings.count(warning))
+				if(jumpWarnings.contains(warning))
 				{
 					++nonJumpCount;
 					break;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -581,7 +581,7 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 		{
 			seen.insert(system);
 			for(const System *neighbor : system->VisibleNeighbors())
-				if(!neighbor->Hidden() || system->Links().count(neighbor))
+				if(!neighbor->Hidden() || system->Links().contains(neighbor))
 					seen.insert(neighbor);
 		}
 	}
@@ -988,8 +988,7 @@ void PlayerInfo::RemoveLicense(const string &name)
 
 bool PlayerInfo::HasLicense(const string &name) const
 {
-	// TODO: This should be changed to use std::set<>::contains when we move to C++20.
-	return licenses.count(name);
+	return licenses.contains(name);
 }
 
 
@@ -2419,16 +2418,16 @@ bool PlayerInfo::HasSeen(const System &system) const
 
 	// Shrouded systems have special considerations as to whether they're currently seen or not.
 	bool shrouded = system.Shrouded();
-	if(!shrouded && seen.count(&system))
+	if(!shrouded && seen.contains(&system))
 		return true;
 
 	auto usesSystem = [&system](const Mission &m) noexcept -> bool
 	{
 		if(!m.IsVisible())
 			return false;
-		if(m.Waypoints().count(&system))
+		if(m.Waypoints().contains(&system))
 			return true;
-		if(m.MarkedSystems().count(&system))
+		if(m.MarkedSystems().contains(&system))
 			return true;
 		for(auto &&p : m.Stopovers())
 			if(p->IsInSystem(&system))
@@ -2447,7 +2446,7 @@ bool PlayerInfo::HasSeen(const System &system) const
 				[&](const System *s) noexcept -> bool { return CanView(*s); }))
 			return true;
 		// A shrouded system not linked to a viewable system must be visible from the current system.
-		if(!system.VisibleNeighbors().count(this->system))
+		if(!system.VisibleNeighbors().contains(this->system))
 			return false;
 		// If a shrouded system is in visible range, then it can be seen if it is not also hidden.
 		return !system.Hidden();
@@ -2471,7 +2470,7 @@ bool PlayerInfo::CanView(const System &system) const
 // Check if the player has visited the given system.
 bool PlayerInfo::HasVisited(const System &system) const
 {
-	return visitedSystems.count(&system);
+	return visitedSystems.contains(&system);
 }
 
 
@@ -2479,7 +2478,7 @@ bool PlayerInfo::HasVisited(const System &system) const
 // Check if the player has visited the given planet.
 bool PlayerInfo::HasVisited(const Planet &planet) const
 {
-	return visitedPlanets.count(&planet);
+	return visitedPlanets.contains(&planet);
 }
 
 
@@ -2509,7 +2508,7 @@ void PlayerInfo::Visit(const System &system)
 	visitedSystems.insert(&system);
 	seen.insert(&system);
 	for(const System *neighbor : system.VisibleNeighbors())
-		if(!neighbor->Hidden() || system.Links().count(neighbor))
+		if(!neighbor->Hidden() || system.Links().contains(neighbor))
 			seen.insert(neighbor);
 }
 
@@ -3768,7 +3767,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		if(!flagship || !flagship->GetPlanet())
 			return false;
 		string attribute = name.substr(strlen("flagship planet attribute: "));
-		return flagship->GetPlanet()->Attributes().count(attribute);
+		return flagship->GetPlanet()->Attributes().contains(attribute);
 	};
 	flagshipPlanetAttributesProvider.SetGetFunction(flagshipPlanetAttributesFun);
 
@@ -4196,10 +4195,10 @@ void PlayerInfo::StepMissions(UI *ui)
 
 	vector<const Mission *> missionsToRemove;
 	for(const auto &it : cargo.MissionCargo())
-		if(!active.count(it.first))
+		if(!active.contains(it.first))
 			missionsToRemove.push_back(it.first);
 	for(const auto &it : cargo.PassengerList())
-		if(!active.count(it.first))
+		if(!active.contains(it.first))
 			missionsToRemove.push_back(it.first);
 	for(const Mission *mission : missionsToRemove)
 		cargo.RemoveMissionCargo(mission);
@@ -4586,7 +4585,7 @@ void PlayerInfo::Fine(UI *ui)
 	// Planets should not fine you if you have mission clearance or are infiltrating.
 	for(const Mission &mission : missions)
 		if(mission.HasClearance(planet) || (!mission.HasFullClearance() &&
-					(mission.Destination() == planet || mission.Stopovers().count(planet))))
+					(mission.Destination() == planet || mission.Stopovers().contains(planet))))
 			return;
 
 	// The planet's government must have the authority to enforce laws.

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -361,7 +361,7 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 			}
 			else if(shift)
 			{
-				if(panelState.AllSelected().count(selectedIndex))
+				if(panelState.AllSelected().contains(selectedIndex))
 					panelState.Deselect(panelState.SelectedIndex());
 				if(isValidIndex)
 					panelState.SetSelectedIndex(selectedIndex);
@@ -522,7 +522,7 @@ bool PlayerInfoPanel::Click(int x, int y, int clicks)
 	if(panelState.CanEdit() && (shift || control || clicks < 2))
 	{
 		// If the control+click was on an already selected ship, deselect it.
-		if(control && panelState.AllSelected().count(hoverIndex))
+		if(control && panelState.AllSelected().contains(hoverIndex))
 			panelState.Deselect(hoverIndex);
 		else
 		{
@@ -536,7 +536,7 @@ bool PlayerInfoPanel::Click(int x, int y, int clicks)
 				panelState.SelectMany(start, end + 1);
 				panelState.SetSelectedIndex(hoverIndex);
 			}
-			else if(panelState.AllSelected().count(hoverIndex))
+			else if(panelState.AllSelected().contains(hoverIndex))
 			{
 				// If the click is on an already selected line, start dragging
 				// but do not change the selection.
@@ -741,7 +741,7 @@ void PlayerInfoPanel::DrawFleet(const Rectangle &bounds)
 		// Check if this row is selected.
 		if(panelState.SelectedIndex() == index)
 			table.DrawHighlight(selectedBack);
-		else if(panelState.AllSelected().count(index))
+		else if(panelState.AllSelected().contains(index))
 			table.DrawHighlight(back);
 
 		// Find out if the mouse is hovering over the ship

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -74,7 +74,7 @@ bool Plugin::PluginDependencies::IsValid() const
 	// Check and log collisions between optional and required dependencies.
 	for(const string &dependency : optional)
 	{
-		if(required.count(dependency))
+		if(required.contains(dependency))
 			dependencyCollisions += dependency + ", ";
 	}
 	if(!dependencyCollisions.empty())
@@ -89,7 +89,7 @@ bool Plugin::PluginDependencies::IsValid() const
 	// Check and log collisions between conflicted and required dependencies.
 	for(const string &dependency : conflicted)
 	{
-		if(required.count(dependency))
+		if(required.contains(dependency))
 		{
 			isValid = false;
 			dependencyCollisions += dependency + ", ";
@@ -107,7 +107,7 @@ bool Plugin::PluginDependencies::IsValid() const
 	// Check and log collisions between optional and conflicted dependencies.
 	for(const string &dependency : conflicted)
 	{
-		if(optional.count(dependency))
+		if(optional.contains(dependency))
 		{
 			isValid = false;
 			dependencyCollisions += dependency + ", ";

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -89,9 +89,9 @@ bool Politics::IsEnemy(const Government *first, const Government *second) const
 		swap(first, second);
 	if(first->IsPlayer())
 	{
-		if(bribed.count(second))
+		if(bribed.contains(second))
 			return false;
-		if(provoked.count(second))
+		if(provoked.contains(second))
 			return true;
 
 		auto it = reputationWith.find(second);
@@ -183,11 +183,11 @@ bool Politics::CanLand(const Planet *planet) const
 		return false;
 	if(!planet->IsInhabited())
 		return true;
-	if(dominatedPlanets.count(planet))
+	if(dominatedPlanets.contains(planet))
 		return true;
-	if(bribedPlanets.count(planet))
+	if(bribedPlanets.contains(planet))
 		return true;
-	if(provoked.count(planet->GetGovernment()))
+	if(provoked.contains(planet->GetGovernment()))
 		return false;
 
 	return Reputation(planet->GetGovernment()) >= planet->RequiredReputation();
@@ -199,7 +199,7 @@ bool Politics::CanUseServices(const Planet *planet) const
 {
 	if(!planet || !planet->GetSystem())
 		return false;
-	if(dominatedPlanets.count(planet))
+	if(dominatedPlanets.contains(planet))
 		return true;
 
 	auto it = bribedPlanets.find(planet);
@@ -231,7 +231,7 @@ void Politics::DominatePlanet(const Planet *planet, bool dominate)
 
 bool Politics::HasDominated(const Planet *planet) const
 {
-	return dominatedPlanets.count(planet);
+	return dominatedPlanets.contains(planet);
 }
 
 
@@ -241,7 +241,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 {
 	// Do nothing if you have already been fined today, or if you evade
 	// detection.
-	if(fined.count(gov) || Random::Real() > security || !gov->GetFineFraction())
+	if(fined.contains(gov) || Random::Real() > security || !gov->GetFineFraction())
 		return "";
 
 	string reason;

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -131,7 +131,7 @@ namespace {
 			for(auto &it : objects)
 			{
 				const Type &object = it.second;
-				if(object.Attributes().count(attribute))
+				if(object.Attributes().contains(attribute))
 					cout << (index++ ? ';' : ',') << DataWriter::Quote(it.first);
 			}
 			cout << '\n';
@@ -714,7 +714,7 @@ bool PrintData::IsPrintDataArgument(const char *const *argv)
 	for(const char *const *it = argv + 1; *it; ++it)
 	{
 		string arg = *it;
-		if(OTHER_VALID_ARGS.count(arg) || OUTFIT_ARGS.count(arg))
+		if(OTHER_VALID_ARGS.contains(arg) || OUTFIT_ARGS.contains(arg))
 			return true;
 	}
 	return false;
@@ -732,7 +732,7 @@ void PrintData::Print(const char *const *argv)
 			Ships(argv);
 			break;
 		}
-		else if(OUTFIT_ARGS.count(arg))
+		else if(OUTFIT_ARGS.contains(arg))
 		{
 			Outfits(argv);
 			break;

--- a/source/Set.h
+++ b/source/Set.h
@@ -35,7 +35,7 @@ public:
 	// pointer rather than creating the item.
 	const Type *Find(const std::string &name) const;
 
-	bool Has(const std::string &name) const { return data.count(name); }
+	bool Has(const std::string &name) const { return data.contains(name); }
 
 	typename std::map<std::string, Type>::iterator begin() { return data.begin(); }
 	typename std::map<std::string, Type>::const_iterator begin() const { return data.begin(); }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -896,8 +896,8 @@ void Ship::FinishLoading(bool isNewInstance)
 			Logger::LogError(message + "\" (no current system).");
 			targetSystem = nullptr;
 		}
-		else if(!currentSystem->Links().count(targetSystem)
-			&& (!navigation.JumpRange() || !currentSystem->JumpNeighbors(navigation.JumpRange()).count(targetSystem)))
+		else if(!currentSystem->Links().contains(targetSystem)
+			&& (!navigation.JumpRange() || !currentSystem->JumpNeighbors(navigation.JumpRange()).contains(targetSystem)))
 		{
 			Logger::LogError(message + "\" by hyperlink or jump from system \"" + currentSystem->Name() + ".\"");
 			targetSystem = nullptr;

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -136,7 +136,7 @@ pair<JumpType, double> ShipJumpNavigation::GetCheapestJumpType(const System *fro
 {
 	if(!from || !to)
 		return make_pair(JumpType::NONE, 0.);
-	bool linked = from->Links().count(to);
+	bool linked = from->Links().contains(to);
 	double hyperFuelNeeded = HyperdriveFuel();
 	// If these two systems are linked, or if the system we're jumping from has its own jump range,
 	// then use the cheapest jump drive available, which is mapped to a distance of 0.
@@ -160,7 +160,7 @@ bool ShipJumpNavigation::CanJump(const System *from, const System *to) const
 	if(!from || !to)
 		return false;
 
-	if(from->Links().count(to) && (hasHyperdrive || hasJumpDrive))
+	if(from->Links().contains(to) && (hasHyperdrive || hasJumpDrive))
 		return true;
 
 	if(!hasJumpDrive)

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -163,7 +163,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 
 	if(selectedShip)
 	{
-		shipInfo.Update(*selectedShip, player, collapsed.count(DESCRIPTION), true);
+		shipInfo.Update(*selectedShip, player, collapsed.contains(DESCRIPTION), true);
 		selectedItem = selectedShip->DisplayModelName();
 
 		const Point spriteCenter(center.X(), center.Y() + 20 + TileSize() / 2);
@@ -186,8 +186,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 
 		if(hasDescription)
 		{
-			// Maintenance note: This can be replaced with collapsed.contains() in C++20
-			if(!collapsed.count(DESCRIPTION))
+			if(!collapsed.contains(DESCRIPTION))
 			{
 				descriptionOffset = shipInfo.DescriptionHeight();
 				shipInfo.DrawDescription(startPoint);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -410,7 +410,7 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				if(CanShowInSidebar(*ship, here))
 					playerShips.insert(ship);
 
-			if(!playerShips.count(playerShip))
+			if(!playerShips.contains(playerShip))
 				playerShip = playerShips.empty() ? nullptr : *playerShips.begin();
 		}
 		else
@@ -424,7 +424,7 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				if(CanShowInSidebar(*ship, here))
 					playerShips.insert(ship);
 
-			if(!playerShips.count(playerShip))
+			if(!playerShips.contains(playerShip))
 				playerShip = playerShips.empty() ? nullptr : *playerShips.begin();
 		}
 	}
@@ -746,7 +746,7 @@ void ShopPanel::DrawShipsSidebar()
 			point.Y() += ICON_TILE;
 		}
 
-		bool isSelected = playerShips.count(ship.get());
+		bool isSelected = playerShips.contains(ship.get());
 		const Sprite *background = SpriteSet::Get(isSelected ? "ui/icon selected" : "ui/icon unselected");
 		SpriteShader::Draw(background, point);
 		// If this is one of the selected ships, check if the currently hovered
@@ -998,7 +998,7 @@ void ShopPanel::DrawMain()
 		point.Y() += bigFont.Height() + 20;
 		nextY += bigFont.Height() + 20;
 
-		bool isCollapsed = collapsed.count(category);
+		bool isCollapsed = collapsed.contains(category);
 		bool isEmpty = true;
 		for(const string &name : it->second)
 		{
@@ -1059,7 +1059,7 @@ void ShopPanel::DrawMain()
 
 int ShopPanel::DrawPlayerShipInfo(const Point &point)
 {
-	shipInfo.Update(*playerShip, player, collapsed.count("description"), true);
+	shipInfo.Update(*playerShip, player, collapsed.contains("description"), true);
 	shipInfo.DrawAttributes(point, !isOutfitter);
 	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
 	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
@@ -1185,7 +1185,7 @@ void ShopPanel::SideSelect(Ship *ship)
 	}
 	else if(!control)
 		playerShips.clear();
-	else if(playerShips.count(ship))
+	else if(playerShips.contains(ship))
 	{
 		playerShips.erase(ship);
 		if(playerShip == ship)

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -127,8 +127,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 		bool removeAll = (remove && !hasValue && !(key == "object" && child.HasChildren()));
 		// If this is the first entry for the given key, and we are not in "add"
 		// or "remove" mode, its previous value should be cleared.
-		bool overwriteAll = (!add && !remove && shouldOverwrite.count(key));
-		overwriteAll |= (!add && !remove && key == "minables" && shouldOverwrite.count("asteroids"));
+		bool overwriteAll = (!add && !remove && shouldOverwrite.contains(key));
+		overwriteAll |= (!add && !remove && key == "minables" && shouldOverwrite.contains("asteroids"));
 		// Clear the data of the given type.
 		if(removeAll || overwriteAll)
 		{

--- a/source/TextReplacements.cpp
+++ b/source/TextReplacements.cpp
@@ -57,7 +57,7 @@ void TextReplacements::Load(const DataNode &node)
 			key += ">";
 			child.PrintTrace("Warning: text replacements must be suffixed by \">\":");
 		}
-		if(reserved.count(key))
+		if(reserved.contains(key))
 		{
 			child.PrintTrace("Skipping reserved substitution key:");
 			continue;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -200,7 +200,7 @@ void UniverseObjects::CheckReferences()
 	// Class objects with a deferred definition should still get named when content is loaded.
 	auto NameIfDeferred = [](const set<string> &deferred, auto &it)
 	{
-		if(deferred.count(it.first))
+		if(deferred.contains(it.first))
 			it.second.SetName(it.first);
 		else
 			return false;
@@ -246,7 +246,7 @@ void UniverseObjects::CheckReferences()
 		// Plugins may alter stock fleets with new variants that exclusively use plugin ships.
 		// Rather than disable the whole fleet due to these non-instantiable variants, remove them.
 		it.second.RemoveInvalidVariants();
-		if(!it.second.IsValid() && !deferred["fleet"].count(it.first))
+		if(!it.second.IsValid() && !deferred["fleet"].contains(it.first))
 			Warn("fleet", it.first);
 	}
 	// Government names are used in mission NPC blocks and LocationFilters.
@@ -271,7 +271,7 @@ void UniverseObjects::CheckReferences()
 			NameAndWarn("outfit", it);
 	// Outfitters are never serialized.
 	for(const auto &it : outfitSales)
-		if(it.second.empty() && !deferred["outfitter"].count(it.first))
+		if(it.second.empty() && !deferred["outfitter"].contains(it.first))
 			Logger::LogError("Warning: outfitter \"" + it.first + "\" is referred to, but has no outfits.");
 	// Phrases are never serialized.
 	for(const auto &it : phrases)
@@ -290,7 +290,7 @@ void UniverseObjects::CheckReferences()
 		}
 	// Shipyards are never serialized.
 	for(const auto &it : shipSales)
-		if(it.second.empty() && !deferred["shipyard"].count(it.first))
+		if(it.second.empty() && !deferred["shipyard"].contains(it.first))
 			Logger::LogError("Warning: shipyard \"" + it.first + "\" is referred to, but has no ships.");
 	// System names are used by a number of classes.
 	for(auto &&it : systems)
@@ -475,7 +475,7 @@ void UniverseObjects::LoadFile(const string &path, bool debugMode)
 		{
 			static const set<string> canDisable = {"mission", "event", "person"};
 			const string &category = node.Token(1);
-			if(canDisable.count(category))
+			if(canDisable.contains(category))
 			{
 				if(node.HasChildren())
 					for(const DataNode &child : node)

--- a/source/pi.h
+++ b/source/pi.h
@@ -20,7 +20,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 
-// Constants to replace M_PI (which is not available on all operating systems).
 constexpr double PI = std::numbers::pi;
 constexpr double TO_RAD = PI / 180.;
 constexpr double TO_DEG = 180. / PI;

--- a/source/pi.h
+++ b/source/pi.h
@@ -16,10 +16,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef PI_H_
 #define PI_H_
 
+#include <numbers>
+
 
 
 // Constants to replace M_PI (which is not available on all operating systems).
-constexpr double PI = 3.14159265358979323846;
+constexpr double PI = std::numbers::pi;
 constexpr double TO_RAD = PI / 180.;
 constexpr double TO_DEG = 180. / PI;
 

--- a/source/test/Test.cpp
+++ b/source/test/Test.cpp
@@ -445,7 +445,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 				// If we encounter a branch entry twice, then resume the gameloop before the second encounter.
 				// Encountering branch entries twice typically only happen in "wait loops" and we should give
 				// the game cycles to proceed if we are in a wait loop for something that happens over time.
-				if(context.branchesSinceGameStep.count(context.callstack.back()))
+				if(context.branchesSinceGameStep.contains(context.callstack.back()))
 				{
 					continueGameLoop = true;
 					break;

--- a/source/text/FontSet.cpp
+++ b/source/text/FontSet.cpp
@@ -29,7 +29,7 @@ namespace {
 
 void FontSet::Add(const string &path, int size)
 {
-	if(!fonts.count(size))
+	if(!fonts.contains(size))
 		fonts[size].Load(path);
 }
 

--- a/tests/unit/include/es-test.hpp
+++ b/tests/unit/include/es-test.hpp
@@ -22,8 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // We require SEH for Windows builds, so we test with SEH support too.
 #define CATCH_CONFIG_WINDOWS_SEH
 // Check for memory leaks from test code.
-// TODO: enable after patching upstream issue
-// #define CATCH_CONFIG_WINDOWS_CRTDBG
+#define CATCH_CONFIG_WINDOWS_CRTDBG
 #endif
 
 #include <catch2/catch_all.hpp>

--- a/tests/unit/src/test_datafile.cpp
+++ b/tests/unit/src/test_datafile.cpp
@@ -89,7 +89,7 @@ node2 hi
 			std::set<std::string> children{"foo", "something"};
 			for(const auto &parent : root)
 				for(const auto &child : parent)
-					REQUIRE(children.count(child.Token(0)));
+					REQUIRE(children.contains(child.Token(0)));
 		}
 		AND_THEN( "iterating child nodes visits their child nodes" ) {
 			for(const auto &parent : root)


### PR DESCRIPTION
**Refactor**

This PR contains various single-line refactors making use of C++20 features.

## Summary
- Replaces various `count()` calls with `contains()`, which expresses the intent better and has better performance on vectors.
- Refactors `Engine::Prune` to use `std::erase_if`
- Uses the standard pi value in pi.h
- Re-enables a previously disabled Catch option on windows

## Testing Done
It compiles and appears to behave as before.

## Performance Impact
Should be marginally faster, though it's likely insignificant.