### PR TITLE
feat(mechanics): Submunition spawning attributes

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -935,6 +935,7 @@ outfit "Firelight Missile Bank"
 		ammo "Firelight Missile"
 		icon "icon/firelight"
 		"hit effect" "firelight ring" 20
+		"die effect" "piercer fire"
 		"velocity" 4
 		"velocity override" 16
 		"lifetime" 10

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -116,22 +116,22 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 {
 	if(--lifetime <= 0)
 	{
-		if(lifetime > -100)
+		if(lifetime > -1000)
 		{
-			// This projectile died a "natural" death. Create any death effects
-			// and submunitions.
+			// This projectile didn't collide with anything. Create any death effects.
 			for(const auto &it : weapon->DieEffects())
 				for(int i = 0; i < it.second; ++i)
 					visuals.emplace_back(*it.first, position, velocity, angle);
 
 			for(const auto &it : weapon->Submunitions())
-				for(size_t i = 0; i < it.count; ++i)
-				{
-					const Weapon *const subWeapon = it.weapon;
-					Angle inaccuracy = Distribution::GenerateInaccuracy(subWeapon->Inaccuracy(),
-							subWeapon->InaccuracyDistribution());
-					projectiles.emplace_back(*this, it.offset, it.facing + inaccuracy, subWeapon);
-				}
+				if(lifetime > -100 ? it.spawnOnNaturalDeath : it.spawnOnAntiMissileDeath)
+					for(size_t i = 0; i < it.count; ++i)
+					{
+						const Weapon *const subWeapon = it.weapon;
+						Angle inaccuracy = Distribution::GenerateInaccuracy(subWeapon->Inaccuracy(),
+								subWeapon->InaccuracyDistribution());
+						projectiles.emplace_back(*this, it.offset, it.facing + inaccuracy, subWeapon);
+					}
 		}
 		MarkForRemoval();
 		return;
@@ -301,7 +301,7 @@ void Projectile::Explode(vector<Visual> &visuals, double intersection, Point hit
 	if(--hitsRemaining == 0)
 	{
 		clip = intersection;
-		lifetime = -100;
+		lifetime = -1000;
 	}
 }
 
@@ -326,7 +326,7 @@ bool Projectile::IsDead() const
 // This projectile was killed, e.g. by an anti-missile system.
 void Projectile::Kill()
 {
-	lifetime = 0;
+	lifetime = -100;
 }
 
 

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -118,7 +118,7 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 	{
 		if(lifetime > -1000)
 		{
-			// This projectile didn't collide with anything. Create any death effects.
+			// This projectile didn't die in a collision. Create any death effects.
 			for(const auto &it : weapon->DieEffects())
 				for(int i = 0; i < it.second; ++i)
 					visuals.emplace_back(*it.first, position, velocity, angle);

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -126,6 +126,8 @@ private:
 	// relative to the firing ship.
 	Point dV;
 	double clip = 1.;
+	// A positive value means the projectile is alive, -100 means it was killed
+	// by an anti-missile system, and -1000 means it exploded in a collision.
 	int lifetime = 0;
 	double distanceTraveled = 0.;
 	uint16_t hitsRemaining = 1U;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -123,12 +123,16 @@ void Weapon::LoadWeapon(const DataNode &node)
 					submunitions.back().facing = Angle(grand.Value(1));
 				else if((grand.Size() >= 3) && (grand.Token(0) == "offset"))
 					submunitions.back().offset = Point(grand.Value(1), grand.Value(2));
-				else if(grand.Size() >= 3 && grand.Token(0) == "spawn on")
+				else if(grand.Size() >= 2 && grand.Token(0) == "spawn on")
 				{
-					if(grand.Token(1) == "natural")
-						submunitions.back().spawnOnNaturalDeath = grand.Value(2) > 0;
-					else if(grand.Token(1) == "anti-missile")
-						submunitions.back().spawnOnAntiMissileDeath = grand.Value(2) > 0;
+					submunitions.back().spawnOnNaturalDeath = false;
+					for(int j = 1; j < grand.Size(); ++j)
+					{
+						if(grand.Token(j) == "natural")
+							submunitions.back().spawnOnNaturalDeath = true;
+						else if(grand.Token(j) == "anti-missile")
+							submunitions.back().spawnOnAntiMissileDeath = true;
+					}
 				}
 				else
 					child.PrintTrace("Skipping unknown or incomplete submunition attribute:");

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -123,10 +123,13 @@ void Weapon::LoadWeapon(const DataNode &node)
 					submunitions.back().facing = Angle(grand.Value(1));
 				else if((grand.Size() >= 3) && (grand.Token(0) == "offset"))
 					submunitions.back().offset = Point(grand.Value(1), grand.Value(2));
-				else if(grand.Size() >= 2 && grand.Token(0) == "spawns on natural death" && grand.Value(1) <= 0)
-					submunitions.back().spawnOnNaturalDeath = false;
-				else if(grand.Size() >= 2 && grand.Token(0) == "spawns on anti-missile death" && grand.Value(1) > 0)
-					submunitions.back().spawnOnAntiMissileDeath = true;
+				else if(grand.Size() >= 3 && grand.Token(0) == "spawn on")
+				{
+					if(grand.Token(1) == "natural")
+						submunitions.back().spawnOnNaturalDeath = grand.Value(2) > 0;
+					else if(grand.Token(1) == "anti-missile")
+						submunitions.back().spawnOnAntiMissileDeath = grand.Value(2) > 0;
+				}
 				else
 					child.PrintTrace("Skipping unknown or incomplete submunition attribute:");
 			}

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -123,6 +123,10 @@ void Weapon::LoadWeapon(const DataNode &node)
 					submunitions.back().facing = Angle(grand.Value(1));
 				else if((grand.Size() >= 3) && (grand.Token(0) == "offset"))
 					submunitions.back().offset = Point(grand.Value(1), grand.Value(2));
+				else if(grand.Size() >= 2 && grand.Token(0) == "spawns on natural death" && grand.Value(1) <= 0)
+					submunitions.back().spawnOnNaturalDeath = false;
+				else if(grand.Size() >= 2 && grand.Token(0) == "spawns on anti-missile death" && grand.Value(1) > 0)
+					submunitions.back().spawnOnAntiMissileDeath = true;
 				else
 					child.PrintTrace("Skipping unknown or incomplete submunition attribute:");
 			}

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -52,6 +52,9 @@ public:
 		Angle facing;
 		// The base offset from the source projectile's position, relative to its current facing.
 		Point offset;
+
+		bool spawnOnNaturalDeath = true;
+		bool spawnOnAntiMissileDeath = false;
 	};
 
 


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #10370.

## Summary
Adds a new submunition attribute, "spawn on". It accepts a list of attributes and overrides the default behavior, which is to spawn only on natural death (without this PR, submunitions are spawned also if the source missile was killed by AM).

## Usage Examples
If you want to spawn the submunition only if the source missile was shot down by AM, you can do this:
```html
submunition <name>
	"spawn on" anti-missile
```
If you want both:
```html
submunition <name>
	"spawn on" natural anti-missile
```

## Testing Done
Fiddled a bit with submunitions of the Firelight.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/40

## Performance Impact
minimal, if any
