### PR TITLE
feat(content): Cut Pers spawn rate by half

### DIFF
--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -26,7 +26,7 @@ gamerules
 	# An attempt to spawn a person ship happens on average every this many frames.
 	# DEFAULT: 36000 frames (ten minutes)
 	# ALLOWABLE VALUES: any integer >= 1
-	"person spawn period" 36000
+	"person spawn period" 72000
 	
 	# While an attempt to spawn a person ship is made on average every number of frames specified
 	# above, a person ship may still not spawn. Each person ship has a "weight" associated with them


### PR DESCRIPTION
**Content**

## Summary
A few times in the past I talked about lowering the spawn rates of person ships. Currently, they show up around the 10 minute mark, sometimes varied depending on the location of the map. For general ships, it is around there, and for some pers ships that only spawn in specific areas, those can appear faster. A good chunk of players note in their experiences that pers ships spawn pretty commonly in their gameplay, and often either A. Scan them (and then fine them if it applies), B. Destroy their targets (sometimes undesirably), and C. Mine a bunch of asteroids (and sometimes steal flotsam).

Person ships are a call-back to the same mechanic from the EV games where these ships are supposed to be generally rare but interesting sights and interactions outside of the normal gameplay loop. In EV, however, persons were much more rare than in ES, taking sometimes upwards of an hour or more to spawn. With the combined impact of more new person ships in the last year or so, their gameplay (sometimes negative) interactions, and the purpose of rarity, I've cut the spawn rate in half (increased the frequency from 36000 to 72000).

Although it can be said that there are times that pers ships save the player as well, that can also be considered as a rarity. More often that not are the other cases above, so this being more rare seems fine and more impactful in a way.
