### PR TITLE
feat(persons): Add formation patterns for Persons (Person ships)

### DIFF
--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Person.h"
 
 #include "DataNode.h"
+#include "FormationPattern.h"
 #include "GameData.h"
 #include "Government.h"
 #include "Ship.h"
@@ -33,6 +34,8 @@ void Person::Load(const DataNode &node)
 			location.Load(child);
 		else if(child.Token(0) == "frequency" && child.Size() >= 2)
 			frequency = child.Value(1);
+		else if(child.Token(0) == "formation" && child.Size() >= 2)
+			formationPattern = GameData::Formations().Get(child.Token(1));
 		else if(child.Token(0) == "ship" && child.Size() >= 2)
 		{
 			// Name ships that are not the flagship with the name provided, if any.
@@ -59,7 +62,11 @@ void Person::Load(const DataNode &node)
 void Person::FinishLoading()
 {
 	for(const shared_ptr<Ship> &ship : ships)
+	{
 		ship->FinishLoading(true);
+		if(formationPattern)
+			ship->SetFormationPattern(formationPattern);
+	}
 }
 
 

--- a/source/Person.h
+++ b/source/Person.h
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 
 class DataNode;
+class FormationPattern;
 class Government;
 class Ship;
 class System;
@@ -65,6 +66,7 @@ private:
 	int frequency = 100;
 
 	std::list<std::shared_ptr<Ship>> ships;
+	const FormationPattern *formationPattern = nullptr;
 	const Government *government = nullptr;
 	Personality personality;
 	Phrase hail;


### PR DESCRIPTION
This PR adds a feature for person ships as discussed in PR #10374

## Summary
This PR adds support for formations around person-ships.

NPC ships typically seem to be too busy planning their next action (landing or jumping) which results in fleets immediately going for landing or jumping, and as a result having the formations not appearing. Fixing those is part of other PRs, this PR is only for adding formations for person-ships.

## Screenshots
See #10374 for an example of a person-ship with a formation around it.

## Usage examples
```
person "Some Person"
	formation "Some Formation"
```

## Testing Done
I've seen a formation briefly appear for ships in #10378 (when they were not busy jumping or landing).

## Save File
N/A. But can be tested in combination with PR #10374.

## Wiki Update
Let's update the wiki when the other formation issues (of NPCs being too busy to form formations) are also fixed. We don't want people to try them today and get stuck.

## Performance Impact
None expected; formations are already supported on ships, it's just that they now also can be loaded on person ships.