### PR TITLE
fix/refactor/enhancement: Wrap text inside tables

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -370,6 +370,8 @@ target_sources(EndlessSkyLib PRIVATE
 	test/TestData.h
 	text/DisplayText.cpp
 	text/DisplayText.h
+	text/FlexTable.cpp
+	text/FlexTable.h
 	text/Font.cpp
 	text/Font.h
 	text/FontSet.cpp

--- a/source/ItemInfoDisplay.h
+++ b/source/ItemInfoDisplay.h
@@ -16,12 +16,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "Point.h"
+#include "text/FlexTable.h"
 #include "text/WrappedText.h"
 
 #include <string>
 #include <vector>
-
-class Table;
 
 
 
@@ -35,38 +34,34 @@ public:
 
 	// Get the panel width.
 	static int PanelWidth();
-	// Get the height of each of the panels.
-	int MaximumHeight() const;
-	int DescriptionHeight() const;
-	int AttributesHeight() const;
+	virtual int AttributesHeight() const;
+
+	bool HasDescription() const;
 
 	// Draw each of the panels.
-	void DrawDescription(const Point &topLeft) const;
-	virtual void DrawAttributes(const Point &topLeft) const;
+	Point DrawDescription(const Point &topLeft) const;
+	virtual Point DrawAttributes(const Point &topLeft) const;
 	void DrawTooltips() const;
 
 	// Update the location where the mouse is hovering.
 	void Hover(const Point &point);
 	void ClearHover();
 
+	static FlexTable CreateTable(const std::vector<std::string> &labels, const std::vector<std::string> &values);
+
 
 protected:
 	void UpdateDescription(const std::string &text, const std::vector<std::string> &licenses, bool isShip);
-	Point Draw(Point point, const std::vector<std::string> &labels, const std::vector<std::string> &values) const;
-	void CheckHover(const Table &table, const std::string &label) const;
+	Point Draw(FlexTable &table, Point drawPoint, int labelIndex = 0) const;
+	void CheckHover(FlexTable &table, Point drawPoint, int labelIndex = 0) const;
 
 
 protected:
 	static const int WIDTH = 250;
 
 	WrappedText description;
-	int descriptionHeight = 0;
 
-	std::vector<std::string> attributeLabels;
-	std::vector<std::string> attributeValues;
-	int attributesHeight = 0;
-
-	int maximumHeight = 0;
+	mutable FlexTable attributes{WIDTH - 20, 2};
 
 	// For tooltips:
 	Point hoverPoint;

--- a/source/ItemInfoDisplay.h
+++ b/source/ItemInfoDisplay.h
@@ -15,8 +15,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "Point.h"
 #include "text/FlexTable.h"
+#include "Point.h"
 #include "text/WrappedText.h"
 
 #include <string>

--- a/source/OutfitInfoDisplay.h
+++ b/source/OutfitInfoDisplay.h
@@ -40,25 +40,24 @@ public:
 
 	// Provided by ItemInfoDisplay:
 	// int PanelWidth();
-	// int MaximumHeight() const;
-	// int DescriptionHeight() const;
-	// int AttributesHeight() const;
-	int RequirementsHeight() const;
+	virtual int AttributesHeight() const override;
 
 	// Provided by ItemInfoDisplay:
-	// void DrawDescription(const Point &topLeft) const;
-	// void DrawAttributes(const Point &topLeft) const;
-	void DrawRequirements(const Point &topLeft) const;
+	// Point DrawDescription(const Point &topLeft) const;
+	virtual Point DrawAttributes(const Point &topLeft) const override;
+	Point DrawRequirements(const Point &topLeft) const;
 
 
 private:
 	void UpdateRequirements(const Outfit &outfit, const PlayerInfo &player, bool canSell, bool descriptionCollapsed);
-	void AddRequirementAttribute(std::string label, double value);
 	void UpdateAttributes(const Outfit &outfit);
 
 
 private:
-	std::vector<std::string> requirementLabels;
-	std::vector<std::string> requirementValues;
-	int requirementsHeight = 0;
+	static void AddRequirementAttribute(const std::string &label, double value, std::vector<std::string> &labels,
+			std::vector<std::string> &values);
+
+
+private:
+	mutable FlexTable requirements{WIDTH, 2};
 };

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -270,17 +270,14 @@ double OutfitterPanel::DrawDetails(const Point &center)
 		if(thumbnail)
 			SpriteShader::Draw(thumbnail, thumbnailCenter);
 
-		const bool hasDescription = outfitInfo.DescriptionHeight();
+		const bool hasDescription = outfitInfo.HasDescription();
 
 		double descriptionOffset = hasDescription ? 40. : 0.;
 
 		if(hasDescription)
 		{
 			if(!collapsed.contains(DESCRIPTION))
-			{
-				descriptionOffset = outfitInfo.DescriptionHeight();
-				outfitInfo.DrawDescription(startPoint);
-			}
+				descriptionOffset = outfitInfo.DrawDescription(startPoint).Y() - startPoint.Y();
 			else
 			{
 				const Color &dim = *GameData::Colors().Get("medium");
@@ -298,11 +295,10 @@ double OutfitterPanel::DrawDetails(const Point &center)
 		}
 
 		const Point requirementsPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
-		const Point attributesPoint(startPoint.X(), requirementsPoint.Y() + outfitInfo.RequirementsHeight());
-		outfitInfo.DrawRequirements(requirementsPoint);
-		outfitInfo.DrawAttributes(attributesPoint);
+		const Point attributesPoint = outfitInfo.DrawRequirements(requirementsPoint);
+		const Point attributesEnd = outfitInfo.DrawAttributes(attributesPoint);
 
-		heightOffset = attributesPoint.Y() + outfitInfo.AttributesHeight();
+		heightOffset = startPoint.Y() - attributesEnd.Y();
 	}
 
 	// Draw this string representing the selected item (if any), centered in the details side panel

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -676,9 +676,8 @@ void PlayerInfoPanel::DrawPlayer(const Rectangle &bounds)
 	if(removedCount)
 	{
 		// DrawList needs to draw at least one row, so make it draw the last row that was in the table.
-		table.PopRow(1);
-		licenses[0] = licenses[licenses.size() - removedCount - 2];
-		licenses.resize(removedCount);
+		table.PopRow();
+		licenses.resize(removedCount + 1);
 		DrawList(licenses, table, "", 1, false);
 	}
 

--- a/source/PlayerInfoPanel.h
+++ b/source/PlayerInfoPanel.h
@@ -80,6 +80,7 @@ private:
 		InfoPanelState::ShipComparator *shipSort = nullptr;
 	};
 
+
 private:
 	PlayerInfo &player;
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -334,7 +334,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	double hullHeat = (hasHullRepair) ? (attributes.Get("hull heat")
 		+ attributes.Get("delayed hull heat"))
 		* (1. + attributes.Get("hull heat multiplier")) : 0.;
-	auto shieldText = (shieldEnergy && hullEnergy) ? "shields / hull:" : hullEnergy ? "repairing hull:" : "charging shields:";
+	auto shieldText = (shieldEnergy && hullEnergy) ? "shields / hull:" : hullEnergy ?
+			"repairing hull:" : "charging shields:";
 	energyHeatTable.FillRow({{shieldText, dim}, {Format::Number(-60. * (shieldEnergy + hullEnergy)), bright},
 			{Format::Number(60. * (shieldHeat + hullHeat)), bright}});
 

--- a/source/ShipInfoDisplay.h
+++ b/source/ShipInfoDisplay.h
@@ -42,37 +42,25 @@ public:
 
 	// Provided by ItemInfoDisplay:
 	// int PanelWidth();
-	// int MaximumHeight() const;
-	// int DescriptionHeight() const;
-	// int AttributesHeight() const;
-	int GetAttributesHeight(bool sale) const;
-	int OutfitsHeight() const;
+	virtual int AttributesHeight() const override;
+	virtual int AttributesHeight(bool sale) const;
 
 	// Provided by ItemInfoDisplay:
-	// void DrawDescription(const Point &topLeft) const;
-	virtual void DrawAttributes(const Point &topLeft) const override;
-	virtual void DrawAttributes(const Point &topLeft, const bool sale) const;
-	void DrawOutfits(const Point &topLeft) const;
+	// Point DrawDescription(const Point &topLeft) const;
+	virtual Point DrawAttributes(const Point &topLeft) const override;
+	virtual Point DrawAttributes(const Point &topLeft, const bool sale) const;
+	Point DrawOutfits(const Point &topLeft) const;
 
 
 private:
 	void UpdateAttributes(const Ship &ship, const PlayerInfo &player, bool descriptionCollapsed, bool scrollingPanel);
 	void UpdateOutfits(const Ship &ship, const PlayerInfo &player, const Depreciation &depreciation);
+	void ResetEnergyHeatTable();
 
 
 private:
-	std::vector<std::string> attributeHeaderLabels;
-	std::vector<std::string> attributeHeaderValues;
-
-	std::vector<std::string> tableLabels;
-	std::vector<std::string> energyTable;
-	std::vector<std::string> heatTable;
-
-	std::vector<std::string> outfitLabels;
-	std::vector<std::string> outfitValues;
-	int outfitsHeight = 0;
-
-	std::vector<std::string> saleLabels;
-	std::vector<std::string> saleValues;
-	int saleHeight = 0;
+	mutable FlexTable attributeHeader;
+	mutable FlexTable energyHeatTable;
+	mutable FlexTable outfits;
+	mutable FlexTable sales;
 };

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -180,7 +180,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 			SpriteShader::Draw(shipSprite, spriteCenter, spriteScale, swizzle);
 		}
 
-		const bool hasDescription = shipInfo.DescriptionHeight();
+		const bool hasDescription = shipInfo.HasDescription();
 
 		double descriptionOffset = hasDescription ? 40. : 0.;
 
@@ -188,8 +188,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 		{
 			if(!collapsed.contains(DESCRIPTION))
 			{
-				descriptionOffset = shipInfo.DescriptionHeight();
-				shipInfo.DrawDescription(startPoint);
+				descriptionOffset = shipInfo.DrawDescription(startPoint).Y() - startPoint.Y();
 			}
 			else
 			{
@@ -208,11 +207,11 @@ double ShipyardPanel::DrawDetails(const Point &center)
 		}
 
 		const Point attributesPoint(startPoint.X(), startPoint.Y() + descriptionOffset);
-		const Point outfitsPoint(startPoint.X(), attributesPoint.Y() + shipInfo.AttributesHeight());
-		shipInfo.DrawAttributes(attributesPoint);
-		shipInfo.DrawOutfits(outfitsPoint);
+		Point outfitsPoint = shipInfo.DrawAttributes(attributesPoint);
+		outfitsPoint.Y() += 10.;
+		const Point end = shipInfo.DrawOutfits(outfitsPoint);
 
-		heightOffset = outfitsPoint.Y() + shipInfo.OutfitsHeight();
+		heightOffset = end.Y();
 	}
 
 	// Draw this string representing the selected ship (if any), centered in the details side panel

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -1060,11 +1060,11 @@ void ShopPanel::DrawMain()
 int ShopPanel::DrawPlayerShipInfo(const Point &point)
 {
 	shipInfo.Update(*playerShip, player, collapsed.contains("description"), true);
-	shipInfo.DrawAttributes(point, !isOutfitter);
-	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
-	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));
+	Point outfitPoint = shipInfo.DrawAttributes(point, !isOutfitter);
+	outfitPoint.Y() += 10.;
+	Point end = shipInfo.DrawOutfits(outfitPoint);
 
-	return attributesHeight + shipInfo.OutfitsHeight();
+	return end.Y() - point.Y();
 }
 
 

--- a/source/text/FlexTable.cpp
+++ b/source/text/FlexTable.cpp
@@ -23,10 +23,10 @@ using namespace std;
 
 
 
-FlexTable::Cell::Cell(FlexTable::Column *column, const string &text) : column(column), wrapWidth(column->table->AverageColumnWidth()),
-		highlightColor(GameData::Colors().Get("faint")), underlineColor(GameData::Colors().Get("medium")),
-		textColor(GameData::Colors().Get("medium")), highlightedTextColor(nullptr),
-		font(&FontSet::Get(14))
+FlexTable::Cell::Cell(FlexTable::Column *column, const string &text) : column(column),
+		wrapWidth(column->table->AverageColumnWidth()), highlightColor(GameData::Colors().Get("faint")),
+		underlineColor(GameData::Colors().Get("medium")), textColor(GameData::Colors().Get("medium")),
+		highlightedTextColor(nullptr), font(&FontSet::Get(14))
 {
 	SetText(text);
 }
@@ -413,8 +413,8 @@ FlexTable::FlexTable(int width, int columns) : width(width), columns(columns, Co
 
 
 
-FlexTable::FlexTable(const FlexTable &other) noexcept : width(other.width), rowSpacing(other.rowSpacing), columnSpacing(other.columnSpacing),
-	flexStrategy(other.flexStrategy), rowCount(other.rowCount)
+FlexTable::FlexTable(const FlexTable &other) noexcept : width(other.width), rowSpacing(other.rowSpacing),
+	columnSpacing(other.columnSpacing), flexStrategy(other.flexStrategy), rowCount(other.rowCount)
 {
 	columns = other.columns;
 
@@ -601,7 +601,8 @@ FlexTable::Cell &FlexTable::GetCell(int row, int column)
 
 
 
-// Fills a row with individual cells. Any extra arguments are discarded, and missing ones are substituted with empty cells.
+// Fills a row with individual cells. Any extra arguments are discarded,
+// and missing ones are substituted with empty cells.
 // Returns a pointer to the first cell in the row, or nullptr if there are no columns in the table.
 FlexTable::Cell *FlexTable::FillRow(const std::initializer_list<std::string> &cellTexts)
 {
@@ -868,7 +869,7 @@ void FlexTable::UpdateLayout()
 		return;
 	}
 
-	//Otherwise, perform all column flexing operations.
+	// Otherwise, perform all column flexing operations.
 
 	// Calculate the size of each column.
 	// Since some columns might be smaller than the initially used average width,

--- a/source/text/FlexTable.cpp
+++ b/source/text/FlexTable.cpp
@@ -749,7 +749,8 @@ Point FlexTable::Draw(const Point &position)
 	Point rowBegin = position;
 	for(int row = 0; row < Rows(); ++row)
 	{
-		int rowHeight = max_element(columns.begin(), columns.end(), [&](const auto &c1, const auto &c2){
+		int rowHeight = max_element(columns.begin(), columns.end(), [&](const auto &c1, const auto &c2)
+		{
 			return c1.Row(row).Height() < c2.Row(row).Height();
 		})->Row(row).Height();
 		Point cellBegin{rowBegin};

--- a/source/text/FlexTable.cpp
+++ b/source/text/FlexTable.cpp
@@ -1,0 +1,1019 @@
+/* FlexTable.cpp
+Copyright (c) 2024 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "FlexTable.h"
+
+#include "../FillShader.h"
+#include "Font.h"
+#include "../GameData.h"
+
+using namespace std;
+
+
+
+FlexTable::Cell::Cell(FlexTable::Column *column, const string &text) : column(column), wrapWidth(column->table->AverageColumnWidth()),
+		highlightColor(GameData::Colors().Get("faint")), underlineColor(GameData::Colors().Get("medium")),
+		textColor(GameData::Colors().Get("medium")), highlightedTextColor(nullptr),
+		font(&FontSet::Get(14))
+{
+	SetText(text);
+}
+
+
+
+void FlexTable::Cell::SetText(const string &input)
+{
+	text.assign(input);
+	column->table->Invalidate();
+}
+
+
+
+const std::string &FlexTable::Cell::Text() const
+{
+	return text;
+}
+
+
+
+// The minimum width of the cell, based on the previous wrap width.
+// This is not an absolute minimum; rather, it indicates how much of the previously configured space is actually used.
+int FlexTable::Cell::MinWidth() const
+{
+	if(SpansRow())
+		return column->table->width;
+	return wrappedText.LongestLineWidth() ? wrappedText.LongestLineWidth() - 2 : 0.;
+}
+
+
+
+// The width and height of the cell, including padding.
+int FlexTable::Cell::Width() const
+{
+	return wrapWidth;
+}
+
+
+
+int FlexTable::Cell::Height() const
+{
+	if(text.empty())
+		return topGap + bottomGap;
+	return wrappedText.Height() + topGap + bottomGap;
+}
+
+
+
+// Set the font. Default is the size 14 font.
+void FlexTable::Cell::SetFont(const Font *font)
+{
+	this->font = font;
+	column->table->Invalidate();
+}
+
+
+
+const Font *FlexTable::Cell::GetFont() const
+{
+	return font;
+}
+
+
+
+// Extra height reserved at the top or bottom of the cell.
+// Gaps are synchronized between all cells in a row.
+void FlexTable::Cell::SetTopGap(int gap)
+{
+	int row = GetRow();
+	for(auto &column : column->table->columns)
+		column.Row(row).topGap = gap;
+}
+
+
+
+void FlexTable::Cell::SetBottomGap(int gap)
+{
+	int row = GetRow();
+	for(auto &column : column->table->columns)
+		column.Row(row).bottomGap = gap;
+}
+
+
+
+int FlexTable::Cell::GetTopGap() const
+{
+	return topGap;
+}
+
+
+
+int FlexTable::Cell::GetBottomGap() const
+{
+	return bottomGap;
+}
+
+
+
+// Configures cell decorations. These affect the entire cell, not just the space occupied by text.
+void FlexTable::Cell::SetHighlight(bool highlight)
+{
+	this->highlight = highlight;
+}
+
+
+
+void FlexTable::Cell::SetUnderline(bool underline)
+{
+	this->underline = underline;
+}
+
+
+
+void FlexTable::Cell::SetTextColor(const Color &textColor)
+{
+	this->textColor = &textColor;
+}
+
+
+
+// Sets the colors for highlights.
+// Setting highlight or underline-related colors automatically enables highlighting/underlining.
+void FlexTable::Cell::SetHighlightedTextColor(const Color &textColor)
+{
+	this->highlightedTextColor = &textColor;
+	SetHighlight();
+}
+
+
+
+void FlexTable::Cell::SetHighlightColor(const Color &highlightColor)
+{
+	this->highlightColor = &highlightColor;
+	SetHighlight();
+}
+
+
+
+void FlexTable::Cell::SetUnderlineColor(const Color &underlineColor)
+{
+	this->underlineColor = &underlineColor;
+	SetUnderline();
+}
+
+
+
+int FlexTable::Cell::GetRow() const
+{
+	for(size_t i = 0; i < column->cells.size(); i++)
+		if(&(column->cells[i]) == this)
+			return i;
+	return -1;
+}
+
+
+
+// Makes the cell span the entire row. This should only be called within the first column.
+void FlexTable::Cell::SpanRow(bool span)
+{
+	spansRow = span;
+	if(span)
+		SetWrapWidth(column->table->Width());
+}
+
+
+
+bool FlexTable::Cell::SpansRow() const
+{
+	return spansRow;
+}
+
+
+
+// The optimal width of the column (the most space the text inside can take up).
+int FlexTable::Cell::OptimalFlexWidth() const
+{
+	if(spansRow)
+		return column->table->width;
+	// WrappedText's width includes 2 pixels of padding on the left side.
+	WrappedText text(*font);
+	text.SetWrapWidth(column->table->width + 2);
+	text.Wrap(Text());
+	return text.LongestLineWidth() - 2;
+}
+
+
+
+void FlexTable::Cell::SetWrapWidth(int width)
+{
+	wrapWidth = width;
+	column->table->Invalidate();
+}
+
+
+
+void FlexTable::Cell::UpdateLayout()
+{
+	wrappedText.SetFont(*font);
+	wrappedText.SetAlignment(column->alignment);
+	wrappedText.SetTruncate(column->truncate);
+	wrappedText.SetWrapWidth(wrapWidth + 2); // WrappedText expects 2 pixels of padding
+	wrappedText.Wrap(text);
+}
+
+
+
+// Draws the cell centered on the given point.
+void FlexTable::Cell::Draw(const Point &position) const
+{
+	double gapWidth = (column->DecoratesGap() && !spansRow && column != &column->table->GetColumn(-1)) ?
+			column->table->columnSpacing : 0.;
+	if(highlight && highlightColor)
+	{
+		const Point &center = position + Point(Width() / 2. + gapWidth / 2., topGap + wrappedText.Height() / 2.);
+		FillShader::Fill(center, Point(Width() + gapWidth, wrappedText.Height()), *highlightColor);
+	}
+	if(underline && underlineColor)
+	{
+		const Point &center = position + Point(Width() / 2. + gapWidth / 2., topGap + wrappedText.Height() - 1);
+		FillShader::Fill(center, Point(Width() + gapWidth, 1), *underlineColor);
+	}
+	// WrappedText has 2 pixels of padding on the left side, so move the text's location to compensate for it.
+	// The text is printed between the top and bottom gaps.
+	const Point &textPos = position + Point(-2., topGap);
+	wrappedText.Draw(textPos, (highlight && highlightedTextColor) ? *highlightedTextColor : *textColor);
+}
+
+
+
+FlexTable::Column::Column(FlexTable *table) : table(table)
+{
+}
+
+
+
+// Gets the cell in the specified row.
+const FlexTable::Cell &FlexTable::Column::Row(int row) const
+{
+	return cells[row];
+}
+
+
+
+FlexTable::Cell &FlexTable::Column::Row(int row)
+{
+	table->ClampRow(row);
+	return cells[row];
+}
+
+
+
+int FlexTable::Column::RowCount() const
+{
+	return cells.size();
+}
+
+
+
+FlexTable::Cell &FlexTable::Column::AddRow(const string &text)
+{
+	Cell &cell = cells.emplace_back(this);
+	cell.SetText(text);
+	return cell;
+}
+
+
+
+// Gets the width of the column (the width of the widest cell in the column).
+// This ignores cells that span across columns.
+int FlexTable::Column::Width() const
+{
+	int width = 0;
+	for(const auto &cell : cells)
+		if(!cell.SpansRow())
+			width = max(width, cell.Width());
+	return width;
+}
+
+
+
+// The width required for this column to best fit in the table,
+// accounting for the amount of text contained in each cell.
+int FlexTable::Column::OptimalFlexWidth() const
+{
+	int maxWidth = 0;
+	for(const auto &cell : cells)
+		if(!cell.SpansRow())
+			maxWidth = max(maxWidth, cell.OptimalFlexWidth());
+	return maxWidth;
+}
+
+
+
+void FlexTable::Column::SetAlignment(Alignment alignment)
+{
+	this->alignment = alignment;
+	table->Invalidate();
+}
+
+
+
+void FlexTable::Column::SetTruncate(Truncate truncate)
+{
+	this->truncate = truncate;
+	table->Invalidate();
+}
+
+
+
+// A flexing column can extend beyond the width of the text it contains.
+void FlexTable::Column::SetFlex(bool flex)
+{
+	canFlex = flex;
+}
+
+
+
+bool FlexTable::Column::CanFlex() const
+{
+	return canFlex;
+}
+
+
+
+// Sets whether cells decorate the spacing after the column.
+void FlexTable::Column::SetDecorateGap(bool decorate)
+{
+	decorateGap = decorate;
+}
+
+
+
+bool FlexTable::Column::DecoratesGap() const
+{
+	return decorateGap;
+}
+
+
+
+// Fits each cell to the given width by setting their padding values.
+// This also sets the column's width to this value.
+void FlexTable::Column::FitToWidth(int width)
+{
+	for(auto &cell : cells)
+		if(!cell.SpansRow())
+			cell.SetWrapWidth(width);
+	UpdateLayout();
+}
+
+
+
+// Sets the wrap width of each cell to the column's minimum width.
+void FlexTable::Column::Pack()
+{
+	int target = 0;
+	for(auto &cell : cells)
+		if(!cell.SpansRow())
+			target = max(target, cell.MinWidth());
+	FitToWidth(target);
+}
+
+
+
+void FlexTable::Column::UpdateLayout()
+{
+	for(auto &cell : cells)
+		cell.UpdateLayout();
+}
+
+
+
+// Removes all cells from this column.
+void FlexTable::Column::Clear()
+{
+	cells.clear();
+}
+
+
+
+FlexTable::FlexTable(int width, int columns) : width(width), columns(columns, Column{this})
+{
+}
+
+
+
+FlexTable::FlexTable(const FlexTable &other) noexcept : width(other.width), rowSpacing(other.rowSpacing), columnSpacing(other.columnSpacing),
+	flexStrategy(other.flexStrategy), rowCount(other.rowCount)
+{
+	columns = other.columns;
+
+	for(auto &column : columns)
+	{
+		column.table = this;
+		for(auto &cell : column.cells)
+			cell.column = &column;
+	}
+
+	Invalidate();
+}
+
+
+
+FlexTable &FlexTable::operator=(const FlexTable &other)
+{
+	width = other.width;
+	rowSpacing = other.rowSpacing;
+	columnSpacing = other.columnSpacing;
+	flexStrategy = other.flexStrategy;
+	columns = other.columns;
+	rowCount = other.rowCount;
+
+	for(auto &column : columns)
+	{
+		column.table = this;
+		for(auto &cell : column.cells)
+			cell.column = &column;
+	}
+
+	Invalidate();
+	return *this;
+}
+
+
+
+// Removes all rows from the table, but preserves columns.
+void FlexTable::Clear()
+{
+	for(auto &column : columns)
+		column.Clear();
+	rowCount = 0;
+}
+
+
+
+void FlexTable::AddColumn()
+{
+	columns.emplace_back(this);
+	Clear();
+}
+
+
+
+int FlexTable::Columns() const
+{
+	return columns.size();
+}
+
+
+
+const FlexTable::Column &FlexTable::GetColumn(int index) const
+{
+	return columns[index];
+}
+
+
+
+FlexTable::Column &FlexTable::GetColumn(int index)
+{
+	ClampColumn(index);
+	return columns[index];
+}
+
+
+
+int FlexTable::Rows() const
+{
+	return rowCount;
+}
+
+
+
+int FlexTable::Width() const
+{
+	return width;
+}
+
+
+
+void FlexTable::SetWidth(int width)
+{
+	this->width = width;
+	for(auto &column : columns)
+		for(auto &cell : column.cells)
+			cell.SetWrapWidth(cell.SpansRow() ? width : AverageColumnWidth());
+	Invalidate();
+}
+
+
+
+// Gets the height of the table until the bottom of the specified row.
+int FlexTable::Height(int untilRow)
+{
+	if(Rows() == 0 || Columns() == 0)
+		return 0;
+
+	ClampRow(untilRow);
+
+	UpdateLayout();
+	int height = -rowSpacing;
+	for(int row = 0; row <= untilRow; ++row)
+	{
+		int rowHeight = 0;
+		for(const auto &column : columns)
+			rowHeight = max(rowHeight, column.Width() > 0 ? column.Row(row).Height() : 0);
+		height += rowHeight + rowSpacing;
+	}
+	return height;
+}
+
+
+
+// Gets the mouse hitbox of a row. This hitbox includes gaps and paddings, but not the spacing between rows.
+// The anchor point must be the same as in Draw().
+Rectangle FlexTable::GetRowHitbox(int targetRow, const Point &anchor)
+{
+	ClampRow(targetRow);
+
+	UpdateLayout();
+
+	int startY = targetRow == 0 ? 0 : Height(targetRow - 1);
+	int endY = Height(targetRow);
+	int topGap = GetCell(targetRow, 0).GetTopGap();
+	int bottomGap = GetCell(targetRow, 0).GetBottomGap();
+
+	startY += topGap;
+	endY -= bottomGap;
+	// Rectangle expects a center point.
+	Point offset = Point(width / 2., (endY - startY) / 2.);
+	Rectangle hitbox(Point(0., startY) + anchor + offset, Point(width, endY - startY - 1));
+
+	return hitbox;
+}
+
+
+
+Rectangle FlexTable::GetCellHitbox(int row, int column, const Point &anchor)
+{
+	ClampRow(row);
+	ClampColumn(column);
+
+	UpdateLayout();
+
+	Cell &cell = GetCell(row, column);
+	Rectangle rowBox = GetRowHitbox(row, anchor);
+
+	int startX = 0;
+	for(int i = 0; i < column; i++)
+		startX += columns[i].Width() + columnSpacing;
+
+	Point offset = Point((startX - rowBox.Width() / 2.) + cell.Width() / 2., 0.);
+	return Rectangle(rowBox.Center() + offset, Point(cell.Width(), rowBox.Height()));
+}
+
+
+
+const FlexTable::Cell &FlexTable::GetCell(int row, int column) const
+{
+	ClampRow(row);
+	ClampColumn(column);
+
+	return GetColumn(column).Row(row);
+}
+
+
+
+FlexTable::Cell &FlexTable::GetCell(int row, int column)
+{
+	// const_cast is safe here, because we are in a non-const object calling the const function
+	return const_cast<FlexTable::Cell &>(const_cast<const FlexTable *>(this)->GetCell(row, column));
+}
+
+
+
+// Fills a row with individual cells. Any extra arguments are discarded, and missing ones are substituted with empty cells.
+// Returns a pointer to the first cell in the row, or nullptr if there are no columns in the table.
+FlexTable::Cell *FlexTable::FillRow(const std::initializer_list<std::string> &cellTexts)
+{
+	if(columns.empty())
+		return nullptr;
+	rowCount++;
+
+	size_t column = 0;
+	for(const std::string &text : cellTexts)
+	{
+		if(column == columns.size())
+			break;
+		columns[column++].AddRow(text);
+	}
+	while(column != columns.size())
+		columns[column++].AddRow("");
+
+	Invalidate();
+	return &columns[0].cells.back();
+}
+
+
+
+FlexTable::Cell *FlexTable::FillRow(const std::initializer_list<std::pair<std::string, const Color &>> &cellTexts)
+{
+	if(columns.empty())
+		return nullptr;
+	rowCount++;
+
+	size_t column = 0;
+	for(const auto &[text, color] : cellTexts)
+	{
+		if(column == columns.size())
+			break;
+		columns[column++].AddRow(text).SetTextColor(color);
+	}
+	while(column != columns.size())
+		columns[column++].AddRow("");
+
+	Invalidate();
+	return &columns[0].cells.back();
+}
+
+
+
+// Fills a row with a single cell. This cell spans across every column.
+// Returns a pointer to the cell, or nullptr if there are no columns in the table.
+FlexTable::Cell *FlexTable::FillUnifiedRow(const std::string &text, const Color &color)
+{
+	if(columns.empty())
+		return nullptr;
+	rowCount++;
+
+	auto it = columns.begin();
+	Cell &first = it->AddRow(text);
+	first.SetTextColor(color);
+	first.SpanRow();
+
+	it++;
+	for(; it != columns.end(); it++)
+		it->AddRow("");
+
+	Invalidate();
+	return &columns[0].cells.back();
+}
+
+
+
+// Removes the last n rows of the table.
+void FlexTable::PopRow(int amount)
+{
+	for(auto &column : columns)
+		for(int i = 0; i < amount; ++i)
+			column.cells.pop_back();
+	rowCount -= amount;
+	Invalidate();
+}
+
+
+
+// Configures the number of empty pixels between each table row (not text rows within a single cell).
+void FlexTable::SetRowSpacing(int spacing)
+{
+	rowSpacing = spacing;
+}
+
+
+
+int FlexTable::GetRowSpacing() const
+{
+	return rowSpacing;
+}
+
+
+
+// Configures the number of empty pixels between each table column.
+// This is ignored around empty columns.
+void FlexTable::SetColumnSpacing(int spacing)
+{
+	columnSpacing = spacing;
+	Invalidate();
+}
+
+
+
+int FlexTable::GetColumnSpacing() const
+{
+	return columnSpacing;
+}
+
+
+
+// Highlights the row containing the specific point, and turns off highlighting for every other cell.
+// Returns the index of the row containing the point, or -1 if it's not in the table.
+// If allowFirstRow is false, the first row is ignored.
+// The anchor point must be the same as in Draw().
+int FlexTable::SetRowHighlight(const Point &point, const Point &anchor, bool allowFirstRow)
+{
+	int foundRow = -1;
+	for(int row = !allowFirstRow; row < Rows(); ++row)
+	{
+		bool contains = GetRowHitbox(row, anchor).Contains(point);
+		if(contains)
+			foundRow = row;
+		for(auto &column : columns)
+			column.Row(row).SetHighlight(contains);
+	}
+	return foundRow;
+}
+
+
+
+// Draws the table, and returns a point under the table for other draw operations.
+// The anchor point is the center of the top edge of the table.
+Point FlexTable::Draw(const Point &position)
+{
+	if(columns.empty())
+		return position;
+
+	UpdateLayout();
+
+	Point rowBegin = position;
+	for(int row = 0; row < Rows(); ++row)
+	{
+		int rowHeight = 0;
+		Point cellBegin{rowBegin};
+		for(const auto &column : columns)
+		{
+			// Skip empty columns
+			if(column.Width() == 0 && !column.Row(row).SpansRow())
+				continue;
+
+			const Cell &cell = column.Row(row);
+			rowHeight = max(rowHeight, cell.Height());
+			cell.Draw(cellBegin);
+			cellBegin.X() += cell.Width() + columnSpacing;
+
+			if(cell.SpansRow())
+				break;
+		}
+		rowBegin.Y() += rowSpacing + rowHeight;
+	}
+	return rowBegin;
+}
+
+
+
+FlexTable::FlexStrategy FlexTable::GetFlexStrategy() const
+{
+	return flexStrategy;
+}
+
+
+
+void FlexTable::SetFlexStrategy(FlexTable::FlexStrategy strategy)
+{
+	flexStrategy = strategy;
+}
+
+
+
+// The width of an average column in the table, without spacing.
+int FlexTable::AverageColumnWidth() const
+{
+	return (width - (columns.size() - 1) * columnSpacing) / columns.size();
+}
+
+
+
+// Marks that the layout of the table has to be recomputed.
+void FlexTable::Invalidate()
+{
+	valid = false;
+}
+
+
+
+void FlexTable::UpdateLayout()
+{
+	// Only update the layout if it changed.
+	if(valid)
+		return;
+	if(columns.empty())
+		return;
+	for(auto &column : columns)
+		column.UpdateLayout();
+
+	// The individual strategy is simple, so let's check for that first.
+	if(flexStrategy == FlexStrategy::INDIVIDUAL)
+	{
+		// Calculate the available space, minus any spacing.
+		int availableWidth = width + columnSpacing;
+		for(auto &column : columns)
+			if(column.Width())
+				availableWidth -= columnSpacing;
+
+		// Flex each row.
+		for(int row = 0; row < Rows(); ++row)
+		{
+			int currentWidth = 0;
+			bool spansRow = false;
+			for(auto &column : columns)
+				if(column.Width())
+				{
+					Cell &cell = column.Row(row);
+					cell.SetWrapWidth(cell.MinWidth());
+					if(cell.SpansRow())
+					{
+						spansRow = true;
+						break;
+					}
+					currentWidth += cell.Width();
+				}
+			if(spansRow) // This row is used by a single cell, so we don't need to distribute space.
+				continue;
+			// Now that we know how much space is available, we can distribute it.
+			for(auto &column : columns)
+			{
+				if(!column.CanFlex())
+					continue;
+
+				Cell &cell = column.Row(row);
+				int extra = cell.OptimalFlexWidth() - cell.Width();
+				if(extra <= availableWidth - currentWidth)
+				{
+					cell.SetWrapWidth(cell.OptimalFlexWidth());
+					currentWidth += extra;
+				}
+				else
+				{
+					cell.SetWrapWidth(cell.Width() + (availableWidth - currentWidth));
+					currentWidth = availableWidth;
+					break;
+				}
+			}
+			// Distribute any leftover space.
+			Cell &first = columns.front().Row(row);
+			first.SetWrapWidth(first.Width() + (availableWidth - currentWidth));
+		}
+		// Update all layouts.
+		for(auto &column : columns)
+			column.UpdateLayout();
+		valid = true;
+		return;
+	}
+
+	//Otherwise, perform all column flexing operations.
+
+	// Calculate the size of each column.
+	// Since some columns might be smaller than the initially used average width,
+	// others can be expanded to fit their contents better.
+	// Empty columns are treated as if they weren't in the table at all (but not empty cells!).
+	int overallWidth = -columnSpacing;
+	vector<Column *> flexColumns; // columns that can to grow
+	for(auto &column : columns)
+	{
+		column.Pack();
+		int width = column.Width();
+		if(width)
+		{
+			overallWidth += width + columnSpacing;
+			if(column.CanFlex())
+				flexColumns.emplace_back(&column);
+		}
+	}
+
+	if(flexColumns.empty()) // No columns can expand, so skip the rest of the computations.
+		return;
+
+	// Calculate what total width the columns are requesting
+	int freeWidth = width - overallWidth;
+	int requestedWidth = 0;
+	for(const auto &column : flexColumns)
+	{
+		int optimal = column->OptimalFlexWidth();
+		requestedWidth += optimal - column->Width();
+	}
+	if(requestedWidth <= freeWidth)
+	{
+		// All columns fit in the table without line breaks, so give them their optimal width.
+		for(const auto column : flexColumns)
+			column->FitToWidth(column->OptimalFlexWidth());
+		// Then make them fill up the rest of the empty space in the table.
+		freeWidth -= requestedWidth;
+		switch(flexStrategy)
+		{
+			case FlexStrategy::INDIVIDUAL: // can't happen
+				break;
+			case FlexStrategy::FIRST:
+				flexColumns.front()->FitToWidth(flexColumns.front()->Width() + freeWidth);
+				break;
+			case FlexStrategy::LAST:
+				flexColumns.back()->FitToWidth(flexColumns.back()->Width() + freeWidth);
+				break;
+			case FlexStrategy::EVEN:
+				int perColumn = freeWidth / flexColumns.size();
+				int remainder = freeWidth % flexColumns.size();
+				//
+				for(auto column : flexColumns)
+					column->FitToWidth(column->Width() + perColumn);
+				flexColumns.front()->FitToWidth(flexColumns.front()->Width() + remainder);
+				break;
+		}
+	}
+	else
+	{
+		// We don't have enough space to fit everything, so start handing out the free space while it lasts.
+		if(flexStrategy == FlexStrategy::FIRST || flexStrategy == FlexStrategy::LAST)
+		{
+			bool first = flexStrategy == FlexStrategy::FIRST;
+			for(size_t i = (first ? 0 : flexColumns.size() - 1); i != (first ? flexColumns.size() : -1); i++)
+			{
+				Column *column = flexColumns[i];
+				int requested = column->OptimalFlexWidth() - column->Width();
+				if(requested >= freeWidth)
+				{
+					column->FitToWidth(column->Width() + freeWidth);
+					break;
+				}
+				else
+				{
+					column->FitToWidth(column->Width() + requested);
+					freeWidth -= requested;
+				}
+			}
+		}
+		else // FlexStrategy::EVEN
+		{
+			// Hand out free space to all columns who still need it.
+			// Some may need less space than what would is distributed, so reuse their extra space as well.
+			while(freeWidth && freeWidth >= static_cast<int>(flexColumns.size()))
+			{
+				int perColumn = freeWidth / flexColumns.size();
+				vector<Column *> remaining;
+				remaining.reserve(flexColumns.size());
+
+				for(auto column : flexColumns)
+				{
+					// Check if the column accepts all of the extra width.
+					int expected = column->OptimalFlexWidth() - column->Width();
+					if(expected > perColumn)
+					{
+						column->FitToWidth(column->Width() + perColumn);
+						freeWidth -= perColumn;
+						remaining.emplace_back(column);
+					}
+					else
+					{
+						column->FitToWidth(column->OptimalFlexWidth());
+						freeWidth -= expected;
+					}
+				}
+				flexColumns = remaining;
+			}
+			// Distribute the remainder. (There are fewer pixels left than columns,
+			// since anything greater would have already been distributed.)
+			for(int i = 0; i < freeWidth; ++i)
+				flexColumns[i]->FitToWidth(flexColumns[i]->Width() + 1);
+
+		}
+		for(auto &column : columns)
+			column.UpdateLayout();
+		// We filled up the entire width of the table; nothing more can be done.
+	}
+	valid = true;
+}
+
+
+
+// Finds the row that corresponds to the given offset, supporting negative values and wrap-arounds.
+void FlexTable::ClampRow(int &row) const
+{
+	if(Rows() == 0)
+		row = 0;
+	else
+	{
+		row %= Rows();
+		if(row < 0)
+			row += Rows();
+	}
+}
+
+
+
+void FlexTable::ClampColumn(int &column) const
+{
+	if(Columns() == 0)
+		column = 0;
+	else
+	{
+		column %= Columns();
+		if(column < 0)
+			column += Columns();
+	}
+}

--- a/source/text/FlexTable.h
+++ b/source/text/FlexTable.h
@@ -84,8 +84,8 @@ public:
 
 		void UpdateLayout();
 
-		// Draws the cell centered on the given point.
-		void Draw(const Point &position) const;
+		// Draws the cell from the given point.
+		void Draw(const Point &position, int rowHeight) const;
 
 
 	private:

--- a/source/text/FlexTable.h
+++ b/source/text/FlexTable.h
@@ -1,0 +1,267 @@
+/* FlexTable.h
+Copyright (c) 2024 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../Color.h"
+#include "FontSet.h"
+#include "layout.hpp"
+#include "../Point.h"
+#include "../Rectangle.h"
+#include "WrappedText.h"
+
+#include <string>
+#include <vector>
+
+
+
+// Helper class for drawing wrapped text formatted in a table, where each column of the
+// table is aligned left, right, or centered. This also handles spacing in
+// between table rows, underlines, selection highlights, etc.
+class FlexTable {
+public:
+	class Column;
+	// A single table cell. Cells use their column's formatting values.
+	// By default, each cell fits tightly to the contained text, and are aligned
+	// by the column setting custom wrap widths, depending on its configuration.
+	class Cell {
+	public:
+		explicit Cell(Column *column, const std::string &text = "");
+
+		void SetText(const std::string &text);
+		const std::string &Text() const;
+
+		// The minimum width of the cell, based on the previous wrap width.
+		// This is not an absolute minimum; rather, it indicates how much of the previously configured space is actually used.
+		int MinWidth() const;
+		// The width and height of the cell, including padding.
+		int Width() const;
+		int Height() const;
+
+		// Set the font. Default is the size 14 font.
+		void SetFont(const Font *font);
+		const Font *GetFont() const;
+
+		// Extra height reserved at the top or bottom of the cell.
+		// Gaps are synchronized between all cells in a row.
+		void SetTopGap(int gap);
+		void SetBottomGap(int gap);
+		int GetTopGap() const;
+		int GetBottomGap() const;
+
+		// Configures cell decorations. These affect the entire cell, not just the space occupied by text.
+		void SetHighlight(bool highlight = true);
+		void SetUnderline(bool underline = true);
+
+		// Sets the colors for highlights, underlines and text.
+		// Setting highlight or underline-related colors automatically enables highlighting/underlining.
+		void SetTextColor(const Color &textColor);
+		void SetHighlightedTextColor(const Color &textColor);
+		void SetHighlightColor(const Color &highlightColor);
+		void SetUnderlineColor(const Color &underlineColor);
+
+	private:
+		int GetRow() const;
+		// Makes the cell span the entire row. This should only be called within the first column.
+		void SpanRow(bool span = true);
+		bool SpansRow() const;
+
+		// The optimal width of the column (the most space the text inside can take up).
+		int OptimalFlexWidth() const;
+		void SetWrapWidth(int width);
+
+		void UpdateLayout();
+
+		// Draws the cell centered on the given point.
+		void Draw(const Point &position) const;
+
+
+	private:
+		Column *column;
+
+		// Cells can span the entire column of a table.
+		// They are only present in the first column; the rest store empty cells
+		// that are skipped when drawing.
+		bool spansRow = false;
+
+		WrappedText wrappedText{};
+		std::string text;
+		int wrapWidth;
+		int topGap = 0;
+		int bottomGap = 0;
+		bool highlight = false;
+		bool underline = false;
+
+		const Color *highlightColor;
+		const Color *underlineColor;
+		const Color *textColor;
+		const Color *highlightedTextColor;
+
+		const Font *font;
+
+		friend class Column;
+		friend class FlexTable;
+	};
+
+	class Column {
+	public:
+		explicit Column(FlexTable *table);
+
+		// Gets the cell in the specified row.
+		const Cell &Row(int row) const;
+		Cell &Row(int row);
+		int RowCount() const;
+
+		// Gets the width of the column (the width of the widest cell in the column).
+		// This ignores cells that span across columns.
+		int Width() const;
+		// The width required for this column to best fit in the table,
+		// accounting for the amount of text contained in each cell.
+		int OptimalFlexWidth() const;
+
+		void SetAlignment(Alignment alignment);
+		void SetTruncate(Truncate truncate);
+
+		// A flexing column can extend beyond the width of the text it contains.
+		void SetFlex(bool flex = true);
+		bool CanFlex() const;
+
+		// Sets whether cells decorate the spacing after the column.
+		void SetDecorateGap(bool decorate);
+		bool DecoratesGap() const;
+
+
+	private:
+		// Fits each cell to the given width by setting their padding values.
+		// This also sets the column's width to this value.
+		void FitToWidth(int width);
+		// Sets the wrap width of each cell to the column's minimum width.
+		void Pack();
+		void UpdateLayout();
+
+		// Removes all cells from this column.
+		void Clear();
+		Cell &AddRow(const std::string &text);
+
+
+	private:
+		Alignment alignment = Alignment::LEFT;
+		Truncate truncate = Truncate::NONE;
+		bool canFlex = true;
+
+		bool decorateGap = true;
+
+		std::vector<Cell> cells;
+		FlexTable *table;
+
+		friend class FlexTable;
+	};
+
+	enum class FlexStrategy {
+		FIRST, // Prioritizes the first column. This column receives its requested width first, and holds all empty space.
+		LAST,
+		EVEN, // Distributes the available space evenly between the columns that request it.
+		INDIVIDUAL // Flexes each cell separately, instead of in columns. This reduces the table's size,
+					// but can be jarring if the columns are misaligned.
+	};
+
+
+public:
+	explicit FlexTable(int width = 0, int columns = 0);
+
+	// Since we are keeping references to tables and columns, we need custom copy behaviour.
+	FlexTable(const FlexTable &other) noexcept;
+	FlexTable &operator=(const FlexTable &other);
+
+	// Removes all rows from the table, but preserves columns.
+	void Clear();
+	void AddColumn();
+
+	int Columns() const;
+	const Column &GetColumn(int index) const;
+	Column &GetColumn(int index);
+	int Rows() const;
+
+	int Width() const;
+	void SetWidth(int width);
+	// Gets the height of the table until the bottom of the specified row.
+	int Height(int untilRow = -1);
+
+	// Gets the mouse hitbox of a row. This hitbox includes gaps and paddings, but not the spacing between rows.
+	// The anchor point must be the same as in Draw().
+	Rectangle GetRowHitbox(int targetRow, const Point &anchor);
+	Rectangle GetCellHitbox(int row, int column, const Point &anchor);
+
+	const Cell &GetCell(int row, int column) const;
+	Cell &GetCell(int row, int column);
+
+	// Fills a row with individual cells. Any extra arguments are discarded, and missing ones are substituted with empty cells.
+	// Returns a pointer to the first cell in the row, or nullptr if there are no columns in the table.
+	Cell *FillRow(const std::initializer_list<std::string> &cellTexts = {});
+	Cell *FillRow(const std::initializer_list<std::pair<std::string, const Color &>> &cellTexts);
+	// Fills a row with a single cell. This cell spans across every column.
+	// Returns a pointer to the cell, or nullptr if there are no columns in the table.
+	Cell *FillUnifiedRow(const std::string &text, const Color &color);
+	// Removes the last n rows of the table.
+	void PopRow(int amount = 1);
+
+	// Configures the number of empty pixels between each table row (not text rows within a single cell).
+	void SetRowSpacing(int spacing);
+	int GetRowSpacing() const;
+	// Configures the number of empty pixels between each table column.
+	// This is ignored around empty columns.
+	void SetColumnSpacing(int spacing);
+	int GetColumnSpacing() const;
+
+	// Highlights the row containing the specific point, and turns off highlighting for every other cell.
+	// Returns the index of the row containing the point, or -1 if it's not in the table.
+	// If allowFirstRow is false, the first row is ignored.
+	// The anchor point must be the same as in Draw().
+	int SetRowHighlight(const Point &point, const Point &anchor, bool allowFirstRow = false);
+
+	// Draws the table, and returns a point under the table for other draw operations.
+	// The anchor point is the center of the top edge of the table.
+	Point Draw(const Point &anchor);
+
+	FlexStrategy GetFlexStrategy() const;
+	void SetFlexStrategy(FlexStrategy strategy);
+
+private:
+	// The width of an average column in the table, without spacing.
+	int AverageColumnWidth() const;
+
+	// Marks that the layout of the table has to be recomputed.
+	void Invalidate();
+	void UpdateLayout();
+
+	// Finds the row that corresponds to the given offset, supporting negative values and wrap-arounds.
+	void ClampRow(int &row) const;
+	void ClampColumn(int &column) const;
+
+
+private:
+	int width;
+	int rowSpacing = 0;
+	int columnSpacing = 10;
+
+	FlexStrategy flexStrategy = FlexStrategy::FIRST;
+
+	bool valid = true;
+
+	std::vector<Column> columns;
+	int rowCount = 0;
+
+	friend class Column;
+};

--- a/source/text/FlexTable.h
+++ b/source/text/FlexTable.h
@@ -207,7 +207,8 @@ public:
 	const Cell &GetCell(int row, int column) const;
 	Cell &GetCell(int row, int column);
 
-	// Fills a row with individual cells. Any extra arguments are discarded, and missing ones are substituted with empty cells.
+	// Fills a row with individual cells. Any extra arguments are discarded,
+	// and missing ones are substituted with empty cells.
 	// Returns a pointer to the first cell in the row, or nullptr if there are no columns in the table.
 	Cell *FillRow(const std::initializer_list<std::string> &cellTexts = {});
 	Cell *FillRow(const std::initializer_list<std::pair<std::string, const Color &>> &cellTexts);

--- a/source/text/WrappedText.cpp
+++ b/source/text/WrappedText.cpp
@@ -313,7 +313,9 @@ void WrappedText::Wrap()
 	// Adjust the spacing of words in the final line of text.
 	AdjustLine(lineBegin, lineWidth, true);
 
-	height = word.y;
+	// We have over-calculated the actual height by an extra paragraph break,
+	// so subtract that.
+	height = max(0, word.y - paragraphBreak);
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10317 (fixes #10317).

## Summary
Adds a new FlexTable class that wraps text inside it. Currently, this co-exists with the old Table, as refactoring every UI element using Table would be far too much code for a single PR. (Most of that code already exists, I just didn't include it here.)

This PR refactors ItemInfoDisplay to use the new FlexTable class, and adjusts panels using it to this change. Some of those panels also got FlexTables, but only where it closely relates to ItemInfoDisplay. It also contains a WrappedText fix from #10323.

FlexTable is a high-level construct, unlike the old Table, which was essentially just a helper. FlexTable stores its content, styling and layout internally, which enables caching.

### Reasons to exist

If we don't have wrapping text in tables, we'll keep running into bugs like the one fixed here, especially on smaller screen sizes.

If we want text wrapping in tables, there are two fundamental options available:
1. Fixed column widths:
    This is easier, but looks rather odd when text wraps in a column even though the next column doesn't take up all of the available space. This is especially problematic when the second column is right-aligned, which is a really common use case in ES.
2. Flexing columns (dynamic widths)
    This looks way better, but has greater complexity, as adding a new row to the table can change the width of the columns, thereby affecting the height of a previous row. This makes it unfeasible to handle a table's layout externally, like we did for the old Table class.

Since FlexTable's rows don't have a fixed position when they are added, they also cannot be highlighted and underlined on the fly. This is why styling information is stored in the table, and why drawing only happens after all of the contents have been added to the table.

Of course, styling has a million parameters, so having getters/setters for all of them requires a ton of boilerplate code. That's the main reason why FlexTable.cpp is so large; the actual code there is waaay less.

## Screenshots
(They are screenshots, so they may not be aligned pixel-perfectly.)
Before:
![image](https://github.com/user-attachments/assets/92a4b1bf-3c89-42cc-b189-3c736d6f24ec)
![image](https://github.com/user-attachments/assets/e504a75d-69c7-4abd-b661-3d0113ef65c5)
![image](https://github.com/user-attachments/assets/41645967-3bbf-4d44-814e-a6d016ae952e)


After:
![image](https://github.com/user-attachments/assets/a2886ece-2f47-4c10-b66f-4a46beb58d55)
![image](https://github.com/user-attachments/assets/2dbca325-2f7a-4608-b0aa-a372bcbc3930)
![image](https://github.com/user-attachments/assets/86ad9afb-01a3-4a37-8863-27aee9f511f0)

(As you can see, licenses now take up all of the available space, whereas previously they always reserved space for tributes.)


## Usage examples
Better highlighting (as that's broken in PreferencesPanel), minimizing text overflow in the UI, and avoiding workarounds with the old Table.

## Testing Done
I tested that the UI components appear as expected, and highlighting and tooltips work.

## Performance Impact
Constructing a FlexTable is more expensive, but it can be cached between frames, so the impact shouldn't be huge.