### PR TITLE
fix(data-files): Fix has, not and assign condition usage in datafiles

### DIFF
--- a/data/hai/hai reveal 2 start.txt
+++ b/data/hai/hai reveal 2 start.txt
@@ -233,7 +233,7 @@ mission "Hai Rescue: Ooonem"
 			branch nohint
 				and
 					not "Hai Rescue: Ooonem Hint: offered"
-					not "Hai Rescue: Ooonem (defer count)" >= 1
+					"Hai Rescue: Ooonem (defer count)" < 1
 			`Following reports of the last time the "angel of death" was sighted, you end up loitering in a twisting street parallel to a main thoroughfare. The few people using it hurry by quickly, and rarely seem to travel any great distance down this street. One very surly looking individual gives you a sour glare on his way past, a collection of weapons on full display. He looks a lot like you'd expect a bounty hunter to look, and as he moves out of sight you observe a shadow, previously motionless, detach from a spot on a wall and head back your direction, laser rifle pointed in the direction of the departing individual. As the shadow approaches, you see there's a lot of hair sticking out from their hood. They might be a Hai. Do you want to talk to them?`
 				goto start
 			label nohint

--- a/data/hai/hai reveal 2 start.txt
+++ b/data/hai/hai reveal 2 start.txt
@@ -233,7 +233,7 @@ mission "Hai Rescue: Ooonem"
 			branch nohint
 				and
 					not "Hai Rescue: Ooonem Hint: offered"
-					"Hai Rescue: Ooonem (defer count)" < 1
+					not "Hai Rescue: Ooonem (defer count)"
 			`Following reports of the last time the "angel of death" was sighted, you end up loitering in a twisting street parallel to a main thoroughfare. The few people using it hurry by quickly, and rarely seem to travel any great distance down this street. One very surly looking individual gives you a sour glare on his way past, a collection of weapons on full display. He looks a lot like you'd expect a bounty hunter to look, and as he moves out of sight you observe a shadow, previously motionless, detach from a spot on a wall and head back your direction, laser rifle pointed in the direction of the departing individual. As the shadow approaches, you see there's a lot of hair sticking out from their hood. They might be a Hai. Do you want to talk to them?`
 				goto start
 			label nohint

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -107,14 +107,13 @@ mission "Hunted"
 	to offer
 		"combat rating" > 8103
 		"armament deterrence" >= 2
-		"ship scale" = "ship: Light Warship" + "ship: Medium Warship" * 2 + "ship: Heavy Warship" * 4
 		or
 			and
 				not "Hunted: active"
-				"ship scale" < 32
-				random < 2 + "ship scale" / 4
+				"ship: Light Warship" + "ship: Medium Warship" * 2 + "ship: Heavy Warship" * 4 < 32
+				random < 8
 			and
-				"ship scale" >= 32 + "Hunted: active" * 4
+				"ship: Light Warship" + "ship: Medium Warship" * 2 + "ship: Heavy Warship" * 4 >= 32 + "Hunted: active" * 4
 				random < 10
 		or
 			not "chosen sides"
@@ -5739,7 +5738,7 @@ mission "Quicksilver Mixup 0"
 			`You're looking at some job listings when a man with a harried face approaches you, carrying a package.`
 			`	"Excuse me, Captain," he says. "I need this package delivered in the next four days. Details are on the package. I'll pay you <payment> once it's done." Without waiting for a response, he shoves the package into your hands and runs off to attend to whatever business has gotten him in such a hurry. The package is addressed to a location on <planet>.`
 			branch "can't make it in time"
-				has "hyperjumps to planet: Silver" > 3
+				"hyperjumps to planet: Silver" > 3
 			`	It's going to be close to his deadline, but it's possible.`
 				goto choice
 			label "can't make it in time"


### PR DESCRIPTION
**Bug fix**

This PR fixes some datafile issues that were found while testing for #10213

## Summary
The `has` and `not` statements should only be followed by a single condition. And the undocumented feature of using assignments within condition-tests was apparently used once within the datafiles.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Those bugs were actually found during some tests.

## Save File
N/A

## Wiki Update
N/A, the wiki already has the correct descriptions of the syntax for conditions.

## Performance Impact
N/A, datafile update only.