### PR TITLE
fix(typo): two/to, than/then in mission texts

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -104,4 +104,4 @@ system Currus
 		"Mian"
 		"i' amazin"          # is amazing (mispronounced)
             * Care Package 2a has been replaced with a new mission, FW Deep Memorial, a set of missions and events that offers regardless of the player's choices, but which has a branch if Brower dies during the attack.
-			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`
+			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man then looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2608,7 +2608,7 @@ mission "Stone of our Fathers 3"
 				decline
 			label accept
 			`	You're surprised at how cool the smooth stone feels in your palm.`
-			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`
+			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man then looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`
 			`	And with that, the man disappears into the crowd.`
 				accept
 	on complete

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -659,7 +659,7 @@ mission "FW Southern Prisoners - Released"
 			`<origin> has become the home of a major Navy base almost overnight; the number of ships and people here is almost overwhelming. You return the prisoners, who have all taken an oath of parole to take no further part in the war against the Free Worlds. One of the four Navy admirals who you and Alondo met with earlier is here, and as you are unloading the prisoners, he says, "More volunteers for the 'Oathkeepers,' I see."`
 			choice
 				`	"Who are the 'Oathkeepers'?"`
-			`	"The officers you granted parole two months ago. We reassigned them all to duty in the north, patrolling for pirates."`
+			`	"The officers you granted parole to months ago. We reassigned them all to duty in the north, patrolling for pirates."`
 			`	"You mean they really do honor their promise not to fight us?" you ask.`
 			`	"Of course. They swore a vow, after all." You suspect it's not quite that simple, but decide that questioning this admiral's word would be pointless. As you are getting ready to leave, he says, "Don't worry, we will be returning Miss Reynolds to you shortly. The ship carrying her should arrive here in a week or two."`
 			`	You hope he is telling the truth. Now, it is time to meet with Freya and Alondo and decide what should be done next.`

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -659,7 +659,7 @@ mission "FW Southern Prisoners - Released"
 			`<origin> has become the home of a major Navy base almost overnight; the number of ships and people here is almost overwhelming. You return the prisoners, who have all taken an oath of parole to take no further part in the war against the Free Worlds. One of the four Navy admirals who you and Alondo met with earlier is here, and as you are unloading the prisoners, he says, "More volunteers for the 'Oathkeepers,' I see."`
 			choice
 				`	"Who are the 'Oathkeepers'?"`
-			`	"The officers you granted parole to months ago. We reassigned them all to duty in the north, patrolling for pirates."`
+			`	"The officers you granted parole two months ago. We reassigned them all to duty in the north, patrolling for pirates."`
 			`	"You mean they really do honor their promise not to fight us?" you ask.`
 			`	"Of course. They swore a vow, after all." You suspect it's not quite that simple, but decide that questioning this admiral's word would be pointless. As you are getting ready to leave, he says, "Don't worry, we will be returning Miss Reynolds to you shortly. The ship carrying her should arrive here in a week or two."`
 			`	You hope he is telling the truth. Now, it is time to meet with Freya and Alondo and decide what should be done next.`


### PR DESCRIPTION
**Bug fix**

## Summary
Just two typoes I noticed...

## Testing Done
None, TBH. :)
