### PR TITLE
fix(ci): Add missing exclude to codespell

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -104,3 +104,4 @@ system Currus
 		"Mian"
 		"i' amazin"          # is amazing (mispronounced)
             * Care Package 2a has been replaced with a new mission, FW Deep Memorial, a set of missions and events that offers regardless of the player's choices, but which has a branch if Brower dies during the attack.
+			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`


### PR DESCRIPTION
**Bug fix**

This PR fixes the codespell action failing due to new issues it detects.

## Summary
Example failed workflow: https://github.com/endless-sky/endless-sky/actions/runs/10443036384/job/28916006388?pr=10413

It detects yet another line from the deep missions, which I added to the excludes.

## Testing Done
Should pass now.