### PR TITLE
fix(Engine): Check if system is not null before making it a reference

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -690,8 +690,7 @@ void Engine::Step(bool isActive)
 					break;
 				}
 			const System *system = escort->GetSystem();
-			bool systemNameKnown = system && player.KnowsName(*system);
-			escorts.Add(*escort, system == currentSystem, systemNameKnown, fleetIsJumping, isSelected);
+			escorts.Add(*escort, system == currentSystem, system && player.KnowsName(*system), fleetIsJumping, isSelected);
 		}
 
 	statuses.clear();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -690,7 +690,8 @@ void Engine::Step(bool isActive)
 					break;
 				}
 			const System *system = escort->GetSystem();
-			escorts.Add(*escort, system == currentSystem, player.KnowsName(*system), fleetIsJumping, isSelected);
+			bool systemNameKnown = system && player.KnowsName(*system);
+			escorts.Add(*escort, system == currentSystem, systemNameKnown, fleetIsJumping, isSelected);
 		}
 
 	statuses.clear();


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature that was reported in my terminal:
.../endless-sky/source/Engine.cpp:693:66: runtime error: reference binding to null pointer of type 'const struct System'

## Summary
We were converting a null-pointer to a system into a reference. This PR adds a check if the pointer is not null before turning it into a reference.

## Testing Done
Verfied that the warning was gone after this change.

## Save File
N/A

## Wiki Update
N/A (fix in code)

## Performance Impact
Should be no impact.