### PR TITLE
doc(building): Mention ccache to speed-up rebuilds

### DIFF
--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -52,7 +52,7 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12.
 If your distro does not provide up-to-date version of these libraries, you can use vcpkg to build the necessary libraries from source by passing `-DES_USE_VCPKG=ON`. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
 
-In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/).
+In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you could also consider to install ccache to speed up re-builds after switching branches.
 
 
 <details>

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -52,7 +52,7 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12.
 If your distro does not provide up-to-date version of these libraries, you can use vcpkg to build the necessary libraries from source by passing `-DES_USE_VCPKG=ON`. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
 
-In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you could also consider installing [ccache](https://ccache.dev/) to speed up rebuilds after switching branches.
+In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you can also consider installing [ccache](https://ccache.dev/) to speed up rebuilds after switching branches.
 
 
 <details>

--- a/docs/readme-cmake.md
+++ b/docs/readme-cmake.md
@@ -52,7 +52,7 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12.
 If your distro does not provide up-to-date version of these libraries, you can use vcpkg to build the necessary libraries from source by passing `-DES_USE_VCPKG=ON`. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
 
-In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you could also consider to install ccache to speed up re-builds after switching branches.
+In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you could also consider installing [ccache](https://ccache.dev/) to speed up rebuilds after switching branches.
 
 
 <details>


### PR DESCRIPTION
**Documentation**

This PR addresses faster rebuilds after switching branches

## Summary
Ccache can significantly speed-up Cmake builds after switching branches. If you are about to build the same code twice, then the build will finish almost instantly the second time, since the build will not execute, but just re-use cached artifacts.

## Usage examples
Install ccache (as mentioned in the instructions) and enjoy re-builds that are a lot faster.

## Testing Done
Installed ccache, and noticed the builds being faster.

## Wiki Update
This is the wiki-update with the build instructions. The developer documentation apparently lives in the main archive.

## Performance Impact
Some more diskspace would be used for caching, but your builds would be faster. Not related to in-game performance.