### PR TITLE
fix(audio): Fix missing sound effect for `star tail hit`

### DIFF
--- a/data/incipias/incipias outfits.txt
+++ b/data/incipias/incipias outfits.txt
@@ -146,7 +146,7 @@ effect "star tail hit"
 	sprite "effect/star tail hit"
 		"no repeat"
 		"frame rate" 40
-	sound "star tail hit"
+	sound "explosion small"
 	"lifetime" 30
 	"velocity scale" 0.
 


### PR DESCRIPTION
**Bug fix**

This incipias weapon had a missing sound file. I replaced the reference to it with `explosion small`, as suggested by @Saugia.

## Testing Done
The game no longer complains about missing audio.