### PR TITLE
fix(audio): Check if the sound name is empty before reporting as undefined

### DIFF
--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -189,7 +189,7 @@ void Audio::CheckReferences()
 	}
 
 	for(auto &&it : sounds)
-		if(it.second.Name().empty())
+		if(it.second.Name().empty() && !it.first.empty())
 			Logger::LogError("Warning: sound \"" + it.first + "\" is referred to, but does not exist.");
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10433

## Summary
In some cases, we use the empty sound name to mark that no sound should be played at all. This sound is intentionally undefined, so we shouldn't warn about referencing it.

In this PR, I added a check before the warning that skips this intentionally undefined sound.

## Testing Done
I tested that the warning no longer appears.