### PR TITLE
feat(UI): Persist shown page in settings

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -144,6 +144,9 @@ namespace {
 	int alertIndicatorIndex = 3;
 
 	int previousSaveCount = 3;
+
+	char previousPage = static_cast<char> (0);
+	int previousPagination = 0;
 }
 
 
@@ -222,6 +225,11 @@ void Preferences::Load()
 			previousSaveCount = max<int>(3, node.Value(1));
 		else if(node.Token(0) == "alt-mouse turning")
 			settings["Control ship with mouse"] = (node.Size() == 1 || node.Value(1));
+		else if(node.Token(0) == "previous page" && node.Size() >= 3)
+		{
+			previousPage = node.Token(1)[0];
+			previousPagination = node.Value(2);
+		}
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
@@ -284,6 +292,8 @@ void Preferences::Save()
 	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
 	out.Write("previous saves", previousSaveCount);
+	if (previousPage)
+		out.Write("previous page", std::string(1,previousPage), previousPagination);
 
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);
@@ -304,6 +314,25 @@ void Preferences::Set(const string &name, bool on)
 	settings[name] = on;
 }
 
+
+// Last shown settings page - saves `PreferencesPanel.page`
+char Preferences::GetPreviousPage()
+{
+	return previousPage;
+}
+
+void Preferences::SetPreviousPage(char page) {
+	previousPage = page;
+}
+
+// The pagination on said page (currentControlsPage / currentSettingsPage).
+int Preferences::GetPreviousPagination() {
+	return previousPagination;
+}
+
+void Preferences::SetPreviousPagination(int pagination) {
+	previousPagination = pagination;
+}
 
 
 void Preferences::ToggleAmmoUsage()

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -292,8 +292,8 @@ void Preferences::Save()
 	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
 	out.Write("previous saves", previousSaveCount);
-	if (previousPage)
-		out.Write("previous page", std::string(1,previousPage), previousPagination);
+	if(previousPage)
+		out.Write("previous page", std::string(1, previousPage), previousPagination);
 
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -110,6 +110,13 @@ public:
 	static bool Has(const std::string &name);
 	static void Set(const std::string &name, bool on = true);
 
+	// Last shown settings page - saves `PreferencesPanel.page`
+	static char GetPreviousPage();
+	static void SetPreviousPage(char page);
+	// The pagination on said page (currentControlsPage / currentSettingsPage).
+	static int GetPreviousPagination();
+	static void SetPreviousPagination(int pagination);
+
 	// Toggle the ammo usage preferences, cycling between "never," "frugally,"
 	// and "always."
 	static void ToggleAmmoUsage();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -253,7 +253,8 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 
 void PreferencesPanel::ResetPluginListRenderBuffers()
 {
-	// Needs to run when the user activates the plugin list view or when the saved state says the plugin list is the initial view
+	// Needs to run when the user activates the plugin list view
+	// or when the saved state says the plugin list is the initial view
 	if(page != 'p') return;
 
 	// Reset the render buffers in case the UI scale has changed.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -132,6 +132,8 @@ PreferencesPanel::PreferencesPanel()
 	pluginListScroll.SetMaxValue(pluginListHeight);
 	Rectangle pluginDescriptionBox = pluginUi->GetBox("plugin description");
 	pluginDescriptionScroll.SetDisplaySize(pluginDescriptionBox.Height());
+
+	ResetPluginListRenderBuffers();
 }
 
 
@@ -212,14 +214,7 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 		hoverItem.clear();
 		selected = 0;
 
-		if(page == 'p')
-		{
-			// Reset the render buffers in case the UI scale has changed.
-			const Interface *pluginUi = GameData::Interfaces().Get("plugins");
-			Rectangle pluginListBox = pluginUi->GetBox("plugin list");
-			pluginListClip = std::make_unique<RenderBuffer>(pluginListBox.Dimensions());
-			RenderPluginDescription(selectedPlugin);
-		}
+		ResetPluginListRenderBuffers();
 	}
 	else if(key == 'o' && page == 'p')
 		Files::OpenUserPluginFolder();
@@ -253,6 +248,19 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 		return false;
 
 	return true;
+}
+
+
+void PreferencesPanel::ResetPluginListRenderBuffers()
+{
+	// Needs to run when the user activates the plugin list view or when the saved state says the plugin list is the initial view
+	if(page != 'p') return;
+
+	// Reset the render buffers in case the UI scale has changed.
+	const Interface *pluginUi = GameData::Interfaces().Get("plugins");
+	Rectangle pluginListBox = pluginUi->GetBox("plugin list");
+	pluginListClip = std::make_unique<RenderBuffer>(pluginListBox.Dimensions());
+	RenderPluginDescription(selectedPlugin);
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -94,12 +94,15 @@ PreferencesPanel::PreferencesPanel()
 	: editing(-1), selected(0), hover(-1)
 {
 	page = Preferences::GetPreviousPage();
-	if (!page) page = 'c';
+	if(!page)
+		page = 'c';
 	currentControlsPage = 0;
 	currentSettingsPage = 0;
 	int pagination = Preferences::GetPreviousPagination();
-	if (page == 'c') currentControlsPage = pagination;
-	else if (page == 's') currentSettingsPage = pagination;
+	if(page == 'c')
+		currentControlsPage = pagination;
+	else if(page == 's')
+		currentSettingsPage = pagination;
 
 	// Select the first valid plugin.
 	for(const auto &plugin : Plugins::Get())

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -93,6 +93,14 @@ namespace {
 PreferencesPanel::PreferencesPanel()
 	: editing(-1), selected(0), hover(-1)
 {
+	page = Preferences::GetPreviousPage();
+	if (!page) page = 'c';
+	currentControlsPage = 0;
+	currentSettingsPage = 0;
+	int pagination = Preferences::GetPreviousPagination();
+	if (page == 'c') currentControlsPage = pagination;
+	else if (page == 's') currentSettingsPage = pagination;
+
 	// Select the first valid plugin.
 	for(const auto &plugin : Plugins::Get())
 		if(plugin.second.IsValid())
@@ -1153,6 +1161,9 @@ void PreferencesPanel::DrawTooltips()
 
 void PreferencesPanel::Exit()
 {
+	Preferences::SetPreviousPage(page);
+	Preferences::SetPreviousPagination(page == 'c' ? currentControlsPage : page == 's' ? currentSettingsPage : 0);
+
 	Command::SaveSettings(Files::Config() + "keys.txt");
 
 	GetUI()->Pop(this);

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -73,6 +73,7 @@ private:
 	// Scroll the plugin list until the selected plugin is visible.
 	void ScrollSelectedPlugin();
 
+	void ResetPluginListRenderBuffers();
 
 private:
 	int editing;

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -91,8 +91,8 @@ private:
 	std::string tooltip;
 	WrappedText hoverText;
 
-	int currentControlsPage;
-	int currentSettingsPage;
+	int currentControlsPage = 0;
+	int currentSettingsPage = 0;
 
 	std::string selectedPlugin;
 

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -82,7 +82,7 @@ private:
 	int oldHover;
 	int latest;
 	// Which page of the preferences we're on.
-	char page = 'c';
+	char page;
 
 	Point hoverPoint;
 	int hoverCount = 0;
@@ -91,8 +91,8 @@ private:
 	std::string tooltip;
 	WrappedText hoverText;
 
-	int currentControlsPage = 0;
-	int currentSettingsPage = 0;
+	int currentControlsPage;
+	int currentSettingsPage;
 
 	std::string selectedPlugin;
 


### PR DESCRIPTION
**Feature**

This PR is a minor UX laziness improvement I've been playing with for a few months.

## Summary
ES remembers which "page" of the settings you were on and reopens it by default. Saves some time when changing options that have no keyboard binding (or where you can't remember it) on the fly, like when you don't want to accidentally kill some deep security vessels while escaping from Midgard for the wood splinter heist. I use it all the time for my non-public Autosell option.

## Screenshots
n/a

## Testing Done
As said, lots of playtesting. Additionally, I have verified the behaviour when downgrading to an earlier version without the feature: The new setting is silently ignored without even an entry in errors.txt.

## Performance Impact
none

## preferences.txt format
e.g. `"previous page" p 0`, `"previous page" s 1` etc.