### PR TITLE
fix(documentation): Add GOG to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the [player's manual](https://github.com/endless-sky/endless-sky/wiki/Player
 
 ## Installing the game
 
-Official releases of Endless Sky are available as direct downloads from [GitHub](https://github.com/endless-sky/endless-sky/releases/latest), on [Steam](https://store.steampowered.com/app/404410/Endless_Sky/), and on [Flathub](https://flathub.org/apps/details/io.github.endless_sky.endless_sky). Other package managers may also include the game, though the specific version provided may not be up-to-date.
+Official releases of Endless Sky are available as direct downloads from [GitHub](https://github.com/endless-sky/endless-sky/releases/latest), on [Steam](https://store.steampowered.com/app/404410/Endless_Sky/), on [GOG](https://gog.com/game/endless_sky), and on [Flathub](https://flathub.org/apps/details/io.github.endless_sky.endless_sky). Other package managers may also include the game, though the specific version provided may not be up-to-date.
 
 ## System Requirements
 


### PR DESCRIPTION
**Documentation**

## Summary
README.md now mentions that Endless Sky is officially available on GOG.
