### PR TITLE
Feat(Misc): Make Dragonflame Penetrate instead of doing Blast Radius Damage

### DIFF
--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -173,7 +173,7 @@ outfit "Dragonflame Cannon"
 		"hull damage" 15000
 		"heat damage" 50000
 		"piercing" 0.4
-		"blast radius" 50
+		"penetration count" 20
 	description "The ancient Sheragi superweapon is simple in concept, but the cost involved in developing something like it is exorbitant. It's hard to envision what could have motivated the creation of such a thing. It uses an obscene amount of energy to trigger an extremely powerful thermonuclear reaction, directing most of the energy from the resulting explosion forwards in a devastatingly powerful beam of gamma radiation."
 
 effect "dragonflame"


### PR DESCRIPTION
## Summary
This PR alters the behaviour of the Dragonflame Cannon, removing its Blast Radius (50) in exchange for Penetration Count (20), making it better against lined up targets while reducing its performance against broader, spread-out clumps.

## Testing Done
Some brief flying around shooting at random things to ensure it works. In normal gameplay, it doesn't seem to affect the weapon's performance much; there are relatively few situations where the player is dealing with huge clumps of enemies, with tributes and extensive time in Mesuket being the only two situations I can think of off the top of my head.

A penetration count of 20 was picked to compensate for the difficulty of lining up multiple targets, while also not massively increasing the weapon's strength. The most notable performance increase occurs in densely asteroided systems, and even then, it's more just an increase to hit probability than anything else.

## Performance Impact
This is a one-line datafile change, I doubt it'll affect performance.
