### PR TITLE
Prevent ringworld quarg news from showing on Ruelogakk

### DIFF
--- a/data/quarg/quarg news.txt
+++ b/data/quarg/quarg news.txt
@@ -469,6 +469,7 @@ news "ringworld quarg"
 		attributes "quarg"
 		attributes "station"
 		not planet "Lagrange"
+		not planet "Ruelogakk"
 	name
 		word
 			"Quarg"

--- a/data/quarg/quarg news.txt
+++ b/data/quarg/quarg news.txt
@@ -467,9 +467,7 @@ news "quarg anywhere"
 news "ringworld quarg"
 	location
 		attributes "quarg"
-		attributes "station"
-		not planet "Lagrange"
-		not planet "Ruelogakk"
+		attributes "ringworld"
 	name
 		word
 			"Quarg"


### PR DESCRIPTION
**Bug fix**

Prevent the "ringworld quarg news" news entries from showing on the station Ruelogakk.

## Summary

The news simply excluded Lagrange, which at the time was the only quarg+station that wasn't a ringworld. With the addition of Ruelogakk in the game with the Gegno, this allowed for the ringworld news to show there, a not-ringworld station.
This PR just changes the news source to be from "quarg" and "ringworld" attributes.

Bug reported by user Uuugggg on the Discord.