### PR TITLE
fix(ui): Don't include destroyed ships in the fleet cargo message

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2440,7 +2440,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 	int free = collector->Cargo().Free();
 	int total = 0;
 	for(const shared_ptr<Ship> &ship : player.Ships())
-		if(!ship->IsParked() && ship->GetSystem() == player.GetSystem())
+		if(!ship->IsDestroyed() && !ship->IsParked() && ship->GetSystem() == player.GetSystem())
 			total += ship->Cargo().Free();
 
 	message += " (" + Format::CargoString(free, "free space") + " remaining";


### PR DESCRIPTION
**Bug fix**

This PR fixes #10454.

## Summary
The cargo collection message now excludes destroyed ships.

Alternatively, we could just remove those ships from the player ship list, but currently they stay there until next landing, because this allows showing them as destroyed in the player info panel.

## Testing Done
yes™

## Performance Impact
N/A
