### PR TITLE
feat(mechanics): Aliens don't assist player escorts if the player doesn't know their language

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1380,6 +1380,11 @@ bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel, con
 	if(!ship.IsDisabled() && ((needsFuel && !helper.CanRefuel(ship)) || (needsEnergy && !helper.CanGiveEnergy(ship))))
 		return false;
 
+	// For player's escorts, check if the player knows the helper's language.
+	if(ship.IsYours() && !helper.GetGovernment()->Language().empty()
+			&& !player.Conditions().Get("language: " + helper.GetGovernment()->Language()))
+		return false;
+
 	return true;
 }
 


### PR DESCRIPTION
This PR resolves #1153.

## Summary
Aliens no longer assist player's escorts if their government has a language that the player doesn't know.

## Testing Done
Tested with the Wanderers.

## Wiki Update
N/A, I think

## Performance Impact
N/A
