### PR TITLE
[Bugfix] Make Tace Mesa inscrutable

### DIFF
--- a/data/incipias/tace mesa.txt
+++ b/data/incipias/tace mesa.txt
@@ -57,6 +57,7 @@ ship "Tace Mesa"
 		"solar collection" 200
 		"fuel capacity" 200
 
+		"inscrutable" 1
 		"heat dissipation" 0.47
 		"energy capacity" 1000
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10457
Fixes #10457

## Summary
Added inscrutable to Tace Mesa so they are not scannable.

Thanks @tekker2234 for flagging this issue.

## Screenshots
N/A

## Usage examples
The new indigineous lifeforms added with the Incipias lack "inscrutiable" and can thus have their outfits scanned.

## Testing Done
None

## Save File
None

## Performance Impact
N/A
