### PR TITLE
fix(mechanics): Unselect destroyed escorts and exclude them from receiving orders

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4835,7 +4835,7 @@ void AI::IssueOrders(const Orders &newOrders, const string &description)
 	if(player.SelectedShips().empty())
 	{
 		for(const shared_ptr<Ship> &it : player.Ships())
-			if(it.get() != player.Flagship() && !it->IsParked())
+			if(it.get() != player.Flagship() && !it->IsParked() && !it->IsDestroyed())
 				ships.push_back(it.get());
 		who = ships.size() > 1 ? "Your fleet is " : "Your escort is ";
 	}

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4832,25 +4832,42 @@ void AI::IssueOrders(const Orders &newOrders, const string &description)
 
 	// Figure out what ships we are giving orders to.
 	vector<const Ship *> ships;
+	size_t destroyedCount = 0;
 	if(player.SelectedShips().empty())
 	{
 		for(const shared_ptr<Ship> &it : player.Ships())
-			if(it.get() != player.Flagship() && !it->IsParked() && !it->IsDestroyed())
-				ships.push_back(it.get());
-		who = ships.size() > 1 ? "Your fleet is " : "Your escort is ";
+			if(it.get() != player.Flagship() && !it->IsParked())
+			{
+				if(it->IsDestroyed())
+					++destroyedCount;
+				else
+					ships.push_back(it.get());
+			}
+		who = (ships.empty() ? destroyedCount : ships.size()) > 1
+			? "Your fleet is " : "Your escort is ";
 	}
 	else
 	{
 		for(const weak_ptr<Ship> &it : player.SelectedShips())
 		{
 			shared_ptr<Ship> ship = it.lock();
-			if(ship)
+			if(!ship)
+				continue;
+			if(ship->IsDestroyed())
+				++destroyedCount;
+			else
 				ships.push_back(ship.get());
 		}
-		who = ships.size() > 1 ? "The selected escorts are " : "The selected escort is ";
+		who = (ships.empty() ? destroyedCount : ships.size()) > 1
+			? "The selected escorts are " : "The selected escort is ";
 	}
 	if(ships.empty())
+	{
+		if(destroyedCount)
+			Messages::Add(who + "destroyed and unable to execute your orders.",
+				Messages::Importance::High);
 		return;
+	}
 
 	Point centerOfGravity;
 	bool isMoveOrder = (newOrders.HasMoveTo());

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1702,7 +1702,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 					eventQueue.emplace_back(nullptr, bay.ship, ShipEvent::DESTROY);
 			// If this is a player ship, make sure it's no longer selected.
 			if(ship->IsYours())
-				player.DeselectShip(ship);
+				player.DeselectShip(ship.get());
 		}
 		return;
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1702,7 +1702,7 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 					eventQueue.emplace_back(nullptr, bay.ship, ShipEvent::DESTROY);
 			// If this is a player ship, make sure it's no longer selected.
 			if(ship->IsYours())
-				player.UnselectShip(ship);
+				player.DeselectShip(ship);
 		}
 		return;
 	}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1700,6 +1700,9 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 			for(const auto &bay : ship->Bays())
 				if(bay.ship)
 					eventQueue.emplace_back(nullptr, bay.ship, ShipEvent::DESTROY);
+			// If this is a player ship, make sure it's no longer selected.
+			if(ship->IsYours())
+				player.UnselectShip(ship);
 		}
 		return;
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2777,7 +2777,7 @@ void PlayerInfo::SelectShip(const Ship *ship, bool hasShift)
 
 
 
-void PlayerInfo::UnselectShip(const shared_ptr<Ship> ship)
+void PlayerInfo::DeselectShip(const shared_ptr<Ship> ship)
 {
 	for(auto it = selectedShips.begin(); it != selectedShips.end(); ++it)
 		if(it->lock() == ship)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2777,10 +2777,10 @@ void PlayerInfo::SelectShip(const Ship *ship, bool hasShift)
 
 
 
-void PlayerInfo::DeselectShip(const shared_ptr<Ship> ship)
+void PlayerInfo::DeselectShip(const Ship *ship)
 {
 	for(auto it = selectedShips.begin(); it != selectedShips.end(); ++it)
-		if(it->lock() == ship)
+		if(it->lock().get() == ship)
 		{
 			selectedShips.erase(it);
 			return;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2777,6 +2777,18 @@ void PlayerInfo::SelectShip(const Ship *ship, bool hasShift)
 
 
 
+void PlayerInfo::UnselectShip(const shared_ptr<Ship> ship)
+{
+	for(auto it = selectedShips.begin(); it != selectedShips.end(); ++it)
+		if(it->lock() == ship)
+		{
+			selectedShips.erase(it);
+			return;
+		}
+}
+
+
+
 void PlayerInfo::SelectGroup(int group, bool hasShift)
 {
 	int bit = (1 << group);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -307,6 +307,7 @@ public:
 	bool SelectShips(const Rectangle &box, bool hasShift);
 	bool SelectShips(const std::vector<const Ship *> &stack, bool hasShift);
 	void SelectShip(const Ship *ship, bool hasShift);
+	void UnselectShip(const std::shared_ptr<Ship> ship);
 	void SelectGroup(int group, bool hasShift);
 	void SetGroup(int group, const std::set<Ship *> *newShips = nullptr);
 	std::set<Ship *> GetGroup(int group);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -307,7 +307,7 @@ public:
 	bool SelectShips(const Rectangle &box, bool hasShift);
 	bool SelectShips(const std::vector<const Ship *> &stack, bool hasShift);
 	void SelectShip(const Ship *ship, bool hasShift);
-	void UnselectShip(const std::shared_ptr<Ship> ship);
+	void DeselectShip(const std::shared_ptr<Ship> ship);
 	void SelectGroup(int group, bool hasShift);
 	void SetGroup(int group, const std::set<Ship *> *newShips = nullptr);
 	std::set<Ship *> GetGroup(int group);

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -307,7 +307,7 @@ public:
 	bool SelectShips(const Rectangle &box, bool hasShift);
 	bool SelectShips(const std::vector<const Ship *> &stack, bool hasShift);
 	void SelectShip(const Ship *ship, bool hasShift);
-	void DeselectShip(const std::shared_ptr<Ship> ship);
+	void DeselectShip(const Ship *ship);
 	void SelectGroup(int group, bool hasShift);
 	void SetGroup(int group, const std::set<Ship *> *newShips = nullptr);
 	std::set<Ship *> GetGroup(int group);


### PR DESCRIPTION
## Summary
Currently, if you have a single escort selected and that escort is destroyed, the game thinks you still have a ship selected and sends your orders only to that destroyed ship.
With this PR, when an escort dies, it's removed from the selected ships.

Unselected destroyed escorts are now excluded too. This doesn't make any difference in which ships receive the orders, but fixes pluralization in the orders messages.

Also, if all escorts you're sending an order to are destroyed, you get a message about it.

## Testing Done
yes.

## Performance Impact
N/A
