### PR TITLE
fix(mechanics): Update default uninhabited spaceports properly

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -238,8 +238,13 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes)
 	// For reverse compatibility, if this planet has a spaceport but it was not custom loaded,
 	// and the planet has the "uninhabited" attribute, replace the spaceport with a special-case
 	// uninhabited spaceport.
-	if(attributes.contains("uninhabited") && HasNamedPort() && !port.CustomLoaded())
-		port.LoadUninhabitedSpaceport();
+	if(HasNamedPort() && !port.CustomLoaded())
+	{
+		if(attributes.contains("uninhabited"))
+			port.LoadUninhabitedSpaceport();
+		else
+			port.LoadDefaultSpaceport();
+	}
 
 	// Apply any auto-attributes to this planet depending on what it has.
 	static const vector<string> AUTO_ATTRIBUTES = {


### PR DESCRIPTION
**Bug fix**

This PR fixes #10051.

## Summary
Now, if the planet doesn't have a custom defined spaceport, but is still supposed to have a spaceport, the game chooses between the uninhabited and normal default configs, depending on the `uninhabited` planet attribute.

## Testing Done
Tested with the save file provided in the original issue.

## Performance Impact
N/A
