### PR TITLE
fix(mechanics): Fix weapon jamming accumulation

### DIFF
--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -323,8 +323,9 @@ void Hardpoint::Jam()
 	// const access), assume Armament checked that this is a valid call.
 
 	// Reset the reload count.
-	reload = outfit->Reload();
-	burstReload = outfit->BurstReload();
+	reload += outfit->Reload();
+	burstReload += outfit->BurstReload();
+	--burstCount;
 }
 
 

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -323,8 +323,8 @@ void Hardpoint::Jam()
 	// const access), assume Armament checked that this is a valid call.
 
 	// Reset the reload count.
-	reload += outfit->Reload();
-	burstReload += outfit->BurstReload();
+	reload = outfit->Reload();
+	burstReload = outfit->BurstReload();
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR fixes #10442.

## Summary
Jamming is supposed to reset the reload counter, so that after the (unsuccessful) attempt to fire, you need to wait another reload cycle. But currently there's a bug that causes the cycles to build up, which means that if you try to fire while your ship is scrambled, you may end up with a single "reload" lasting many normal reload cycles.
Edit: this may be even more complicated (see the comments below).

With this patch, a single jam never blocks the weapon for more than one reload cycle.

## Testing Done
It's kinda hard to reliably test this, but it seems to work now.

## Wiki Update
N/A

## Performance Impact
N/A
