### PR TITLE
Fix: Heliarch no longer like Incipias Quarg

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -738,11 +738,12 @@ government "Heliarch"
 	"hostile hail" "hostile heliarch"
 	"hostile disabled hail" "hostile disabled heliarch"
 	"attitude toward"
-		"Quarg" -.01
-		"Quarg (Hai)" -.01
-		"Quarg (Kor Efret)" -.01
-		"Quarg (Gegno)" -.01
 		"Coalition" 1
+		"Quarg" -.01
+		"Quarg (Gegno)" -.01
+		"Quarg (Hai)" -.01
+		"Quarg (Incipias)" -.01
+		"Quarg (Kor Efret)" -.01
 
 government "Heliarch Test Dummy"
 	"display name" "Heliarch"


### PR DESCRIPTION
**Bug fix**

## Summary
When the Incipias were added with their new Quarg government, the Heliarch did not get a negative reputation toward that new government. This adds that, and alphabetizes the Heliarch `reputation toward`s, just because I was right there anyway.

## Screenshots
N/A

## Testing Done
No.

## Save File
This save file can be used to test these changes:
Not really.
