### PR TITLE
Don't send the appeasement message from "mute" ships or when the player doesn't know the language

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2888,13 +2888,16 @@ void AI::DoAppeasing(const shared_ptr<Ship> &ship, double *threshold) const
 			toDump -= dumped;
 		}
 
+	*threshold = (1. - health) + .1;
+
+	if(ship->GetPersonality().IsMute())
+		return;
 	const Government *government = ship->GetGovernment();
 	const string &language = government->Language();
 	if(language.empty() || player.Conditions().Get("language: " + language))
 		Messages::Add(government->GetName() + " " + ship->Noun() + " \"" + ship->Name()
 			+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::Low);
 
-	*threshold = (1. - health) + .1;
 }
 
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2888,8 +2888,11 @@ void AI::DoAppeasing(const shared_ptr<Ship> &ship, double *threshold) const
 			toDump -= dumped;
 		}
 
-	Messages::Add(ship->GetGovernment()->GetName() + " " + ship->Noun() + " \"" + ship->Name()
-		+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::Low);
+	const Government *government = ship->GetGovernment();
+	const string &language = government->Language();
+	if(language.empty() || player.Conditions().Get("language: " + language))
+		Messages::Add(government->GetName() + " " + ship->Noun() + " \"" + ship->Name()
+			+ "\": Please, just take my cargo and leave me alone.", Messages::Importance::Low);
 
 	*threshold = (1. - health) + .1;
 }


### PR DESCRIPTION
**Feature**

## Summary
When a ship dumps cargo as part of "appeasement", it sends a message requesting its attacker take its cargo and leave it alone. This message is visible to the player, even if that government will otherwise not communicate with the player in a way they can understand.
This PR skips sending that message if the government has a "language" that the player does not know.

## Testing Done
I didn't.

## Save File
This save file can be used to test these changes:
Maybe I'll add one later.
