### PR TITLE
Avoid continuity issue in Remnant: Void Sprites: 3

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -581,7 +581,8 @@ mission "Remnant: Void Sprites 1"
 				`	"Yes, I'd be glad to."`
 					goto end
 				`	"Wait, that sounds super shady. Can you explain why you think it's safe for me to enter that star system, but not for you to do so?"`
-
+			action
+				set "remnant: void sprites 1: asked for more details"
 			`	He says, "We studied the organisms and determined that they could not possibly be sentient. Therefore we saw no moral issues with collecting, well, ah... a sample. Unexpected things happened and certain grudges have been, ah, borne against Remnant ships for centuries as a result."`
 			choice
 				`	"Well, as long as you don't ask me to do something that will get me in similar trouble, I'll help you out."`
@@ -686,7 +687,13 @@ mission "Remnant: Void Sprites 3"
 			`The Remnant researcher seems disappointed that an outfit scan didn't reveal any information about the void sprites, but he is also excited about a new idea for studying them. "I found that we have several old mothballed ships suitable for exploring the upper atmosphere of a gas giant," he says. "Until I can publish my results I will not have the resources to compensate you, but I can provide you with one of our ships. Then you could land on the void sprite worlds and observe them in their natural habitat."`
 			choice
 				`	"How much will it cost to buy one?"`
+				`	"You said before you cannot safely approach these organisms. How will I land on their planets in one of your ships?"`
+					to display
+						not "remnant: void sprites 1: asked for more details"
+					goto attack
 				`	"Didn't you say before that anyone entering that system in a Remnant ship gets attacked?"`
+					to display
+						has "remnant: void sprites 1: asked for more details"
 					goto attack
 				`	"Sorry, I'm not interested in helping you anymore."`
 					decline


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #7696 

## Summary
A dialog choice in "Remnant: Void Sprites 3" is written with the assumption that you (the player) were told in "Remnant: Void Sprites 1" that Remnant ships are attacked when in the Nenia system.
While this information is provided in that mission, it is only given if the player asks for more details. There is the option to accept the mission without receiving this additional detail. In this case, you are only told that "[the Remnant] can no longer safely approach the organisms." This is much more ambiguous and does not necessarily mean their ships are attacked when in that system.

This PR sets a condition when asking for the additional information in "Remnant: Void Sprites 1" and gives alternate text in "Remnant: Void Sprites 3" to players who did not ask that question. It assumes that whatever Plume was alluding to previously could prevent the player from landing on the gas giants in Nenia in a Remnant ship without stating information the player wasn't necessarily given.

## Testing Done
None.

## Save File
This save file can be used to test these changes:
Maybe there'll be one soon.
