### PR TITLE
Don't delete cargo dumped from a carried ship

### DIFF
--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -69,7 +69,7 @@ void Flotsam::Place(const Ship &source)
 
 // Place this flotsam with its starting position at the specified bay of the source ship,
 // instead of the center of the ship.
-void Flotsam::Place(const Ship &source, int bayIndex)
+void Flotsam::Place(const Ship &source, size_t bayIndex)
 {
 	Place(source);
 	if(source.Bays().size() > bayIndex)

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -73,7 +73,7 @@ void Flotsam::Place(const Ship &source, size_t bayIndex)
 {
 	Place(source);
 	if(source.Bays().size() > bayIndex)
-		this->position += source.Bays()[bayIndex].point;
+		position += source.Bays()[bayIndex].point;
 }
 
 

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -72,8 +72,8 @@ void Flotsam::Place(const Ship &source)
 void Flotsam::Place(const Ship &source, int bayIndex)
 {
 	Place(source);
-	const auto it = std::next(source.Bays().begin(), bayIndex);
-	this->position += it->point;
+	if(source.Bays().size() > bayIndex)
+		this->position += source.Bays().at(bayIndex).point;
 }
 
 

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -67,6 +67,17 @@ void Flotsam::Place(const Ship &source)
 
 
 
+// Place this flotsam with its starting position at the specified bay of the source ship,
+// instead of the centre of the ship.
+void Flotsam::Place(const Ship &source, int bayIndex)
+{
+	Place(source);
+	const auto it = std::next(source.Bays().begin(), bayIndex);
+	this->position += it->point;
+}
+
+
+
 // Place flotsam coming from something other than a ship. Optionally specify
 // the maximum relative velocity, or the exact relative velocity as a vector.
 void Flotsam::Place(const Body &source, double maxVelocity)

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -73,7 +73,7 @@ void Flotsam::Place(const Ship &source, size_t bayIndex)
 {
 	Place(source);
 	if(source.Bays().size() > bayIndex)
-		position += source.Bays()[bayIndex].point;
+		position += source.Facing().Rotate(source.Bays()[bayIndex].point);
 }
 
 

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -68,7 +68,7 @@ void Flotsam::Place(const Ship &source)
 
 
 // Place this flotsam with its starting position at the specified bay of the source ship,
-// instead of the centre of the ship.
+// instead of the center of the ship.
 void Flotsam::Place(const Ship &source, int bayIndex)
 {
 	Place(source);

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -73,7 +73,7 @@ void Flotsam::Place(const Ship &source, size_t bayIndex)
 {
 	Place(source);
 	if(source.Bays().size() > bayIndex)
-		this->position += source.Bays().at(bayIndex).point;
+		this->position += source.Bays()[bayIndex].point;
 }
 
 

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -49,7 +49,7 @@ public:
 	void Place(const Ship &source);
 	// Place this flotsam with its starting position at the specified bay of the source ship,
 	// instead of the center of the ship.
-	void Place(const Ship &source, int bayIndex);
+	void Place(const Ship &source, size_t bayIndex);
 	// Place flotsam coming from something other than a ship. Optionally specify
 	// the maximum relative velocity, or the exact relative velocity as a vector.
 	void Place(const Body &source, double maxVelocity = .5);

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -48,7 +48,7 @@ public:
 	// several frames before it finishes dumping it all.
 	void Place(const Ship &source);
 	// Place this flotsam with its starting position at the specified bay of the source ship,
-	// instead of the centre of the ship.
+	// instead of the center of the ship.
 	void Place(const Ship &source, int bayIndex);
 	// Place flotsam coming from something other than a ship. Optionally specify
 	// the maximum relative velocity, or the exact relative velocity as a vector.

--- a/source/Flotsam.h
+++ b/source/Flotsam.h
@@ -47,6 +47,9 @@ public:
 	// separate function because a ship may queue up flotsam to dump but take
 	// several frames before it finishes dumping it all.
 	void Place(const Ship &source);
+	// Place this flotsam with its starting position at the specified bay of the source ship,
+	// instead of the centre of the ship.
+	void Place(const Ship &source, int bayIndex);
 	// Place flotsam coming from something other than a ship. Optionally specify
 	// the maximum relative velocity, or the exact relative velocity as a vector.
 	void Place(const Body &source, double maxVelocity = .5);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3865,10 +3865,10 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 			for(shared_ptr<Flotsam> &it : jettisoned)
 				it->Place(*this);
 			flotsam.splice(flotsam.end(), jettisoned);
-			for(auto &it : jettisonedFromBay)
+			for(auto &[newFlotsam, bayIndex] : jettisonedFromBay)
 			{
-				it.first->Place(*this, it.second);
-				flotsam.emplace_back(it.first);
+				newFlotsam->Place(*this, bayIndex);
+				flotsam.emplace_back(std::move(newFlotsam));
 			}
 			jettisonedFromBay.clear();
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4254,24 +4254,8 @@ void Ship::DoPassiveEffects(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &
 
 void Ship::DoJettison(list<shared_ptr<Flotsam>> &flotsam)
 {
-	if(jettisoned.empty())
-		return;
-	// If this ship is currently being carried by another, transfer Flotsam to be jettisoned to the carrier.
-	if(!currentSystem)
-	{
-		shared_ptr<Ship> carrier = parent.lock();
-		if(!carrier)
-			return;
-		for(const auto &bay : carrier->Bays())
-		{
-			if(bay.ship.get() != this)
-				continue;
-			carrier->jettisoned.splice(carrier->jettisoned.end(), jettisoned);
-			break;
-		}
-	}
 	// Jettisoned cargo effects (only for ships in the current system).
-	else if(!forget)
+	if(!jettisoned.empty() && !forget)
 	{
 		jettisoned.front()->Place(*this);
 		flotsam.splice(flotsam.end(), jettisoned, jettisoned.begin());

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4272,9 +4272,9 @@ void Ship::DoJettison(list<shared_ptr<Flotsam>> &flotsam)
 	}
 	if(!jettisonedFromBay.empty())
 	{
-		auto &it = jettisonedFromBay.front();
-		it.first->Place(*this, it.second);
-		flotsam.emplace_back(it.first);
+		auto &[newFlotsam, bayIndex] = jettisonedFromBay.front();
+		newFlotsam->Place(*this, bayIndex);
+		flotsam.emplace_back(std::move(newFlotsam));
 		jettisonedFromBay.pop_front();
 	}
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1388,6 +1388,7 @@ void Ship::Place(Point position, Point velocity, Angle angle, bool isDeparting)
 	disabledRecoveryCounter = 0;
 	isInvisible = !HasSprite();
 	jettisoned.clear();
+	jettisonedFromBay.clear();
 	hyperspaceCount = 0;
 	forget = 1;
 	targetShip.reset();
@@ -5067,11 +5068,14 @@ void Ship::Jettison(shared_ptr<Flotsam> toJettison)
 	shared_ptr<Ship> carrier = parent.lock();
 	if(!carrier)
 		return;
+	int bayIndex = 0;
 	for(const auto &bay : carrier->Bays())
 	{
-		if(bay.ship.get() != this)
-			continue;
-		carrier->jettisoned.emplace_back(toJettison);
-		break;
+		if(bay.ship.get() == this)
+		{
+			carrier->jettisonedFromBay.emplace_back(toJettison, bayIndex);
+			break;
+		}
+		++bayIndex;
 	}
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -5084,7 +5084,7 @@ void Ship::Jettison(shared_ptr<Flotsam> toJettison)
 	shared_ptr<Ship> carrier = parent.lock();
 	if(!carrier)
 		return;
-	int bayIndex = 0;
+	size_t bayIndex = 0;
 	for(const auto &bay : carrier->Bays())
 	{
 		if(bay.ship.get() == this)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3865,6 +3865,12 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 			for(shared_ptr<Flotsam> &it : jettisoned)
 				it->Place(*this);
 			flotsam.splice(flotsam.end(), jettisoned);
+			for(auto &it : jettisonedFromBay)
+			{
+				it.first->Place(*this, it.second);
+				flotsam.emplace_back(it.first);
+			}
+			jettisonedFromBay.clear();
 
 			// Any ships that failed to launch from this ship are destroyed.
 			for(Bay &bay : bays)
@@ -4255,11 +4261,21 @@ void Ship::DoPassiveEffects(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &
 
 void Ship::DoJettison(list<shared_ptr<Flotsam>> &flotsam)
 {
+	if(forget)
+		return;
 	// Jettisoned cargo effects (only for ships in the current system).
-	if(!jettisoned.empty() && !forget)
+	if(!jettisoned.empty())
 	{
 		jettisoned.front()->Place(*this);
 		flotsam.splice(flotsam.end(), jettisoned, jettisoned.begin());
+		return;
+	}
+	if(!jettisonedFromBay.empty())
+	{
+		auto &it = jettisonedFromBay.front();
+		it.first->Place(*this, it.second);
+		flotsam.emplace_back(it.first);
+		jettisonedFromBay.pop_front();
 	}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4254,8 +4254,24 @@ void Ship::DoPassiveEffects(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &
 
 void Ship::DoJettison(list<shared_ptr<Flotsam>> &flotsam)
 {
+	if(jettisoned.empty())
+		return;
+	// If this ship is currently being carried by another, transfer Flotsam to be jettisoned to the carrier.
+	if(!currentSystem)
+	{
+		shared_ptr<Ship> carrier = parent.lock();
+		if(!carrier)
+			return;
+		for(const auto &bay : carrier->Bays())
+		{
+			if(bay.ship.get() != this)
+				continue;
+			carrier->jettisoned.splice(carrier->jettisoned.end(), jettisoned);
+			break;
+		}
+	}
 	// Jettisoned cargo effects (only for ships in the current system).
-	if(!jettisoned.empty() && !forget)
+	else if(!forget)
 	{
 		jettisoned.front()->Place(*this);
 		flotsam.splice(flotsam.end(), jettisoned, jettisoned.begin());

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -543,6 +543,9 @@ private:
 	double CalculateAttraction() const;
 	double CalculateDeterrence() const;
 
+	// Helper function for jettisonning flotsam.
+	void Jettison(std::shared_ptr<Flotsam> toJettison);
+
 
 private:
 	// Protected member variables of the Body class:

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -623,7 +623,7 @@ private:
 	std::map<const Outfit *, int> outfits;
 	CargoHold cargo;
 	std::list<std::shared_ptr<Flotsam>> jettisoned;
-	std::list<std::pair<std::shared_ptr<Flotsam>, int>> jettisonedFromBay;
+	std::list<std::pair<std::shared_ptr<Flotsam>, size_t>> jettisonedFromBay;
 
 	std::vector<Bay> bays;
 	// Cache the mass of carried ships to avoid repeatedly recomputing it.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -623,6 +623,7 @@ private:
 	std::map<const Outfit *, int> outfits;
 	CargoHold cargo;
 	std::list<std::shared_ptr<Flotsam>> jettisoned;
+	std::list<std::pair<std::shared_ptr<Flotsam>, int>> jettisonedFromBay;
 
 	std::vector<Bay> bays;
 	// Cache the mass of carried ships to avoid repeatedly recomputing it.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -543,7 +543,7 @@ private:
 	double CalculateAttraction() const;
 	double CalculateDeterrence() const;
 
-	// Helper function for jettisonning flotsam.
+	// Helper function for jettisoning flotsam.
 	void Jettison(std::shared_ptr<Flotsam> toJettison);
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #6727

## Summary
Currently, when cargo is dumped, it is moved to a list of "jettisoned" items which are gradually added to the global collection of `Flotsam` to make them appear in system. When this process occurs for a carried ship, items are instead essentially discarded because the ship is considered to be outside the player's current system.
This PR instead passes any items to be jettisoned by a carried ship up to its carrier, from which they will be jettisoned normally.

## Testing Done
Using the attached save file:
- Take off.
- Open the player info panel.
- Navigate to the ship info panel page for either of the two Daggers.
- Dump their cargo.

Without this PR, the cargo is removed from the ships but no flotsam appears. :(
With this PR, flotsam spawns from the flagship! :)

## Save File
This save file can be used to test these changes:
[warp core carried ship dumping cargo.txt](https://github.com/user-attachments/files/17036463/warp.core.carried.ship.dumping.cargo.txt)

## Performance Impact
I don't expect anything measurable.
