### PR TITLE
[Bugfix] Delay hull repair on Black Diamond

### DIFF
--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -180,8 +180,8 @@ ship "Black Diamond"
 		"outfit space" 152
 		"weapon capacity" 35
 		"engine capacity" 38
-		"hull repair rate" 1
-		"hull delay" 60
+		"delayed hull repair rate" 1
+		"repair delay" 60
 		weapon
 			"blast radius" 24
 			"shield damage" 240


### PR DESCRIPTION
Thanks to MidnightPlugins for reporting. 

**Bug fix**

This PR addresses the bug described by MidnightPlugins in Discord.

## Summary
Black Diamond hull repair is currently not delayed due to not having proper "delayed hull repair rate" and "repair delay" attributes introduced in 10.7. This PR makes 2 changes:
- `"hull repair rate" 1` --> `"delayed hull repair rate" 1`
- `"hull delay" 60` --> `"repair delay" 60`
		
		

## Testing Done
Tested a Black Diamond in current state and with the fix.

## Save File
N/A

## Performance Impact
N/A
