### PR TITLE
Lunarium Intro: questions properly disappear

### DIFF
--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1905,33 +1905,54 @@ mission "Lunarium: Quarg Interview"
 			label questions
 			choice
 				`	"What are you all going to do if you do manage to take down the Heliarchs?"`
+					to display
+						not "lunarium questions: takedown"
 				`	"You'll need to fight the Heliarchs at some point. Are you capable of doing that?"`
+					to display
+						not "lunarium questions: fightthem"
 					goto fight
 				`	"Am I the only outsider helping you?"`
+					to display
+						not "lunarium questions: outsider"
 					goto outsiders
 				`	"How do you pay for all this?"`
+					to display
+						not "lunarium questions: money"
 					goto pay
 				`	"I'm fine for now. What about this task you need me for?"`
 					goto task
+			action
+				set "lunarium questions: takedown"
 			`	"Rebuild, first we will need to," Chiree responds. "Fight tooth and nail to remain in power, they will, so a great deal of damage to the Coalition, we expect."`
 			`	"Once back in order, everything is, focus on reassuring the populace we should. A change for the better, it will be, and help in making sure everyone realizes that, House Bebliss will," Lobmab jumps in. "Earn back what they took from us, we will."`
 			`	Once the head of House Bebliss is done, Chiree continues. "Pointless, our fight will have been, if corrupted in those rings again, our successors thousands of years from now become. Set up transparency measures and means to ensure that absolute power, the consuls do not have, we will."`
 				goto questions
 			label fight
+			action
+				set "lunarium questions: fightthem"
 			`	"Try and fool you, I will not. At a tremendous disadvantage, to say the least, we are," Pyakri answers. "Weaker, our ships are, and far less powerful weapons, we boast. Mostly human designs. Due to being simpler, easier to produce in what factories we have, they are. Also lack experience, the troops do..."`
 			`	The mood around the table quickly dims as she goes on listing the ways the Lunarium is lacking in comparison to your opponents. Elirom stands up, putting both hands on the table to draw attention. "Smarter than us, they are not. Assure you of that, I can. Wanting in many areas we are, yes, but only because hoard our best materials, they do. Already preparing some deadlier weapons, we are. Finished, the blueprints have been. Only lacking the right materials, we are. When secured those, we have, move on to reforming our arsenal we can, and maybe get some better ships produced, too."`
 			`	"And suppose I do that, intend to tell me where to attack for such materials, you do?" Pyakri asks as she stands up herself. "Caught by 'the unforeseen' will my men again be? By an Arach battalion you forgot to mention, again?"`
 			`	Caught off-guard by the question, apparently, Elirom looks at her for a few seconds, then resigns himself to sit back down.`
 				goto questions
 			label outsiders
+			action
+				set "lunarium questions: outsider"
 			`	For a few seconds, they simply exchange looks at your question, until Lobmab speaks up. "Transmissions and messages from some source, Bebliss has received for centuries now. Told us they have of Heliarch activity, fleet movements, training drills, propaganda plans. Always exactly right in their predictions, the messages were. Also pointed us to equipment caches - caches with outfits previously found nowhere in the Coalition - they have. Human weaponry, blueprints, factory parts..."`
 			`	"Aware of the identity of whoever does it, we are not," Elirom says. "An arbiter I was, and though a great deal I knew, still kept from me, some critical information was. Possible, it is, that from one of the consuls, the information comes. Though, difficult to steal a jump drive to bring in the weapons, it would be, even for a consul." He pauses, a dead stare in his eyes as he bites lightly on a finger. "Also received word of... experiments, we have from the messages. Some manner of procedure to take over bodies... stop whatever it is being done in the rings, we must."`
 				goto questions
 			label pay
+			action
+				set "lunarium questions: money"
 			`	The rest of the table look to Lobmab at the same time, prompting her explanation. "Amassed great fortune over our history, House Bebliss has. As part of our gracious help to the Lunarium, providing nearly everything in financial terms we have been."`
 			`	She stops, with the others still looking at her, as if expecting something more. She remains silent, so Chiree looks back at you, continuing, "Also taken some loans from House Plumtab in our stead, Houses Bebliss and Idriss have. Not terribly passionate for our cause, Plumtab's bankers are, but share our interest in booting the Heliarchs, they do, even if meet or talk with us, they never do."`
 				goto questions
 			label task
+			action
+				clear "lunarium questions: fightthem"
+				clear "lunarium questions: money"
+				clear "lunarium questions: outsider"
+				clear "lunarium questions: takedown"
 			`	Tummug goes around the table, handing copies of some documents to the other leaders before answering. "One of the centerpoints of Heliarch propaganda, the fear of the Quarg is. Served to justify their budget, and their obsession with hoarding the military, for millennia it has. Thought up a way to mitigate the effect that has on the populace, Oobat has."`
 			`	With this cue, Oobat goes further into the plan. "Not seen in Coalition space in over six thousand years, a Quarg ship has been. Most likely moved on from our war, they have, unlike the Heliarchs. If proof of the Quarg's lack of interest in waging war against us, we had, spread it to the people, we could. Given the Captain's resourcefulness, and possession of a jump drive, think we did that the best way to acquire that proof, meeting up with the Quarg is." She grabs one of the documents, pointing to it. "For you all to review these questions, I would like. Careful we should be, with regard to their wording. Once done, we are, board Captain <last>'s ship, I will. Meet with the Quarg in human space, we must," she says the last part looking at you. "Met with the Quarg before, have you, Captain?"`
 			branch metquarg


### PR DESCRIPTION
**Bug Fix**

Fixes #9792.

## Summary
Adds and clears conditions so that questions properly disappear after selecting.

## Screenshots
None

## Testing Done
None

## Save File
None (issue had none)