### PR TITLE
Quarg battery description fix

### DIFF
--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -19,7 +19,7 @@ outfit "Nanotech Battery"
 	"mass" 25
 	"outfit space" -25
 	"energy capacity" 60000
-	description "Human engineers who first came into contact with the Quarg were astonished by the sheer efficiency of their technology. The energy density of Quarg batteries is unparalleled, storing nearly a third more energy than the best human batteries while being less than a third the size."
+	description "Human engineers who first came into contact with the Quarg were astonished by the sheer efficiency of their technology. The energy density of Quarg batteries is unparalleled, storing nearly a third more energy than the best human batteries while being over a third smaller."
 
 outfit "Antimatter Core"
 	category "Power"

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -16,8 +16,8 @@ outfit "Nanotech Battery"
 	category "Power"
 	cost 3000000
 	thumbnail "outfit/quarg nanotech battery"
-	"mass" 25
-	"outfit space" -25
+	"mass" 50
+	"outfit space" -50
 	"energy capacity" 60000
 	description "Human engineers who first came into contact with the Quarg were astonished by the sheer efficiency of their technology. The energy density of Quarg batteries is unparalleled, storing nearly a third more energy than the best human batteries while being over a third smaller."
 

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -16,8 +16,8 @@ outfit "Nanotech Battery"
 	category "Power"
 	cost 3000000
 	thumbnail "outfit/quarg nanotech battery"
-	"mass" 50
-	"outfit space" -50
+	"mass" 25
+	"outfit space" -25
 	"energy capacity" 60000
 	description "Human engineers who first came into contact with the Quarg were astonished by the sheer efficiency of their technology. The energy density of Quarg batteries is unparalleled, storing nearly a third more energy than the best human batteries while being less than a third the size."
 

--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -26,7 +26,7 @@ ship "Quarg Skylark"
 		"heat dissipation" .47
 		"fuel capacity" 1000
 		"cargo space" 200
-		"outfit space" 600
+		"outfit space" 575
 		"weapon capacity" 200
 		"engine capacity" 120
 		"hull repair rate" 5
@@ -80,7 +80,7 @@ ship "Quarg Wardragon"
 		"heat dissipation" .34
 		"fuel capacity" 800
 		"cargo space" 50
-		"outfit space" 600
+		"outfit space" 575
 		"weapon capacity" 200
 		"engine capacity" 120
 		"hull repair rate" 5

--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -26,7 +26,7 @@ ship "Quarg Skylark"
 		"heat dissipation" .47
 		"fuel capacity" 1000
 		"cargo space" 200
-		"outfit space" 575
+		"outfit space" 600
 		"weapon capacity" 200
 		"engine capacity" 120
 		"hull repair rate" 5
@@ -80,7 +80,7 @@ ship "Quarg Wardragon"
 		"heat dissipation" .34
 		"fuel capacity" 800
 		"cargo space" 50
-		"outfit space" 575
+		"outfit space" 600
 		"weapon capacity" 200
 		"engine capacity" 120
 		"hull repair rate" 5


### PR DESCRIPTION
**Bug fix**


Fixes #8515.

## Summary
Tweaked the Quarg Nanotech Battery description so that it no longer says that it is "less than a third the size", the human battery nerf changed that.

## Screenshots
None

## Testing Done
None

## Save File
This save file can be used to test these changes:
None - I don't steal.
