### PR TITLE
Making Nenia Drak hate Remnant Ships

### DIFF
--- a/data/drak/drak missions.txt
+++ b/data/drak/drak missions.txt
@@ -105,10 +105,28 @@ mission "Drak guarding Void Sprites"
 	repeat
 	to offer
 		not "Drak guarding Void Sprites: active"
+		not "Chill Drak guarding Void Sprites: active"
+		"Drak Sleeping Dragon chill" <= 0
 	to complete
-		never
+		"Drak Sleeping Dragon chill" >= 1
 	npc save
-		government Drak
+		government "Drak (Nenia)"
+		personality heroic vindictive staying frugal
+		system Nenia
+		ship "Archon (Cloaked)" "Sleeping Dragon"
+
+mission "Chill Drak guarding Void Sprites"
+	invisible
+	landing
+	repeat
+	to offer
+		not "Drak guarding Void Sprites: active"
+		not "Chill Drak guarding Void Sprites: active"
+		"Drak Sleeping Dragon chill" >= 1
+	to complete
+		"Drak Sleeping Dragon chill" <= 0
+	npc save
+		government "Drak"
 		personality heroic vindictive staying frugal
 		system Nenia
 		ship "Archon (Cloaked)" "Sleeping Dragon"

--- a/data/drak/drak missions.txt
+++ b/data/drak/drak missions.txt
@@ -111,7 +111,7 @@ mission "Drak guarding Void Sprites"
 		"Drak Sleeping Dragon chill" >= 1
 	npc save
 		government "Drak (Nenia)"
-		personality heroic vindictive staying frugal
+		personality heroic vindictive staying frugal surveillance
 		system Nenia
 		ship "Archon (Cloaked)" "Sleeping Dragon"
 
@@ -127,7 +127,7 @@ mission "Chill Drak guarding Void Sprites"
 		"Drak Sleeping Dragon chill" <= 0
 	npc save
 		government "Drak"
-		personality heroic vindictive staying frugal
+		personality heroic vindictive staying frugal surveillance
 		system Nenia
 		ship "Archon (Cloaked)" "Sleeping Dragon"
 

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -116,7 +116,7 @@ ship "Archon" "Archon (Cloaked)"
 		"cloaked scanning" 1
 		"outfit scan power" 250
 		"outfit scan efficiency" 150
-		"hyperdrive sound" "no sound"
+		"silent jumps" 1
 	"final explode" "archon c teleport"
 
 ship "Archon" "Archon (Hyperdrive Cloaked)"

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -50,6 +50,8 @@ ship "Archon"
 		"turn" 2400
 		"turning energy" 10
 		"turning heat" 5
+		"outfit scan power" 250
+		"outfit scan efficiency" 150
 		weapon
 			"blast radius" 500
 			"shield damage" 10000

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -50,8 +50,6 @@ ship "Archon"
 		"turn" 2400
 		"turning energy" 10
 		"turning heat" 5
-		"outfit scan power" 250
-		"outfit scan efficiency" 150
 		weapon
 			"blast radius" 500
 			"shield damage" 10000
@@ -115,6 +113,9 @@ ship "Archon" "Archon (Cloaked)"
 	"never disabled"
 	add attributes
 		"cloak" .04
+		"cloaked scanning"
+		"outfit scan power" 250
+		"outfit scan efficiency" 150
 	"final explode" "archon c teleport"
 
 ship "Archon" "Archon (Hyperdrive Cloaked)"

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -116,6 +116,7 @@ ship "Archon" "Archon (Cloaked)"
 		"cloaked scanning" 1
 		"outfit scan power" 250
 		"outfit scan efficiency" 150
+		"outfit scan sound" ""
 	"final explode" "archon c teleport"
 
 ship "Archon" "Archon (Hyperdrive Cloaked)"

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -113,7 +113,7 @@ ship "Archon" "Archon (Cloaked)"
 	"never disabled"
 	add attributes
 		"cloak" .04
-		"cloaked scanning"
+		"cloaked scanning" 1
 		"outfit scan power" 250
 		"outfit scan efficiency" 150
 	"final explode" "archon c teleport"

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -116,7 +116,6 @@ ship "Archon" "Archon (Cloaked)"
 		"cloaked scanning" 1
 		"outfit scan power" 250
 		"outfit scan efficiency" 150
-		"outfit scan sound" ""
 	"final explode" "archon c teleport"
 
 ship "Archon" "Archon (Hyperdrive Cloaked)"

--- a/data/drak/drak ships.txt
+++ b/data/drak/drak ships.txt
@@ -116,6 +116,7 @@ ship "Archon" "Archon (Cloaked)"
 		"cloaked scanning" 1
 		"outfit scan power" 250
 		"outfit scan efficiency" 150
+		"hyperdrive sound" "no sound"
 	"final explode" "archon c teleport"
 
 ship "Archon" "Archon (Hyperdrive Cloaked)"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -264,6 +264,7 @@ government "Drak (Nenia)"
 		"Ember Waste" 1
 	illegals
 		ignore "Nerve Gas"
+		ignore "Microbot Defense Station"
 	atrocities
 		ship "Albatross"
 		ship "Modified Dromedary"

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -254,6 +254,32 @@ government "Drak (Incipias)"
 		"Conlatio" 1
 		"Incipias Civilian" 1
 
+government "Drak (Nenia)"
+	"display name" "Drak"
+	swizzle 0
+	color 1 1 1
+	"player reputation" 1
+	"attitude toward"
+		"Indigenous Lifeform" 1
+		"Ember Waste" 1
+	illegals
+		ignore "Nerve Gas"
+	atrocities
+		ship "Albatross"
+		ship "Modified Dromedary"
+		ship "Gull"
+		ship "Heron"
+		ship "Ibis"
+		ship "Merganser"
+		ship "Pelican"
+		ship "Penguin"
+		ship "Peregrine"
+		ship "Petrel"
+		ship "Puffin"
+		ship "Smew"
+		ship "Starling"
+		ship "Tern"
+
 government "Elenctic Commune"
 	swizzle 0
 	color "governments: Neutral"

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -709,6 +709,7 @@ mission "Remnant: Void Sprites 3"
 	on accept
 		event "remnant: puffin"
 		give ship "Puffin" "Shadow in the Depths"
+		"Drak Sleeping Dragon chill"++
 	npc
 		government "Drak (Hostile)"
 		system "Nenia"
@@ -722,6 +723,7 @@ mission "Remnant: Void Sprites 3"
 	on visit
 		dialog phrase "generic missing stopover or cargo"
 	on complete
+		"Drak Sleeping Dragon chill"--
 		event "remnant: void sprite research" 20
 		log "Factions" "Void Sprites" `The "void sprites" are space-dwelling lifeforms. They are apparently not sentient. They evolved in the atmosphere of a gas giant, but have some biological mechanism for altering or reflecting gravity that allows them to fly into outer space, in the same way that human ships use antigravity to escape a planet's gravity well. The void sprites are not particularly powerful or dangerous creatures, but they are guarded by a Drak Archon.`
 		log "Factions" "Archons" `Archons are partly biological, but do not seem to be naturally evolved creatures. Some of their biological characteristics may have been based on the "void sprites" that inhabit the Ember Waste.`
@@ -1994,6 +1996,7 @@ mission "Remnant: Return the Samples"
 		has "Remnant: Technology Available: offered"
 		random < 50
 	on offer
+		"Drak Sleeping Dragon chill"++
 		conversation
 			`As you are walking through the spaceport, the researcher you previously assisted with the studies on the void sprites approaches you in a hustle. "We have made some new discoveries!" he exclaims in a trill. "Some of the samples that we took all those years ago are actually eggs of some kind. So the Archon must view our previous research as being disruptive to the void sprites' lifecycles.`
 			`	"We have been storing these eggs in a cryogenic stasis tank, so they should still be viable and intact. Well, most of them, anyway." His notes trail off on a mournful tone.`
@@ -2022,6 +2025,7 @@ mission "Remnant: Return the Samples"
 	on visit
 		dialog phrase "generic stopover on visit"
 	on complete
+		"Drak Sleeping Dragon chill"--
 		conversation
 			`Back on the ground, you report on how the release went. The researcher is pleased to hear that the void sprites responded to their presence. "We will give them a few weeks, then try sending another ship to monitor them. Hopefully the Archon will be pacified by this. Meet me in the alien environments lab just off the spaceport if you are interested in pursuing this."`
 
@@ -2035,6 +2039,7 @@ mission "Remnant: Return the Samples 2"
 	to offer
 		has "Remnant: Return the Samples: done"
 	on offer
+		"Drak Sleeping Dragon chill"++
 		conversation
 			`Following Plume's directions, you find a lab tucked behind the main area of the spaceport, where a short walkway leads into an underground structure. Stepping inside the door you note a rack of camouflage netting positioned easily at hand. Given what you have learned of their history, it is probably a last-ditch preparation in case they need to hide the entrance from a raid.`
 			`	The lab itself is a microcosm of Remnant development. The structure appears to be some strange semi-organic material, and you can see an eclectic mix of familiar and unfamiliar shapes cluttering the tables. If you had to guess, you would say that this lab was the result of several different families of technology, only one of which was human.`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -709,7 +709,7 @@ mission "Remnant: Void Sprites 3"
 	on accept
 		event "remnant: puffin"
 		give ship "Puffin" "Shadow in the Depths"
-		"Drak Sleeping Dragon chill"++
+		"Drak Sleeping Dragon chill" ++
 	npc
 		government "Drak (Hostile)"
 		system "Nenia"
@@ -723,7 +723,7 @@ mission "Remnant: Void Sprites 3"
 	on visit
 		dialog phrase "generic missing stopover or cargo"
 	on complete
-		"Drak Sleeping Dragon chill"--
+		"Drak Sleeping Dragon chill" --
 		event "remnant: void sprite research" 20
 		log "Factions" "Void Sprites" `The "void sprites" are space-dwelling lifeforms. They are apparently not sentient. They evolved in the atmosphere of a gas giant, but have some biological mechanism for altering or reflecting gravity that allows them to fly into outer space, in the same way that human ships use antigravity to escape a planet's gravity well. The void sprites are not particularly powerful or dangerous creatures, but they are guarded by a Drak Archon.`
 		log "Factions" "Archons" `Archons are partly biological, but do not seem to be naturally evolved creatures. Some of their biological characteristics may have been based on the "void sprites" that inhabit the Ember Waste.`
@@ -1996,7 +1996,7 @@ mission "Remnant: Return the Samples"
 		has "Remnant: Technology Available: offered"
 		random < 50
 	on offer
-		"Drak Sleeping Dragon chill"++
+		"Drak Sleeping Dragon chill" ++
 		conversation
 			`As you are walking through the spaceport, the researcher you previously assisted with the studies on the void sprites approaches you in a hustle. "We have made some new discoveries!" he exclaims in a trill. "Some of the samples that we took all those years ago are actually eggs of some kind. So the Archon must view our previous research as being disruptive to the void sprites' lifecycles.`
 			`	"We have been storing these eggs in a cryogenic stasis tank, so they should still be viable and intact. Well, most of them, anyway." His notes trail off on a mournful tone.`
@@ -2025,7 +2025,7 @@ mission "Remnant: Return the Samples"
 	on visit
 		dialog phrase "generic stopover on visit"
 	on complete
-		"Drak Sleeping Dragon chill"--
+		"Drak Sleeping Dragon chill" --
 		conversation
 			`Back on the ground, you report on how the release went. The researcher is pleased to hear that the void sprites responded to their presence. "We will give them a few weeks, then try sending another ship to monitor them. Hopefully the Archon will be pacified by this. Meet me in the alien environments lab just off the spaceport if you are interested in pursuing this."`
 
@@ -2039,7 +2039,7 @@ mission "Remnant: Return the Samples 2"
 	to offer
 		has "Remnant: Return the Samples: done"
 	on offer
-		"Drak Sleeping Dragon chill"++
+		"Drak Sleeping Dragon chill" ++
 		conversation
 			`Following Plume's directions, you find a lab tucked behind the main area of the spaceport, where a short walkway leads into an underground structure. Stepping inside the door you note a rack of camouflage netting positioned easily at hand. Given what you have learned of their history, it is probably a last-ditch preparation in case they need to hide the entrance from a raid.`
 			`	The lab itself is a microcosm of Remnant development. The structure appears to be some strange semi-organic material, and you can see an eclectic mix of familiar and unfamiliar shapes cluttering the tables. If you had to guess, you would say that this lab was the result of several different families of technology, only one of which was human.`


### PR DESCRIPTION
**Content (Missions)**

This PR addresses the bug described in issue #10475
This PR fixes #10475

## Summary
It's possible for some Remnant ships to travel to the Nenia system (not on purpose, only if they spawned somewhere else and then traveled with you). It is said that the Archon would attack any Remnant ships that enter the system (and that's the reason why it attacks the player). However, nothing happens.

This PR makes it so that one of the 2 Archons will attack anyone they detect in a Remnant ship, except during Remnant missions where the Lifted Lorax is hostile to keep Remnant Nenia missions the same.

This PR does so by:

- Creating a Drak (Nenia) government that has Remnant ships as atrocities.
- Giving Drak ships Outfit Scanning to detect the above atrocities.
- Setting 2 switchable Nenia Drak Missions for the Nenia Drak to have either the normal Drak or Drak (Nenia) government so that it's either "chill" or aggressive towards Remnant ships.
- Adding toggles to Remnant missions for the Sleeping Dragon to be neutral when Lifted Lorax is hostile and permanently neutral after the Archons relax their stance towards the Remnant.


## Testing Done
Tested each part individually in Omnis, and once all together.

## Save File
Save with an Albatross & Punisher that has met the Remnant. Can go to Nenia with either, or start the Nenia missions.
[Nenia Archon Tester~Met Remnant.txt](https://github.com/user-attachments/files/17091803/Nenia.Archon.Tester.Met.Remnant.txt)
