### PR TITLE
fix(ui): Don't generate key presses from inactive interfaces

### DIFF
--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -253,7 +253,7 @@ void BankPanel::Draw()
 		table.Draw("[apply]", selected);
 	}
 
-	Information info;
+	info.ClearConditions();
 	if((crewSalariesOwed || maintenanceDue) && player.Accounts().Credits() > 0)
 		info.SetCondition("can pay");
 	else

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -156,7 +156,7 @@ void BoardingPanel::Draw()
 	}
 
 	// Set which buttons are active.
-	Information info;
+	info.ClearConditions();
 	if(CanExit())
 		info.SetCondition("can exit");
 	if(CanTake())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -179,7 +179,7 @@ void HailPanel::Draw()
 {
 	DrawBackdrop();
 
-	Information info;
+	info.ClearConditions();
 	info.SetString("header", header);
 	if(ship)
 	{

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -47,7 +47,7 @@ void HiringPanel::Draw()
 {
 	const Ship *flagship = player.Flagship();
 	const Interface *hiring = GameData::Interfaces().Get("hiring");
-	Information info;
+	info.ClearConditions();
 
 	int flagshipBunks = 0;
 	int flagshipRequired = 0;

--- a/source/Information.cpp
+++ b/source/Information.cpp
@@ -143,6 +143,13 @@ bool Information::HasCondition(const string &condition) const
 
 
 
+void Information::ClearConditions()
+{
+	conditions.clear();
+}
+
+
+
 void Information::SetOutlineColor(const Color &color)
 {
 	outlineColor = color;

--- a/source/Information.h
+++ b/source/Information.h
@@ -49,6 +49,7 @@ public:
 
 	void SetCondition(const std::string &condition);
 	bool HasCondition(const std::string &condition) const;
+	void ClearConditions();
 
 	void SetOutlineColor(const Color &color);
 	const Color &GetOutlineColor() const;

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -623,7 +623,7 @@ void Interface::TextElement::Draw(const Rectangle &rect, const Information &info
 void Interface::TextElement::Place(const Rectangle &bounds, Panel *panel) const
 {
 	if(buttonKey && panel)
-		panel->AddZone(bounds, buttonKey);
+		panel->AddZone(bounds, buttonKey, activeIf);
 }
 
 

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -623,7 +623,7 @@ void Interface::TextElement::Draw(const Rectangle &rect, const Information &info
 void Interface::TextElement::Place(const Rectangle &bounds, Panel *panel) const
 {
 	if(buttonKey && panel)
-		panel->AddZone(bounds, buttonKey, activeIf);
+		panel->AddZone(bounds, buttonKey, {visibleIf, activeIf});
 }
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -137,7 +137,7 @@ void LoadPanel::Draw()
 	GameData::Background().Draw(Point(), Point());
 	const Font &font = FontSet::Get(14);
 
-	Information info;
+	info.ClearConditions();
 	if(loadedInfo.IsLoaded())
 	{
 		info.SetString("pilot", loadedInfo.Name());

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -332,7 +332,7 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 	// Remember which buttons we're showing.
 	MapPanel::buttonCondition = buttonCondition;
 
-	Information info;
+	info.ClearConditions();
 	info.SetCondition(buttonCondition);
 	const Interface *mapInterface = GameData::Interfaces().Get("map");
 	if(player.MapZoom() >= static_cast<int>(mapInterface->GetValue("max zoom")))

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -117,7 +117,7 @@ void MenuPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 
-	Information info;
+	info.ClearConditions();
 	if(player.IsLoaded() && !player.IsDead())
 	{
 		info.SetCondition("pilot loaded");

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -63,7 +63,7 @@ void MessageLogPanel::Draw()
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + width);
 
-	Information info;
+	info.ClearConditions();
 	if(messages.empty())
 	{
 		info.SetCondition("empty");

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -836,7 +836,7 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos, const std::li
 
 void MissionPanel::DrawMissionInfo()
 {
-	Information info;
+	info.ClearConditions();
 
 	// The "accept / abort" button text and activation depends on what mission,
 	// if any, is selected, and whether missions are available.

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -101,12 +101,14 @@ void Panel::AddZone(const Rectangle &rect, const function<void()> &fun)
 
 
 
-void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const string &activeIf)
+void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const vector<string> &conditions)
 {
-	AddZone(rect, [this, key, &activeIf]()
+	AddZone(rect, [this, key, &conditions]()
 	{
-		if(info.HasCondition(activeIf))
-			this->KeyDown(key, 0, Command(), true);
+		for(const string &condition : conditions)
+			if(!info.HasCondition(condition))
+				return;
+		this->KeyDown(key, 0, Command(), true);
 	});
 }
 

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -101,9 +101,13 @@ void Panel::AddZone(const Rectangle &rect, const function<void()> &fun)
 
 
 
-void Panel::AddZone(const Rectangle &rect, SDL_Keycode key)
+void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const string &activeIf)
 {
-	AddZone(rect, [this, key](){ this->KeyDown(key, 0, Command(), true); });
+	AddZone(rect, [this, key, &activeIf]()
+	{
+		if(info.HasCondition(activeIf))
+			this->KeyDown(key, 0, Command(), true);
+	});
 }
 
 

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -103,7 +103,7 @@ void Panel::AddZone(const Rectangle &rect, const function<void()> &fun)
 
 void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const vector<string> &conditions)
 {
-	AddZone(rect, [this, key, &conditions]()
+	AddZone(rect, [this, key, conditions]()
 	{
 		for(const string &condition : conditions)
 			if(!info.HasCondition(condition))

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -101,11 +101,11 @@ void Panel::AddZone(const Rectangle &rect, const function<void()> &fun)
 
 
 
-void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const vector<string> &conditions)
+void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const vector<string> &conditionsToEnable)
 {
-	AddZone(rect, [this, key, conditions]()
+	AddZone(rect, [this, key, conditionsToEnable]()
 	{
-		for(const string &condition : conditions)
+		for(const string &condition : conditionsToEnable)
 			if(!info.HasCondition(condition))
 				return;
 		this->KeyDown(key, 0, Command(), true);

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -69,7 +69,7 @@ public:
 	void ClearZones();
 	// Add a clickable zone to the panel.
 	void AddZone(const Rectangle &rect, const std::function<void()> &fun);
-	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::string &activeIf = "");
+	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::vector<std::string> &conditions);
 	// Check if a click at the given coordinates triggers a clickable zone. If
 	// so, apply that zone's action and return true.
 	bool ZoneClick(const Point &point);

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -69,7 +69,7 @@ public:
 	void ClearZones();
 	// Add a clickable zone to the panel.
 	void AddZone(const Rectangle &rect, const std::function<void()> &fun);
-	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::vector<std::string> &conditions);
+	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::vector<std::string> &conditions = {});
 	// Check if a click at the given coordinates triggers a clickable zone. If
 	// so, apply that zone's action and return true.
 	bool ZoneClick(const Point &point);

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "Information.h"
 #include "Rectangle.h"
 
 #include <functional>
@@ -68,7 +69,7 @@ public:
 	void ClearZones();
 	// Add a clickable zone to the panel.
 	void AddZone(const Rectangle &rect, const std::function<void()> &fun);
-	void AddZone(const Rectangle &rect, SDL_Keycode key);
+	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::string &activeIf = "");
 	// Check if a click at the given coordinates triggers a clickable zone. If
 	// so, apply that zone's action and return true.
 	bool ZoneClick(const Point &point);
@@ -149,6 +150,10 @@ private:
 	// object. Recursion stops as soon as any child returns true.
 	template<typename...FARGS, typename...ARGS>
 	bool EventVisit(bool(Panel::*f)(FARGS ...args), ARGS ...args);
+
+
+protected:
+	Information info;
 
 
 private:

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -69,7 +69,7 @@ public:
 	void ClearZones();
 	// Add a clickable zone to the panel.
 	void AddZone(const Rectangle &rect, const std::function<void()> &fun);
-	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::vector<std::string> &conditions = {});
+	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::vector<std::string> &conditionsToEnable = {});
 	// Check if a click at the given coordinates triggers a clickable zone. If
 	// so, apply that zone's action and return true.
 	bool ZoneClick(const Point &point);

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -110,7 +110,7 @@ void PlanetPanel::Step()
 
 void PlanetPanel::Draw()
 {
-	Information info;
+	info.ClearConditions();
 	info.SetSprite("land", planet.Landscape());
 
 	const Ship *flagship = player.Flagship();

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -198,8 +198,8 @@ void PlayerInfoPanel::Draw()
 	DrawBackdrop();
 
 	// Fill in the information for how this interface should be drawn.
-	Information interfaceInfo;
-	interfaceInfo.SetCondition("player tab");
+	info.ClearConditions();
+	info.SetCondition("player tab");
 	if(panelState.CanEdit() && !panelState.Ships().empty())
 	{
 		bool allParked = true;
@@ -217,8 +217,8 @@ void PlayerInfoPanel::Draw()
 			}
 		if(hasOtherShips)
 		{
-			interfaceInfo.SetCondition(allParked ? "show unpark all" : "show park all");
-			interfaceInfo.SetCondition(allParkedSystem ? "show unpark system" : "show park system");
+			info.SetCondition(allParked ? "show unpark all" : "show park all");
+			info.SetCondition(allParkedSystem ? "show unpark system" : "show park system");
 		}
 
 		// If ships are selected, decide whether the park or unpark button
@@ -238,8 +238,8 @@ void PlayerInfoPanel::Draw()
 			}
 			if(parkable)
 			{
-				interfaceInfo.SetCondition("can park");
-				interfaceInfo.SetCondition(allParked ? "show unpark" : "show park");
+				info.SetCondition("can park");
+				info.SetCondition(allParked ? "show unpark" : "show park");
 			}
 		}
 
@@ -247,16 +247,16 @@ void PlayerInfoPanel::Draw()
 		// show the save order button. Any manual sort by the player
 		// is applied immediately and doesn't need this button.
 		if(panelState.CanEdit() && panelState.CurrentSort())
-			interfaceInfo.SetCondition("show save order");
+			info.SetCondition("show save order");
 	}
 
-	interfaceInfo.SetCondition("three buttons");
+	info.SetCondition("three buttons");
 	if(player.HasLogs())
-		interfaceInfo.SetCondition("enable logbook");
+		info.SetCondition("enable logbook");
 
 	// Draw the interface.
 	const Interface *infoPanelUi = GameData::Interfaces().Get("info panel");
-	infoPanelUi->Draw(interfaceInfo, this);
+	infoPanelUi->Draw(info, this);
 
 	// Draw the player and fleet info sections.
 	menuZones.clear();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -138,7 +138,7 @@ void PreferencesPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 
-	Information info;
+	info.ClearConditions();
 	info.SetBar("volume", Audio::Volume());
 	if(Plugins::HasChanged())
 		info.SetCondition("show plugins changed");

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -92,32 +92,32 @@ void ShipInfoPanel::Draw()
 	DrawBackdrop();
 
 	// Fill in the information for how this interface should be drawn.
-	Information interfaceInfo;
-	interfaceInfo.SetCondition("ship tab");
+	info.ClearConditions();
+	info.SetCondition("ship tab");
 	if(panelState.CanEdit() && shipIt != panelState.Ships().end()
 			&& (shipIt->get() != player.Flagship() || (*shipIt)->IsParked()))
 	{
 		if(!(*shipIt)->IsDisabled())
-			interfaceInfo.SetCondition("can park");
-		interfaceInfo.SetCondition((*shipIt)->IsParked() ? "show unpark" : "show park");
-		interfaceInfo.SetCondition("show disown");
+			info.SetCondition("can park");
+		info.SetCondition((*shipIt)->IsParked() ? "show unpark" : "show park");
+		info.SetCondition("show disown");
 	}
 	else if(!panelState.CanEdit())
 	{
-		interfaceInfo.SetCondition("show dump");
+		info.SetCondition("show dump");
 		if(CanDump())
-			interfaceInfo.SetCondition("enable dump");
+			info.SetCondition("enable dump");
 	}
 	if(player.Ships().size() > 1)
-		interfaceInfo.SetCondition("five buttons");
+		info.SetCondition("five buttons");
 	else
-		interfaceInfo.SetCondition("three buttons");
+		info.SetCondition("three buttons");
 	if(player.HasLogs())
-		interfaceInfo.SetCondition("enable logbook");
+		info.SetCondition("enable logbook");
 
 	// Draw the interface.
 	const Interface *infoPanelUi = GameData::Interfaces().Get("info panel");
-	infoPanelUi->Draw(interfaceInfo, this);
+	infoPanelUi->Draw(info, this);
 
 	// Draw all the different information sections.
 	ClearZones();
@@ -130,7 +130,7 @@ void ShipInfoPanel::Draw()
 	DrawCargo(cargoBounds);
 
 	// If the player hovers their mouse over a ship attribute, show its tooltip.
-	info.DrawTooltips();
+	infoDisplay.DrawTooltips();
 }
 
 
@@ -288,7 +288,7 @@ bool ShipInfoPanel::Click(int x, int y, int /* clicks */)
 bool ShipInfoPanel::Hover(int x, int y)
 {
 	Point point(x, y);
-	info.Hover(point);
+	infoDisplay.Hover(point);
 	return Hover(point);
 }
 
@@ -321,7 +321,7 @@ void ShipInfoPanel::UpdateInfo()
 		return;
 
 	const Ship &ship = **shipIt;
-	info.Update(ship, player);
+	infoDisplay.Update(ship, player);
 	if(player.Flagship() && ship.GetSystem() == player.GetSystem() && &ship != player.Flagship())
 		player.Flagship()->SetTargetShip(*shipIt);
 
@@ -363,7 +363,7 @@ void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 
 	table.DrawTruncatedPair("ship:", dim, ship.Name(), bright, Truncate::MIDDLE, true);
 
-	info.DrawAttributes(table.GetRowBounds().TopLeft() - Point(10., 10.));
+	infoDisplay.DrawAttributes(table.GetRowBounds().TopLeft() - Point(10., 10.));
 }
 
 
@@ -763,7 +763,7 @@ void ShipInfoPanel::Dump()
 	selectedCommodity.clear();
 	selectedPlunder = nullptr;
 
-	info.Update(**shipIt, player);
+	infoDisplay.Update(**shipIt, player);
 	if(loss)
 		Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
 			, Messages::Importance::High);
@@ -779,7 +779,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 	{
 		loss += count * selectedPlunder->Cost();
 		(*shipIt)->Jettison(selectedPlunder, count);
-		info.Update(**shipIt, player);
+		infoDisplay.Update(**shipIt, player);
 
 		if(loss)
 			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
@@ -799,7 +799,7 @@ void ShipInfoPanel::DumpCommodities(int count)
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
 		(*shipIt)->Jettison(selectedCommodity, count);
-		info.Update(**shipIt, player);
+		infoDisplay.Update(**shipIt, player);
 
 		if(loss)
 			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -84,7 +84,7 @@ private:
 	std::vector<std::shared_ptr<Ship>>::const_iterator shipIt;
 
 	// Information about the currently selected ship.
-	ShipInfoDisplay info;
+	ShipInfoDisplay infoDisplay;
 	std::map<std::string, std::vector<const Outfit *>> outfits;
 
 	// Track all the clickable parts of the UI (other than the buttons).

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -296,7 +296,7 @@ void StartConditionsPanel::ScrollToSelected()
 void StartConditionsPanel::Select(StartConditionsList::iterator it)
 {
 	// Clear the displayed information.
-	info = Information();
+	info.ClearConditions();
 
 	startIt = it;
 	if(startIt == scenarios.end())

--- a/source/StartConditionsPanel.h
+++ b/source/StartConditionsPanel.h
@@ -71,8 +71,6 @@ private:
 	const Color &selectedBackground;
 	// The selected scenario's description.
 	WrappedText description;
-	// Displayed information for the selected scenario.
-	Information info;
 
 	bool hasHover = false;
 	Point hoverPoint;

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -209,7 +209,7 @@ void TradingPanel::Draw()
 	if(showProfit)
 		font.Draw("Profit", Point(MIN_X + PROFIT_X, FIRST_Y), selected);
 
-	Information info;
+	info.ClearConditions();
 	if(sellOutfits)
 		info.SetCondition("can sell outfits");
 	else if(player.Cargo().HasOutfits() || canSell)


### PR DESCRIPTION
**Bug fix**

This PR fixes a bug where inactive interface buttons would continue to work.

## Summary
This PR stores the Information object for each Panel, allowing condition checks when an interface zone is clicked in. In addition, interfaces now pass their `activeIf` and `visibleIf` conditions when being added to the panel.

Information got a `ClearConditions()` function to allow reusing it; strings, sprites etc. don't need to be cleared every frame.

## Testing Done
I tested that active buttons still work, and that inactive buttons don't. You can verify this by clicking the disabled `Attack` or `Defend` buttons in BoardingPanel, for instance.

## Save File
N/A