### PR TITLE
Make 10 the previous save number

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -143,7 +143,7 @@ namespace {
 	const vector<string> ALERT_INDICATOR_SETTING = {"off", "audio", "visual", "both"};
 	int alertIndicatorIndex = 3;
 
-	int previousSaveCount = 3;
+	int previousSaveCount = 10;
 }
 
 
@@ -219,7 +219,7 @@ void Preferences::Load()
 		else if(node.Token(0) == "alert indicator")
 			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size() - 1));
 		else if(node.Token(0) == "previous saves" && node.Size() >= 2)
-			previousSaveCount = max<int>(3, node.Value(1));
+			previousSaveCount = max<int>(10, node.Value(1));
 		else if(node.Token(0) == "alt-mouse turning")
 			settings["Control ship with mouse"] = (node.Size() == 1 || node.Value(1));
 		else


### PR DESCRIPTION
**Feature**

## Summary
Made 10 the number of previous saves, as opposed to 3.
This lets players go further back if it turns out they made a wrong choice, or flew into a big battle too soon, or anything like that.

## Screenshots
None.

## Testing Done
Some. Seems to work reasonably.

## Save File
This save file can be used to test these changes:
Launch the game and launch/land a bunch of times.

## Wiki Update
Not that I know of.