### PR TITLE
(fix): Successors mission and fleet fixes

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -332,6 +332,7 @@ mission "Successors: First Contact 3"
 	description `The scions of House Sioeora have instructed you to visit the planet <planet stopovers> and capture a "Kijra-riitaa" to safely return to them at <planet>. Return by <date> or they will consider you to have kidnapped Sieasej.`
 	source "Staja-Kella-Oa"
 	to offer
+		has "Successors: First Contact 2: done"
 		not "Successors: First Contact 2: rejected"
 	to fail
 		has "Successors: Unified Defense: offered"

--- a/data/successors/successor fleets.txt
+++ b/data/successors/successor fleets.txt
@@ -15,6 +15,7 @@ fleet "Light Successor Freight"
 	government "Successor"
 	names "successor"
 	cargo 3
+	outfitters "Successor Basics"
 	personality
 		appeasing timid
 		confusion 30
@@ -35,6 +36,7 @@ fleet "Medium Successor Freight"
 	government "Successor"
 	names "successor"
 	cargo 3
+	outfitters "Successor Civilian"
 	personality
 		appeasing timid
 		confusion 30
@@ -55,7 +57,7 @@ fleet "Medium Successor Freight"
 fleet "Small Successor Transport"
 	government "Successor"
 	names "successor"
-	cargo 2
+	cargo 0
 	personality
 		timid
 		confusion 30
@@ -120,6 +122,7 @@ fleet "People's Houses"
 	government "People's Houses"
 	names "successor"
 	cargo 3
+	outfitters "Successor Basics"
 	personality
 		disables harvests mining plunders
 		confusion 20

--- a/data/successors/successor fleets.txt
+++ b/data/successors/successor fleets.txt
@@ -14,6 +14,7 @@
 fleet "Light Successor Freight"
 	government "Successor"
 	names "successor"
+	cargo 3
 	personality
 		appeasing timid
 		confusion 30
@@ -33,6 +34,7 @@ fleet "Light Successor Freight"
 fleet "Medium Successor Freight"
 	government "Successor"
 	names "successor"
+	cargo 3
 	personality
 		appeasing timid
 		confusion 30
@@ -53,6 +55,7 @@ fleet "Medium Successor Freight"
 fleet "Small Successor Transport"
 	government "Successor"
 	names "successor"
+	cargo 2
 	personality
 		timid
 		confusion 30
@@ -78,6 +81,7 @@ fleet "Small Successor Transport"
 fleet "Successor Miners"
 	government "Successor"
 	names "successor"
+	cargo 0
 	personality
 		appeasing frugal harvests mining staying
 		confusion 30
@@ -96,6 +100,7 @@ fleet "Successor Miners"
 fleet "Successor Miners (Well-Defended)"
 	government "Successor"
 	names "successor"
+	cargo 0
 	personality
 		appeasing frugal harvests mining staying
 		confusion 30
@@ -114,6 +119,7 @@ fleet "Successor Miners (Well-Defended)"
 fleet "People's Houses"
 	government "People's Houses"
 	names "successor"
+	cargo 3
 	personality
 		disables harvests mining plunders
 		confusion 20
@@ -144,6 +150,7 @@ fleet "People's Houses"
 fleet "People's Houses Raiders"
 	government "People's Houses (Hostile)"
 	names "successor"
+	cargo 0
 	personality
 		disables harvests plunders
 		confusion 20
@@ -165,6 +172,7 @@ fleet "Small Old Houses"
 		heroic
 	government "Old Houses"
 	names "high houses"
+	cargo 0
 	variant 6
 		"Stolsaqra (Military)"
 	variant 2
@@ -184,6 +192,7 @@ fleet "Small Old Houses"
 fleet "Large Old Houses"
 	government "Old Houses"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10
@@ -199,6 +208,7 @@ fleet "Large Old Houses"
 fleet "Old Houses Surveillance"
 	government "Old Houses"
 	names "high houses"
+	cargo 0
 	personality
 		heroic opportunistic
 	variant 10
@@ -209,10 +219,11 @@ fleet "Old Houses Surveillance"
 		"Stolsaqra (Military)" 2
 
 fleet "Small New Houses"
-	personality
-		heroic
 	government "New Houses"
 	names "high houses"
+	cargo 0
+	personality
+		heroic
 	variant 10
 		"Stolsaqra (Military)"
 	variant 10
@@ -239,6 +250,7 @@ fleet "Small New Houses"
 fleet "Large New Houses"
 	government "New Houses"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10
@@ -273,6 +285,7 @@ fleet "Large New Houses"
 fleet "New Houses Surveillance"
 	government "New Houses"
 	names "high houses"
+	cargo 0
 	personality
 		heroic opportunistic
 	variant 5
@@ -287,6 +300,7 @@ fleet "New Houses Surveillance"
 fleet "Kaatrij Home"
 	government "House Kaatrij"
 	names "high houses"
+	cargo 0
 	personality
 		heroic opportunistic
 	variant 10
@@ -305,6 +319,7 @@ fleet "Kaatrij Home"
 fleet "Aqrabe Home"
 	government "House Aqrabe"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10
@@ -321,6 +336,7 @@ fleet "Aqrabe Home"
 fleet "Seineq Home"
 	government "House Seineq"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10
@@ -338,6 +354,7 @@ fleet "Seineq Home"
 fleet "Chydiyi Home"
 	government "House Chydiyi"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10
@@ -361,6 +378,7 @@ fleet "Chydiyi Home"
 fleet "Myurej Home"
 	government "House Myurej"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10
@@ -379,6 +397,7 @@ fleet "Myurej Home"
 fleet "Sioeora Home"
 	government "House Sioeora"
 	names "high houses"
+	cargo 0
 	personality
 		heroic
 	variant 10

--- a/data/successors/successor fleets.txt
+++ b/data/successors/successor fleets.txt
@@ -15,6 +15,7 @@ fleet "Light Successor Freight"
 	government "Successor"
 	names "successor"
 	cargo 3
+	commodities "Food" "Clothing" "Metal" "Plastic" "Medical" "Heavy Metals"
 	outfitters "Successor Basics"
 	personality
 		appeasing timid
@@ -36,6 +37,7 @@ fleet "Medium Successor Freight"
 	government "Successor"
 	names "successor"
 	cargo 3
+	commodities "Food" "Clothing" "Metal" "Plastic" "Medical" "Heavy Metals" "Luxury Goods"
 	outfitters "Successor Civilian"
 	personality
 		appeasing timid
@@ -57,7 +59,8 @@ fleet "Medium Successor Freight"
 fleet "Small Successor Transport"
 	government "Successor"
 	names "successor"
-	cargo 0
+	commodities "Food" "Clothing" "Metal" "Plastic" "Medical" "Heavy Metals" "Luxury Goods"
+	cargo 3
 	personality
 		timid
 		confusion 30
@@ -122,6 +125,7 @@ fleet "People's Houses"
 	government "People's Houses"
 	names "successor"
 	cargo 3
+	commodities "Food" "Clothing" "Metal" "Plastic" "Medical" "Heavy Metals"
 	outfitters "Successor Basics"
 	personality
 		disables harvests mining plunders

--- a/data/successors/successor side missions.txt
+++ b/data/successors/successor side missions.txt
@@ -120,6 +120,7 @@ mission "Successors: Predecessor Research 1"
 			`	"Glorious and beautiful, it was; as much a sort of art as of engineering. Our Predecessors' works were envied even by the Quarg, whose mastery of art and science only few may equal. T'were exotic in their natures and unique in applications; living metal grown in stars, subtle points to pierce space itself. We have descriptions, enough to make rudimentary imitations of their processes, but even if we had a perfect understanding of wha'twas, the space of our new systems seems unsuitable to manifest that mastery. We fail even to replicate the heirlooms kept by the High Houses; the materials and techniques they use are always out of reach."`
 				goto questions
 			label end
+			`	You leave the researchers to study their findings.`
 			action
 				clear "Successors: who"
 				clear "Successors: collapse"
@@ -205,6 +206,7 @@ mission "Successors: Biology Research 1"
 			`	"Thou asks at a fortuitous time! This planet, and the life that lives upon it, may provide to us a better answer to that question. Many of the stars here are hot and young and therefore harsh to nascent life, and yet thou hast surely seen the verdant worlds that orbit them! While some of this results from early settlement during the old empire, much of it does not and therefore remains a vexing point. How could life develop here? If we can track the path taken by the life of this planet, we may find the answer both you and I seek."`
 				goto questions
 			label end
+			`	You leave Katiiora to their business and make your preparations to take off, when ready.`
 			action
 				clear "Successors: successor"
 				clear "Successors: predecessor"

--- a/data/successors/successor side missions.txt
+++ b/data/successors/successor side missions.txt
@@ -206,7 +206,7 @@ mission "Successors: Biology Research 1"
 			`	"Thou asks at a fortuitous time! This planet, and the life that lives upon it, may provide to us a better answer to that question. Many of the stars here are hot and young and therefore harsh to nascent life, and yet thou hast surely seen the verdant worlds that orbit them! While some of this results from early settlement during the old empire, much of it does not and therefore remains a vexing point. How could life develop here? If we can track the path taken by the life of this planet, we may find the answer both you and I seek."`
 				goto questions
 			label end
-			`	You leave Katiiora to their business and make your preparations to take off, when ready.`
+			`	You leave Katiiora to their business and make your preparations to take off when ready.`
 			action
 				clear "Successors: successor"
 				clear "Successors: predecessor"


### PR DESCRIPTION
**Bug fix**

This PR addresses bugs and unintended behaviors described on the Discord [here](https://discordapp.com/channels/251118043411775489/1287895983207878686/1288231585132314644). 

## Summary
* `Successors: First Contact 3` now offers only if `Successors: First Contact 2` has been completed
* Civilian Successor and People's Houses fleets can no longer carry High Houses outfits in their cargo
	* Mining fleets and High Houses naval fleets no longer carry cargo
* The `end` labels in `Successors: Predecessor Research 1` and `Successors: Biology Research 1` now contain a sentence so the conversation does not proceed to a blank `(done)` screen.

## Testing Done
Missions offer and complete as expected. Scanning Successor fleets shows they do not carry outfits in their cargo that they shouldn't be able to have.