### PR TITLE
Guerilla -> Guerrilla - human news.txt

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -2457,7 +2457,7 @@ news "ccor gendarme"
 		word
 			`"`
 		word
-			"Report any signs of guerilla or pirate activity to us."
+			"Report any signs of guerrilla or pirate activity to us."
 			"Move along, now."
 			"If you see any defacement of local insignia, tell us and we'll have it sorted."
 			"We are here to keep the peace in this spaceport."


### PR DESCRIPTION
**Typo Fix**

## Summary
Typo fix: guerilla -> guerrilla.
Guerilla is spelled with two r's on the next news line, and from what I could find people seem to prefer guerrilla. For example, Marriam-Webster lists guerilla as an alternate spelling.

## Screenshots
None.

## Testing Done
None.

## Save File
This save file can be used to test these changes:
Not really.