### PR TITLE
feat(mechanics): Government attribute to ignore default illegals

### DIFF
--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -597,9 +597,9 @@ int CargoHold::IllegalCargoFine(const Government *government, const PlayerInfo &
 		if(!it.second)
 			continue;
 
-		int fine = government->Fines(it.first);
 		if(government->Condemns(it.first))
 			return -1;
+		int fine = government->Fines(it.first);
 		if(fine < 0)
 			return fine;
 		totalFine = max(totalFine, fine / 2);
@@ -611,9 +611,9 @@ int CargoHold::IllegalCargoFine(const Government *government, const PlayerInfo &
 	for(const auto &it : missionCargo)
 	{
 		int fine = it.first->Fine();
-		if(fine < 0)
+		if(fine < 0 && !government->IgnoresUniversalAtrocities())
 			return fine;
-		if(!it.first->IsFailed(player))
+		if(!it.first->IsFailed(player) && !government->IgnoresUniversalIllegals())
 			totalFine += fine;
 	}
 
@@ -628,9 +628,9 @@ int CargoHold::IllegalPassengersFine(const Government *government, const PlayerI
 	for(const auto &it : passengers)
 	{
 		int fine = it.first->Fine();
-		if(fine < 0)
+		if(fine < 0 && !government->IgnoresUniversalAtrocities())
 			return fine;
-		if(!it.first->IsFailed(player))
+		if(!it.first->IsFailed(player) && !government->IgnoresUniversalIllegals())
 			totalFine += fine;
 	}
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -122,9 +122,11 @@ public:
 	// Check to see if the items are condemnable (atrocities) or warrant a fine.
 	bool Condemns(const Outfit *outfit) const;
 	bool Condemns(const Ship *ship) const;
+	bool IgnoresUniversalAtrocities() const;
 	// Returns the fine for given item for this government.
 	int Fines(const Outfit *outfit) const;
 	int Fines(const Ship *ship) const;
+	bool IgnoresUniversalIllegals() const;
 	// Check if given ship has illegal outfits or cargo.
 	bool FinesContents(const Ship *ship, const PlayerInfo &player) const;
 
@@ -163,8 +165,10 @@ private:
 	std::map<int, double> penaltyFor;
 	std::map<const Outfit*, int> illegalOutfits;
 	std::map<std::string, int> illegalShips;
+	bool ignoreUniversalIllegals = false;
 	std::map<const Outfit*, bool> atrocityOutfits;
 	std::map<std::string, bool> atrocityShips;
+	bool ignoreUniversalAtrocities = false;
 	double bribe = 0.;
 	double fine = 1.;
 	std::vector<LocationFilter> enforcementZones;

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -241,7 +241,7 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 {
 	// Do nothing if you have already been fined today, or if you evade
 	// detection.
-	if(fined.contains(gov) || Random::Real() > security || !gov->GetFineFraction())
+	if(fined.contains(gov) || Random::Real() > security)
 		return "";
 
 	string reason;


### PR DESCRIPTION
**Feature**

## Summary
Currently, if you want to ignore all illegals and atrocities, you have to use `fine 0`, but it disables both illegals and atrocities, including even those defined only for this government. I don't want to change this, because that could cause some confusion and break compatibility. Instead, a new method was added, which allows disabling universal illegals/atrocities (ships/outfits with illegal/atrocity attributes, and illegal/atrocious missions) - see the syntax below.

## Usage examples
```html
government <name>
	illegals
		"ignore by default" <value> # This affects only illegals
	atrocities
		"ignore by default" <value> # This affects only atrocities
```
Where value is boolean and defaults to false.

## Testing Done
yes.

## Wiki Update
soon

## Performance Impact
N/A
