### PR TITLE
(fix): Successors First Contact 3 offer fix

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -332,7 +332,7 @@ mission "Successors: First Contact 3"
 	description `The scions of House Sioeora have instructed you to visit the planet <planet stopovers> and capture a "Kijra-riitaa" to safely return to them at <planet>. Return by <date> or they will consider you to have kidnapped Sieasej.`
 	source "Staja-Kella-Oa"
 	to offer
-		has "Successors: First Contact 2: done"
+		has "Successors: First Contact 2: declined"
 		not "Successors: First Contact 2: rejected"
 	to fail
 		has "Successors: Unified Defense: offered"

--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -332,7 +332,7 @@ mission "Successors: First Contact 3"
 	description `The scions of House Sioeora have instructed you to visit the planet <planet stopovers> and capture a "Kijra-riitaa" to safely return to them at <planet>. Return by <date> or they will consider you to have kidnapped Sieasej.`
 	source "Staja-Kella-Oa"
 	to offer
-		has "Successors: First Contact 2: declined"
+		has "event: successors: first contact wait"
 		not "Successors: First Contact 2: rejected"
 	to fail
 		has "Successors: Unified Defense: offered"


### PR DESCRIPTION
**Bug fix**

## Summary
I made a significant error in my previous PR; the `Successors: First Contact 2` mission always reaches a `decline` endpoint and is never `done`. Adding `has "Successors: First Contact 2: done"` to the offer conditions of `Successors: First Contact 3` prevented it from offering. This PR fixes that by changing that `done` requirement to `has "event: successors: first contact wait"` instead, allowing FC3 to offer both at all and during the same day as FC2.

## Testing Done
Hopefully better than last time. First Contact 2 Prompt, First Contact 2, and First Contact 3 all offer and complete as expected. Also provided a save so you can verify.

## Save File
This save file can be used to test these changes:
[Done Declined.txt](https://github.com/user-attachments/files/17154873/Done.Declined.txt)
