### PR TITLE
fix(mechanics): Prevent death sentences from closing automatically

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -79,7 +79,7 @@ void PlanetPanel::Step()
 	if(player.IsDead())
 	{
 		player.SetPlanet(nullptr);
-		GetUI()->PopThrough(this);
+		GetUI()->Pop(this);
 		return;
 	}
 


### PR DESCRIPTION
**Bug fix**

Fixes #10504.

## Summary
When the player is dead, the planet panel automatically closes itself and any other panels that are higher, including any conversations and dialogs that appear. This, combined with the fact that atrocities kill the player as soon as the death sentence dialog/conversation is displayed, causes the conversation to disappear.

With this fix, the planet panel closes only itself (and its children), leaving the death sentence panel until the player closes it manually.

## Screenshots
N/A

## Testing Done
Tested with the save file provided in the issue.

## Performance Impact
N/A
