### PR TITLE
Add a missing branch condition for Successors Unified Defense

### DIFF
--- a/data/successors/successor side missions.txt
+++ b/data/successors/successor side missions.txt
@@ -435,6 +435,7 @@ mission "Successors: Unified Defense"
 			`	A wave of bristling black runs over the Successor's body before they end the transmission.`
 			label end
 			branch "uninhabited end"
+				has "flagship planet attribute: uninhabited"
 			`	Your landing permission is revoked and the contingent of officers train their weapons on your ship. As several interceptors begin to hover over your landing pad, weapons ready, you are forced to take off.`
 				flee
 			label "uninhabited end"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10506.

## Summary
Add a missing `branch` condition so that `flee` works in the Successors United Defense mission.
TomGoodIdea pointed out why it didn't work: https://github.com/endless-sky/endless-sky/issues/10506#issuecomment-2378748602

## Screenshots
None

## Testing Done
Works for me

## Save File
This save file can be used to test these changes:
Use the save from the issue