### PR TITLE
feat(balance): Reduce missile relock rate from 15% to 1%

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -846,7 +846,7 @@ outfit "Meteor Missile Launcher"
 		"drag" .1
 		"turn" 1.8
 		"homing" 1
-		"infrared tracking" .65
+		"infrared tracking" .75
 		"shield damage" 360
 		"hull damage" 220
 		"hit force" 330
@@ -884,7 +884,7 @@ outfit "Meteor Missile Pod"
 		"drag" .1
 		"turn" 1.8
 		"homing" 1
-		"infrared tracking" .65
+		"infrared tracking" .75
 		"shield damage" 360
 		"hull damage" 220
 		"hit force" 330
@@ -1161,7 +1161,7 @@ outfit "Torpedo Launcher"
 		"drag" .025
 		"turn" 1.5
 		"homing" 3
-		"optical tracking" .8
+		"optical tracking" .9
 		"shield damage" 820
 		"hull damage" 820
 		"hit force" 450
@@ -1199,7 +1199,7 @@ outfit "Torpedo Pod"
 		"drag" .025
 		"turn" 1.5
 		"homing" 3
-		"optical tracking" .8
+		"optical tracking" .9
 		"shield damage" 820
 		"hull damage" 820
 		"hit force" 450
@@ -1262,7 +1262,7 @@ outfit "Typhoon Launcher"
 		"drag" .02
 		"turn" 1.5
 		"homing" 4
-		"optical tracking" .9
+		"optical tracking" .95
 		"shield damage" 1050
 		"hull damage" 1050
 		"hit force" 675
@@ -1300,7 +1300,7 @@ outfit "Typhoon Pod"
 		"drag" .02
 		"turn" 1.5
 		"homing" 4
-		"optical tracking" .9
+		"optical tracking" .95
 		"shield damage" 1050
 		"hull damage" 1050
 		"hit force" 675

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -397,7 +397,7 @@ void Projectile::BreakTarget()
 // guided missiles.
 void Projectile::CheckLock(const Ship &target)
 {
-	double base = hasLock ? 1. : .15;
+	double base = hasLock ? 1. : .01;
 	hasLock = false;
 
 	// For each tracking type, calculate the probability twice every second that a


### PR DESCRIPTION
<!--
## Testing Done
More than you will.
-->

## Summary
After losing a lock, a missile has a chance to reacquire its lock equal to 15% of its usual tracking rate. A missile with `.9` tracking has a 13.5% chance of regaining its lock, while a missile with `.5` tracking only has a 7.5% chance. As more and more missiles lose their locks over time, the proportion of unlocked missiles increases, which in turn increases the rate of missiles regaining their lock. This means that, no matter how much time you spend dodging missiles, you'll eventually reach a point where you can't break the lock of missiles faster than they lock on again.

You can find the point at which the number of missiles that lose their lock is equal to the number of missiles that regain it by using the following equation:

`p = ( r * t ) / ( 1 + t * ( r - 1 ))`

, where `p` is the proportion of locked missiles as a decimal, `t` is the tracking value of the missiles and `r` is the tracking multiplier for unlocked missiles (0.15). Using `t` as the x-axis and `p` as the y-axis produces the following graph:

![image](https://github.com/user-attachments/assets/224ac13c-e429-4eb5-b505-808a50a21535)

At `.9` tracking, equilibrium is reached when 57% of missiles are locked. At `.5` tracking, equilibrium is at 13%. At `.15` tracking, it's at 2.6%. Under these points, the only way to avoid more missiles is by continuously dodging them until their lifetime expires (or by using anti-missile).

Except the game doesn't use the tracking value in the data files; it uses the 5th root of tracking after type-specific modifiers are applied. For example, a Meteor targeting a 100% heat target at a distance of 1500 has a 91.7% chance of retaining its lock (adjusted from 65%), a Torpedo targeting a Quicksilver has a 68.9% chance to retain lock (adjusted from 15.5%) and a Sidewinder targeting a ship with a Large Radar Jammer at point blank has a 60.6% chance of maintaining a lock (adjusted from 8.2%).

Accounting for this conversion yields the following graph:

![image](https://github.com/user-attachments/assets/565b2ebf-733c-4d9d-9638-016defbc9545)

The Meteor against a 100% heat target reaches equilibrium at 62.5%. The Torpedo's equilibrium is at 24.9%. The Sidewinder's is 18.7%.

While there are some missiles that can be dodged, the majority of missiles (especially those with `homing 4`) are practically guaranteed to score a hit so long as they have a lock, meaning that the equilibrium effectively acts as the minimum hit rate for a missile. This is especially problematic with smaller ships, where even something as little as a 10% hit rate can quickly be lethal. Additionally, when missiles regain their locks, they've usually already flown past the target ship. Because the target is busy dodging missiles coming from the direction of the firing ship, these relocked missiles are able to turn and hit the ship from a difficult-to-avoid angle.

All in all, having such a high equilibrium is harmful for the purposes of missile dodging and jamming gameplay.

## Changes
This PR reduces the relock rate of missiles from 15% to 1%.

![image](https://github.com/user-attachments/assets/56a77f88-5bfd-4984-ba5a-942846bd8297)

However, reducing the relock rate also has an effect on the general homing capabilities of a couple of the missiles, namely the Meteor, which loses missile locks fast enough that relocked missiles make up a large portion of its hits, and the Torpedo and Typhoon, who are s. The rest of the missiles either have a high enough tracking value or are fast enough that reducing the relock rate doesn't affect them much.

To compensate for these changes, Meteors have had their IR tracking increased from `.65` to `.75`, Torpedoes have had their optical tracking increased from `.8` to `.9`, and Typhoons have had their optical tracking increased from `.9` to `.95`.

Using the examples from earlier, the Meteor aimed at a 100% heat target now has an equilibrium of 14.4%, the Torpedo aimed at a Quicksilver has an equilibrium of 5.7% and the Sidewinder aimed at a ship with a Large Jammer has an equilibrium of 1.5%.