### PR TITLE
fix(ci): Fix dependency installation for python checks

### DIFF
--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         show-progress: false
     - name: Install dependencies
-      run: sudo pip install --break-system-packages python-debian
+      run: pip install --break-system-packages python-debian
     - name: Validate copyright file with python-debian
       run: python3 ./utils/check_copyright.py
     - name: Validate copyright file with debian-control-linter
@@ -96,7 +96,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: sudo pip install --break-system-packages regex
+      run: pip install --break-system-packages regex
     - name: Run style checker
       run: python ./utils/check_code_style.py
 
@@ -114,6 +114,6 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: sudo pip install --break-system-packages regex
+      run: pip install --break-system-packages regex
     - name: Run style checker
       run: python ./utils/check_content_style.py

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         show-progress: false
     - name: Install dependencies
-      run: python3 -m pip install --user python-debian
+      run: sudo pip install --break-system-packages python-debian
     - name: Validate copyright file with python-debian
       run: python3 ./utils/check_copyright.py
     - name: Validate copyright file with debian-control-linter
@@ -96,7 +96,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: pip install regex
+      run: sudo pip install --break-system-packages regex
     - name: Run style checker
       run: python ./utils/check_code_style.py
 
@@ -114,6 +114,6 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: pip install regex
+      run: sudo pip install --break-system-packages regex
     - name: Run style checker
       run: python ./utils/check_content_style.py

--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -60,7 +60,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
         show-progress: false
     - uses: codespell-project/actions-codespell@master
       with:


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug/feature described on [discord](https://discord.com/channels/251118043411775489/536900466655887360/1289041499232796683) and in #10511.

## Summary
Github is migrating the `ubuntu-latest` tag to Ubuntu 24.04, which has a newer python/pip setup. This new setup doesn't allow installing system-wide packages by default, which breaks our setup.

I added the `--break-system-packages` option, which re-enables the previous behaviour. This is the same fix that was applied by @MCOfficer in the [plugin repo](https://github.com/endless-sky/endless-sky-plugins/commit/464b663c245252586df8327e5f31afb7b18795f6).

## Testing Done
The checks passed here.