### PR TITLE
feat(ui): Ship category code added for non-scrollable panels (ship info) + test for it

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -905,10 +905,10 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 
 	// If it is required to show a category code in a model name for panels without scrolling
-	const string& full_category = BaseAttributes().Category();
+	const string &full_category = BaseAttributes().Category();
 	string category_code;
 
-	if (full_category.find(' ') != string::npos)
+	if(full_category.find(' ') != string::npos)
 		category_code = full_category.substr(0, 1) + full_category.substr(full_category.find(' ') + 1, 1);
 	else
 		category_code = full_category.substr(0, 2);
@@ -1209,7 +1209,8 @@ const string &Ship::PluralModelName() const
 }
 
 
-const string& Ship::CategoryCode() const
+
+const string &Ship::CategoryCode() const
 {
 	return categoryCode;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -903,6 +903,18 @@ void Ship::FinishLoading(bool isNewInstance)
 			targetSystem = nullptr;
 		}
 	}
+
+	// If it is required to show a category code in a model name for panels without scrolling
+	const string& full_category = BaseAttributes().Category();
+	string category_code;
+
+	if (full_category.find(' ') != string::npos)
+		category_code = full_category.substr(0, 1) + full_category.substr(full_category.find(' ') + 1, 1);
+	else
+		category_code = full_category.substr(0, 2);
+
+	categoryCode = category_code;
+	displayModelNameWithCategoryCode = displayModelName + " (" + category_code + ")";
 }
 
 
@@ -1184,9 +1196,9 @@ const string &Ship::TrueModelName() const
 
 
 
-const string &Ship::DisplayModelName() const
+const string &Ship::DisplayModelName(bool showCategoryCode) const
 {
-	return displayModelName;
+	return showCategoryCode ? displayModelNameWithCategoryCode : displayModelName;
 }
 
 
@@ -1196,6 +1208,11 @@ const string &Ship::PluralModelName() const
 	return pluralModelName;
 }
 
+
+const string& Ship::CategoryCode() const
+{
+	return categoryCode;
+}
 
 
 // Get the name of this ship as a variant.

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -58,7 +58,7 @@ class Visual;
 // Class representing a ship (either a model for sale or an instance of it). A
 // ship's information can be saved to a file, so that it can later be read back
 // in exactly the same state. The same class is used for the player's ship as
-// for all other ships, so their capabilities are exactly the same  within the
+// for all other ships, so their capabilities are exactly the same within the
 // limits of what the AI knows how to command them to do.
 class Ship : public Body, public std::enable_shared_from_this<Ship> {
 public:
@@ -149,8 +149,9 @@ public:
 	// Set / Get the name of this model of ship.
 	void SetTrueModelName(const std::string &model);
 	const std::string &TrueModelName() const;
-	const std::string &DisplayModelName() const;
+	const std::string &DisplayModelName(bool showCategoryCode = false) const;
 	const std::string &PluralModelName() const;
+	const std::string &CategoryCode() const;
 	// Get the name of this ship as a variant.
 	const std::string &VariantName() const;
 	// Get the generic noun (e.g. "ship") to be used when describing this ship.
@@ -558,6 +559,8 @@ private:
 	const Ship *base = nullptr;
 	std::string trueModelName;
 	std::string displayModelName;
+	std::string displayModelNameWithCategoryCode;
+	std::string categoryCode;
 	std::string pluralModelName;
 	std::string variantName;
 	std::string noun;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -142,7 +142,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeHeaderValues.clear();
 
 	attributeHeaderLabels.push_back("model:");
-	attributeHeaderValues.push_back(ship.DisplayModelName());
+	attributeHeaderValues.push_back(ship.DisplayModelName(!scrollingPanel));
 
 	attributesHeight = 20;
 

--- a/tests/unit/src/test_ship.cpp
+++ b/tests/unit/src/test_ship.cpp
@@ -18,6 +18,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // Include only the tested class's header.
 #include "../../../source/Ship.h"
 
+// Include a helper for creating well-formed DataNodes.
+#include "datanode-factory.h"
+
 // ... and any system includes needed for the test file.
 #include <memory>
 #include <string>
@@ -99,7 +102,65 @@ SCENARIO( "A Ship::Bay instance is being copied", "[ship][bay]") {
 	}
 }
 // Constructing useful Ship instances requires Ship::Load, which requires all of GameData & runtime deps.
+SCENARIO("A Ship::Ship instance", "[ship][ship]") {
 
+	// Ship example DataNode
+	DataNode ship_node = AsDataNode(
+"ship \"Aerie\"\n\
+\tsprite \"ship/aerie\"\n\
+\tthumbnail \"thumbnail/aerie\"\n\
+\tattributes\n\
+\t\tcategory \"Medium Warship\"\n\
+\t\t\"cost\" 3500000\n\
+\t\t\"shields\" 5700\n\
+\t\t\"hull\" 1900\n\
+\t\t\"required crew\" 10\n\
+\t\t\"bunks\" 28\n\
+\t\t\"mass\" 390\n\
+\t\t\"drag\" 6.15\n\
+\t\t\"heat dissipation\" .47\n\
+\t\t\"fuel capacity\" 500\n\
+\t\t\"cargo space\" 50\n\
+\t\t\"outfit space\" 390\n\
+\t\t\"weapon capacity\" 150\n\
+\t\t\"engine capacity\" 95\n\
+\t\tweapon\n\
+\t\t\t\"blast radius\" 80\n\
+\t\t\t\"shield damage\" 800\n\
+\t\t\t\"hull damage\" 400\n\
+\t\t\t\"hit force\" 1200\n\
+\n\
+\tengine 15 97\n\
+\tengine - 15 97\n\
+\tleak \"leak\" 50 50\n\
+\tleak \"flame\" 50 80\n\
+\tleak \"big leak\" 90 30\n\
+\texplode \"tiny explosion\" 10\n\
+\texplode \"small explosion\" 25\n\
+\texplode \"medium explosion\" 25\n\
+\texplode \"large explosion\" 10\n\
+\t\"final explode\" \"final explosion medium\"\n\
+\tdescription \"The Lionheart Aerie is a light carrier, designed to be just big enough for \
+two fighter bays plus a decent armament of its own. Variations on this same ship design have been \
+in use in the Deep for almost half a millennium, but this model comes with the very latest \
+in generator and weapon technology.\""
+	);
+	
+	GIVEN( "ship tests" ) {
+		auto ship = Ship(ship_node);
+		ship.FinishLoading(true);
+
+		WHEN( "a basic ship constructor" ) {
+			THEN( "check ship names" ) {
+				CHECK( ship.TrueModelName() == "Aerie" );
+				CHECK( ship.DisplayModelName() == "Aerie" );
+				CHECK( ship.DisplayModelName(true) == "Aerie (MW)" );
+				CHECK( ship.PluralModelName() == "Aeries");
+				CHECK( ship.CategoryCode() == "MW" );
+			}
+		}
+	}
+}
 
 
 // Test code goes here. Preferably, use scenario-driven language making use of the SCENARIO, GIVEN,

--- a/tests/unit/src/test_ship.cpp
+++ b/tests/unit/src/test_ship.cpp
@@ -145,7 +145,6 @@ two fighter bays plus a decent armament of its own. Variations on this same ship
 in use in the Deep for almost half a millennium, but this model comes with the very latest \
 in generator and weapon technology.\""
 	);
-	
 	GIVEN( "ship tests" ) {
 		auto ship = Ship(ship_node);
 		ship.FinishLoading(true);


### PR DESCRIPTION
Heading: **Feature**

Sorry, this is my very first pull request to Endless Sky master, so it maybe requires correction.

I was surprised that it is impossible to get a ship type on the Ship Info panel (and even on the Player Info panel in a list of ships)

## Summary
For Ship Info (and in general for all non-scrollable panels) now a ship name additionally reflects a category code as 2 first letters code, wrapped in parentesis, eg: Aerie -> Aerie (MW)

Category code pattern:
* For a 2 words category: Medium Warship -> MW
* For a single word category: Fighter -> Fi

The change preserves backward capability by adding a default arg to a function

Screenshot before change:
![image](https://github.com/user-attachments/assets/4407cc6d-a046-407c-adfa-5c68be4bbcbb)

Sceenshot after change:
![image](https://github.com/user-attachments/assets/cc002d87-b11c-4e67-b8bc-4302dadac15f)


## Usage examples
No game data changed

## Testing Done
A corresponding unit-test is provided

## Save File
Any save file is valid for testing

## Artwork Checklist
No artwork change is provided

## Wiki Update
No update

## Performance Impact
N/A
