### PR TITLE
Correct the error message for incorrect syntax in the children of a text node within a conversation

### DIFF
--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -555,7 +555,7 @@ bool Conversation::ElementIsValid(int node, int element) const
 
 
 // Parse the children of the given node to see if then contain any "gotos," or
-// "to shows." If so, link them up properly. Return true if gotos or
+// "to displays." If so, link them up properly. Return true if gotos or
 // conditions were found.
 bool Conversation::LoadDestinations(const DataNode &node)
 {

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -597,7 +597,7 @@ bool Conversation::LoadDestinations(const DataNode &node)
 				}
 			}
 			else
-				child.PrintTrace("Warning: Expected goto, to show, or endpoint in conversation, found this:");
+				child.PrintTrace("Warning: Expected goto, to display, or endpoint in conversation, found this:");
 		}
 	}
 	return hasGoto || hasCondition;

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -554,8 +554,8 @@ bool Conversation::ElementIsValid(int node, int element) const
 
 
 
-// Parse the children of the given node to see if then contain any "gotos," or
-// "to displays." If so, link them up properly. Return true if gotos or
+// Parse the children of the given node to see if then contain any "goto" or
+// "to display" nodes. If so, link them up properly. Return true if gotos or
 // conditions were found.
 bool Conversation::LoadDestinations(const DataNode &node)
 {


### PR DESCRIPTION
**Bug fix**

Thanks to acquire_squids on Disocrd for reporting this.

## Summary
The correct syntax is `to display`, but the error message says `to show`.
This PR updates the message to describe the correct syntax.

## Testing Done
No.

