### PR TITLE
feat(content): New uninhabited planet: Donya

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -1102,7 +1102,8 @@ planet "Dlia Jzaur"
 planet "Donya"
 	attributes uninhabited
 	landscape land/fields29
-	description `Donya is a lush, green, Earth-like world filled with vegetation and growing matter. With clouds and a blue sky, it was idyllic to the eyes of early settlers. Despite that, it remains unsettled as rains of poisonous acid fall on regular timeframes, rendering the planet uninhabitable to human life. The foliage planted by the initial wave of colonists seems to have adjusted to the terrible rain quite well unlike their masters, who left at the first opportunity.`
+	description `Donya is a lush, green, Earth-like world filled with vegetation and growing matter. With clouds and a blue sky, it was idyllic in the eyes of early settlers and the billionaire philanthropists who funded them.`
+	description `	Despite the beauty and the funding, it remains unsettled, as rains of poisonous acid fall on regular timeframes, rendering the planet uninhabitable to human life. The foliage planted by the initial wave of colonists to scrub the skies of the rain seems to have adjusted to the terrible liquid quite well, although it hasn't managed to entirely eliminate it. The planters, who couldn't bear the dreadful weather, left when they discovered that they couldn't stop the rains.`
 	government Uninhabited
 
 planet "Double Haze"

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -1102,7 +1102,7 @@ planet "Dlia Jzaur"
 planet "Donya"
 	attributes uninhabited
 	landscape land/fields29
-	description `Donya is a lush green world much like Earth, filled with vegetation and growing matter. It even has clouds and a blue sky, making it idyllic to the eyes of settlers, who mostly had been experiencing unearthly conditions on other planets. However, it remains unsettled, because the clouds release sheets of poisonous acid on a regular timeframe. Between these moments of unrest the planet is completely peaceful. The trees and grasses planted by the initial wave of colonists seem to have adjusted to the terrible rain quite well, unlike their masters, who left at the first opportunity.`
+	description `Donya is a lush, green, Earth-like world filled with vegetation and growing matter. With clouds and a blue sky, it was idyllic to the eyes of early settlers. Despite that, it remains unsettled as rains of poisonous acid fall on regular timeframes, rendering the planet uninhabitable to human life. The foliage planted by the initial wave of colonists seems to have adjusted to the terrible rain quite well unlike their masters, who left at the first opportunity.`
 	government Uninhabited
 
 planet "Double Haze"

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -1099,6 +1099,12 @@ planet "Dlia Jzaur"
 	description `	Oddly enough, Dlia Jzaur has many unnatural looking formations on the surface that seem to reach up to the sky in areas where eclipses often occur. The formations are hollow underneath, but show no signs of Gegno involvement.`
 	government Uninhabited
 
+planet "Donya"
+	attributes uninhabited
+	landscape land/fields29
+	description `Donya is a lush green world much like Earth, filled with vegetation and growing matter. It even has clouds and a blue sky, making it idyllic to the eyes of settlers, who mostly had been experiencing unearthly conditions on other planets. However, it remains unsettled, because the clouds release sheets of poisonous acid on a regular timeframe. Between these moments of unrest the planet is completely peaceful. The trees and grasses planted by the initial wave of colonists seem to have adjusted to the terrible rain quite well, unlike their masters, who left at the first opportunity.`
+	government Uninhabited
+
 planet "Double Haze"
 	attributes factory farming kimek urban
 	landscape land/fields2

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -37436,7 +37436,7 @@ system Zubenelgenubi
 		sprite planet/desert9
 		distance 730.693
 		period 250.467
-	object
+	object Donya
 		sprite planet/cloud0
 		distance 1318.13
 		period 606.856


### PR DESCRIPTION
**Content (Planet)**

## Summary
Added a new planet in Zubenelgenubi called Donya. It has poisonous rain and uses one of the new landscape images added in #10261.

This would be one of the colonies that the "billionaire philanthropists" tried to start. However, here they were not as lucky as on planets like Zug.

## Screenshots
<img width="1920" alt="donya" src="https://github.com/user-attachments/assets/46ff985f-f442-4dda-998e-168df57bbd93">


The landscape image and description of the planet.

![map](https://github.com/user-attachments/assets/84ac45d4-c4ab-4939-ad99-051c25c59658)

Where it is on the map.

## Testing Done
Took screenshot, landed, launched, landed, etc.

## Save File
This save file can be used to test these changes:
[Asiah Racer~Donya.txt](https://github.com/user-attachments/files/17199144/Asiah.Racer.Donya.txt)

Load the save, take off, jump, and land. The travel course is already mapped out.