### PR TITLE
fix(content): Make `Ringworld Debris: Quarg` not offer on Incipias Quarg planets

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -248,6 +248,7 @@ mission "Ringworld Debris: Quarg"
 	source
 		attributes "quarg"
 		not attributes "gegno quarg"
+		not attributes "incipias quarg"
 	to offer
 		has "ringworld debris"
 		has "First Contact: Quarg: offered"

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -246,10 +246,8 @@ mission "Ringworld Debris: Quarg"
 	landing
 	invisible
 	source
-		attributes "quarg"
-		not attributes "gegno quarg"
-		not attributes "incipias quarg"
-		not attributes "korath quarg"
+		attributes "human quarg" "hai quarg"
+		attributes "ringworld"
 	to offer
 		has "ringworld debris"
 		has "First Contact: Quarg: offered"

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -249,6 +249,7 @@ mission "Ringworld Debris: Quarg"
 		attributes "quarg"
 		not attributes "gegno quarg"
 		not attributes "incipias quarg"
+		not attributes "korath quarg"
 	to offer
 		has "ringworld debris"
 		has "First Contact: Quarg: offered"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [discord](https://discord.com/channels/251118043411775489/536900466655887360/1290124748797513839)

## Summary
This can now only offer on Hai and human quarg settlements, as those are the only ones where the human languages are spoken properly. It's also restricted to ringworlds to better fit the wording.

## Testing Done
Not yet.

## Save File
None yet.