### PR TITLE
fix(content): Successors FC2 Prompt does not offer after FC2

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -218,9 +218,9 @@ mission "Successors: First Contact 2 Prompt"
 	destination "Staja-Kella-Oa"
 	to offer
 		has "event: successors: first contact wait"
+		not "Successors: First Contact 2: offered"
 	to fail
 		has "Successors: Unified Defense: offered"
-		has "Successors: First Contact 2: offered"
 	on offer
 		event "successors: tardy for sioeora" 14
 		conversation


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described [on Steam](https://steamcommunity.com/app/404410/discussions/1/4848778277267041650/).

## Summary
`Successors: First Contact 2 Prompt` no longer offers after `Successors: First Contact 2` has been offered. Because `to offer` and `to fail` conditions are ANDed together rather than ORed, the mission wasn't failing to offer appropriately. Who knew the fundamentals of Boolean algebra were so important?

## Testing Done
I reproduced the steps listed in the bug report and confirmed that the error did not occur. I also played through all the mainline `Successors: First Contact` missions from a fresh save post-fix and can confirm that this fix does not introduce any new issues to them that I can see.

## Save File
This save file can be used to test these changes:
Let me know if you really need one.