### PR TITLE
fix(content): allow players to land to complete Successors: Predecessor Research 1

### DIFF
--- a/data/successors/successor side missions.txt
+++ b/data/successors/successor side missions.txt
@@ -16,6 +16,7 @@ mission "Successors: Predecessor Research 1"
 	landing
 	name "Assist Predecessor Research"
 	description "Transport these <bunks> scholars researching the Predecessors to <planet stopovers> and back home to <destination> by <date>."
+	clearance
 	passengers 7
 	deadline 30
 	to offer


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described ~~where else but on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1290992266592260137)~~

## Summary
You get clearance to land for the `Successors: Predecessor Research 1` mission.

## Screenshots
No

## Testing Done
Not yet.

## Save File
This save file can be used to test these changes:
None.