### PR TITLE
Fix mac os info.plist entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,8 @@ if(APPLE AND ES_CREATE_BUNDLE)
 	set_target_properties(EndlessSky PROPERTIES
 		MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/resources/EndlessSky-Info.plist"
 		XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME endless-sky)
-	set_target_properties(EndlessSky PROPERTIES OUTPUT_NAME "Endless Sky")
+	set(OUTPUT_NAME "Endless Sky")
+	set_target_properties(EndlessSky PROPERTIES OUTPUT_NAME ${OUTPUT_NAME})
 elseif(WIN32)
 	add_executable(EndlessSky WIN32 source/main.cpp source/WinApp.rc)
 	set_target_properties(EndlessSky PROPERTIES OUTPUT_NAME "Endless Sky")

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>Endless Sky</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>endless-sky</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<string>io.github.endless-sky</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -25,7 +25,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.role-playing-games</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>endless-sky</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Endless Sky</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>${OUTPUT_NAME}</string>
 	<key>CFBundleIconFile</key>
 	<string>endless-sky</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
**Bug fix**

Reported by comradecandy on Discord.

## Summary
Some of the substitutions in the info.plist file used included in the MacOS package are incorrect, and so those values are not being correctly set by CMake.
One of the issues this results in is the name of the whole package needing to be the same as the executable within it. If the package is renamed, MacOS will no longer be able to find the executable within it and it will no longer run.
This PR corrects the substitution used for the executable name so it should be set correctly by CMake, as well as correcting syntax for the bundle identifier replacement and the name used for the minimum version replacement.

## Testing Done
We'll see when it builds.
