### PR TITLE
fix(ci): Remove unneeded Steam configurations from CI and enable testing for Steam

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -58,16 +58,6 @@ ci_config:
   - '.github/path-filters.yml'
   - '.github/workflows/compute-changes.yml'
 
-cd_config:
-  - '.github/workflows/cd.yml'
-  - '.github/path-filters.yml'
-  - '.github/workflows/compute-changes.yml'
-
-release_config:
-  - '.github/workflows/cd_release.yml'
-  - '.github/path-filters.yml'
-  - '.github/workflows/compute-changes.yml'
-
 projects_check_config:
   - '.github/workflows/projects_check.yml'
   - '.github/path-filters.yml'

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -14,6 +14,9 @@ unit_tests:
 integration_tests:
   - 'tests/integration/config/plugins/integration-tests/**'
 
+steam:
+  - 'steam/**'
+
 doxygen_config:
   - 'Doxyfile'
 
@@ -52,6 +55,16 @@ changelog:
 
 ci_config:
   - '.github/workflows/ci.yml'
+  - '.github/path-filters.yml'
+  - '.github/workflows/compute-changes.yml'
+
+cd_config:
+  - '.github/workflows/cd.yml'
+  - '.github/path-filters.yml'
+  - '.github/workflows/compute-changes.yml'
+
+release_config:
+  - '.github/workflows/cd_release.yml'
   - '.github/path-filters.yml'
   - '.github/workflows/compute-changes.yml'
 

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -153,10 +153,6 @@ jobs:
       run: |
         cd steam
         docker compose run steam-x64
-    - name: Test Endless Sky
-      run: |
-        cd steam
-        docker compose run test-steam-x64
     - name: Prepare binary
       run: cp build/steam-x64/endless-sky .
     - name: Upload Steam Depot

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -153,6 +153,10 @@ jobs:
       run: |
         cd steam
         docker compose run steam-x64
+    - name: Test Endless Sky
+      run: |
+        cd steam
+        docker compose run test-steam-x64
     - name: Prepare binary
       run: cp build/steam-x64/endless-sky .
     - name: Upload Steam Depot

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -1,7 +1,6 @@
 name: Release CD
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       release_version:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -1,6 +1,7 @@
 name: Release CD
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       release_version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,15 @@ name: CI
 
 on:
   push:
-    # Run for pushes to master or a release branch, e.g. a PR was merged ...
+    # Run for pushes to master, e.g. a PR was merged ...
     branches:
       - master
-      - releases/v[0-9]+.[0-9]+.[0-9]+
     # ... and only when we've possibly changed how the game will function.
     paths:
     - 'source/**'
     - 'data/**'
+    - 'images/**'
+    - 'sounds/**'
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'
@@ -23,6 +24,8 @@ on:
     paths:
     - 'source/**'
     - 'data/**'
+    - 'images/**'
+    - 'sounds/**'
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
     paths:
     - 'source/**'
     - 'data/**'
-    - 'images/**'
-    - 'sounds/**'
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'
@@ -25,8 +23,6 @@ on:
     paths:
     - 'source/**'
     - 'data/**'
-    - 'images/**'
-    - 'sounds/**'
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'
+    - 'steam/**'
     - 'CMakeLists.txt'
     - 'CMakePresets.json'
     - Doxyfile
@@ -29,6 +30,7 @@ on:
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'
+    - 'steam/**'
     - 'CMakeLists.txt'
     - 'CMakePresets.json'
     - Doxyfile
@@ -92,7 +94,7 @@ jobs:
   build_steam:
     name: Steam
     needs: changed
-    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.integration_tests == 'true' || needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.steam_config == 'true' }}
+    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.integration_tests == 'true' || needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.ci_config == 'true' || needs.changed.outputs.steam == 'true' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     - 'data/**'
     - 'tests/**'
     - '.github/workflows/**'
+    - '.github/path-filters.yml'
     - 'CMakeLists.txt'
     - 'CMakePresets.json'
     - Doxyfile
@@ -24,6 +25,7 @@ on:
     - 'data/**'
     - 'tests/**'
     - '.github/workflows/**'
+    - '.github/path-filters.yml'
     - 'CMakeLists.txt'
     - 'CMakePresets.json'
     - Doxyfile
@@ -82,6 +84,36 @@ jobs:
         testPreset: ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
     - name: Run Benchmarks
       run: ctest --preset ${{ matrix.opengl == 'GL' && 'linux-ci-benchmark' || 'linux-gles-ci-benchmark' }}
+
+
+  build_steam:
+    name: Steam
+    needs: changed
+    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.integration_tests == 'true' || needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.steam_config == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Setup cached directories
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/sccache
+          key: ${{ runner.os }}-steam-ci-sccache-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-steam-ci-sccache-refs/heads/master
+      - name: Setup sccache
+        uses: Mozilla-Actions/sccache-action@v0.0.5
+      - name: Build Endless Sky
+        run: |
+          cd steam
+          docker compose run steam-x64
+      - name: Test Endless Sky
+        run: |
+          cd steam
+          docker compose run test-steam-x64
 
 
   build_windows:

--- a/.github/workflows/compute-changes.yml
+++ b/.github/workflows/compute-changes.yml
@@ -11,6 +11,8 @@ on:
         value: ${{ jobs.changed.outputs.unit_tests }}
       integration_tests:
         value: ${{ jobs.changed.outputs.integration_tests }}
+      steam:
+        value: ${{ jobs.changed.outputs.steam }}
       doxygen_config:
         value: ${{ jobs.changed.outputs.doxygen_config }}
       codespell:
@@ -42,6 +44,7 @@ jobs:
       game_code: ${{ steps.filter.outputs.game_code }}
       unit_tests: ${{ steps.filter.outputs.unit_tests }}
       integration_tests: ${{ steps.filter.outputs.integration_tests }}
+      steam: ${{ steps.filter.outputs.steam }}
       codespell: ${{ steps.filter.outputs.codespell }}
       editorconfig_files: ${{ steps.filter.outputs.editorconfig_files }}
       content_style_check: ${{ steps.filter.outputs.content_style_check }}

--- a/steam/docker-compose.yml
+++ b/steam/docker-compose.yml
@@ -27,4 +27,4 @@ services:
         cd build/steam-x64
         ninja
         ./endless-sky --version
-        ctest --label-exclude "(benchmark|integration-debug)"
+        ctest --label-exclude "integration-debug"

--- a/steam/docker-compose.yml
+++ b/steam/docker-compose.yml
@@ -15,21 +15,6 @@ services:
         ninja EndlessSky
 
 
-  steam-x86:
-    image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
-    working_dir: /endless-sky
-    volumes:
-      - '..:/endless-sky'
-    command:
-      - '/bin/bash'
-      - '-c'
-      - |
-        mkdir -p build/steam-x86
-        cd build/steam-x86
-        cmake ../../ -GNinja -DES_STEAM=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-m32 -DVCPKG_TARGET_TRIPLET=linux-x86-release-static
-        ninja EndlessSky
-
-
   test-steam-x64:
     image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
     volumes:
@@ -40,21 +25,6 @@ services:
       - '-c'
       - |
         cd build/steam-x64
-        ninja
-        ./endless-sky --version
-        ctest --label-exclude "(benchmark|integration-debug)"
-
-
-  test-steam-x86:
-    image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest
-    volumes:
-      - '..:/endless-sky'
-    working_dir: /endless-sky
-    command:
-      - '/bin/bash'
-      - '-c'
-      - |
-        cd build/steam-x86
         ninja
         ./endless-sky --version
         ctest --label-exclude "(benchmark|integration-debug)"


### PR DESCRIPTION
**CI/CD/Testing**

This PR removes unused configurations from the steam docker config and enables an extra test. It also applies some generic fixes to the CI setup.

## Summary
- We don't use the x86 steam builds anymore, so those configurations were removed from docker.
- The existing test configuration for the x64 build was added to the CI via a new job.
- ~~Changes in the `sounds` and `images` directories can now trigger the CI, as there are errors that can be generated from only these data changes.~~
- The CI trigger for release branches was removed, as we don't use release branches and no other workflows are configured to work with them.
- The CI can now trigger for changes made only to the path filter configuration. (If it doesn't affect the CI, all jobs get skipped.)

## Testing Done
Workflows.