### PR TITLE
[Bugfix] Minimum Distance for Successor Rush Delivery Jobs

### DIFF
--- a/data/successors/successor jobs.txt
+++ b/data/successors/successor jobs.txt
@@ -777,6 +777,7 @@ mission "Successors: Old Houses Rush Delivery"
 		attributes "successor"
 	destination
 		government "Old Houses" "House Chydiyi" "House Myurej" "House Sioeora"
+		distance 2 20
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete
@@ -804,6 +805,7 @@ mission "Successors: New Houses Rush Delivery"
 		attributes "successor"
 	destination
 		government "New Houses" "House Kaatrij" "House Seineq" "House Aqrabe"
+		distance 2 20
 	on visit
 		dialog phrase "generic cargo on visit"
 	on complete


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in Discord -- thanks DAK for reporting!

## Summary
Currently Successor Old & New House rush delivery jobs don't have a minimum distance, so that the rush delivery can have the destination be the same planet you're already on. This PR should be reviewed by @Daeridanii1 

## Testing Done
None yet

## Save File
None yet