### PR TITLE
fix(content): "Gegno Intervention" no longer offers if you have done "Gegno Anticipation"

### DIFF
--- a/data/gegno/gegno I corroboration.txt
+++ b/data/gegno/gegno I corroboration.txt
@@ -580,6 +580,7 @@ mission "Gegno Anticipation"
 	to offer
 		has "Return to Giaru Gegno: offered"
 		not "Gegno Genocide Defense: offered"
+		not "Gegno Intervention: offered"
 		not "event: gegno: apprehension"
 		"reputation: Gegno Vi" > -100
 		"reputation: Gegno Scin" > -50
@@ -926,6 +927,7 @@ mission "Gegno Intervention"
 	to offer
 		has "event: gegno: apprehension"
 		not "Gegno Genocide Defense: offered"
+		not "Gegno Anticipation: offered"
 	source "Giaru Gegno"
 	destination "Dueyu Eitch"
 	deadline 8


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**
**Bug fix**

## Summary
Reported on discord, someone was offered "Gegno Intervention" after the current extent of the new missions, when it is supposed to be an alternate version of "Gegno Anticipation". Although the player did the latter, they eventually met the conditions for the former (enough negative rep/actions), which still offers even if the other has already been offered. Added said conditions.

Not sure if I need to add a patch fix yet.

## Testing Done
Soon if needed.

## Save File
This save file can be used to test these changes:
Soon.
