### PR TITLE
feat(balance): Rebalance certain defense-heavy outfits to account for defense being used more often.

### DIFF
--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -795,7 +795,7 @@ outfit "Microbot Defense Station"
 	thumbnail "outfit/microbot defense station"
 	mass 2
 	"outfit space" -3
-	"capture defense" 45
+	"capture defense" 18
 	illegal 10000000
 	"energy consumption" 0.01
 	"heat generation" 0.1

--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -336,7 +336,7 @@ outfit "Pug Biodefenses"
 	category "Hand to Hand"
 	cost 100000
 	thumbnail "outfit/pug biodefenses"
-	"capture defense" 250
+	"capture defense" 100
 	"unplunderable" 1
 	description "This semi-organic defense system is designed to release a highly lethal bioengineered virus capable of rapidly infecting any foreign entities present on the ship that it is installed on while leaving the crew of the ship unharmed. The virus, when combined with the defense system itself, is highly accurate at automatically determining friend from foe."
 

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -103,7 +103,7 @@ outfit "Intrusion Countermeasures"
 	plural "Intrusion Countermeasures"
 	category "Hand to Hand"
 	thumbnail "outfit/quarg countermeasures"
-	"capture defense" 60
+	"capture defense" 24
 	"unplunderable" 1
 	description "Quarg ships are outfitted with special systems for repelling boarders. Because no one wants to be caught by the Quarg with stolen technology, these systems are pretty much worthless on the open market."
 


### PR DESCRIPTION
**Balance**

## Summary
With the changes to the boarding calculations made recently, `capture defense` will now come into play every round, rather than only on rounds the AI chooses to defend. This will make it far more powerful.
This creates a problem, because for a while we have been balancing capturing around the low capture defense exploit - and hence, made that exploit the only way to capture many things. In order to preserve the best-case performance while no longer requiring this exploit, we need to scale down the defense of these outfits to balance out the fact that that defense comes into play more often.
I have divided the defense of these outfits by 2.5. This is based on some screenshots of boarding combat prior to this change, which seemed to suggest about a 5:1 ratio between the enemy choosing to attack and the enemy choosing to defend when using the nerve gas setup - that is, the enemy's defense was used 1/5 of the time. Now that a round where the enemy attacks is instead resolved with one round where the enemy's attack is used and one where their defense is used, their defense will come into play at least half the time - that is, a minimum of 2.5 times more often than before. That is the reason for the scaling factor of 2.5 used.

## Testing Done
None yet.

## Save File
I don't have a good save file for this, can someone who practices korath/quarg capping post one?