### PR TITLE
refactor: Replace *_s functions if they're not needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,6 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT EndlessSky)
 set(CMAKE_VS_JUST_MY_CODE_DEBUGGING ON)
 
-# Suppress warnings about non-secure functions in MSVC.
-if(WIN32 AND NOT MINGW)
-	target_compile_definitions(EndlessSkyLib PUBLIC _CRT_SECURE_NO_WARNINGS)
-endif()
-
 project("Endless Sky" VERSION 0.10.10
 	DESCRIPTION "Space exploration, trading, and combat game."
 	HOMEPAGE_URL https://endless-sky.github.io/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT EndlessSky)
 set(CMAKE_VS_JUST_MY_CODE_DEBUGGING ON)
 
+# Suppress warnings about non-secure functions in MSVC.
+if(WIN32 AND NOT MINGW)
+	target_compile_definitions(EndlessSkyLib PUBLIC _CRT_SECURE_NO_WARNINGS)
+endif()
+
 project("Endless Sky" VERSION 0.10.10
 	DESCRIPTION "Space exploration, trading, and combat game."
 	HOMEPAGE_URL https://endless-sky.github.io/

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -6,6 +6,7 @@ if(MSVC)
 	target_compile_options(EndlessSkyLib PUBLIC "/W3" "/permissive-" "/sdl" "/GR-" "/analyze-"
 		"-Wno-nonportable-include-path" "$<$<CONFIG:Release>:/Gy;/Oi>")
 	target_compile_definitions(EndlessSkyLib PUBLIC "_UNICODE" "UNICODE")
+	target_compile_definitions(EndlessSkyLib PUBLIC "_CRT_SECURE_NO_WARNINGS")
 else()
 	target_compile_options(EndlessSkyLib PUBLIC
 		"-Wall" "-pedantic-errors" "-Wold-style-cast" "-fno-rtti")

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -492,8 +492,7 @@ string Files::Name(const string &path)
 FILE *Files::Open(const string &path, bool write)
 {
 #if defined _WIN32
-	FILE *file = _wfopen(Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
-	return file;
+	return _wfopen(Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
 #else
 	return fopen(path.c_str(), write ? "wb" : "rb");
 #endif

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -493,7 +493,7 @@ FILE *Files::Open(const string &path, bool write)
 {
 #if defined _WIN32
 	FILE *file = nullptr;
-	_wfopen_s(&file, Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
+	_wfopen(&file, Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
 	return file;
 #else
 	return fopen(path.c_str(), write ? "wb" : "rb");

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -492,8 +492,7 @@ string Files::Name(const string &path)
 FILE *Files::Open(const string &path, bool write)
 {
 #if defined _WIN32
-	FILE *file = nullptr;
-	_wfopen(&file, Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
+	FILE *file = _wfopen(Utf8::ToUTF16(path).c_str(), write ? L"w" : L"rb");
 	return file;
 #else
 	return fopen(path.c_str(), write ? "wb" : "rb");

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -581,22 +581,19 @@ void InitConsole()
 	// Perform console redirection.
 	if(redirectStdout)
 	{
-		FILE *fstdout = nullptr;
-		freopen(&fstdout, "CONOUT$", "w", stdout);
+		FILE *fstdout = freopen("CONOUT$", "w", stdout);
 		if(fstdout)
 			setvbuf(stdout, nullptr, _IOFBF, 4096);
 	}
 	if(redirectStderr)
 	{
-		FILE *fstderr = nullptr;
-		freopen(&fstderr, "CONOUT$", "w", stderr);
+		FILE *fstderr = freopen("CONOUT$", "w", stderr);
 		if(fstderr)
 			setvbuf(stderr, nullptr, _IOLBF, 1024);
 	}
 	if(redirectStdin)
 	{
-		FILE *fstdin = nullptr;
-		freopen(&fstdin, "CONIN$", "r", stdin);
+		FILE *fstdin = freopen("CONIN$", "r", stdin);
 		if(fstdin)
 			setvbuf(stdin, nullptr, _IONBF, 0);
 	}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -582,21 +582,21 @@ void InitConsole()
 	if(redirectStdout)
 	{
 		FILE *fstdout = nullptr;
-		freopen_s(&fstdout, "CONOUT$", "w", stdout);
+		freopen(&fstdout, "CONOUT$", "w", stdout);
 		if(fstdout)
 			setvbuf(stdout, nullptr, _IOFBF, 4096);
 	}
 	if(redirectStderr)
 	{
 		FILE *fstderr = nullptr;
-		freopen_s(&fstderr, "CONOUT$", "w", stderr);
+		freopen(&fstderr, "CONOUT$", "w", stderr);
 		if(fstderr)
 			setvbuf(stderr, nullptr, _IOLBF, 1024);
 	}
 	if(redirectStdin)
 	{
 		FILE *fstdin = nullptr;
-		freopen_s(&fstdin, "CONIN$", "r", stdin);
+		freopen(&fstdin, "CONIN$", "r", stdin);
 		if(fstdin)
 			setvbuf(stdin, nullptr, _IONBF, 0);
 	}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -579,23 +579,11 @@ void InitConsole()
 		return;
 
 	// Perform console redirection.
-	if(redirectStdout)
-	{
-		FILE *fstdout = freopen("CONOUT$", "w", stdout);
-		if(fstdout)
-			setvbuf(stdout, nullptr, _IOFBF, 4096);
-	}
-	if(redirectStderr)
-	{
-		FILE *fstderr = freopen("CONOUT$", "w", stderr);
-		if(fstderr)
-			setvbuf(stderr, nullptr, _IOLBF, 1024);
-	}
-	if(redirectStdin)
-	{
-		FILE *fstdin = freopen("CONIN$", "r", stdin);
-		if(fstdin)
+	if(redirectStdout && freopen("CONOUT$", "w", stdout))
+		setvbuf(stdout, nullptr, _IOFBF, 4096);
+	if(redirectStderr && freopen("CONOUT$", "w", stderr))
+		setvbuf(stderr, nullptr, _IOLBF, 1024);
+	if(redirectStdin && freopen("CONIN$", "r", stdin))
 			setvbuf(stdin, nullptr, _IONBF, 0);
-	}
 }
 #endif


### PR DESCRIPTION
**Refactor**

## Summary
Replaced some _s functions with their normal versions. The _s means that the function will perform some nullchecks, which in these cases aren't needed as the arguments point to addresses of variables defined earlier.

Also refactored some win32 `#ifdef`s to avoid returning a pair with one unused element.

## Testing Done
none.

## Performance Impact
No negative impact.
