### PR TITLE
Two new pull request template categories

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 **Balance**
 **Feature**
 **Bug fix**
+**Typo fix**
 **CI/CD/Testing**
 **Documentation**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 **Bug fix**
 **Typo fix**
 **CI/CD/Testing**
+**Refactor**
 **Documentation**
 
 This PR addresses the bug/feature described in issue #{{insert number}}


### PR DESCRIPTION
**GitHub**

## Summary
PR templates now have **Typo fix** as an option for a header.

Also added **Refactor** at the request of TomGoodIdea.