### PR TITLE
feat(content): Reduce offer rate of Strike Breaker jobs

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -2308,7 +2308,8 @@ mission "Strike Breakers [large mining]"
 	description "Bring <bunks> strike breakers to <destination>, to take the place of mine workers who are on strike. The company will pay you <payment>."
 	passengers 40 4 .08
 	to offer
-		random < ( "passenger space" - 45 ) / 2
+		random < "passenger space" - 45
+		random < 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2318,7 +2319,7 @@ mission "Strike Breakers [large mining]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 130000 100
+		payment 130000 120
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
 mission "Strike Breakers [textile]"
@@ -2350,7 +2351,8 @@ mission "Strike Breakers [large textile]"
 	description "Bring <bunks> strike breakers to <destination>, to take the place of textile workers who are on strike. The company will pay you <payment>."
 	passengers 40 4 .08
 	to offer
-		random < ( "passenger space" - 45 ) / 2
+		random < "passenger space" - 45
+		random < 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2360,7 +2362,7 @@ mission "Strike Breakers [large textile]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 130000 100
+		payment 130000 120
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
 mission "Strike Breakers [factory]"
@@ -2392,7 +2394,8 @@ mission "Strike Breakers [large factory]"
 	description "Bring <bunks> strike breakers to <destination>, to take the place of factory workers who are on strike. The company will pay you <payment>."
 	passengers 40 4 .08
 	to offer
-		random < ( "passenger space" - 45 ) / 2
+		random < "passenger space" - 45
+		random < 10
 	source
 		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
 	destination
@@ -2402,7 +2405,7 @@ mission "Strike Breakers [large factory]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 130000 100
+		payment 130000 120
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
 mission "Colonists [0]"

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -386,7 +386,7 @@ mission "Escort (Large, Northern, Dangerous Destination)"
 			variant
 				"Behemoth"
 	on complete
-		payment 000
+		payment 120000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -432,7 +432,7 @@ mission "Escort (Large, Northern, Dangerous Origin)"
 			variant
 				"Behemoth"
 	on complete
-		payment 000
+		payment 120000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -908,7 +908,7 @@ mission "Escort (Large, Core, Dangerous Destination)"
 			variant
 				"Container Transport"
 	on complete
-		payment 000
+		payment 120000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -954,7 +954,7 @@ mission "Escort (Large, Core, Dangerous Origin)"
 			variant
 				"Container Transport"
 	on complete
-		payment 000
+		payment 120000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"

--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -386,7 +386,7 @@ mission "Escort (Large, Northern, Dangerous Destination)"
 			variant
 				"Behemoth"
 	on complete
-		payment 120000
+		payment 000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -432,7 +432,7 @@ mission "Escort (Large, Northern, Dangerous Origin)"
 			variant
 				"Behemoth"
 	on complete
-		payment 120000
+		payment 000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -908,7 +908,7 @@ mission "Escort (Large, Core, Dangerous Destination)"
 			variant
 				"Container Transport"
 	on complete
-		payment 120000
+		payment 000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -954,7 +954,7 @@ mission "Escort (Large, Core, Dangerous Origin)"
 			variant
 				"Container Transport"
 	on complete
-		payment 120000
+		payment 000
 		dialog phrase "generic safe escort completion dialog"
 	on visit
 		dialog phrase "generic arrived-without-npc dialog"
@@ -2319,7 +2319,7 @@ mission "Strike Breakers [large mining]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 130000 120
+		payment 130000 100
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
 mission "Strike Breakers [textile]"
@@ -2362,7 +2362,7 @@ mission "Strike Breakers [large textile]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 130000 120
+		payment 130000 100
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
 mission "Strike Breakers [factory]"
@@ -2405,7 +2405,7 @@ mission "Strike Breakers [large factory]"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
-		payment 130000 120
+		payment 130000 100
 		dialog "You unload the strike breakers amid an angry crowd of protesters held back by police. When you return to your ship, you find that the company has transferred the agreed-upon payment of <payment> into your account."
 
 mission "Colonists [0]"


### PR DESCRIPTION
In a similar vein to #9501, it's been brought up that the strike breaker jobs offer far more often than what should be expected. This PR reduces the offer rate of the jobs ~while increasing their payment~.