### PR TITLE
fix(content): give Vulpa a missing government

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -5546,6 +5546,7 @@ planet Vulpa
 	attributes "requires: gaslining"
 	landscape land/vulpa
 	description `At first sight this planet looks fairly hospitable for a gas giant. The blue tones suggest an ocean world, but looks can be deceiving; its clouds contain countless small glass droplets moving at tremendous speeds, cutting through everything in their way. Your spaceship's hull is able to deflect most of them, but it is advisable not to stay here for too long.`
+	government Uninhabited
 
 planet Vyraa-Giiq-Sora
 	attributes "bold tourism" successor uninhabited


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1294058016748077117).

## Summary
Vulpa now has a government.

## Screenshots
No.

## Testing Done
Not really.

## Save File
This save file can be used to test these changes:
Any save that has gaslining.