### PR TITLE
refactor: use constexpr array for formatting credits

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -293,7 +293,7 @@ string Format::Credits(int64_t value)
 	int64_t absolute = abs(value);
 
 	// Handle numbers bigger than a million.
-	static const array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {{
+	static constexpr array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {{
 		{1000000000000ll, 'T'},
 		{1000000000ll, 'B'},
 		{1000000ll, 'M'}

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <functional>
 #include <sstream>
 #include <unordered_set>
+#include <utility>
 
 using namespace std;
 
@@ -293,20 +294,23 @@ string Format::Credits(int64_t value)
 	int64_t absolute = abs(value);
 
 	// Handle numbers bigger than a million.
-	static const vector<char> SUFFIX = {'T', 'B', 'M'};
-	static const vector<int64_t> THRESHOLD = {1000000000000ll, 1000000000ll, 1000000ll};
-	for(size_t i = 0; i < SUFFIX.size(); ++i)
-		if(absolute > THRESHOLD[i])
+	static const array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {{
+		{1000000000000ll, 'T'},
+		{1000000000ll, 'B'},
+		{1000000ll, 'M'}
+	}};
+	for(const auto &[threshold, suffix] : THRESHOLD_SUFFIX)
+		if(absolute > threshold)
 		{
-			result += SUFFIX[i];
-			int decimals = (absolute / (THRESHOLD[i] / 1000)) % 1000;
+			result += suffix;
+			int decimals = (absolute / (threshold / 1000)) % 1000;
 			for(int d = 0; d < 3; ++d)
 			{
 				result += static_cast<char>('0' + decimals % 10);
 				decimals /= 10;
 			}
 			result += '.';
-			absolute /= THRESHOLD[i];
+			absolute /= threshold;
 			break;
 		}
 

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -293,11 +293,11 @@ string Format::Credits(int64_t value)
 	int64_t absolute = abs(value);
 
 	// Handle numbers bigger than a million.
-	static constexpr array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {
+	static constexpr array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {{
 		{1000000000000ll, 'T'},
 		{1000000000ll, 'B'},
 		{1000000ll, 'M'}
-	};
+	}};
 	for(const auto &[threshold, suffix] : THRESHOLD_SUFFIX)
 		if(absolute > threshold)
 		{

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -23,7 +23,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <functional>
 #include <sstream>
 #include <unordered_set>
-#include <utility>
 
 using namespace std;
 

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -293,11 +293,11 @@ string Format::Credits(int64_t value)
 	int64_t absolute = abs(value);
 
 	// Handle numbers bigger than a million.
-	static constexpr array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {{
+	static constexpr array<pair<int64_t, char>, 3> THRESHOLD_SUFFIX = {
 		{1000000000000ll, 'T'},
 		{1000000000ll, 'B'},
 		{1000000ll, 'M'}
-	}};
+	};
 	for(const auto &[threshold, suffix] : THRESHOLD_SUFFIX)
 		if(absolute > threshold)
 		{


### PR DESCRIPTION
**Refactor**

## Summary
Refactors `Format::Credits` to store million, billion, and trillion threshold values and suffixes in an `std::array<std::pair<int64_t, char>>` instead of two `std::vector`s.

Related: https://github.com/endless-sky/endless-sky/pull/10473#discussion_r1769378014

## Testing Done
The unit tests test it.
