### PR TITLE
Prevent Plume from turning into a ghost in Remnant: Cognizance 7

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -308,6 +308,7 @@ mission "Remnant: Cognizance 7"
 	description "Plume wants to witness firsthand what is going on in Nenia, and would like to visit <planet>."
 	source "Caelian"
 	destination "Nasqueron"
+	passengers 1
 	to offer
 		has "Remnant: Cognizance 6: done"
 	on offer


### PR DESCRIPTION
**Bug fix**

## Summary

Plume is a tangible passenger who takes up a bunk in Cognizance 6. But he turns into a ghost in 7, not needing to occupy a bunk.