### PR TITLE
feat(mechanics): Cloaked shield permeability

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -642,6 +642,9 @@ tip "high shield permeability:"
 tip "low shield permeability:"
 	`This percentage of all incoming damage will bypass shields and apply directly to the hull as shields approach zero.`
 
+tip "cloaked shield permeability:"
+	`This percentage of all incoming damage will bypass shields and apply directly to the hull while you are cloaked.`
+
 tip "shields (charge):"
 	`Total shield strength and regeneration rate per second.`
 

--- a/source/DamageProfile.cpp
+++ b/source/DamageProfile.cpp
@@ -128,7 +128,7 @@ void DamageProfile::PopulateDamage(DamageDealt &damage, const Ship &ship) const
 			- attributes.Get("piercing resistance")));
 		double highPermeability = attributes.Get("high shield permeability");
 		double lowPermeability = attributes.Get("low shield permeability");
-		double permeability = ship.IsCloaked() ? attributes.Get("cloaked shield permeability") : 0.;
+		double permeability = ship.Cloaking() * attributes.Get("cloaked shield permeability");
 		if(highPermeability || lowPermeability)
 		{
 			// Determine what portion of its maximum shields the ship is currently at.

--- a/source/DamageProfile.cpp
+++ b/source/DamageProfile.cpp
@@ -128,13 +128,13 @@ void DamageProfile::PopulateDamage(DamageDealt &damage, const Ship &ship) const
 			- attributes.Get("piercing resistance")));
 		double highPermeability = attributes.Get("high shield permeability");
 		double lowPermeability = attributes.Get("low shield permeability");
-		double permeability = 0.;
+		double permeability = (ship.IsCloaked() ? attributes.Get("cloaked shield permeability") : 0.);
 		if(highPermeability || lowPermeability)
 		{
 			// Determine what portion of its maximum shields the ship is currently at.
 			// Only do this if there is nonzero permeability involved, otherwise don't.
 			double shieldPortion = shields / ship.MaxShields();
-			permeability = max((highPermeability * shieldPortion) +
+			permeability += max((highPermeability * shieldPortion) +
 				(lowPermeability * (1. - shieldPortion)), 0.);
 		}
 		shieldFraction = (1. - min(piercing + permeability, 1.)) /

--- a/source/DamageProfile.cpp
+++ b/source/DamageProfile.cpp
@@ -128,7 +128,7 @@ void DamageProfile::PopulateDamage(DamageDealt &damage, const Ship &ship) const
 			- attributes.Get("piercing resistance")));
 		double highPermeability = attributes.Get("high shield permeability");
 		double lowPermeability = attributes.Get("low shield permeability");
-		double permeability = (ship.IsCloaked() ? attributes.Get("cloaked shield permeability") : 0.);
+		double permeability = ship.IsCloaked() ? attributes.Get("cloaked shield permeability") : 0.;
 		if(highPermeability || lowPermeability)
 		{
 			// Determine what portion of its maximum shields the ship is currently at.

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -189,6 +189,7 @@ namespace {
 		{"overheat damage threshold", 3},
 		{"high shield permeability", 3},
 		{"low shield permeability", 3},
+		{"cloaked shield permeability", 3},
 		{"acceleration multiplier", 3},
 		{"turn multiplier", 3},
 


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #5805 

## Summary
While you are cloaked, your shields' permeability is increased by your `cloaked shield permeability`
Stacks additively with the existing permeability attributes; final permeability value is safely bounded to be below 1 to prevent unintended behaviour.

## Usage examples
```
outfit "cloaking device that makes shields slightly less efficient while active"
	...
	"cloaked shield permeability" .1
```

```
outfit "cloaking device that makes shields entirely defunct while active"
	...
	"cloaked shield permeability" 1
```

## Testing Done
Put `"cloaked shield permeability" 1` on the cloaking device, and confirmed that my shields were pierced by non-piercing weapons when I was cloaked, and when I was in the process of cloaking or decloaking, but not when I was uncloaked.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/60

## Performance Impact
Calls ship.iscloaked() every time a ship takes damage. Also adds an attribute check iff the ship is cloaked.
