### PR TITLE
fix(ui): Show sold non-installable outfits as "in stock"

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -196,8 +196,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 			font.Draw(label, labelPos, bright);
 		}
 	}
-	// Don't show the "in stock" amount if the outfit has an unlimited stock or
-	// if it is not something that you can buy.
+	// Don't show the "in stock" amount if the outfit has an unlimited stock.
 	int stock = 0;
 	if(!outfitter.Has(outfit))
 		stock = max(0, player.Stock(outfit));

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -199,7 +199,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 	// Don't show the "in stock" amount if the outfit has an unlimited stock or
 	// if it is not something that you can buy.
 	int stock = 0;
-	if(!outfitter.Has(outfit) && outfit->Get("installable") >= 0.)
+	if(!outfitter.Has(outfit))
 		stock = max(0, player.Stock(outfit));
 	int cargo = player.Cargo().Get(outfit);
 	int storage = player.Storage().Get(outfit);


### PR DESCRIPTION
**Bug fix**

This PR fixes #10605.

## Summary
Currently, non-installable outfits (such as minerals and Void Sprite Parts) for some reason are excluded from being displayed as "in stock" even though you can still buy them directly to cargo. This PR fixes this problem.

# Screenshots
![iron](https://github.com/user-attachments/assets/493ce1b3-f4e1-4bcb-9f02-681eb3ab2a5b)

## Testing Done
yes.

## Performance Impact
N/A
