### PR TITLE
fix(ci): Add missing setup-python step to the old copyright check

### DIFF
--- a/.github/workflows/projects_check.yml
+++ b/.github/workflows/projects_check.yml
@@ -39,6 +39,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
     - name: Install dependencies
       run: pip install --break-system-packages python-debian
     - name: Validate copyright file with python-debian


### PR DESCRIPTION
**CI/CD/Testing**

This PR adds a missing `setup-python` step to the old copyright action.

## Summary
The missing setup step results in using the python and pip version shipped by the runner image, instead of what we configured to use. This can break the check when the runner version changes, as seen in #10522.

Github [reverted](https://github.com/endless-sky/endless-sky/pull/10522#issuecomment-2418780018) the change as it broke too many things, but as we already fixed our setup, github broke it again.

The setup-python action is more stable, as it installs a python environment that is not externally managed. It also ships a new enough version of pip that it recognizes the `--break-system-packages` option. Using this action should therefore help us avoid future breakages due to ubuntu version changes.

## Testing Done
It should pass now.