### PR TITLE
fix(mechanics): Stop ships when their velocity is exceedingly low

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1132,7 +1132,7 @@ void AI::Step(Command &activeCommands)
 			else
 			{
 				command.SetTurn(TurnToward(*it, TargetAim(*it)));
-				it->SetVelocity({0, 0});
+				it->SetVelocity({0., 0.});
 			}
 		}
 		else if(FollowOrders(*it, command))
@@ -1729,7 +1729,7 @@ bool AI::FollowOrders(Ship &ship, Command &command)
 		else
 		{
 			command.SetTurn(TurnToward(ship, TargetAim(ship)));
-			ship.SetVelocity({0, 0});
+			ship.SetVelocity({0., 0.});
 		}
 	}
 	else if(order.HasMine() && targetAsteroid)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1130,7 +1130,10 @@ void AI::Step(Command &activeCommands)
 			if(it->Velocity().Length() > .001 || !target)
 				Stop(*it, command);
 			else
+			{
 				command.SetTurn(TurnToward(*it, TargetAim(*it)));
+				it->SetVelocity({0, 0});
+			}
 		}
 		else if(FollowOrders(*it, command))
 		{
@@ -1724,7 +1727,10 @@ bool AI::FollowOrders(Ship &ship, Command &command)
 		if(ship.Velocity().Length() > .001 || !ship.GetTargetShip())
 			Stop(ship, command);
 		else
+		{
 			command.SetTurn(TurnToward(ship, TargetAim(ship)));
+			ship.SetVelocity({0, 0});
+		}
 	}
 	else if(order.HasMine() && targetAsteroid)
 	{


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in #10620.

## Summary
Ships will now stop completely when ordered to and their velocity is exceedingly low. This shouldn't affect ships that try to move at a low speed. 

## Testing Done
I did not observe any movement with these changes. I tested with various heavy ships that didn't always stop properly in the old version.