### PR TITLE
Khosa-Kella-Oa is at the southern not eastern end

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2620,7 +2620,7 @@ planet Khosa-Kella-Oa
 	description `Devoid of atmosphere, this small and rocky world sits at the very edge of the galaxy. This may very well be the last planet for millions of light years, the furthest child of the Milky Way.`
 		to display
 			not "known to the successors"
-	description `Devoid of atmosphere, this small and rocky world sits at the southern end of Successor space, orbiting a dim star. Because of the Successors' location on the rim of the galaxy, this may very well be the last planet for millions of light years, the furthest child of the Milky Way.`
+	description `Devoid of atmosphere, this small and rocky world sits at the western end of Successor space, orbiting a dim star. Because of the Successors' location on the rim of the galaxy, this may very well be the last planet for millions of light years, the furthest child of the Milky Way.`
 		to display
 			has "known to the successors"
 

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2620,7 +2620,7 @@ planet Khosa-Kella-Oa
 	description `Devoid of atmosphere, this small and rocky world sits at the very edge of the galaxy. This may very well be the last planet for millions of light years, the furthest child of the Milky Way.`
 		to display
 			not "known to the successors"
-	description `Devoid of atmosphere, this small and rocky world sits at the eastern end of Successor space, orbiting a dim star. Because of the Successors' location on the rim of the galaxy, this may very well be the last planet for millions of light years, the furthest child of the Milky Way.`
+	description `Devoid of atmosphere, this small and rocky world sits at the southern end of Successor space, orbiting a dim star. Because of the Successors' location on the rim of the galaxy, this may very well be the last planet for millions of light years, the furthest child of the Milky Way.`
 		to display
 			has "known to the successors"
 


### PR DESCRIPTION
**Typo fix**

This PR addresses the bug/feature described in issue N/A

## Summary
The description of Successor space planet Khosa-Kella-Oa says it's at the eastern end but it is at the southern end.

(You could arguably say southwestern end of Successor space, but it's the southern end of the entire galaxy which is the interesting part)

## Screenshots
![image](https://github.com/user-attachments/assets/c33f5856-b8d4-452c-86ef-18ea3f7c0e39)