### PR TITLE
Silent scans and jumps

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -664,7 +664,7 @@ tip "silent jumps:"
 	`Prevents a ship from making hyperdrive or jump drive sounds when entering or leaving a system.`
 
 tip "silent scans:"
-	`Prevents a ship from generating scan sounds (not even the default scan sound).`
+	`Prevents a ship from generating scan sounds.`
 
 tip "slowing protection:"
 	`Protection against slowing damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in slowing damage, while a total value of 11 only results in a 10 percent reduction.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -663,6 +663,9 @@ tip "shield protection:"
 tip "silent jumps:"
 	`Prevents a ship from making hyperspace or jump drive sounds when entering or leaving the player's system.`
 
+tip "silent scans:"
+	`Prevents a non-player owned ship from generating scan sounds (not even the default scan sound) when it is scanning a player owned ship.`
+
 tip "slowing protection:"
 	`Protection against slowing damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in slowing damage, while a total value of 11 only results in a 10 percent reduction.`
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -661,7 +661,7 @@ tip "shield protection:"
 	`Protection against shield damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in shield damage, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "silent jumps:"
-	`Prevents a ship from making hyperspace or jump drive sounds when entering or leaving the player's system.`
+	`Prevents a ship from making hyperdrive or jump drive sounds when entering or leaving a system.`
 
 tip "silent scans:"
 	`Prevents a non-player owned ship from generating scan sounds (not even the default scan sound) when it is scanning a player owned ship.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -664,7 +664,7 @@ tip "silent jumps:"
 	`Prevents a ship from making hyperdrive or jump drive sounds when entering or leaving a system.`
 
 tip "silent scans:"
-	`Prevents a non-player owned ship from generating scan sounds (not even the default scan sound) when it is scanning a player owned ship.`
+	`Prevents a ship from generating scan sounds (not even the default scan sound).`
 
 tip "slowing protection:"
 	`Protection against slowing damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in slowing damage, while a total value of 11 only results in a 10 percent reduction.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -660,6 +660,9 @@ tip "depleted shield delay:"
 tip "shield protection:"
 	`Protection against shield damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in shield damage, while a total value of 11 only results in a 10 percent reduction.`
 
+tip "silent jumps:"
+	`Prevents a ship from making hyperspace or jump drive sounds when entering or leaving the player's system.`
+
 tip "slowing protection:"
 	`Protection against slowing damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in slowing damage, while a total value of 11 only results in a 10 percent reduction.`
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1718,7 +1718,11 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		{
 			const map<const Sound *, int> &jumpSounds = isJump
 				? ship->Attributes().JumpOutSounds() : ship->Attributes().HyperOutSounds();
-			if(jumpSounds.empty())
+			if(ship->Attributes().Get("silent jumps"))
+			{
+				// No sounds.
+			}
+			else if(jumpSounds.empty())
 				Audio::Play(Audio::Get(isJump ? "jump out" : "hyperdrive out"), position);
 			else
 				for(const auto &sound : jumpSounds)
@@ -1730,7 +1734,11 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 		{
 			const map<const Sound *, int> &jumpSounds = isJump
 				? ship->Attributes().JumpInSounds() : ship->Attributes().HyperInSounds();
-			if(jumpSounds.empty())
+			if(ship->Attributes().Get("silent jumps"))
+			{
+				// No sounds.
+			}
+			else if(jumpSounds.empty())
 				Audio::Play(Audio::Get(isJump ? "jump in" : "hyperdrive in"), position);
 			else
 				for(const auto &sound : jumpSounds)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1465,7 +1465,11 @@ void Engine::CalculateStep()
 		bool isJumping = flagship->IsUsingJumpDrive();
 		const map<const Sound *, int> &jumpSounds = isJumping
 			? flagship->Attributes().JumpSounds() : flagship->Attributes().HyperSounds();
-		if(jumpSounds.empty())
+		if(flagship->Attributes().Get("silent jumps"))
+		{
+			// No sounds.
+		}
+		else if(jumpSounds.empty())
 			Audio::Play(Audio::Get(isJumping ? "jump drive" : "hyperdrive"));
 		else
 			for(const auto &sound : jumpSounds)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1937,7 +1937,11 @@ int Ship::Scan(const PlayerInfo &player)
 			for(const auto &sound : sounds)
 				Audio::Play(sound.first, position);
 	};
-	if(isYours || (target->isYours && !attributes.Get("silent scans")))
+	if(attributes.Get("silent scans"))
+	{
+		// No sounds.
+	}
+	else if(isYours || (target->isYours))
 	{
 		if(activeScanning & ShipEvent::SCAN_CARGO)
 			playScanSounds(attributes.CargoScanSounds(), position);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1937,7 +1937,7 @@ int Ship::Scan(const PlayerInfo &player)
 			for(const auto &sound : sounds)
 				Audio::Play(sound.first, position);
 	};
-	if(isYours || (target->isYours))
+	if(isYours || (target->isYours && !attributes.Get("silent scans")))
 	{
 		if(activeScanning & ShipEvent::SCAN_CARGO)
 			playScanSounds(attributes.CargoScanSounds(), position);


### PR DESCRIPTION
**Feature**

## Summary
This PR is an alternative to #10510.
Currently, a ship with no jump sounds or scan sounds listed will play the default sounds.
This PR adds attributes that can be used to prevent the playing of those default sounds (or any other sounds that may be present on the ship).

~The silent jumps is only applied to ships that are not the flagship. It could also be done for the flagship, but that would just remove an indicator to the player that they have jumped, which seems unnecessary and unhelpful. It certainly wouldn't serve the purpose of having a ship stealthily follow the player.~

~Similarly, scan sounds from player ships will not be silenced, since this would just remove an indicator for the person playing the game.~

## Usage examples
```
ship "whatever"
    attributes
        "silent scans"

ship "whateverer"
    attributes
        "silent jumps"

outfit "whateverest"
    attributes
        "silent scans"
        "silent jumps"
```

## Testing Done
None.

## Save File
This save file can be used to test these changes:
Maybe tomorrow.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/62
