### PR TITLE
Fix Shattered Light duplication

### DIFF
--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -501,6 +501,7 @@ mission "Remnant: Shattered Light 3"
 		conversation
 			action
 				set "remnant: scanned specter"
+				fail
 			`As the scan results arrive the data is relayed down to the team in the cargo hold. Your video feed shows a large hologram of the system floating in midair above one of the pallets. Nearby, terminals flash rolling readouts and analyses. As the data on the spectral ship solidifies, cones of projected courses appear on the display. Line by line the cone tightens in as additional data flows from your telemetry, closing in on a path intersecting with the nearby world.`
 			`	While the system continues to refine the orbital paths, the team seemed disinclined to wait: Ruach activates her commlink, broadcasting quickly to you. "It is on a crash course for Far Monad!" she exclaims. "Quick, land there!" Behind her, you can see her team scrambling to move equipment around near your cargo door and seal their spacesuits.`
 	to complete
@@ -517,7 +518,6 @@ mission "Remnant: Shattered Light 4"
 	to offer
 		has "remnant: scanned specter"
 	on offer
-		fail "Remnant: Shattered Light 3"
 		conversation
 			`With the Shattered Light careening towards the surface of Far Monad, you push the <ship> into a dive. As you focus on finding a safe place to land within close proximity of the approaching ship, you notice out the corner of your eye that the Remnant team have all suited up and are pushing their equipment to the cargo hatch. A message appears on your console.`
 			`	"Ready for drop, Captain. Just get us along side the Shattered Light without too much forward velocity. We can handle the rest."`

--- a/data/remnant/remnant 2 side missions.txt
+++ b/data/remnant/remnant 2 side missions.txt
@@ -501,9 +501,11 @@ mission "Remnant: Shattered Light 3"
 		conversation
 			action
 				set "remnant: scanned specter"
-				fail
 			`As the scan results arrive the data is relayed down to the team in the cargo hold. Your video feed shows a large hologram of the system floating in midair above one of the pallets. Nearby, terminals flash rolling readouts and analyses. As the data on the spectral ship solidifies, cones of projected courses appear on the display. Line by line the cone tightens in as additional data flows from your telemetry, closing in on a path intersecting with the nearby world.`
 			`	While the system continues to refine the orbital paths, the team seemed disinclined to wait: Ruach activates her commlink, broadcasting quickly to you. "It is on a crash course for Far Monad!" she exclaims. "Quick, land there!" Behind her, you can see her team scrambling to move equipment around near your cargo door and seal their spacesuits.`
+	to fail
+		has "remnant: scanned specter"
+		has "flagship planet: Far Monad"
 	to complete
 		never
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10644 (and several reports on Steam, linked in the comments of that issue).

## Summary
The mission "Remnant: Shattered Light 3" spawns a "ghostly" Shattered Light in Lucina. The player is to carry out an outfit scan of the ship and land on Far Monad in that system.
After scanning the ship and landing on Far Monad, the player is offered "Remnant: Shattered Light 4", which "fails" the preceding mission when it is offered.
However, by the time new missions are instantiated and offered, the processing of existing missions is already finished and so failed missions will not be removed until the next time the player lands on a planet.
This results in the "ghostly" NPC spawned by mission 3 persisting, while mission 4 spawns its own NPC that is supposed to be the same ship.

This PR adds "to fail" conditions to "Remnant: Shattered Light 3".
In particular, the mission will fail when the "remnant: scanned specter" and "flagship planet: Far Monad" conditions are present.
The former is set when completing the required outfit scan, and is hte same condition that the next mission in the chain requires to offer.
Also requiring that the flagship be on Far Monad ensures that this mission will not be removed until the next mission is about to be offered.

## Testing Done
Using the attached save (thanks to @opusforlife2 for providing it):
1. Take off,
2. Land on the same planet,
3. Visit the spaceport, "Remnant: Shattered Light 3" will be offered,
4. Accept the mission,
5. Travel to Lucina,
6. Scan the "ghostly" Shattered Light,
7. Land on Far Monad,
8. Finish the conversation,
9. Take off.

Without this PR, the "ghostly" Shattered Light will still be present, alongside the corporeal mission escort Shattered Light, and the previuos mission will still be in the mission list alongside hte new one.
With this PR, the "ghostly" Shattered Light will not be present, only the corporeal one associated with the new mission, which will be the only active mission in the list.

## Save File
This save file can be used to test these changes (courtesy of @opusforlife2):
[Peter Quill Shattered Light Testing~3020-05-23.txt](https://github.com/user-attachments/files/17445808/Peter.Quill.Shattered.Light.Testing.3020-05-23.txt)
