### PR TITLE
feat(enhancement): Support for live effects on minables

### DIFF
--- a/source/Minable.h
+++ b/source/Minable.h
@@ -51,6 +51,18 @@ public:
 		double toughness = 1.;
 	};
 
+	class LiveEffect {
+	public:
+		LiveEffect(const DataNode &node);
+
+		const Effect *effect;
+		// Average interval between instances of the effect, in frames.
+		unsigned interval = 1;
+		// If set to true, the effect behaves like a comet tail,
+		// always facing away from the system center.
+		bool relativeToSystem = false;
+	};
+
 
 public:
 	// Inherited from Body:
@@ -126,6 +138,7 @@ private:
 	double prospecting = 0.;
 	// Material released when this object is destroyed.
 	std::vector<Payload> payload;
+	std::vector<LiveEffect> liveEffects;
 	// Explosion effects created when this object is destroyed.
 	std::map<const Effect *, int> explosions;
 	// The expected value of the payload of this minable.


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #9737 (resolves #9737).

## Summary
Minable asteroids can create effects while orbiting in space. The effects can either rotate with the object, or face away from the system center.

## Screenshots
<details>
<summary>Examples</summary>

![random](https://github.com/user-attachments/assets/bedcfb6a-9734-42b4-957c-62fdfeeda29a)

![relative](https://github.com/user-attachments/assets/e77554bc-8e57-4b98-aad2-8906569ce18c)

</details>

## Usage examples
```
minable <name>
	"live effect" <effect name> <interval#> # the average number of frames between spawns
		"relative to system center" # add if you want an effect like a comet tail
```

## Testing Done
yes.

## Wiki Update
soon

## Performance Impact
N/A
