### PR TITLE
Fix(content): Prevent repeated symbiont discussion in Remnant: Keystone Research 7

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3350,6 +3350,8 @@ mission "Remnant: Keystone Research 7"
 				`	"The Remnant sure like to eat."`
 				`	"Why do the Remnant eat so much?"`
 					goto foodvolume
+					to display
+						not "remnant symbionts info"
 				`	"Maybe I should import some spices."`
 					goto spices
 				`	"What is our next step?"`


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in discussion https://github.com/endless-sky/endless-sky/discussions/10638.

## Summary
Stopped the "Why do the Remnant eat so much?" option from appearing if the player has the condition `remnant symbionts info`

## Testing Done
None yet

## Save File
I don't have a save for this. @opusforlife2, do you?