### PR TITLE
fix(mechanics): Fix bug where over-capacity fleets don't unload all their cargo

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -438,6 +438,14 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 			out << " that you do not have space for.";
 		}
 		out << "\nAre you sure you want to continue?";
+		// To make sure all cargo and passengers get unloaded from each ship,
+		// temporarily uncap the player's cargo and bunk capacity.
+		player.Cargo().SetSize(-1);
+		player.Cargo().SetBunks(-1);
+		// Pool cargo together, so that the cargo number on the trading panel
+		// is still accurate while the popup is active.
+		player.PoolCargo();
+		player.UpdateCargoCapacities();
 		GetUI()->Push(new Dialog(this, &PlanetPanel::WarningsDialogCallback, out.str()));
 		return;
 	}
@@ -452,16 +460,12 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 void PlanetPanel::WarningsDialogCallback(const bool isOk)
 {
 	if(isOk)
-		TakeOff(false);
-	else
 	{
-		// To make sure all cargo and passengers get unloaded from each ship,
-		// temporarily uncap the player's cargo and bunk capacity.
-		player.Cargo().SetSize(-1);
-		player.Cargo().SetBunks(-1);
-		player.PoolCargo();
-		player.UpdateCargoCapacities();
+		player.DistributeCargo();
+		TakeOff(false);
 	}
+	else
+		return;
 }
 
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -456,8 +456,6 @@ void PlanetPanel::WarningsDialogCallback(const bool isOk)
 {
 	if(isOk)
 		TakeOff(true);
-	else
-		return;
 }
 
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -438,14 +438,9 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 			out << " that you do not have space for.";
 		}
 		out << "\nAre you sure you want to continue?";
-		// To make sure all cargo and passengers get unloaded from each ship,
-		// temporarily uncap the player's cargo and bunk capacity.
-		player.Cargo().SetSize(-1);
-		player.Cargo().SetBunks(-1);
 		// Pool cargo together, so that the cargo number on the trading panel
 		// is still accurate while the popup is active.
 		player.PoolCargo();
-		player.UpdateCargoCapacities();
 		GetUI()->Push(new Dialog(this, &PlanetPanel::WarningsDialogCallback, out.str()));
 		return;
 	}
@@ -460,10 +455,7 @@ void PlanetPanel::CheckWarningsAndTakeOff()
 void PlanetPanel::WarningsDialogCallback(const bool isOk)
 {
 	if(isOk)
-	{
-		player.DistributeCargo();
-		TakeOff(false);
-	}
+		TakeOff(true);
 	else
 		return;
 }

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -454,7 +454,14 @@ void PlanetPanel::WarningsDialogCallback(const bool isOk)
 	if(isOk)
 		TakeOff(false);
 	else
+	{
+		// To make sure all cargo and passengers get unloaded from each ship,
+		// temporarily uncap the player's cargo and bunk capacity.
+		player.Cargo().SetSize(-1);
+		player.Cargo().SetBunks(-1);
 		player.PoolCargo();
+		player.UpdateCargoCapacities();
+	}
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1952,8 +1952,9 @@ bool PlayerInfo::HasLogs() const
 
 
 
-// Call this after missions update, or if leaving the outfitter, shipyard, or
-// hiring panel. Updates the information on how much space is available.
+// Call this after missions update, if leaving the outfitter, shipyard, or
+// hiring panel, or after backing out of a take-off warning.
+// Updates the information on how much space is available.
 void PlayerInfo::UpdateCargoCapacities()
 {
 	int size = 0;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1864,9 +1864,15 @@ void PlayerInfo::PoolCargo()
 	// This can only be done while landed.
 	if(!planet)
 		return;
+
+	// To make sure all cargo and passengers get unloaded from each ship,
+	// temporarily uncap the player's cargo and bunk capacity.
+	cargo.SetSize(-1);
+	cargo.SetBunks(-1);
 	for(const shared_ptr<Ship> &ship : ships)
 		if(ship->GetPlanet() == planet && !ship->IsParked())
 			ship->Cargo().TransferAll(cargo);
+	UpdateCargoCapacities();
 }
 
 


### PR DESCRIPTION
## Summary
If you try to run `PoolCargo()` while you have more cargo than you have cargo space, then not all your cargo ends up being unloaded from your ships. This leads to some bugs, as seen by following these instructions:
1. Start a new save and buy a Star Barge.
2. Get more than 20 tons of cargo by buying commodities/accepting jobs.
3. Sell your Star Barge and buy a Shuttle.
4. Attempt to take off and back out of the warning dialog saying that you don't have enough cargo capacity.
5. Notice that the amount of free cargo space you have has suddenly increased.
6. Attempt to take off again, and see that the take-off warning lists you as needing to get rid of more cargo than the trade panel says you do.

This PR fixes this bug by temporarily uncapping the player's cargo and bunk capacity while pooling their cargo after a failed take-off attempt.

## Testing Done
Followed the numbered instructions above with this PR enabled and encountered no bugs.

## Performance Impact
When selecting "no" on the take-off warning dialog, the game now runs `SetSize()`, `SetBunks()` and `UpdateCargoCapacities()`.