### PR TITLE
feat(content): Add stats for the Heavy Gust

### DIFF
--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -279,7 +279,7 @@ ship "Heavy Gust"
 		"outfit space" 534
 		"weapon capacity" 224
 		"engine capacity" 132
-		"tactical scan power" 50
+		"tactical scan power" 75
 		weapon
 			"blast radius" 220
 			"shield damage" 2200

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -294,7 +294,7 @@ ship "Heavy Gust"
 		
 		"White Sun Reactor"
 		"Dark Storm Shielding"
-		"Wanderer Ramscoop" 2
+		"Wanderer Ramscoop"
 		
 		"Type 4 Radiant Thruster"
 		"Type 4 Radiant Steering"

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -259,6 +259,64 @@ ship "Strong Wind"
 
 
 
+ship "Heavy Gust"
+	sprite "ship/heavy gust"
+	thumbnail "thumbnail/heavy gust"
+	attributes
+		category "Medium Warship"
+		licenses
+			"Wanderer Military"
+		"cost" 17600000
+		"shields" 35200
+		"hull" 21200
+		"required crew" 22
+		"bunks" 34
+		"mass" 652
+		"drag" 7.4
+		"heat dissipation" .45
+		"fuel capacity" 600
+		"cargo space" 52
+		"outfit space" 534
+		"weapon capacity" 224
+		"engine capacity" 132
+		"tactical scan power" 50
+		weapon
+			"blast radius" 220
+			"shield damage" 2200
+			"hull damage" 1100
+			"hit force" 3300
+	outfits
+		"Sunbeam" 4
+		"Thunderhead Launcher" 2
+		"Thunderhead Missile" 100
+		"Thunderhead Storage Array"
+		"Wanderer Anti-Missile"
+		
+		"White Sun Reactor"
+		"Dark Storm Shielding"
+		"Wanderer Ramscoop" 2
+		
+		"Type 4 Radiant Thruster"
+		"Type 4 Radiant Steering"
+		"Hyperdrive"
+		
+	engine -35 130
+	engine 35 130
+	gun -66 17 "Sunbeam"
+	gun 66 17 "Sunbeam"
+	gun -59 23 "Sunbeam"
+	gun 59 23 "Sunbeam"
+	gun -38 54 "Thunderhead Launcher"
+	gun 38 54 "Thunderhead Launcher"
+	turret 0 27 "Wanderer Anti-Missile"
+	explode "small explosion" 70
+	explode "medium explosion" 45
+	explode "large explosion" 22
+	"final explode" "final explosion medium"
+	description "The Heavy Gust is a further modification of the Strong Wind, adjusted even more heavily for combat purposes at the expense of much of its precursor's peacetime utility."
+
+
+
 ship "Tempest"
 	sprite "ship/tempest"
 	thumbnail "thumbnail/tempest"

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -271,7 +271,7 @@ ship "Heavy Gust"
 		"hull" 21200
 		"required crew" 22
 		"bunks" 34
-		"mass" 652
+		"mass" 598
 		"drag" 7.4
 		"heat dissipation" .45
 		"fuel capacity" 600

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -313,7 +313,7 @@ ship "Heavy Gust"
 	explode "medium explosion" 45
 	explode "large explosion" 22
 	"final explode" "final explosion medium"
-	description "The Heavy Gust is a further modification of the Strong Wind, adjusted even more heavily for combat purposes at the expense of much of its precursor's peacetime utility."
+	description "The Heavy Gust is a further modification of the Strong Wind, adjusted even more heavily for combat purposes at the expense of much of its precursor's peacetime utility. These modifications make the Heavy Gust a fast medium warship, agile enough to keep up with foes too quick to be caught with a Tempest."
 
 
 


### PR DESCRIPTION
**(Content, Balance)**

## Summary
Adds stats for the Wanderers' Heavy Gust. The comparison to the Strong Wind mirrors the comparison between the Autumn Leaf and Summer Leaf, as is (I understand) the intent.
The Heavy Gust loses the Strong Wind's integrated scanning, with the exception of the tactical scanning which it instead improves on.

In terms of implementation, I'm thinking this should appear alongside, or slightly after, the Autumn leaf. It will become _available_ alongside the Tempest, as it requires the Wanderer Military License, but it'll be visible and present in fleets before that point.
As suggested by Amazinite when the Heavy Gust was conceptualised, this adds a visible ship to the game that requires the military license and can be seen before you gain that license, and serves as an alternative option to the Tempest (being faster but weaker defensively).

Description feels a little short and could do with being expanded on.
