### PR TITLE
fix(mechanics): Outfits stored on take-off no longer count towards excess cargo sold

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1845,15 +1845,25 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	cargo.Clear();
 	stockDepreciation = Depreciation();
 	sold -= ceil(stored);
-	if(sold)
+	if(sold || stored)
 	{
-		// Report how much excess cargo was sold, and what profit you earned.
+		// Report how much excess cargo was sold (and what profit you earned),
+		// and how many tons of outfits were stored.
 		ostringstream out;
-		out << "You sold " << Format::CargoString(sold, "excess cargo") << " for " << Format::CreditString(income);
-		if(totalBasis && totalBasis != income)
-			out << " (for a profit of " << Format::CreditString(income - totalBasis) << ").";
-		else
-			out << ".";
+		out << "You ";
+		if(sold)
+		{
+			out << "sold " << Format::CargoString(sold, "excess cargo") << " for " << Format::CreditString(income);
+			if(totalBasis && totalBasis != income)
+				out << " (for a profit of " << Format::CreditString(income - totalBasis) << ")";
+			if(stored)
+				out << ", and ";
+		}
+		if(stored)
+		{
+			out << "stored " << Format::CargoString(stored, "outfits") << " you could not carry";
+		}
+		out << ".";
 		Messages::Add(out.str(), Messages::Importance::High);
 	}
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1796,6 +1796,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	int day = date.DaysSinceEpoch();
 	int64_t sold = cargo.Used();
 	int64_t totalBasis = 0;
+	double stored = 0.;
 	if(sold)
 	{
 		for(const auto &commodity : cargo.Commodities())
@@ -1836,12 +1837,14 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 				// Transfer the outfits from cargo to the storage on this planet.
 				if(!outfit.second)
 					continue;
+				stored += outfit.first->Mass() * outfit.second;
 				cargo.Transfer(outfit.first, outfit.second, Storage());
 			}
 	}
 	accounts.AddCredits(income);
 	cargo.Clear();
 	stockDepreciation = Depreciation();
+	sold -= ceil(stored);
 	if(sold)
 	{
 		// Report how much excess cargo was sold, and what profit you earned.


### PR DESCRIPTION
## Summary
`sold`, the integer used to store the tons of excess outfits and commodities are sold when taking off, is calculated before the cargo is removed from cargo. However, if the player is landed on a planet with an outfitter, outfits are stored instead of sold. Despite this, the take-off message still considers the outfits as being sold for zero credits. This PR subtracts the mass of outfits stored this way from the amount of excess cargo sold, and appends the tons of outfits stored to the main message.

## Testing Done
- Took off with 40 tons of outfits in a Shuttle. Game wrote out that 20 tons of outfits were stored.
- Took off with 50 tons of cargo. Game wrote out that 30 tons of cargo were sold.
- Took off with 40 tons of outfits and 10 tons of cargo. Game wrote out that 10 tons of cargo were sold and 20 tons of outfits were stored.

## Performance Impact
Basically nothing.
