### PR TITLE
feat(mechanics): Fall back to the vanilla starting location when a custom one is invalid

### DIFF
--- a/source/CoreStartData.cpp
+++ b/source/CoreStartData.cpp
@@ -69,18 +69,18 @@ Date CoreStartData::GetDate() const
 
 const Planet &CoreStartData::GetPlanet() const
 {
-	return planet ? *planet : *GameData::Planets().Get("New Boston");
+	return (planet && planet->IsValid()) ? *planet : *GameData::Planets().Get("New Boston");
 }
 
 
 
 const System &CoreStartData::GetSystem() const
 {
-	if(system)
+	if(system && system->IsValid())
 		return *system;
 	const System *planetSystem = GetPlanet().GetSystem();
 
-	return planetSystem ? *planetSystem : *GameData::Systems().Get("Rutilicus");
+	return (planetSystem && planetSystem->IsValid()) ? *planetSystem : *GameData::Systems().Get("Rutilicus");
 }
 
 


### PR DESCRIPTION
**Feature**/**Bug fix**

## Summary
If your current system is invalid, the game teleports you to the place where you started the game. But what if that location is invalid too? You have an opportunity to visit the famous 0 0 system (#2369) with no way out, even with a jump drive.

The game already switches to the vanilla starting point (New Boston) in some cases, so I've enabled it also in this case.

## Testing Done
Load [this](https://github.com/user-attachments/files/17529788/nullsystem.zip) test plugin. Start a new game with the start provided by the plugin, then disable the plugin and load the pilot. On master, you stay in the 0 0 system; with this patch, you are transported to New Boston.

## Performance Impact
N/A
