### PR TITLE
Revert the workaround for SSil Vida jump ranges

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -815,7 +815,7 @@ event "remnant: ssil vida activation"
 
 
 
-# TODO: Jump range of other systems nearby may need to be reduced on activation 
+# TODO: Jump range of other systems nearby may need to be reduced on activation
 # to prevent escorts outside the Postverta cluster jumping into that region.
 # Or create an entire new system to handle this "dimensional bubble"
 event "remnant: ssil vida deactivation"

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -815,10 +815,9 @@ event "remnant: ssil vida activation"
 
 
 
-# The default value of a system's "jump range" is 0. In this state, the global default will be used.
-# When the bug preventing ships from jumping when the destination system has too little jump range is fixed,
-# the resetting of jump range on deactivation can be removed. Instead, jump range of other systems nearby
-# may need to be reduced on activation to prevent escorts outside the Postverta cluster jumping into that region.
+# TODO: Jump range of other systems nearby may need to be reduced on activation 
+# to prevent escorts outside the Postverta cluster jumping into that region.
+# Or create an entire new system to handle this "dimensional bubble"
 event "remnant: ssil vida deactivation"
 	clear "remnant: ssil vida active"
 	planet Fertriery
@@ -837,7 +836,6 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 1505.92
 		haze _menu/haze-red
-		"jump range" 0
 		link Statina
 		link Vaticanus
 		asteroids "small rock" 1 8
@@ -886,7 +884,6 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 534.375
 		haze _menu/haze-red
-		"jump range" 0
 		link Statina
 		link Postverta
 		asteroids "small rock" 65 3
@@ -941,7 +938,6 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 135
 		haze _menu/haze-red
-		"jump range" 0
 		link Diespiter
 		link Prosa
 		link Statina
@@ -987,7 +983,6 @@ event "remnant: ssil vida deactivation"
 		habitable 2372.76
 		belt 2000
 		haze _menu/haze-red
-		"jump range" 0
 		link Vaticanus
 		link Postverta
 		asteroids "medium metal" 11 2
@@ -1042,7 +1037,6 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 135
 		haze _menu/haze-red
-		"jump range" 0
 		link Diespiter
 		link Egeria
 		link Postverta
@@ -1094,7 +1088,6 @@ event "remnant: ssil vida deactivation"
 		belt 2000
 		habitable 320
 		haze _menu/haze-red
-		"jump range" 0
 		link Egeria
 		link Prosa
 		asteroids "small rock" 3 6


### PR DESCRIPTION
**Revert**

## Summary
Revert #7377 so SSil Vida space gets lower jump range permanently (as it was originally, right?)

Since the DistanceMap Rework #6940 is in, AI ships use jump range correctly so the changes from #7377 can be reverted.

## Note
Note, there could a bit more to be done around this. #7377 Added the comment: "Instead, jump range of other systems nearby may need to be reduced on activation to prevent escorts outside the Postverta cluster jumping into that region." 

Yes, escort ships can now jump into the dimensional bubble (from Edusa or Levana). The jump range for those two systems could be changed with this activation/deactivation event, but then that also technically changes the theoretical fleet maneuvers you could order while in SSil Vida space. Plus, any map changes around there would need to consider this event. So it's not clean to just change a few jump ranges.

TL;DR there needs to deeper engine support to cut off systems temporarily. A system's Jump Range override is stopping you from getting out, but nothing stops escorts from getting in.

## Screenshots
![image](https://github.com/user-attachments/assets/fa32fc55-9645-4f30-bbbf-d1e49358c031)

## Testing Done
Played the missions to activate/deactivate Ssil Vida, things work as expected. Jump ranges are not reset to default and you have to re-discover and take the wormhole in Prosa out, but can jump back in

## Save File
This save file can be used to test these changes:
[Io Blackest of all cats~Jump to SSil.txt](https://github.com/user-attachments/files/17535079/Io.Blackest.of.all.cats.Jump.to.SSil.txt)

## Performance Impact
N/A
