### PR TITLE
Fix #10462: Systems with increased "jump range" work

### DIFF
--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -167,10 +167,7 @@ bool ShipJumpNavigation::CanJump(const System *from, const System *to) const
 		return false;
 
 	const double distanceSquared = from->Position().DistanceSquared(to->Position());
-	if(from->JumpRange() && from->JumpRange() * from->JumpRange() < distanceSquared)
-		return false;
-
-	const double maxRange = jumpDriveCosts.rbegin()->first;
+	double maxRange = from->JumpRange() ? from->JumpRange() : jumpDriveCosts.rbegin()->first;
 	return maxRange * maxRange >= distanceSquared;
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10462 

## Summary
#10462 describes that a system with higher jump range override isn't working. The problem was a validation check added 2023, in #9289 which invalidates the selected travel plan. That code used the system's jump range incorrectly, assuming it could only lower the range. This bugfix has the system's jump range override the ship's range, since it can be higher .

## Screenshots
![image](https://github.com/user-attachments/assets/b716c41a-c5b2-466a-a5c1-b1ec148a02b2)

## Testing Done
Edit map systems.txt and set "jump range" to 500 for whatever system you're in (with a jump drive). See that plotting and taking a course works as expected.

## Performance Impact
N/A
