### PR TITLE
Fix flagship highlight with scaled ship sprites

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -606,8 +606,11 @@ void Engine::Step(bool isActive)
 	// Add the flagship outline last to distinguish the flagship from other ships.
 	if(flagship && !flagship->IsDestroyed() && Preferences::Has("Highlight player's flagship"))
 	{
-		outlines.emplace_back(flagship->GetSprite(), (flagship->Center() - center) * zoom, flagship->Unit() * zoom,
-			flagship->GetFrame(), *GameData::Colors().Get("flagship highlight"));
+		outlines.emplace_back(flagship->GetSprite(),
+			(flagship->Center() - center) * zoom,
+			flagship->Unit() * zoom * flagship->Scale(),
+			flagship->GetFrame(),
+			*GameData::Colors().Get("flagship highlight"));
 	}
 
 	// Any of the player's ships that are in system are assumed to have


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10713

## Summary
The size of the outline was not taking into account the `scale` property of the `Body`, so the outline was always using the original size of the sprite instead of scaling it as appropriate.
This PR applies the `scale` to the outline as it is drawn.

## Screenshots
before | after
-- | --
![image](https://github.com/user-attachments/assets/72770bed-7b4e-4923-abaf-bccad5b9f312) | ![image](https://github.com/user-attachments/assets/3e0f5a38-136e-41d8-babe-2c055eb3bb80)
![image](https://github.com/user-attachments/assets/f5e2c921-a372-446e-b0ea-5b0830bfae79) | ![image](https://github.com/user-attachments/assets/54356654-5821-4272-89c8-904bcf6caa7d)

## Testing Done
What it took to make the above screenshots.

## Save File
This save file can be used to test these changes:
[test test 2.txt](https://github.com/user-attachments/files/17558797/test.test.2.txt)

## Performance Impact
May be noticeable on some particularly low performance systems (likely only old ones) with particularly complex or large sprites or large scales, but just turn the outline off in such cases? The alternative is that the outline is just wrong which is hardly a good option.