### PR TITLE
Fix navigation while mid-jump

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -815,7 +815,7 @@ void MapPanel::Select(const System *system)
 			flagship->SetTargetSystem(nullptr);
 
 		plan = distance.Plan(*system);
-		if (isJumping)
+		if(isJumping)
 			plan.push_back(source);
 	}
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -815,6 +815,8 @@ void MapPanel::Select(const System *system)
 			flagship->SetTargetSystem(nullptr);
 
 		plan = distance.Plan(*system);
+		if (isJumping)
+			plan.push_back(source);
 	}
 
 	// Reset the travel destination if the final system in the travel plan has changed.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10722

## Summary
Restoring this piece of code from merge conflicts from recent #6940 merge. Seems to fix this easily reproducible mid-jump navigation hiccup, where simply creating a new path that backtracked would break it.

## Testing Done
New game shuttle, chart a few systems, plot courses 2 jumps away, set new path, mid-jump now works fine