### PR TITLE
Some editor config updates that at least Visual Studio uses:

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,6 @@ indent_style = tab
 # Code files
 [{*.{cpp,h,rc,hpp}, SConstruct, SConscript}]
 indent_style = tab
-#cpp_new_line_before_open_brace_block = new_line # also applies to do {} so can't have this
 cpp_space_pointer_reference_alignment = right
 cpp_space_after_keywords_in_control_flow_statements = false
 # Except any third-party libraries

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ indent_style = tab
 # Code files
 [{*.{cpp,h,rc,hpp}, SConstruct, SConscript}]
 indent_style = tab
+trim_trailing_whitespace = true
+cpp_new_line_before_open_brace_block = new_line
+cpp_space_pointer_reference_alignment = right
+cpp_space_after_keywords_in_control_flow_statements = false
 # Except any third-party libraries
 [catch.hpp]
 indent_style = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,8 +14,7 @@ indent_style = tab
 # Code files
 [{*.{cpp,h,rc,hpp}, SConstruct, SConscript}]
 indent_style = tab
-trim_trailing_whitespace = true
-cpp_new_line_before_open_brace_block = new_line
+#cpp_new_line_before_open_brace_block = new_line # also applies to do {} so can't have this
 cpp_space_pointer_reference_alignment = right
 cpp_space_after_keywords_in_control_flow_statements = false
 # Except any third-party libraries


### PR DESCRIPTION
**Code Style**

## Summary

a few `.editorconfig` settings that Visual Studio will use to enforce the code style:
- New lines for control blocks
- Align the pointer `*` to the right
- No space after if

(More could be done but these trip me up all the time)
Possible values are here:
https://learn.microsoft.com/en-us/visualstudio/ide/cpp-editorconfig-properties?view=vs-2022
Global settings are in Tools -> Options -> Text Editor -> C++ -> Code Style -> Formatting -> (various) which are overridden by the value in .editorconfig

(I dunno where the actual code style rules are and if they exist, why doesn't visual studio know about them already so I have to duplicate them here)