### PR TITLE
tweak: update a Coalition culture conversation

### DIFF
--- a/data/coalition/coalition culture conversations.txt
+++ b/data/coalition/coalition culture conversations.txt
@@ -447,7 +447,7 @@ mission "Coalition Incident: Ring of Wisdom"
 	invisible
 	to offer
 		has "Coalition: First Contact: done"
-		random < 10
+		random < 3
 	source "Ring of Wisdom"
 	on offer
 		conversation

--- a/data/coalition/coalition culture conversations.txt
+++ b/data/coalition/coalition culture conversations.txt
@@ -447,7 +447,7 @@ mission "Coalition Incident: Ring of Wisdom"
 	invisible
 	to offer
 		has "Coalition: First Contact: done"
-		random < 1
+		random < 10
 	source "Ring of Wisdom"
 	on offer
 		conversation


### PR DESCRIPTION
**Content**

## Summary
#10663 increased the frequency of single-planet culture conversations, but didn't check for non-human culture conversations that met the same criteria.
This PR increases `Coalition Incident: Ring of Wisdom`'s offer chance to 10.