### PR TITLE
fix(bug): display the fuel cost for the Fusion Drive correctly 

### DIFF
--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -100,6 +100,7 @@ outfit "Fusion Drive"
 	"outfit space" -480
 	"engine capacity" -230
 	"unique" 1
+	"jump fuel" 100
 	"jump speed" 0.2
 	"hyperdrive" 1
 	"energy generation" 54


### PR DESCRIPTION
**Bug Fix**

This PR addresses the bug/feature described in issue #10729 

## Summary
Added a `"fuel cost" 100` to the Fusion Drive, so that it shows up correctly.
This doesn't change how much fuel it costs to jump, because the default is 100, but is a workaround for the moment until the underlying issue of #10729 is addressed.