### PR TITLE
Fix destroyed ship landing message

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2050,7 +2050,8 @@ void Engine::HandleMouseClicks()
 						else
 						{
 							activeCommands |= Command::LAND;
-							Messages::Add("Landing on " + planet->Name() + ".", Messages::Importance::High);
+							if(!flagship->IsDestroyed())
+								Messages::Add("Landing on " + planet->Name() + ".", Messages::Importance::High);
 						}
 					}
 					else

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2047,11 +2047,10 @@ void Engine::HandleMouseClicks()
 						if(!planet->CanLand(*flagship))
 							Messages::Add("The authorities on " + planet->Name()
 									+ " refuse to let you land.", Messages::Importance::Highest);
-						else
+						else if(!flagship->IsDestroyed())
 						{
 							activeCommands |= Command::LAND;
-							if(!flagship->IsDestroyed())
-								Messages::Add("Landing on " + planet->Name() + ".", Messages::Importance::High);
+							Messages::Add("Landing on " + planet->Name() + ".", Messages::Importance::High);
 						}
 					}
 					else


### PR DESCRIPTION
**Bug fix**

## Summary
If your ship is destroyed and you attempt to land on a planet, a message incorrectly appears, stating that you are landing on the planet, even though your ship is destroyed.

I have fixed this issue by adding a check to verify that the ship is not destroyed before displaying the landing message.

```
if(!flagship->IsDestroyed())
    Messages::Add("Landing on " + planet->Name() + ".", Messages::Importance::High);
```

## Screenshots
Before:
![first](https://github.com/user-attachments/assets/89f5ee19-8ae4-4921-ab2e-d7875da8bae6)
After:
![second](https://github.com/user-attachments/assets/9a34b1f1-f4c4-4a59-b77f-7652f6657ba0)

## Testing Done
See screenshots

## Performance Impact
N/A