### PR TITLE
Bugfix: hai first contact conditions in hai start and other

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4662,8 +4662,8 @@ mission "Block Hai Wormhole Warning"
 	invisible
 	to offer
 		or
-			has "First Contact: Hai: declined"
-			has "First Contact: Unfettered: declined"
+			has "First Contact: Hai: offered"
+			has "First Contact: Unfettered: offered"
 		has "chosen sides"
 		not "main plot completed"
 	on offer
@@ -4676,8 +4676,8 @@ mission "Hai Wormhole Warning"
 		not attributes "deep"
 	to offer
 		or
-			has "First Contact: Hai: declined"
-			has "First Contact: Unfettered: declined"
+			has "First Contact: Hai: offered"
+			has "First Contact: Unfettered: offered"
 		not "Block Hai Wormhole Warning: offered"
 		not "Wanderers: Alpha Surveillance E: offered"
 		not "hr: meet the team"

--- a/data/korath/korath missions.txt
+++ b/data/korath/korath missions.txt
@@ -273,7 +273,7 @@ mission "Efreti: Distress Call 1"
 	to offer
 		not "event: wanderers: kor mereti friendly"
 		has "First Contact: Karek Fornati: offered"
-		has "First Contact: Hai: declined"
+		has "First Contact: Hai: offered"
 		has "visited system: Fah Soom"
 		random < 30
 		"combat rating" > 250

--- a/data/starts.txt
+++ b/data/starts.txt
@@ -99,7 +99,7 @@ start "hai space"
 	set "First Contact: Unfettered: offered"
 	set "First Contact: Unfettered: declined"
 	set "Ask the Hai about the Unfettered: offered"
-	set "Ask the Hai about the Unfettered: done"
+	set "Ask the Hai about the Unfettered: declined"
 
 
 conversation "hai intro"

--- a/data/starts.txt
+++ b/data/starts.txt
@@ -95,7 +95,10 @@ start "hai space"
 	set "hai space start"
 	# need to set it here to not have it trigger alongside the invisible mission
 	set "First Contact: Hai: offered"
+	set "First Contact: Hai: declined"
 	set "First Contact: Unfettered: offered"
+	set "First Contact: Unfettered: declined"
+	set "Ask the Hai about the Unfettered: offered"
 	set "Ask the Hai about the Unfettered: done"
 
 


### PR DESCRIPTION
**Bug fix**
This PR addresses the bug/feature described in issue #10741

## Summary
I made sure the conditions after starting with the hai start were the same as with normal play if one did these missions.
I also spotted inconsistencies in how the First contact conditions were checked and made them only check for offered in the hai cases.

## Testing Done
I don't think it's needed since it's just condition updating.
