### PR TITLE
feat(content): Edits to Remnant: Logistics 1

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3821,12 +3821,29 @@ mission "Remnant: Logistics 1"
 	to offer
 		has "remnant: blood test pure"
 		has "Remnant: Defense 1: done"
+		has "license: Remnant"
 	on offer
 		conversation
 			`You step out of the <ship> amidst the strange sight of the <origin> spaceport. The structures that surround the landing pads look as much grown as built, and they seem to merge into the landing pads themselves. As usual, the dock entrance is busy. When your commlink vibrates, you have to find a place where the traffic eddies so you can step aside. When you do, you learn you need to check in with the information desk.`
-			`	The woman working the desk seems startled to see you when you walk up. You can see the realization dawn on her as she looks you over with a practiced eye. "Ah," she sings, "you are the ancestral sojourner among us."`
-			`	It is typical for people to gawk at you, so you respond by singing, "The Embers guided me to friends I didn't know, and your message invited me to meet a new one."`
-			`	Her hands make a short series of shakes and a moment later she remembers to laugh for you. The delayed response makes her laugh again, spontaneously this time, and you both join in. When she recovers herself, she sings, "Logistics have requested that we find someone who can carry <tons> of cargo to <planet>. Is the <ship> available immediately?"`
+			`	The woman working the desk seems startled to see you when you walk up. You can see the realization dawn on her as she looks you over with a practiced eye. "Ah," she sings, "you are the ancestral sojourner among us." You are by now used to the Remnant gawking at you.`
+			choice
+				(Sing in reply.)
+				goto sing
+				(Sign in reply.)
+				to display 
+					has "event: remnant: sign studies complete"
+				(Talk in reply.)
+			`You clear your throat. "Yes, and I believe someone requested that I come here."`
+				goto shesings
+			label sign
+			`You begin to sign, "Yes, and I believe someone requested that I come here."`
+			`	Her face lights up as she realizes that you are signing in her language. "I am happy to see that you have learned our language, but I can tell that it comes with considerable effort to you," she sings in a soft voice. "I will use the ancestral tongue in order to make sure my message is clear to you."`
+				goto shesings
+			label sing
+			`You respond by singing, "The Embers guided me to friends I didn't know, and your message invited me to meet a new one."`
+			`	Her hands make a short series of shakes and a moment later she remembers to laugh for you. The delayed response makes her laugh again, spontaneously this time, and you both join in. When she recovers herself, she begins to sing.`
+			label shesings
+			`	"Logistics have requested that we find someone who can carry <tons> of cargo to <planet>. Is the <ship> available immediately?"`
 			choice
 				`	"Certainly!"`
 					goto willdo

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3833,14 +3833,14 @@ mission "Remnant: Logistics 1"
 					to display
 						has "event: remnant: sign studies complete"
 				`	(Talk in reply.)`
-			`You clear your throat. "Yes, and I believe someone requested that I come here."`
+			`	You clear your throat. "Yes, and I believe someone requested that I come here."`
 				goto shesings
 			label sign
-			`You begin to sign, "Yes, and I believe someone requested that I come here."`
+			`	You begin to sign, "Yes, and I believe someone requested that I come here."`
 			`	Her face lights up as she realizes that you are signing in her language. "I am happy to see that you have learned our language, but I can tell that it comes with considerable effort to you," she sings in a soft voice. "I will use the ancestral tongue in order to make sure my message is clear to you."`
 				goto shesings
 			label sing
-			`You respond by singing, "The Embers guided me to friends I didn't know, and your message invited me to meet a new one."`
+			`	You respond by singing, "The Embers guided me to friends I didn't know, and your message invited me to meet a new one."`
 			`	Her hands make a short series of shakes and a moment later she remembers to laugh for you. The delayed response makes her laugh again, spontaneously this time, and you both join in. When she recovers herself, she begins to sing.`
 			label shesings
 			`	"Logistics have requested that we find someone who can carry <tons> of cargo to <planet>. Is the <ship> available immediately?"`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3827,12 +3827,12 @@ mission "Remnant: Logistics 1"
 			`You step out of the <ship> amidst the strange sight of the <origin> spaceport. The structures that surround the landing pads look as much grown as built, and they seem to merge into the landing pads themselves. As usual, the dock entrance is busy. When your commlink vibrates, you have to find a place where the traffic eddies so you can step aside. When you do, you learn you need to check in with the information desk.`
 			`	The woman working the desk seems startled to see you when you walk up. You can see the realization dawn on her as she looks you over with a practiced eye. "Ah," she sings, "you are the ancestral sojourner among us." You are by now used to the Remnant gawking at you.`
 			choice
-				(Sing in reply.)
-				goto sing
-				(Sign in reply.)
-				to display
-					has "event: remnant: sign studies complete"
-				(Talk in reply.)
+				`	(Sing in reply.)`
+					goto sing
+				`	(Sign in reply.)`
+					to display
+						has "event: remnant: sign studies complete"
+				`	(Talk in reply.)`
 			`You clear your throat. "Yes, and I believe someone requested that I come here."`
 				goto shesings
 			label sign

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3830,7 +3830,7 @@ mission "Remnant: Logistics 1"
 				(Sing in reply.)
 				goto sing
 				(Sign in reply.)
-				to display 
+				to display
 					has "event: remnant: sign studies complete"
 				(Talk in reply.)
 			`You clear your throat. "Yes, and I believe someone requested that I come here."`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3821,7 +3821,7 @@ mission "Remnant: Logistics 1"
 	to offer
 		has "remnant: blood test pure"
 		has "Remnant: Defense 1: done"
-		has "license: Remnant"
+		has "Remnant: Technology Available: offered"
 	on offer
 		conversation
 			`You step out of the <ship> amidst the strange sight of the <origin> spaceport. The structures that surround the landing pads look as much grown as built, and they seem to merge into the landing pads themselves. As usual, the dock entrance is busy. When your commlink vibrates, you have to find a place where the traffic eddies so you can step aside. When you do, you learn you need to check in with the information desk.`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3820,7 +3820,6 @@ mission "Remnant: Logistics 1"
 	deadline 2
 	to offer
 		has "remnant: blood test pure"
-		has "Remnant: Defense 1: done"
 		has "Remnant: Technology Available: offered"
 	on offer
 		conversation


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Minor edits and additions to the Remnant: Logistics 1 mission. I changed the `to offer` conditions so that it would only show up after you had heard the phrase 'the Embers' used metaphorically by the Remnant, as in 'may the Embers burn bright for you'. When I played this mission I had not gotten very far through the Remnant storyline and my character would be unaware of the significance of that saying in Remnant culture, so I thought it was odd that I could sing about the Embers despite this. To fix this I locked this mission behind the first mission I could find that mentions the Embers in a metaphorical way.
In addition, I decided to add a few more options for the player when responding to the woman working at the information desk, with the choice of signing, singing, or talking to her. I thought this would be more engaging and give the player some more roleplaying opportunities, while adding some easter eggs about Remnant culture.

## Testing Done
TBD

## Save File
TBD
