### PR TITLE
feat(content): Remove interim spaceport visits during FW Escort

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -626,9 +626,6 @@ mission "FW Escort: Escorts"
 	to fail
 		or
 			has "chosen sides"
-			and
-				has "event: fw escorts abandon timer"
-				not "FW Escort 2: offered"
 	to complete
 		never
 	npc
@@ -797,8 +794,6 @@ mission "FW Escort 1B"
 		dialog `You have reached <planet>, but you left part of the convoy behind! Better depart and wait for them to arrive in this star system.`
 	on complete
 		payment 400000
-		event "fw escorts abandon timer"
-		dialog `Upon returning with the freighters, you are once again met by Tomek. He thanks you and the other escort captains for your service, and pays you each <payment>. "The convoy is heading out again immediately," he says, "so meet me in the spaceport if you are willing to volunteer for escort duty again. Same pay."`
 
 
 
@@ -808,25 +803,27 @@ event "fw escorts abandon timer"
 
 mission "FW Escort 2"
 	autosave
+	landing
 	name "Free Worlds Escort"
 	description "Escort a Free Worlds supply convoy safely to <destination>."
 	source "Longjump"
 	destination "Wayfarer"
 	to offer
 		has "FW Escort 1B: done"
-		not "event: fw escorts abandon timer"
 	to fail
 		has "chosen sides"
 	
 	on offer
 		conversation
-			`A few of the escort pilots, yourself included, have stuck around for another mission, and luckily a few new faces have joined in as well. Tomek meets you in the spaceport and says, "You know the drill. Escort the freighters to <planet> and back. 400,000 credits for your troubles. Plus, please believe that all of you are known to the Council, and your bravery will not be forgotten. We can't afford to lose any of these freighters. Who's willing to help escort them?"`
+			`Tomek is waiting on <origin>'s spaceport to receive the freighters. After double-checking that the cargo is all intact, he turns to you and the rest of the escort captains and says, "All of you have done a great service for the Free Worlds." He walks over and personally presents a credit chip to each captain.`
+			`	After handing over your payment, Tomek announces, "The convoy is heading back out for <planet> immediately. Same deal as before: 400,000 credits for the safe return of the freighters, their crew, and their cargo. And I swear your courage will never be forgotten by the Council or the Free Worlds. If you wish to volunteer a second time, please stay here."`
+			`	Tomek leaves, presumably to gather replacements for the captains who have already run off.`
 			choice
 				`	(Volunteer.)`
-				`	(Go find some other work to do.)`
+				`	(Ditch the escort group.)`
 					decline
 			
-			`	"Great!" says Tomek. "Good luck to all of you, and I pray to see you all safely back here in a couple of weeks."`
+			`	You stick around with a few of the other escort pilots, and Tomek returns, luckily with some new faces in tow. "You know the drill," he says. "We can't afford to lose any of these freighters. Good luck to all of you, and I pray to see you all safely back here in a couple of weeks."`
 				accept
 	
 	on decline
@@ -924,12 +921,12 @@ mission "FW Escort 2B"
 	on complete
 		fail "FW Escort: Escorts"
 		payment 400000
-		dialog `Again, Tomek Voigt meets you and the rest of the convoy at the spaceport, thanks you all for your courage and dedication, and pays you each <payment>. Then, he pulls you aside and says, "Captain <last>, if you're interested in helping us further, please meet me in the spaceport bar."`
 
 
 
 mission "FW Escort 3"
 	autosave
+	landing
 	name "Stranded Freighter"
 	description "Repair the <npc>, which is stranded in the <waypoints> system, and escort it safely back to <destination>."
 	source "Longjump"
@@ -941,12 +938,13 @@ mission "FW Escort 3"
 	
 	on offer
 		conversation
-			`When you walk into the bar, Tomek looks very glad to see you. "Here's the deal," he says. "One of our freighters, the <npc>, was just disabled in the <waypoints> system. We need you to fly there immediately, repair it, and bring it back here before it can be captured by pirates. Do you think you're up to the task?"`
+			`Once again, Tomek Voigt meets you and the rest of the convoy at the spaceport, thanks you all for your courage and dedication, and pays you each 400,000 credits. Afterwards, he pulls you aside and asks you to follow.`
+			`	Tomek brings you to one of the spaceport bars, exchanging greetings with the patrons before sitting at the counter. "Here's the deal," he says. "One of our freighters, the <npc>, was just disabled in the <waypoints> system. We need you to fly there immediately, repair it, and bring it back here before it can be captured by pirates. Do you think you're up to the task?"`
 			choice
 				`	"Sure!"`
 				`	"Sorry, I'm just a merchant captain. The Free Worlds shouldn't be asking me to do combat missions."`
 					decline
-		
+			
 			`	"Glad to hear it," he says. "The crew of that freighter is depending on you. I know I don't have to tell you what will happen to them if pirates board them before you get there, so get moving quickly."`
 				accept
 	

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -938,7 +938,7 @@ mission "FW Escort 3"
 	
 	on offer
 		conversation
-			`Once again, Tomek Voigt meets you and the rest of the convoy at the spaceport, thanks you all for your courage and dedication, and pays you each 400,000 credits. Afterwards, he pulls you aside and asks you to follow.`
+			`Once again, Tomek Voigt meets you and the rest of the convoy at the spaceport, thanks you all for your courage and dedication, and pays you each 400,000 credits. Afterwards, he pulls you aside and says, "Captain <last>, please follow me."`
 			`	Tomek brings you to one of the spaceport bars, exchanging greetings with the patrons before sitting at the counter. "Here's the deal," he says. "One of our freighters, the <npc>, was just disabled in the <waypoints> system. We need you to fly there immediately, repair it, and bring it back here before it can be captured by pirates. Do you think you're up to the task?"`
 			choice
 				`	"Sure!"`

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -944,7 +944,7 @@ mission "FW Escort 3"
 				`	"Sure!"`
 				`	"Sorry, I'm just a merchant captain. The Free Worlds shouldn't be asking me to do combat missions."`
 					decline
-			
+		
 			`	"Glad to hear it," he says. "The crew of that freighter is depending on you. I know I don't have to tell you what will happen to them if pirates board them before you get there, so get moving quickly."`
 				accept
 	


### PR DESCRIPTION
## Summary
The FW Escort mission chain is rather unintuitive right now. It stands as the only instance where a spaceport mission is only available immediately after the previous mission, as opposed to being able to leave it indefinitely. This PR removes the spaceport visits from `FW Escort 2` and `FW Escort 3`, making the next mission offer as soon as the last one is done. While `FW Escort 3` is technically fine, it doesn't make sense to have it as a spaceport mission if the rest of the mission chain only has landing missions.

## Save File
This save file can be used to test these changes:

[Meat Girl~FW Clean.txt](https://github.com/user-attachments/files/17624334/Meat.Girl.FW.Clean.txt)
