### PR TITLE
fix(content): Stop Hai tourism jobs from using Swiftsong as a destination

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -72,6 +72,7 @@ mission "Hai Vacation [1]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+		not attributes "station"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
@@ -96,6 +97,7 @@ mission "Hai Vacation [2]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+		not attributes "station"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
@@ -120,6 +122,7 @@ mission "Hai Vacation [3]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+		not attributes "station"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete
@@ -144,6 +147,7 @@ mission "Hai Vacation [4]"
 	destination
 		distance 2 7
 		attributes "hai tourism"
+		not attributes "station"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete


### PR DESCRIPTION
**Bug fix**

## Summary
Prevents Hai tourism missions from having a station as their destination, as these are implied to be for Hai who want to go on a vacation to a Hai world that's mildly dangerous and unpredictable - a Hai station does not fit that bill. 

## Testing Done
TBD

## Save File
TBD