### PR TITLE
fix(content): Fix overlapping planets in a few Gegno systems

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -37066,7 +37066,7 @@ system Zeinar
 		period 185.218
 	object
 		sprite planet/gas1-b
-		distance 650
+		distance 1080
 		period 321.540
 		object Cipi
 			sprite planet/ice7-b

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -16910,7 +16910,7 @@ system Heutesl
 		period 60.0582
 	object "Dueyu Eitch"
 		sprite planet/desert7-b
-		distance 1000
+		distance 820
 		period 349.481
 	object
 		sprite planet/gas4
@@ -30936,7 +30936,7 @@ system Scija
 			period 413.1
 	object
 		sprite planet/saturn
-		distance 8500
+		distance 9400
 		period 4188.84
 		object
 			sprite planet/europa


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses an issue raised in discord by Witch in discord, along with some other cases.

## Summary
This PR fixes a few overlapping orbits in Gegno systems Zeinar, Heutesl, and Scija (which ironically are all three capital systems).

## Testing Done
N/A - did it in an editor.

## Save File
N/A