### PR TITLE
feat(content): Adjust Gegno Vi Slate description

### DIFF
--- a/data/gegno/gegno ships.txt
+++ b/data/gegno/gegno ships.txt
@@ -577,7 +577,7 @@ ship "Slate"
 	leak "leak" 60 50
 	explode "small explosion" 5
 	explode "tiny explosion" 10
-	description `Designed by the Gegno Vi, the Slate is a modified Shale with a stronger hull and more space, a prime characteristic of Vi vessels. Slightly larger than other shuttle ships to suit the Vi's stature, it is able to carry several Gegno cadets along with a small cargo load.`
+	description `Designed by the Gegno Vi, the Slate is a modified Shale with a stronger hull and more space, a prime characteristic of Vi vessels. Slightly larger than other shuttle ships to suit the Vi's stature, it is able to carry a few Gegno cadets, along with a decently increased cargo capacity.`
 
 ship "Schist"
 	sprite "ship/gegno schist a"


### PR DESCRIPTION
(Choose one heading, or add your own.)
**Content (Artwork / Missions / Jobs)**

This PR addresses a writing suggestion brought up by @Arachi-Lover in discord.

## Summary
After the Gegno ships were re-balanced before their introduction to the game, the Slate received a bit more love than the Mica or Shale, gaining a bit more cargo than it started out with and fell into the Light Freighter role.

The current description talks about it being a Shale variant that is slightly larger for the larger Vi with some cargo room to spare, but the stats suggest it got a decent amount of cargo room increase from the Shale. Edited the description to reflect this better.

## Save File
N/A - can just read the PR changes, since the description is shorter.