### PR TITLE
fix(content): Shorten News entry about Betelgeuse ships

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -2663,7 +2663,7 @@ news "betelgeuse stolen ship advisory"
 		word
 			" "
 		word
-			"has the time-tested quality that Betelgeuse is known for"
+			"has the longevity that Betelgeuse is known for"
 			"will live up to your high expectations"
 			"is the genuine article"
 		word


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
The news entry "betelgeuse stolen ship advisory" can overflow the text box, as evident in the below image. This PR reduces the length of one of the longer lines in the third word section, as the other two are shorter. Still might need testing considering the length of the phrases in the fifth word section.

## Screenshots
![overlapping hail](https://github.com/user-attachments/assets/4b736728-d3ed-49c1-99b7-20b892271e88)
I only have a before image at the moment - it's hidden behind a dialog because I rushed to take it. If it's really necessary, I can sit and spam news or make a plug-in for it to come back (unless someone else gets to the clicking before me). 

## Save File
N/A - news is RNG. Though, for extreme testing, could test this in a plug-in of sorts.