### PR TITLE
fix(content): Shorten Hai station Sandsnap's description

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -4334,7 +4334,7 @@ planet Sandsnap
 	attributes hai station uninhabited
 	landscape land/station40
 	description `This station was mothballed sometime in the last sixty thousand years. The docking area has an atmosphere, and a status panel indicates that the station's generators are functional but shut down, with standby mechanisms running on solar power alone.`
-	description `	A tourist FAQ in the docking area cheerily informs any visitors that after the opening of the wormhole in Waypoint, Sandsnap was briefly considered as a possible destination for humans looking to settle in Hai space. Reopening the station would have provided ample room for millions of potential migrants without disturbing planetary ecosystems. Ultimately, it was decided that the slow trickle of human settlers to Hai space did not justify the costs of bringing Sandsnap back online and that it would be better for both humans and Hai if the two species weren't sequestered from each other.`
+	description `	A tourist FAQ in the docking area cheerily informs visitors that after the opening of the wormhole in Waypoint, Sandsnap was briefly considered as a destination for humans looking to settle in Hai space. The station would have provided ample room for millions of potential migrants without disturbing planetary ecosystems. Ultimately, it was decided that the slow trickle of human settlers did not justify the costs of bringing Sandsnap back online and that it would be better for both humans and Hai if the two species weren't sequestered from each other.`
 	government Uninhabited
 	bribe 0
 	security 0


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Sandsnap's description touches the bottom of the textbox, which we try to avoid. This PR cuts out some of the descriptors and words in the description that don't hurt the original meaning or writing of the description to resolve the issue.

## Screenshots

Before:
![sandsnapb4](https://github.com/user-attachments/assets/94ff9f9b-f970-4572-8f2d-2aba4872fe79)

After:
![sandsnapaft](https://github.com/user-attachments/assets/7d7a3fff-d731-45e8-86e3-4b42f44f7644)

## Save File
It's fairly easy to get to the system.