### PR TITLE
feat(balance): Tone down the excessively high drag of many human freighters.

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -500,7 +500,7 @@ ship "Behemoth"
 		"required crew" 12
 		"bunks" 30
 		"mass" 1120
-		"drag" 18.2
+		"drag" 14.6
 		"heat dissipation" .26
 		"fuel capacity" 600
 		"cargo space" 490
@@ -752,7 +752,7 @@ ship "Bulk Freighter"
 		"required crew" 12
 		"bunks" 21
 		"mass" 1510
-		"drag" 21
+		"drag" 16.8
 		"heat dissipation" .27
 		"fuel capacity" 900
 		"cargo space" 640
@@ -972,7 +972,7 @@ ship "Class C Freighter"
 		"required crew" 18
 		"bunks" 43
 		"mass" 1525
-		"drag" 21
+		"drag" 16.8
 		"heat dissipation" .27
 		"fuel capacity" 900
 		"cargo space" 20
@@ -1154,7 +1154,7 @@ ship "Container Transport"
 		"required crew" 6
 		"bunks" 18
 		"mass" 1525
-		"drag" 26.4
+		"drag" 21.1
 		"heat dissipation" .4
 		"fuel capacity" 600
 		"cargo space" 550

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2074,7 +2074,7 @@ ship "Hauler"
 		"required crew" 3
 		"bunks" 12
 		"mass" 490
-		"drag" 14.7
+		"drag" 9.8
 		"heat dissipation" .43
 		"fuel capacity" 400
 		"cargo space" 130
@@ -2133,7 +2133,7 @@ ship "Hauler II"
 		"required crew" 3
 		"bunks" 12
 		"mass" 640
-		"drag" 16.1
+		"drag" 10.7
 		"heat dissipation" .43
 		"fuel capacity" 400
 		"cargo space" 260
@@ -2194,7 +2194,7 @@ ship "Hauler III"
 		"required crew" 3
 		"bunks" 12
 		"mass" 790
-		"drag" 17.5
+		"drag" 11.6
 		"heat dissipation" .43
 		"fuel capacity" 400
 		"cargo space" 390
@@ -2855,7 +2855,7 @@ ship "Nest"
 		"required crew" 5
 		"bunks" 14
 		"mass" 510
-		"drag" 14.7
+		"drag" 9.8
 		"heat dissipation" .48
 		"fuel capacity" 500
 		"cargo space" 40
@@ -3262,7 +3262,7 @@ ship "Roost"
 		"required crew" 7
 		"bunks" 16
 		"mass" 680
-		"drag" 16.1
+		"drag" 10.7
 		"heat dissipation" .48
 		"fuel capacity" 600
 		"cargo space" 80
@@ -3530,7 +3530,7 @@ ship "Skein"
 		"required crew" 7
 		"bunks" 18
 		"mass" 850
-		"drag" 17.5
+		"drag" 11.6
 		"heat dissipation" .51
 		"fuel capacity" 700
 		"cargo space" 120


### PR DESCRIPTION
**Balance**

This PR addresses the bug/feature described in various discord comments.

## Summary
Human heavy freighters are slow. They're slow because they have very little engine space for their size. This is deliberate, and I am not changing it here.

However, on top of being slow, they also have a weird acceleration profile - which, counterintuitively, is arguably _more_ responsive than other ships. They reach their top speeds much more quickly than any other ship does.
This is because they have excessively high drag stats relative to their mass.
It has been suggested at various times that heavy freighters should instead accelerate slowly relative to their top speeds. They already accelerate slowly relative to other ships - this is due to the aforementioned low engine space - but relative to their top speeds they have the highest accelerations of almost any acquirable ship.

This PR gives the Behemoth, Bulk Freighter, Class C freighter and Container Transport +25% max speed, and the Hauler and its various modifications +50%, bringing their acceleration:drag ratios more in line with other ships.

Changes to ship top speeds (stock):

| Ship  | Hauler/Nest | Hauler II/Roost | Hauler III/Skein | Behemoth | Bulk Freighter | Class C Freighter | Container Transport |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Before | 158 | 144 | 133 | 142 | 123 | 131 | 98 |
| After | 237 | 216 | 177 | 177 | 154 | 163 | 122 |

As you can see, they are still slow. But, they're now more bearable in large systems, and handle in a manner more consistent with other ships.

## Testing Done
None.

## Save File
I don't have any saves on which I used any of these ships, because they're extremely slow and painful to use.

