### PR TITLE
feat(content): Clarify unlock conditions for the Hai start

### DIFF
--- a/data/globals.txt
+++ b/data/globals.txt
@@ -20,11 +20,19 @@ mission "Ask the Hai about the Unfettered: global"
 		set "global: Ask the Hai about the Unfettered"
 		fail
 
-mission "main plot completed: global"
+mission "Hai Start Unlocked"
 	landing
-	invisible
+	substitutions
+		<campaign> "Free Worlds"
+			has "free worlds plot completed"
 	to offer
+		has "Ask the Hai about the Unfettered: offered"
 		has "main plot completed"
+		not "global: Hai Start Unlocked"
 	on offer
-		set "global: main plot completed"
-		fail
+		set "global: Hai Start Unlocked"
+		conversation
+			scene "scene/hai start"
+			`By completing the <campaign> campaign and discovering the conflict between the Hai and Unfettered Hai, you have unlocked the "Hai Origins" start for future playthroughs.`
+			`	(To begin a new game from this start, open the "Load/Save" panel on the main menu and select "New Pilot.")`
+				decline

--- a/data/globals.txt
+++ b/data/globals.txt
@@ -34,5 +34,5 @@ mission "Hai Start Unlocked"
 		conversation
 			scene "scene/hai start"
 			`By completing the <campaign> campaign and discovering the conflict between the Hai and Unfettered Hai, you have unlocked the "Hai Origins" start for future playthroughs.`
-			`	(To begin a new game from this start, open the "Load/Save" panel on the main menu and select "New Pilot.")`
+			`	(To begin a new game with this start, open the "Load/Save" panel on the main menu and select "New Pilot.")`
 				decline

--- a/data/starts.txt
+++ b/data/starts.txt
@@ -67,20 +67,22 @@ start "hai space"
 	system "Fah Soom"
 	planet "Greenwater"
 	date 16 11 3013
+	on display
+		description `This start is locked.`
 	to reveal
 		has "Ask the Hai about the Unfettered"
 	on reveal
 		name "Hai Origins"
-		description `You grew up on Greenwater, a Hai world with a rich and mixed culture thanks to its climate. You've dreamed of owning your own fleet since you were given toy spaceships as a small child. To reach that goal, you worked hard at a travel company, recommending locations in human space.`
+		description `You grew up on Greenwater, a Hai world with a rich and mixed culture thanks to its climate. You've dreamed of owning your own fleet since you were given toy spaceships as a small child, and you've worked hard at a travel company to reach this goal.`
 		description `	Now, as your ferry docks at the main spaceport, you feel like this is the start of a new life as a captain.`
+		description `	To unlock this start, you must complete the main human campaign.`
 		system "Fah Soom"
 		planet "Greenwater"
 		date "Tue, 16 Nov 3013"
 		credits "1.431M"
 		debt "1.431M"
 	to unlock
-		has "main plot completed"
-		has "Ask the Hai about the Unfettered"
+		has "Hai Start Unlocked"
 		# TODO: think about what point of HR should unlock this once it's back in the game, if any
 		# has "event: hai-human resolution announced"
 	conversation "hai intro"


### PR DESCRIPTION
This PR addresses parts of #10741 

## Summary
This PR makes the unlocks requirements for the Hai start clearer, by directly stating that it's locked under `on display`, and that you need to complete the FW campaign under `on reveal`. It also adds a mission that notifies the player that they've unlocked the start when they land in a save where they've completed the main plot and have asked the Hai about the Unfettered. To make this mission work as cleanly as possible, `"main plot completed: global"` has been removed, and the Hai start now directly checks for a global condition set by the Hai start notification mission.

The description for the `on reveal` is also slightly shorter to make space for the unlock requirements.

## Testing Done
Tested `"Ask the Hai about the Unfettered"` followed by `"main plot completed"` and got the unlock. Tested `"main plot completed"` followed by `"Ask the Hai about the Unfettered"` and also got the unlock.

## Save File
This save file can be used to test these changes:
[combat testless~start unlock test.txt](https://github.com/user-attachments/files/17626882/combat.testless.start.unlock.test.txt)

You'll need to clear `global conditions.txt` to test these changes.