### PR TITLE
fix(content): Make "Tarazed neutrality" apply immediately

### DIFF
--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -442,7 +442,7 @@ mission "FW Syndicate Diplomacy 1C"
 		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
 	
 	on offer
-		event "Tarazed neutrality"
+		event "Tarazed neutrality" 0
 		log "The extra Syndicate supplies have begun arriving at Tarazed, and they include weaponry and outfits not normally shipped to the South. Spoke with Emily Lane, the CEO of the Tarazed Corporation. She is suspicious of this supposed gesture of good will from the Syndicate, and suggests remaining vigilant of the Syndicate's actions."
 		conversation
 			`When you arrive at <origin>, you find that there are already some Syndicate ships here unloading cargo that must have been sent ahead of you. You catch a glimpse of some of the crates and see large amounts of ship materials, as well as crates of blasters, Proton Guns, and other Syndicate products.`


### PR DESCRIPTION
## Summary
This PR gives `"Tarazed neutrality"` a delay of 0, meaning that the new outfits and government changes are immediately available after completing the mission, instead of needing to take off to see the changes.

## Save File
This save file can be used to test these changes:
[Meat Girl.txt](https://github.com/user-attachments/files/17639162/Meat.Girl.txt)
