### PR TITLE
Change "Load / Save" to "Manage Pilots"

### DIFF
--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -27,7 +27,7 @@ help "basics 2"
 
 help "dead"
 	`Uh-oh! You just died. The universe can be a dangerous place for new captains!`
-	`Fortunately, your game is automatically saved every time you leave a planet. To load your most recent saved game, press <Show main menu> to return to the main menu, then click on "Load / Save" and "Enter Ship."`
+	`Fortunately, your game is automatically saved every time you leave a planet. To load your most recent saved game, press <Show main menu> to return to the main menu, then click on "Manage Pilots..." and "Enter Ship."`
 
 help "disabled"
 	`Your ship just got disabled! Before an enemy ship finishes you off, you should find someone to help you.`

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -266,7 +266,7 @@ interface "main menu"
 		dimensions 90 30
 	
 	visible
-	button l "_Load / Save..."
+	button l "Manage Pi_lots..."
 		center 300 155
 		dimensions 120 30
 	


### PR DESCRIPTION
**Feature**
"Load / Save..." to "Manage Pilots..."

This PR addresses the bug/feature described in issue #10611.

## Summary
Changed the displayed value of the button text for hotkey L from "Load / Save..." to "Manage Pilots...".  Changed associated help.txt entry.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/77

## Testing Done
Opened game and confirmed displayed value of the button text ("Manage Pilots...") and the hot key (Still used the letter L, associated the underline with the L in Pilots).

## Performance Impact
N/A