### PR TITLE
fix(bug): remove duplicate outfits node in a Splinter variant

### DIFF
--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -3488,7 +3488,6 @@ ship "Splinter" "Splinter (Proton)"
 
 ship "Splinter" "Splinter (Tractor Beam)"
 	outfits
-	outfits
 		"Twin Modified Blaster" 2
 		"Proton Turret" 2
 		"Tractor Beam"


### PR DESCRIPTION
**Bug Fix**?

This PR addresses the bug described on Discord.

## Summary
Removed a duplicate `outfit` node in the `Splinter (Tractor Beam)`'a definition.