### PR TITLE
fix(ui): Fix duplicated display of the new fuel attributes

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -438,13 +438,10 @@ tip "scramble resistance heat:"
 tip "jump speed:"
 	`The maximum velocity the ship can jump at.`
 
-tip "jump fuel:"
-	`Fuel consumed when jumping between systems using this drive.`
-
-tip "hyperdrive fuel"
+tip "hyperdrive fuel:"
 	`Fuel consumed when jumping between systems using this hyperdrive.`
 
-tip "jump drive fuel"
+tip "jump drive fuel:"
 	`Fuel consumed when jumping between systems using this jump drive.`
 
 tip "jump range:"

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -347,6 +347,8 @@ void Outfit::Load(const DataNode &node)
 		double jumpFuel = attributes.Get("jump fuel");
 		attributes["jump drive fuel"] = (jumpFuel > 0. ? jumpFuel : DEFAULT_JUMP_DRIVE_COST);
 	}
+	if(attributes.Get("jump fuel"))
+		attributes["jump fuel"] = 0.;
 
 	// Only outfits with the jump drive and jump range attributes can
 	// use the jump range, so only keep track of the jump range on


### PR DESCRIPTION
**Bug fix**

This PR fixes two regressions introduced in #10732. Related: https://github.com/endless-sky/endless-sky/commit/c11fd9029e2a59edad169fb7925aaf5e033ee122#r148916170

## Summary
The tooltips didn't show up in-game due to a typo. The fuel cost was also displayed twice if the old "jump fuel" attribute was used instead of the new attributes, as it would be displayed both as "hyperdrive fuel" and as "jump fuel".

I also removed the tooltip for the now-unused jump fuel.

## Testing Done
I tested that the tooltips now show up, and the fuel cost is only displayed once.

## Save File
N/A