### PR TITLE
fix(mechanics): Don't allow buying outfits with insufficient credits

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -401,12 +401,10 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 		// Buying into cargo, so check cargo space vs mass.
 		double mass = selectedOutfit->Mass();
 		double freeCargo = player.Cargo().FreePrecise();
-		if(!mass || freeCargo >= mass)
-			return true;
-
-		errors.push_back("You cannot " + string(onlyOwned ? "load" : "buy") + " this outfit, because it takes up "
-			+ Format::CargoString(mass, "mass") + " and your fleet has "
-			+ Format::CargoString(freeCargo, "cargo space") + " free.");
+		if(mass && freeCargo < mass)
+			errors.push_back("You cannot " + string(onlyOwned ? "load" : "buy") + " this outfit, because it takes up "
+				+ Format::CargoString(mass, "mass") + " and your fleet has "
+				+ Format::CargoString(freeCargo, "cargo space") + " free.");
 	}
 	else
 	{

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -395,6 +395,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 				Format::CreditString(licenseCost - credits));
 	}
 
+	bool anyShipCanInstall = true;
 	// Check if the outfit will fit.
 	if(!playerShip)
 	{
@@ -408,11 +409,18 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 	}
 	else
 	{
+		anyShipCanInstall = false;
 		// Find if any ship can install the outfit.
 		for(const Ship *ship : playerShips)
 			if(ShipCanBuy(ship, selectedOutfit))
-				return true;
+			{
+				anyShipCanInstall = true;
+				break;
+			}
+	}
 
+	if(!anyShipCanInstall)
+	{
 		// If no selected ship can install the outfit,
 		// report error based on playerShip.
 		double outfitNeeded = -selectedOutfit->Get("outfit space");

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -395,7 +395,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 				Format::CreditString(licenseCost - credits));
 	}
 
-	// Check if the outfit will fit
+	// Check if the outfit will fit.
 	if(!playerShip)
 	{
 		// Buying into cargo, so check cargo space vs mass.

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -470,8 +470,8 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 
 		// For unhandled outfit requirements, show a catch-all error message.
 		if(errors.empty())
-		errors.push_back("You cannot install this outfit in your ship, "
-			"because it would reduce one of your ship's attributes to a negative amount. "
+			errors.push_back("You cannot install this outfit in your ship, "
+				"because it would reduce one of your ship's attributes to a negative amount. "
 				"For example, it may use up more cargo space than you have left.");
 	}
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10775.

## Summary
The game will no longer allow you to buy an outfit into cargo or install it on a ship if you have insufficient credits.

## Screenshots
before | after
-- | --
![image](https://github.com/user-attachments/assets/b58e9940-8886-403c-b896-63f61c5474fb) | ![image](https://github.com/user-attachments/assets/ece89179-543b-4ef2-9785-9501e93ac204)
![image](https://github.com/user-attachments/assets/c213fb66-c599-449e-a4d6-e3bee2491fe6) | ![image](https://github.com/user-attachments/assets/31bbd092-2b1b-4d62-9bc2-a0a657a31efc)
![image](https://github.com/user-attachments/assets/56471df1-9a91-44ed-9bc4-c2d481fb19af) | ![image](https://github.com/user-attachments/assets/7c1db03a-cc75-48a6-b5d7-af741f03b832)
![image](https://github.com/user-attachments/assets/557b250a-5eb8-4807-bcb8-8990440edf6e) | ![image](https://github.com/user-attachments/assets/8351590a-d4d9-4189-be39-e9ca1702b486)

## Usage examples
N/A

## Testing Done
What it took to make the above screenshots.

## Save File
This save file can be used to test these changes:
[test buying ibut not installing.txt](https://github.com/user-attachments/files/17705158/test.buying.ibut.not.installing.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Immeasurable.
