### PR TITLE
fix(ui): Apply proper swizzle to 'target sprite' and 'player sprite' in 'fast' 'outline' mode

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -727,7 +727,8 @@ void Engine::Step(bool isActive)
 		if(Preferences::Has("Rotate flagship in HUD"))
 			shipFacingUnit = flagship->Facing().Unit();
 
-		info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit, flagship->GetFrame(step));
+		info.SetSprite("player sprite", flagship->GetSprite(), shipFacingUnit, flagship->GetFrame(step),
+			flagship->GetSwizzle());
 	}
 	if(currentSystem)
 		info.SetString("location", currentSystem->Name());
@@ -813,7 +814,8 @@ void Engine::Step(bool isActive)
 		info.SetSprite("target sprite",
 			targetAsteroid->GetSprite(),
 			targetAsteroid->Facing().Unit(),
-			targetAsteroid->GetFrame(step));
+			targetAsteroid->GetFrame(step),
+			0);
 		info.SetString("target name", targetAsteroid->DisplayName() + " " + targetAsteroid->Noun());
 
 		targetVector = targetAsteroid->Position() - center;
@@ -830,14 +832,14 @@ void Engine::Step(bool isActive)
 	{
 		if(target->GetSystem() == player.GetSystem() && !target->IsCloaked())
 			targetUnit = target->Facing().Unit();
-		info.SetSprite("target sprite", target->GetSprite(), targetUnit, target->GetFrame(step));
+		targetSwizzle = target->GetSwizzle();
+		info.SetSprite("target sprite", target->GetSprite(), targetUnit, target->GetFrame(step), targetSwizzle);
 		info.SetString("target name", target->Name());
 		info.SetString("target type", target->DisplayModelName());
 		if(!target->GetGovernment())
 			info.SetString("target government", "No Government");
 		else
 			info.SetString("target government", target->GetGovernment()->GetName());
-		targetSwizzle = target->GetSwizzle();
 		info.SetString("mission target", target->GetPersonality().IsTarget() ? "(mission target)" : "");
 
 		int targetType = RadarType(*target, step);

--- a/source/Information.cpp
+++ b/source/Information.cpp
@@ -43,11 +43,12 @@ bool Information::HasCustomRegion() const
 
 
 
-void Information::SetSprite(const string &name, const Sprite *sprite, const Point &unit, float frame)
+void Information::SetSprite(const string &name, const Sprite *sprite, const Point &unit, float frame, int swizzle)
 {
 	sprites[name] = sprite;
 	spriteUnits[name] = unit;
 	spriteFrames[name] = frame;
+	spriteSwizzles[name] = swizzle;
 }
 
 
@@ -76,6 +77,14 @@ float Information::GetSpriteFrame(const string &name) const
 {
 	auto it = spriteFrames.find(name);
 	return (it == spriteFrames.end()) ? 0.f : it->second;
+}
+
+
+
+int Information::GetSwizzle(const string &name) const
+{
+	auto it = spriteSwizzles.find(name);
+	return (it == spriteSwizzles.end()) ? 0 : it->second;
 }
 
 

--- a/source/Information.cpp
+++ b/source/Information.cpp
@@ -84,7 +84,7 @@ float Information::GetSpriteFrame(const string &name) const
 int Information::GetSwizzle(const string &name) const
 {
 	auto it = spriteSwizzles.find(name);
-	return (it == spriteSwizzles.end()) ? 0 : it->second;
+	return it == spriteSwizzles.end() ? 0 : it->second;
 }
 
 

--- a/source/Information.h
+++ b/source/Information.h
@@ -35,7 +35,8 @@ public:
 	const Rectangle &GetCustomRegion() const;
 	bool HasCustomRegion() const;
 
-	void SetSprite(const std::string &name, const Sprite *sprite, const Point &unit = Point(0., -1.), float frame = 0.f, int swizzle = 0);
+	void SetSprite(const std::string &name, const Sprite *sprite, const Point &unit = Point(0., -1.), float frame = 0.f, 
+		int swizzle = 0);
 	const Sprite *GetSprite(const std::string &name) const;
 	const Point &GetSpriteUnit(const std::string &name) const;
 	float GetSpriteFrame(const std::string &name) const;

--- a/source/Information.h
+++ b/source/Information.h
@@ -56,7 +56,6 @@ public:
 	const Color &GetOutlineColor() const;
 
 
-
 private:
 	Rectangle region;
 	bool hasCustomRegion = false;

--- a/source/Information.h
+++ b/source/Information.h
@@ -35,10 +35,11 @@ public:
 	const Rectangle &GetCustomRegion() const;
 	bool HasCustomRegion() const;
 
-	void SetSprite(const std::string &name, const Sprite *sprite, const Point &unit = Point(0., -1.), float frame = 0.f);
+	void SetSprite(const std::string &name, const Sprite *sprite, const Point &unit = Point(0., -1.), float frame = 0.f, int swizzle = 0);
 	const Sprite *GetSprite(const std::string &name) const;
 	const Point &GetSpriteUnit(const std::string &name) const;
 	float GetSpriteFrame(const std::string &name) const;
+	int GetSwizzle(const std::string &name) const;
 
 	void SetString(const std::string &name, const std::string &value);
 	const std::string &GetString(const std::string &name) const;
@@ -54,6 +55,7 @@ public:
 	const Color &GetOutlineColor() const;
 
 
+
 private:
 	Rectangle region;
 	bool hasCustomRegion = false;
@@ -61,6 +63,7 @@ private:
 	std::map<std::string, const Sprite *> sprites;
 	std::map<std::string, Point> spriteUnits;
 	std::map<std::string, float> spriteFrames;
+	std::map<std::string, int> spriteSwizzles;
 	std::map<std::string, std::string> strings;
 	std::map<std::string, double> bars;
 	std::map<std::string, double> barSegments;

--- a/source/Information.h
+++ b/source/Information.h
@@ -35,7 +35,7 @@ public:
 	const Rectangle &GetCustomRegion() const;
 	bool HasCustomRegion() const;
 
-	void SetSprite(const std::string &name, const Sprite *sprite, const Point &unit = Point(0., -1.), float frame = 0.f, 
+	void SetSprite(const std::string &name, const Sprite *sprite, const Point &unit = Point(0., -1.), float frame = 0.f,
 		int swizzle = 0);
 	const Sprite *GetSprite(const std::string &name) const;
 	const Point &GetSpriteUnit(const std::string &name) const;

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -503,7 +503,10 @@ void Interface::ImageElement::Draw(const Rectangle &rect, const Information &inf
 		OutlineShader::Draw(sprite, rect.Center(), rect.Dimensions(), color, unit, frame);
 	}
 	else
-		SpriteShader::Draw(sprite, rect.Center(), rect.Width() / sprite->Width(), 0, frame, unit);
+	{
+		int swizzle = info.GetSwizzle(name);
+		SpriteShader::Draw(sprite, rect.Center(), rect.Width() / sprite->Width(), swizzle, frame, unit);
+	}
 }
 
 


### PR DESCRIPTION
**Bug fix** ?

## Summary
The "fast" method of displaying the "target sprite" and "player sprite" graphical elements of the HUD were not showing proper swizzling colors.

## Screenshots
| Before | After | After |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/d46537cd-28c3-4931-bc09-eb30d632928d)| ![image](https://github.com/user-attachments/assets/860fc62c-9637-4e79-8552-df7a8ec6f657) | ![image](https://github.com/user-attachments/assets/874032d4-54fe-4013-8068-e416461a8ab8) |
| no swizzle | pirate | syndicate | 

Another thing, though is that with this "fast" "outline" (i.e. sprites, no outline) there is also no color indicating the threat...
```c++
		int targetType = RadarType(*target, step);
		info.SetOutlineColor(GetTargetOutlineColor(targetType));
```

I actually don't know what the sprites look like when they are `Radar::BLINK`, but something tells me that this `FRIENDLY`/`UNFRIENDLY`/`HOSTILE`/`BLINK` stuff is just missing from the "fast" implementation also.

## Some additional thoughts on game play
I really think that the "outline", although considered "fancy" is something that the game perhaps ought to force on the user as  evidence of having only basic scanning capabilities until the player upgrades their scanner -- e.g. tactical scanner could provide  sprites instead of outlines.  (Yeah, like the original EV and the IFF decoder that upgraded the radar from monochrome green to colors -- I miss that)

## Testing Done
Yes

## Performance Impact
None