### PR TITLE
feat(ui): Add a help message describing how to see help messages

### DIFF
--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -26,7 +26,7 @@ help "basics 2"
 	`For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
 
 help "basics 3"
-	`To see help messages again, press <Show help> or go to the main menu, go to preferences, go to settings, go to page two, then select "Reactivate first-time help."`
+	`To see a help messages again, press <Show help>. To see all help messages again, go to the main menu, go to preferences, go to settings, go to page two, then select "Reactivate first-time help."`
 
 help "dead"
 	`Uh-oh! You just died. The universe can be a dangerous place for new captains!`

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -26,7 +26,7 @@ help "basics 2"
 	`For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
 
 help "basics 3"
-	`To see a help message again, press <Show help>. To see all help messages again, go to the main menu, go to preferences, go to settings, go to page two, then select "Reactivate first-time help."`
+	`To see a help message again, press <Show help>. To see all help messages again, go to the main menu, select Preferences, then go to Settings. Navigate to page two, then select "Reactivate first-time help."`
 
 help "dead"
 	`Uh-oh! You just died. The universe can be a dangerous place for new captains!`

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -25,6 +25,9 @@ help "basics 1"
 help "basics 2"
 	`For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
 
+help "basics 3"
+	`To see help messages again, press <Show help> or go to the main menu, go to preferences, go to settings, go to page two, then select "Reactivate first-time help."`
+
 help "dead"
 	`Uh-oh! You just died. The universe can be a dangerous place for new captains!`
 	`Fortunately, your game is automatically saved every time you leave a planet. To load your most recent saved game, press <Show main menu> to return to the main menu, then click on "Load / Save" and "Enter Ship."`

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -26,7 +26,7 @@ help "basics 2"
 	`For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
 
 help "basics 3"
-	`To see a help messages again, press <Show help>. To see all help messages again, go to the main menu, go to preferences, go to settings, go to page two, then select "Reactivate first-time help."`
+	`To see a help message again, press <Show help>. To see all help messages again, go to the main menu, go to preferences, go to settings, go to page two, then select "Reactivate first-time help."`
 
 help "dead"
 	`Uh-oh! You just died. The universe can be a dangerous place for new captains!`

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1402,6 +1402,7 @@ void Engine::EnterSystem()
 	{
 		Messages::Add(GameData::HelpMessage("basics 1"), Messages::Importance::High);
 		Messages::Add(GameData::HelpMessage("basics 2"), Messages::Importance::High);
+		Messages::Add(GameData::HelpMessage("basics 3"), Messages::Importance::High);
 	}
 }
 

--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -3,6 +3,7 @@
 "help: bank" 1
 "help: basics 1" 1
 "help: basics 2" 1
+"help: basics 3" 1
 "help: dead" 1
 "help: disabled" 1
 "help: fleet asteroid mining shortcuts" 1


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in discussion #10776

## Summary
While the game shows help messages, they are shown once, and it can be difficult to figure out that it is possible to see them again. This PR adds a third “basic” help message which describes how to view help messages or reactivate them, so that players know that they can review these messages as necessary.

## Screenshots
![image](https://github.com/user-attachments/assets/ee358a73-d220-49ee-84a8-2125b42f4b08)
EDIT: Updated screenshot

## Testing Done
Made sure the help messaged showed up for the first few days, then did not show up again even after reactivating help.

## Save File
Make a new pilot.

## Performance Impact
Not zero, but barely so.