### PR TITLE
feat(ui): Allow Copy&Paste in string input dialogs

### DIFF
--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -224,13 +224,14 @@ bool Dialog::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool i
 {
 	auto it = KEY_MAP.find(key);
 	bool isCloseRequest = key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI)));
-	if(stringFun && (mod & KMOD_CTRL) && (key == 'c' || key == 'v')) {
+	if(stringFun && (mod & KMOD_CTRL) && (key == 'c' || key == 'v'))
+	{
 		if(key == 'c')
 			SDL_SetClipboardText(input.c_str());
 		else if(SDL_HasClipboardText())
 		{
 			input.clear();
-			char* clipboardText = SDL_GetClipboardText();
+			char *clipboardText = SDL_GetClipboardText();
 			int n = 0;
 			for(auto cp = clipboardText; *cp && n < 120; cp++, n++)
 				if(*cp >= ' ' && *cp <= '~')

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -230,7 +230,6 @@ bool Dialog::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool i
 			SDL_SetClipboardText(input.c_str());
 		else if(SDL_HasClipboardText())
 		{
-			input.clear();
 			char *clipboardText = SDL_GetClipboardText();
 			int n = 0;
 			for(auto cp = clipboardText; *cp && n < 120; cp++, n++)

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -224,7 +224,21 @@ bool Dialog::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool i
 {
 	auto it = KEY_MAP.find(key);
 	bool isCloseRequest = key == SDLK_ESCAPE || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI)));
-	if((it != KEY_MAP.end() || (key >= ' ' && key <= '~')) && !isMission && (intFun || stringFun) && !isCloseRequest)
+	if(stringFun && (mod & KMOD_CTRL) && (key == 'c' || key == 'v')) {
+		if(key == 'c')
+			SDL_SetClipboardText(input.c_str());
+		else if(SDL_HasClipboardText())
+		{
+			input.clear();
+			char* clipboardText = SDL_GetClipboardText();
+			int n = 0;
+			for(auto cp = clipboardText; *cp && n < 120; cp++, n++)
+				if(*cp >= ' ' && *cp <= '~')
+					input += *cp;
+			SDL_free(clipboardText);
+		}
+	}
+	else if((it != KEY_MAP.end() || (key >= ' ' && key <= '~')) && !isMission && (intFun || stringFun) && !isCloseRequest)
 	{
 		int ascii = (it != KEY_MAP.end()) ? it->second : key;
 		char c = ((mod & KMOD_SHIFT) ? SHIFT[ascii] : ascii);


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #10701

## Summary
See issue discussion. This implements whole-field copy using Ctrl-C and whole-field paste using Ctrl-V for all string-accepting dialogs (not number-accepting ones).

As mentioned, a "contra" argument would be that it raises unfulfilled expectations, as there's still no "cursor" other than the field's end let alone a selection, so no partial edists and/or partial copy-pasta. Still, I've played with the patch in my codebase for a while and by now think it's better than nothing, and have actually used it once.

As for the sanitizing comment in the issue - this now filters to ascii only.

Does not work for the name of a new pilot - duh, that's not a Dialog.

## Screenshots
N/A - not really. 

## Testing Done
Just basic - I can paste a ship name from clipboard (buying) or copy a ship name to the clipboard (from rename).

## Performance Impact
N/A