### PR TITLE
feat(ui): Allow steering while reversing

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4544,7 +4544,7 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 		AutoFire(ship, firingCommands, false, true);
 
 	const bool mouseTurning = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
-	if(mouseTurning && !ship.IsBoarding() && !ship.IsReversing())
+	if(mouseTurning && !ship.IsBoarding() && (!ship.IsReversing() || ship.Attributes().Get("reverse thrust")))
 		command.SetTurn(TurnToward(ship, mousePosition));
 
 	if(activeCommands)


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #10546

## Summary
See issue discussion: I've been playing this long enough by now (a month) to feel confident it's okay and has no unexpected drawbacks.

## Screenshots
N/A

## Testing Done
* "Control ship with mouse" option on, some reverse thruster installed: Steer while reversing by holding down arrow and moving mouse: Works as expected.
* Option is on, no reverse thruster installed: Down arrow orients the ship such that thrusting would counter the current motion vector, while held only, when releasing key orientation goes back to follow mouse. Not really _perfectly_ intuitive, but same as master.
* Option is off, with reverse thrusters: Unchanged, Holding L/R+Down complements L/R+Up as expected.
* Option is off, no reverse thruster installed: same as with option on, feels intuitive in this case, same as master.
* Shift-Down stops ship in all combinations: Yes.

## Performance Impact
N/A