### PR TITLE
fix(ghactions): remove aesthetic and variants from `.codespell.words.exclude`

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -1,9 +1,7 @@
 		"Ikrehpeb haslrikpeb ikpecem sara nives"      # Stop acting like a child
 		"akmac pano nives ralret umsab lravriv" # a pasta of small snakes with mice meatballs
-		"haet sunt"                     # heat shunt (mispronounced)
 		"Yoo no gud fite so gif up."      # You are no good in a fight, so give up. (mispronounced)
 		"do gud"             # [do|does] good (mispronounced)
-		"We Korath imotal!"     # We, the Korath, are immortal! (mispronounced)
 		"a's no gud"         # is no good (mispronounced)
 		"ain' gud"           # ain't good (mispronounced)
 		"do gud"             # [do|does] good (mispronounced)
@@ -11,15 +9,7 @@
 		"Can hav" 3     # Can have (mispronounced)
 		"yoo ded mor"          # you dead more (mispronounced)
 		"'oo wil" 3     # You will (mispronounced)
-		"bomance novals"           # [romance|bromance] novels (mispronounced)
-		"cley n kiln"              # clay and kiln (mispronounced)
-		"benjos"                   # banjos (mispronounced)
-		"bokets f painte"          # buckets of paint (mispronounced)
-		"easls ith trypods"        # easels with tripods (mispronounced)
-		"recerd playrs"            # record players (mispronounced)
-		"relegos tects"            # religious texts (mispronounced)
 		"blak muusic shee's"       # blank music sheets (mispronounced)
-		"sinin boowl sets"         # singing bowl set (mispronounced)
 		"Wee taek yur"           # We take your (mispronounced)
 		"Te"                     # The (mispronounced)
 		"blong to u'."           # belong to us (mispronounced)
@@ -69,10 +59,6 @@
 			`	"I do not know vhy you sent us to that place. But I am happy to be home. So go, and maybe one day I vill not hate to see you again."`
 			`A familiar woman is waiting for you outside your ship. Although it's been more than seven years since you've last seen her, you recognize Hjlod instantly. Her eyes are brighter than when last you parted, and she has the same lopsided grin that you remember. "<first>, I saw your ship landing, and thought I vould say hello."`
 			`	She reaches into her pocket and pulls out a small wooden box, similar to the one you saw displayed at Asgard years ago. "I have been thinking," Hjlod says. "Maybe all this vas vill of Skade. Maybe you took us to Asgard to make us stronger, to make us better. It is bitter lesson, but I understand it now."`
-			`	"A data archive with the latest briefings and analyses. Heavily shielded and encrypted, of course, so no need to worry about it showing up on a scan. It has to get there by <date>. So, could you do it?" They hold out a small case with a data crystal visible through the window.`
-			`As the scan results arrive the data is relayed down to the team in the cargo hold. Your video feed shows a large hologram of the system floating in midair above one of the pallets. Nearby, terminals flash rolling readouts and analyses. As the data on the spectral ship solidifies, cones of projected courses appear on the display. Line by line the cone tightens in as additional data flows from your telemetry, closing in on a path intersecting with the nearby world.`
-			`	He gestures confidently. "A team of Remnant, for instance, could all review incoming data from an experiment, form their own analyses, and then hold what amounts to a conference where each fully presents their thoughts and ideas with supporting data and reasoning within the span of a few minutes."`
-system Nnaug
 	object "Sies Upi"
 planet "Sies Upi"
 	description `Sies Upi is one of the most recently colonized planets of the Gegno Vi. This hot, dry, and harsh world serves as more of an outpost than it does a colony, but nevertheless the Vi have found ways to create manageable living conditions for their settlers.`

--- a/.codespell.words.exclude
+++ b/.codespell.words.exclude
@@ -1,5 +1,2 @@
-aesthetic
-aesthetics
-aesthetically
 ket
 ser


### PR DESCRIPTION
**Unknown**

## Summary
Removed aesthetic and related words from `.codespell.words.exclude`, as they are no longer needed. Pointed out by @ziproot in #10797.