### PR TITLE
fix: Increase Venta ammo count

### DIFF
--- a/data/incipias/incipias ships.txt
+++ b/data/incipias/incipias ships.txt
@@ -45,7 +45,7 @@ ship "Venta"
 		"Metallic Hydrogen Cell"
 		"Plasma Discharger" 2
 		"Star Tail" 4
-		"Star Tail Cell" 80
+		"Star Tail Cell" 120
 		"Star Tail Storage" 2
 		"Cloud Piercer" 40
 


### PR DESCRIPTION
**Bug fix**

This PR increases the ammo count of the stock Venta from 80 to 120, which is its true max capacity.

## Summary

Just changes the # of ammunition on the stock Venta from 80 to 120.