### PR TITLE
fix(text/dates): Date::LongString should output the DDth of Month

### DIFF
--- a/source/Date.cpp
+++ b/source/Date.cpp
@@ -136,9 +136,9 @@ string Date::LongString() const
 	Preferences::DateFormat dateFormat = Preferences::GetDateFormat();
 	string result;
 	if(dateFormat == Preferences::DateFormat::YMD || dateFormat == Preferences::DateFormat::MDY)
-		result += std::move(month) + " " + std::move(dayString);
+		result = month + " " + dayString;
 	else if(dateFormat == Preferences::DateFormat::DMY)
-		result += std::move(dayString) + " of " + std::move(month);
+		result = "the " + dayString + " of " + month;
 
 	return result;
 }


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in https://github.com/endless-sky/endless-sky/pull/10800#discussion_r1849125539.

## Summary
Prior to the option to change date formats between DMY, MDY, and YMD, Date::LongString (which is used for the "<day>" substitution in missions) would produce an output of the form "the DDth of Month". 
See: https://github.com/endless-sky/endless-sky/blob/839f5af27fa92c7030284502648e81a1baad0e31/source/main.cpp#L534
And the wiki: 
https://github.com/endless-sky/endless-sky/wiki/CreatingMissions#text-replacements
> <day> = the deadline in conversational form ("the DDth of Month")

However, when adding support for the other date formats, this result was changed to the form: "DDth of Month".
This PR restores the expected "the" preceding the day of the month in the DMY format. The MDY and YMD format is unaffected and will continue to produce strings of the form "Month DDth".
Additionally, I've removed calls to `std::move` in that piece of code because their usage is non-sensical: `string::operator+` can only copy, and one of the other strings is `const` and so cannot be moved from anyway.
Similarly, replaced calls to `string::operator+=` with `string::operator=` because appending to an empty string is silly.

## Testing Done
None

## Wiki Update
The behaviour after this change already matches the description in the wiki.
