### PR TITLE
fix(condition-validation): Silently forget no longer valid condition

### DIFF
--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -165,6 +165,10 @@ void ConditionsStore::Load(const DataNode &node)
 {
 	for(const DataNode &child : node)
 	{
+		// Let's just silently forget this condition that once existed, but that no longer has a valid name.
+		if(child.Token(0).starts_with("00 Spaceport Reminder: "))
+			continue;
+
 		if(!DataNode::IsConditionName(child.Token(0)))
 			child.PrintTrace("Invalid condition during savegame-load:");
 		Set(child.Token(0), (child.Size() >= 2) ? child.Value(1) : 1);


### PR DESCRIPTION
This PR addresses the bug noticed after merge of #10369

## Summary
The PR for basic condition name validation was merged just after another PR added a new condition (`"00 Spaceport Reminder: done"`) that wouldn't pass this new validation.

Players would now suddenly get a warning if they run a new version of the game, and their old save-games contain this condition.

This PR specifically removes this invalid condition. We might want to consider to always remove conditions that don't pass validation, but that would be a somewhat bigger change.

## Testing Done
I verified that the game compiled and that my savegame was loaded successfully. (I however didn't have `"00 Spaceport Reminder: done"` in my savegame.)

## Save File
Not provided, the issue hasn't shown up in my own savegames.
(But it did appear for at least 2 persons that commented on #10369, so I could ask them to provide a savegame if desired.)

## Performance Impact
This code only runs on game loading, so no serious impact is expected. (Loading might take a few milliseconds longer.)