### PR TITLE
fix(typo): Fix tabulator character in condition name

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -9003,7 +9003,7 @@ mission "Timothy Radrickson 5d: Greenrock"
 			label getmed
 			action
 				set "med2"
-				"timothy radrickson	medicine" = 2
+				"timothy radrickson medicine" = 2
 				payment -50000
 			`	"Trust me, it's still good," the drug-dealer says as he takes your <payment>. He hands you the drugs with a smirk.`
 				goto greenoptions


### PR DESCRIPTION
**Typo fix**

This PR addresses the bug described in https://github.com/endless-sky/endless-sky/pull/9977#discussion_r1855392414

## Summary
The condition name had a tab in it instead of a space. This makes it a different condition, which seems to be an accident. This is also the only place it is used with a tab.

## Testing Done
N/A

## Save File
N/A