### PR TITLE
style(doxygen): Allow doxygen single line comments from style checker

### DIFF
--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -36,9 +36,9 @@ public:
 	};
 
 	enum class DateFormat : int_fast8_t {
-		DMY = 0, // Day-first format. (Sat, 4 Oct 1941)
-		MDY,     // Month-first format. (Sat, Oct 4, 1941)
-		YMD      // All-numeric ISO 8601. (1941-10-04)
+		DMY = 0, ///< Day-first format. (Sat, 4 Oct 1941)
+		MDY,     ///< Month-first format. (Sat, Oct 4, 1941)
+		YMD      ///< All-numeric ISO 8601. (1941-10-04)
 	};
 
 	enum class OverlayState : int_fast8_t {
@@ -110,21 +110,18 @@ public:
 	static bool Has(const std::string &name);
 	static void Set(const std::string &name, bool on = true);
 
-	// Toggle the ammo usage preferences, cycling between "never," "frugally,"
-	// and "always."
+	/// Toggle the ammo usage preferences, cycling between "never," "frugally," and "always."
 	static void ToggleAmmoUsage();
 	static std::string AmmoUsage();
 
-	// Date format preferences.
+	/// Date format preferences.
 	static void ToggleDateFormat();
 	static DateFormat GetDateFormat();
 	static const std::string &DateFormatSetting();
 
-	// Scroll speed preference.
 	static int ScrollSpeed();
 	static void SetScrollSpeed(int speed);
 
-	// View zoom.
 	static double ViewZoom();
 	static bool ZoomViewIn();
 	static bool ZoomViewOut();
@@ -135,7 +132,7 @@ public:
 	static void ToggleScreenMode();
 	static const std::string &ScreenModeSetting();
 
-	// VSync setting, either "on", "off", or "adaptive".
+	/// VSync setting, either "on", "off", or "adaptive".
 	static bool ToggleVSync();
 	static VSync VSyncState();
 	static const std::string &VSyncSetting();
@@ -148,37 +145,37 @@ public:
 	static OverlayState StatusOverlaysState(OverlayType type);
 	static const std::string &StatusOverlaysSetting(OverlayType type);
 
-	// Auto aim setting, either "off", "always on", or "when firing".
+	/// Auto aim setting, either "off", "always on", or "when firing".
 	static void ToggleAutoAim();
 	static AutoAim GetAutoAim();
 	static const std::string &AutoAimSetting();
 
-	// Auto fire setting, either "off", "on", "guns only", or "turrets only".
+	/// Auto fire setting, either "off", "on", "guns only", or "turrets only".
 	static void ToggleAutoFire();
 	static AutoFire GetAutoFire();
 	static const std::string &AutoFireSetting();
 
-	// Background parallax setting, either "fast", "fancy", or "off".
+	/// Background parallax setting, either "fast", "fancy", or "off".
 	static void ToggleParallax();
 	static BackgroundParallax GetBackgroundParallax();
 	static const std::string &ParallaxSetting();
 
-	// Extended jump effects setting, either "off", "medium", or "heavy".
+	/// Extended jump effects setting, either "off", "medium", or "heavy".
 	static void ToggleExtendedJumpEffects();
 	static ExtendedJumpEffects GetExtendedJumpEffects();
 	static const std::string &ExtendedJumpEffectsSetting();
 
-	// Boarding target setting, either "proximity", "value" or "mixed".
+	/// Boarding target setting, either "proximity", "value" or "mixed".
 	static void ToggleBoarding();
 	static BoardingPriority GetBoardingPriority();
 	static const std::string &BoardingSetting();
 
-	// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
+	/// Flotsam setting, either "off", "on", "flagship only", or "escorts only".
 	static void ToggleFlotsam();
 	static FlotsamCollection GetFlotsamCollection();
 	static const std::string &FlotsamSetting();
 
-	// Red alert siren and symbol
+	/// Red alert siren and symbol
 	static void ToggleAlert();
 	static AlertIndicator GetAlertIndicator();
 	static const std::string &AlertSetting();

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -227,6 +227,8 @@ def sanitize(lines, skip_checks=False):
 				continue
 			# Handling comments
 			first_two = line[i:i + 2]
+			first_three = line[i:i + 3]
+			first_four = line[i:i + 4]
 			if is_multiline_comment:
 				if first_two == "*/":
 					if not skip_checks:
@@ -239,7 +241,25 @@ def sanitize(lines, skip_checks=False):
 					i += 1
 					start_index = i + 1
 				continue
-			if (not is_string) and first_two == "//":
+			if (not is_string) and first_four == "///<":
+				segments.append(line[start_index:i].rstrip())
+				if not skip_checks:
+					# Checking for space after comment
+					if len(line) > i + 4:
+						if re.search(after_comment, line[i + 4:i + 5]):
+							errors.append(Error(line[i:i + 5], line_count,
+												"missing space after beginning of single-line Doxygen back comment"))
+				break
+			else if (not is_string) and first_three == "///":
+				segments.append(line[start_index:i].rstrip())
+				if not skip_checks:
+					# Checking for space after comment
+					if len(line) > i + 3:
+						if re.search(after_comment, line[i + 3:i + 4]):
+							errors.append(Error(line[i:i + 4], line_count,
+												"missing space after beginning of single-line Doxygen comment"))
+				break
+			else if (not is_string) and first_two == "//":
 				segments.append(line[start_index:i].rstrip())
 				if not skip_checks:
 					# Checking for space after comment

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -250,7 +250,7 @@ def sanitize(lines, skip_checks=False):
 							errors.append(Error(line[i:i + 5], line_count,
 												"missing space after beginning of single-line Doxygen back comment"))
 				break
-			else if (not is_string) and first_three == "///":
+			elif (not is_string) and first_three == "///":
 				segments.append(line[start_index:i].rstrip())
 				if not skip_checks:
 					# Checking for space after comment
@@ -259,7 +259,7 @@ def sanitize(lines, skip_checks=False):
 							errors.append(Error(line[i:i + 4], line_count,
 												"missing space after beginning of single-line Doxygen comment"))
 				break
-			else if (not is_string) and first_two == "//":
+			elif (not is_string) and first_two == "//":
 				segments.append(line[start_index:i].rstrip())
 				if not skip_checks:
 					# Checking for space after comment

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -240,7 +240,7 @@ def sanitize(lines, skip_checks=False):
 					start_index = i + 1
 				continue
 			commentMatch = re.search("^//(/<?)?", line[i:i + 4])
-			if (not is_string and not commentMatch is None):
+			if (not is_string and commentMatch):
 				segments.append(line[start_index:i].rstrip())
 				if not skip_checks:
 					cLen = commentMatch.end()

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -106,6 +106,7 @@ segment_exclude = [re.compile(regex) for regex in [
 after_comment = re.compile("[^\\s#]")
 whitespace_only = re.compile("^\\s*$")
 whitespaces = re.compile("\\s+")
+singleLineComment = re.compile("^//(/<?)?")
 
 # List of "" and <> includes to be treated as the other type;
 # that is, any listed "" include should be grouped with <> includes,
@@ -239,7 +240,7 @@ def sanitize(lines, skip_checks=False):
 					i += 1
 					start_index = i + 1
 				continue
-			commentMatch = re.search("^//(/<?)?", line[i:i + 4])
+			commentMatch = re.search(singleLineComment, line[i:i + 4])
 			if (not is_string and commentMatch):
 				segments.append(line[start_index:i].rstrip())
 				if not skip_checks:

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -227,8 +227,6 @@ def sanitize(lines, skip_checks=False):
 				continue
 			# Handling comments
 			first_two = line[i:i + 2]
-			first_three = line[i:i + 3]
-			first_four = line[i:i + 4]
 			if is_multiline_comment:
 				if first_two == "*/":
 					if not skip_checks:
@@ -241,33 +239,17 @@ def sanitize(lines, skip_checks=False):
 					i += 1
 					start_index = i + 1
 				continue
-			if (not is_string) and first_four == "///<":
+			commentMatch = re.search("^//(/<?)?", line[i:i + 4])
+			if (not is_string and not commentMatch is None):
 				segments.append(line[start_index:i].rstrip())
 				if not skip_checks:
+					cLen = commentMatch.end()
 					# Checking for space after comment
-					if len(line) > i + 4:
-						if re.search(after_comment, line[i + 4:i + 5]):
-							errors.append(Error(line[i:i + 5], line_count,
-												"missing space after beginning of single-line Doxygen back comment"))
-				break
-			elif (not is_string) and first_three == "///":
-				segments.append(line[start_index:i].rstrip())
-				if not skip_checks:
-					# Checking for space after comment
-					if len(line) > i + 3:
-						if re.search(after_comment, line[i + 3:i + 4]):
-							errors.append(Error(line[i:i + 4], line_count,
-												"missing space after beginning of single-line Doxygen comment"))
-				break
-			elif (not is_string) and first_two == "//":
-				segments.append(line[start_index:i].rstrip())
-				if not skip_checks:
-					# Checking for space after comment
-					if len(line) > i + 2:
-						if re.search(after_comment, line[i + 2:i + 3]):
-							errors.append(Error(line[i:i + 3], line_count,
+					if len(line) > (i + cLen):
+						if re.search(after_comment, line[i + cLen:i + cLen + 1]):
+							errors.append(Error(line[i:i + cLen + 1], line_count,
 												"missing space after beginning of single-line comment"))
-				break
+				break;
 			elif (not is_string) and first_two == "/*":
 				segments.append(line[start_index:i].rstrip())
 				is_multiline_comment = True

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -249,7 +249,7 @@ def sanitize(lines, skip_checks=False):
 						if re.search(after_comment, line[i + cLen:i + cLen + 1]):
 							errors.append(Error(line[i:i + cLen + 1], line_count,
 												"missing space after beginning of single-line comment"))
-				break;
+				break
 			elif (not is_string) and first_two == "/*":
 				segments.append(line[start_index:i].rstrip())
 				is_multiline_comment = True


### PR DESCRIPTION
**Feature**

This PR updates the style checker for Doxygen comments as discussed in #10497

## Summary
Updates the style checker to allow `///` and `///<` comments in addition to `//` comments. Also updated Preferences.h to follow this new format (both as an example, and to verify that the style checker is doing what it should be doing.)

## Screenshots
N/A

## Usage examples
N/A (use Doxygen as discussed and specified)

## Testing Done
I verified that the script still runs without issues.

## Wiki Update
I'm not sure if the Wiki update was already done as part of #10497. If not, then that also needs to happen before those new comment formats are actually allowed.

## Performance Impact
N/A, this is a style checker during compilation. (So doesn't impact our end-users.)