### PR TITLE
fix(bug): Use "AA" instead of "aa" in the Spaceport Reminder Resetter

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4353,8 +4353,8 @@ mission "Spaceport Reminder Setter"
 		"spaceport reminder month" = "month"
 		fail
 
-# Use of "aa" at the start of the mission name is to make it offer only if no other missions have.
-mission "aa Spaceport Reminder Resetter"
+# Use of "AA" at the start of the mission name is to make it offer only if no other missions have.
+mission "AA Spaceport Reminder Resetter"
 	minor
 	invisible
 	repeat


### PR DESCRIPTION
**Bug Fix**

Should fix #10816.

## Summary
In #10369, numbers at the beginning of mission names were removed. `00 Spaceport Reminder Resetter` was changed to `aa Spaceport Reminder Resetter`. @warp-core pointed out that `minor` missions are offered in reverse alphabetical order. Well, all vanilla mission names start with capital letters, so using "aa" blocks them.
This pull request fixes that by changing the mission to begin with "AA" instead of "aa".