### PR TITLE
Fix boarding panel buttons

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1147,7 +1147,7 @@ interface "boarding"
 		dimensions 80 30
 	
 	active if "can defend"
-	button d "_Defend"
+	button D "_Defend"
 		center 210 185
 		dimensions 80 30
 

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -305,6 +305,8 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		// to your ship in peace. That is to allow the player to "cancel" if
 		// they did not really mean to try to capture the ship.
 		bool youAttack = (key == 'a' && (yourStartCrew > 1 || !victim->RequiredCrew()));
+		if(key == 'a' && !youAttack)
+			return true;
 		bool enemyAttacks = defenseOdds.Odds(enemyStartCrew, yourStartCrew) > .5;
 		if(isFirstCaptureAction && !youAttack)
 			enemyAttacks = false;

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -295,7 +295,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		messages.push_back("The airlock blasts open. Combat has begun!");
 		messages.push_back("(It will end if you both choose to \"defend.\")");
 	}
-	else if((key == 'a' || key == 'd') && CanAttack())
+	else if((key == 'a' || key == 'd' || key == 'D') && CanAttack())
 	{
 		int yourStartCrew = you->Crew();
 		int enemyStartCrew = victim->Crew();


### PR DESCRIPTION
**Bug fix**

## Summary
This PR fixes two issues on the boarding panel:
1. In the boarding panel, when not in combat, clicking the "Defend" button sends the 'd' key as input, which results in the panel being closed as though you pressed 'd' or clicked the "Done" button.
This PR changes the "Defend" key to sending 'D', so as to not trigger the exit condition when not in combat. The 'd' key on your keyboard will still count as "Defend" when in combat.
2. When in combat, clicking the "Attack" button when attacking is not possible (because you only have one crew and the target ship requires crew) will defend. This PR changes it so that nothing happens, instead.

## Testing Done
No.

## Save File
[test test 2.txt](https://github.com/user-attachments/files/17921408/test.test.2.txt)
Try boarding the disabled Vanguard in orbit and see what you can do.
