### PR TITLE
Revert "fix(ui): Don't generate key presses from inactive interfaces …

### DIFF
--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -253,7 +253,7 @@ void BankPanel::Draw()
 		table.Draw("[apply]", selected);
 	}
 
-	info.ClearConditions();
+	Information info;
 	if((crewSalariesOwed || maintenanceDue) && player.Accounts().Credits() > 0)
 		info.SetCondition("can pay");
 	else

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -156,7 +156,7 @@ void BoardingPanel::Draw()
 	}
 
 	// Set which buttons are active.
-	info.ClearConditions();
+	Information info;
 	if(CanExit())
 		info.SetCondition("can exit");
 	if(CanTake())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -179,7 +179,7 @@ void HailPanel::Draw()
 {
 	DrawBackdrop();
 
-	info.ClearConditions();
+	Information info;
 	info.SetString("header", header);
 	if(ship)
 	{

--- a/source/HiringPanel.cpp
+++ b/source/HiringPanel.cpp
@@ -47,7 +47,7 @@ void HiringPanel::Draw()
 {
 	const Ship *flagship = player.Flagship();
 	const Interface *hiring = GameData::Interfaces().Get("hiring");
-	info.ClearConditions();
+	Information info;
 
 	int flagshipBunks = 0;
 	int flagshipRequired = 0;

--- a/source/Information.cpp
+++ b/source/Information.cpp
@@ -152,13 +152,6 @@ bool Information::HasCondition(const string &condition) const
 
 
 
-void Information::ClearConditions()
-{
-	conditions.clear();
-}
-
-
-
 void Information::SetOutlineColor(const Color &color)
 {
 	outlineColor = color;

--- a/source/Information.h
+++ b/source/Information.h
@@ -51,7 +51,6 @@ public:
 
 	void SetCondition(const std::string &condition);
 	bool HasCondition(const std::string &condition) const;
-	void ClearConditions();
 
 	void SetOutlineColor(const Color &color);
 	const Color &GetOutlineColor() const;

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -626,7 +626,7 @@ void Interface::TextElement::Draw(const Rectangle &rect, const Information &info
 void Interface::TextElement::Place(const Rectangle &bounds, Panel *panel) const
 {
 	if(buttonKey && panel)
-		panel->AddZone(bounds, buttonKey, {visibleIf, activeIf});
+		panel->AddZone(bounds, buttonKey);
 }
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -137,7 +137,7 @@ void LoadPanel::Draw()
 	GameData::Background().Draw(Point(), Point());
 	const Font &font = FontSet::Get(14);
 
-	info.ClearConditions();
+	Information info;
 	if(loadedInfo.IsLoaded())
 	{
 		info.SetString("pilot", loadedInfo.Name());

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -333,7 +333,7 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 	// Remember which buttons we're showing.
 	MapPanel::buttonCondition = buttonCondition;
 
-	info.ClearConditions();
+	Information info;
 	info.SetCondition(buttonCondition);
 	const Interface *mapInterface = GameData::Interfaces().Get("map");
 	if(player.MapZoom() >= static_cast<int>(mapInterface->GetValue("max zoom")))

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -127,7 +127,7 @@ void MenuPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 
-	info.ClearConditions();
+	Information info;
 	if(player.IsLoaded() && !player.IsDead())
 	{
 		info.SetCondition("pilot loaded");

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -63,7 +63,7 @@ void MessageLogPanel::Draw()
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + width);
 
-	info.ClearConditions();
+	Information info;
 	if(messages.empty())
 	{
 		info.SetCondition("empty");

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -838,7 +838,7 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos, const std::li
 
 void MissionPanel::DrawMissionInfo()
 {
-	info.ClearConditions();
+	Information info;
 
 	// The "accept / abort" button text and activation depends on what mission,
 	// if any, is selected, and whether missions are available.

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -101,15 +101,9 @@ void Panel::AddZone(const Rectangle &rect, const function<void()> &fun)
 
 
 
-void Panel::AddZone(const Rectangle &rect, SDL_Keycode key, const vector<string> &conditionsToEnable)
+void Panel::AddZone(const Rectangle &rect, SDL_Keycode key)
 {
-	AddZone(rect, [this, key, conditionsToEnable]()
-	{
-		for(const string &condition : conditionsToEnable)
-			if(!info.HasCondition(condition))
-				return;
-		this->KeyDown(key, 0, Command(), true);
-	});
+	AddZone(rect, [this, key](){ this->KeyDown(key, 0, Command(), true); });
 }
 
 

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -15,7 +15,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "Information.h"
 #include "Rectangle.h"
 
 #include <functional>
@@ -69,7 +68,7 @@ public:
 	void ClearZones();
 	// Add a clickable zone to the panel.
 	void AddZone(const Rectangle &rect, const std::function<void()> &fun);
-	void AddZone(const Rectangle &rect, SDL_Keycode key, const std::vector<std::string> &conditionsToEnable = {});
+	void AddZone(const Rectangle &rect, SDL_Keycode key);
 	// Check if a click at the given coordinates triggers a clickable zone. If
 	// so, apply that zone's action and return true.
 	bool ZoneClick(const Point &point);
@@ -150,10 +149,6 @@ private:
 	// object. Recursion stops as soon as any child returns true.
 	template<typename...FARGS, typename...ARGS>
 	bool EventVisit(bool(Panel::*f)(FARGS ...args), ARGS ...args);
-
-
-protected:
-	Information info;
 
 
 private:

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -110,7 +110,7 @@ void PlanetPanel::Step()
 
 void PlanetPanel::Draw()
 {
-	info.ClearConditions();
+	Information info;
 	info.SetSprite("land", planet.Landscape());
 
 	const Ship *flagship = player.Flagship();

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -198,8 +198,8 @@ void PlayerInfoPanel::Draw()
 	DrawBackdrop();
 
 	// Fill in the information for how this interface should be drawn.
-	info.ClearConditions();
-	info.SetCondition("player tab");
+	Information interfaceInfo;
+	interfaceInfo.SetCondition("player tab");
 	if(panelState.CanEdit() && !panelState.Ships().empty())
 	{
 		bool allParked = true;
@@ -217,8 +217,8 @@ void PlayerInfoPanel::Draw()
 			}
 		if(hasOtherShips)
 		{
-			info.SetCondition(allParked ? "show unpark all" : "show park all");
-			info.SetCondition(allParkedSystem ? "show unpark system" : "show park system");
+			interfaceInfo.SetCondition(allParked ? "show unpark all" : "show park all");
+			interfaceInfo.SetCondition(allParkedSystem ? "show unpark system" : "show park system");
 		}
 
 		// If ships are selected, decide whether the park or unpark button
@@ -238,8 +238,8 @@ void PlayerInfoPanel::Draw()
 			}
 			if(parkable)
 			{
-				info.SetCondition("can park");
-				info.SetCondition(allParked ? "show unpark" : "show park");
+				interfaceInfo.SetCondition("can park");
+				interfaceInfo.SetCondition(allParked ? "show unpark" : "show park");
 			}
 		}
 
@@ -247,16 +247,16 @@ void PlayerInfoPanel::Draw()
 		// show the save order button. Any manual sort by the player
 		// is applied immediately and doesn't need this button.
 		if(panelState.CanEdit() && panelState.CurrentSort())
-			info.SetCondition("show save order");
+			interfaceInfo.SetCondition("show save order");
 	}
 
-	info.SetCondition("three buttons");
+	interfaceInfo.SetCondition("three buttons");
 	if(player.HasLogs())
-		info.SetCondition("enable logbook");
+		interfaceInfo.SetCondition("enable logbook");
 
 	// Draw the interface.
 	const Interface *infoPanelUi = GameData::Interfaces().Get("info panel");
-	infoPanelUi->Draw(info, this);
+	infoPanelUi->Draw(interfaceInfo, this);
 
 	// Draw the player and fleet info sections.
 	menuZones.clear();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -138,7 +138,7 @@ void PreferencesPanel::Draw()
 	glClear(GL_COLOR_BUFFER_BIT);
 	GameData::Background().Draw(Point(), Point());
 
-	info.ClearConditions();
+	Information info;
 	info.SetBar("volume", Audio::Volume());
 	if(Plugins::HasChanged())
 		info.SetCondition("show plugins changed");

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -92,32 +92,32 @@ void ShipInfoPanel::Draw()
 	DrawBackdrop();
 
 	// Fill in the information for how this interface should be drawn.
-	info.ClearConditions();
-	info.SetCondition("ship tab");
+	Information interfaceInfo;
+	interfaceInfo.SetCondition("ship tab");
 	if(panelState.CanEdit() && shipIt != panelState.Ships().end()
 			&& (shipIt->get() != player.Flagship() || (*shipIt)->IsParked()))
 	{
 		if(!(*shipIt)->IsDisabled())
-			info.SetCondition("can park");
-		info.SetCondition((*shipIt)->IsParked() ? "show unpark" : "show park");
-		info.SetCondition("show disown");
+			interfaceInfo.SetCondition("can park");
+		interfaceInfo.SetCondition((*shipIt)->IsParked() ? "show unpark" : "show park");
+		interfaceInfo.SetCondition("show disown");
 	}
 	else if(!panelState.CanEdit())
 	{
-		info.SetCondition("show dump");
+		interfaceInfo.SetCondition("show dump");
 		if(CanDump())
-			info.SetCondition("enable dump");
+			interfaceInfo.SetCondition("enable dump");
 	}
 	if(player.Ships().size() > 1)
-		info.SetCondition("five buttons");
+		interfaceInfo.SetCondition("five buttons");
 	else
-		info.SetCondition("three buttons");
+		interfaceInfo.SetCondition("three buttons");
 	if(player.HasLogs())
-		info.SetCondition("enable logbook");
+		interfaceInfo.SetCondition("enable logbook");
 
 	// Draw the interface.
 	const Interface *infoPanelUi = GameData::Interfaces().Get("info panel");
-	infoPanelUi->Draw(info, this);
+	infoPanelUi->Draw(interfaceInfo, this);
 
 	// Draw all the different information sections.
 	ClearZones();
@@ -130,7 +130,7 @@ void ShipInfoPanel::Draw()
 	DrawCargo(cargoBounds);
 
 	// If the player hovers their mouse over a ship attribute, show its tooltip.
-	infoDisplay.DrawTooltips();
+	info.DrawTooltips();
 }
 
 
@@ -288,7 +288,7 @@ bool ShipInfoPanel::Click(int x, int y, int /* clicks */)
 bool ShipInfoPanel::Hover(int x, int y)
 {
 	Point point(x, y);
-	infoDisplay.Hover(point);
+	info.Hover(point);
 	return Hover(point);
 }
 
@@ -321,7 +321,7 @@ void ShipInfoPanel::UpdateInfo()
 		return;
 
 	const Ship &ship = **shipIt;
-	infoDisplay.Update(ship, player);
+	info.Update(ship, player);
 	if(player.Flagship() && ship.GetSystem() == player.GetSystem() && &ship != player.Flagship())
 		player.Flagship()->SetTargetShip(*shipIt);
 
@@ -363,7 +363,7 @@ void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 
 	table.DrawTruncatedPair("ship:", dim, ship.Name(), bright, Truncate::MIDDLE, true);
 
-	infoDisplay.DrawAttributes(table.GetRowBounds().TopLeft() - Point(10., 10.));
+	info.DrawAttributes(table.GetRowBounds().TopLeft() - Point(10., 10.));
 }
 
 
@@ -763,7 +763,7 @@ void ShipInfoPanel::Dump()
 	selectedCommodity.clear();
 	selectedPlunder = nullptr;
 
-	infoDisplay.Update(**shipIt, player);
+	info.Update(**shipIt, player);
 	if(loss)
 		Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
 			, Messages::Importance::High);
@@ -779,7 +779,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 	{
 		loss += count * selectedPlunder->Cost();
 		(*shipIt)->Jettison(selectedPlunder, count);
-		infoDisplay.Update(**shipIt, player);
+		info.Update(**shipIt, player);
 
 		if(loss)
 			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
@@ -799,7 +799,7 @@ void ShipInfoPanel::DumpCommodities(int count)
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
 		(*shipIt)->Jettison(selectedCommodity, count);
-		infoDisplay.Update(**shipIt, player);
+		info.Update(**shipIt, player);
 
 		if(loss)
 			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -84,7 +84,7 @@ private:
 	std::vector<std::shared_ptr<Ship>>::const_iterator shipIt;
 
 	// Information about the currently selected ship.
-	ShipInfoDisplay infoDisplay;
+	ShipInfoDisplay info;
 	std::map<std::string, std::vector<const Outfit *>> outfits;
 
 	// Track all the clickable parts of the UI (other than the buttons).

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -296,7 +296,7 @@ void StartConditionsPanel::ScrollToSelected()
 void StartConditionsPanel::Select(StartConditionsList::iterator it)
 {
 	// Clear the displayed information.
-	info.ClearConditions();
+	info = Information();
 
 	startIt = it;
 	if(startIt == scenarios.end())

--- a/source/StartConditionsPanel.h
+++ b/source/StartConditionsPanel.h
@@ -71,6 +71,8 @@ private:
 	const Color &selectedBackground;
 	// The selected scenario's description.
 	WrappedText description;
+	// Displayed information for the selected scenario.
+	Information info;
 
 	bool hasHover = false;
 	Point hoverPoint;

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -209,7 +209,7 @@ void TradingPanel::Draw()
 	if(showProfit)
 		font.Draw("Profit", Point(MIN_X + PROFIT_X, FIRST_Y), selected);
 
-	info.ClearConditions();
+	Information info;
 	if(sellOutfits)
 		info.SetCondition("can sell outfits");
 	else if(player.Cargo().HasOutfits() || canSell)


### PR DESCRIPTION
…(#10491)"

This reverts commit c63e24bae08974d815b0eea0bced45294ed31d80.

**Bug fix**

## Summary
#10491 changes how Interface buttons and interface Information objects are handled, in particular, visible but inactive buttons will no longer send key presses to the UI. The goal was to prevent buttons doing things when they are inactive.
This goal is incomplete because it is still possible to send those key presses with the keyboard, even if clicking the buttons won't do it. This means that the "KeyDown" method of the relevant Panel still needs to check if the action is allowed. This means there isn't much use for not sending keypresses from buttons, except in cases where the character cannot be sent by an ordinary keyboard (though, an on-screen keyboard may still send such characters).

Additionally, it is intended that visible but inactive buttons can still send keypresses so the Panel might be able to give feedback, such as why the button has no effect (I don't think we currently use this functionality, but it could be used in, for example, the shop panels, where the buy and sell buttons still provide feedback when "inactive".)

Furthermore, the changes in #10491 included local interface Information objects being replaced by a protected class field in Panel, inherited by all its derivatives. This was so that Panel could examine the conditions at click time to determine if each click zone is active. Each Panel object would clear these conditions and repopulate them as appropriate on every frame. However, this implies a one-to-one-to-one relationship between a Panel, an Interface, and an interface Information object. While any given Interface will only ever use one Information object, it's not true that each Panel will only ever want to draw one Interface. As a result, giving each Panel a single persistent Information object is problematic because it suggests multiple Interfaces should be drawn with the same Information. Where the properties and parameters of those Interfaces share no overlap, this is not a problem, but it'd be very easily for the conditions or other properties set for one Interface to collide or override information for another Interface.

Finally, @Arachi-Lover has reported on Discord that the Accept and Abort buttons in the mission panel (job board) do not work. It is still possible to accept jobs with the 'a' key, but not by clicking on the accept button. This is because MapPanel::FinishLoading, which MissionPanel inherits, is clearing the conditions of the Information object after MissionPanel has configured and drawn itself. As a result, when those buttons are clicked and Panel checks the conditions that have been set, it does not see the conditions that would make either of those butons active, and so considers them inactive and does not pass along the key presses. This particular issue could be resolved by ensuring that the Panels that extend MapPanel all only contain a single call to "info.ClearConditions", probably at the beginning of MapPanel::Draw, but this leaves, I think, too much room for similar errors in the future.
Between this and what I have described furhter above, I think it's best to revert this change.

The problem that that PR was seeking to fix was that, in the boarding panel, clicking the "Attack" button still does something even when you shouldn't be able to attack (because you only have one crew and the other ship requires crew). However, this has always simply led to the player's ship defending (there is nothing else you can do in this situation, anyway).
Another issue was that clicking the "Defend" button when not in combat would close the panel as though you clicked the "Done" button or pressed the 'd' key.
I believe both of these issues would be better corrected in another way: #10820

## Testing Done
No.
