### PR TITLE
Don't override ship cargo display with pooled cargo when not appropriate

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -570,7 +570,7 @@ void ShipInfoPanel::DrawCargo(const Rectangle &bounds)
 	Color backColor = *GameData::Colors().Get("faint");
 	const Ship &ship = **shipIt;
 
-	// Cargo list: Show pooled cargo instead if the ship to display is landed together with the flagship.
+	// Cargo list: show pooled cargo instead if the ship to display is landed together with the flagship.
 	const bool showPooled = ship.GetPlanet() == player.GetPlanet() && player.Cargo().Used();
 	const CargoHold &cargo = (showPooled ? player.Cargo() : ship.Cargo());
 	Table table;

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -571,7 +571,7 @@ void ShipInfoPanel::DrawCargo(const Rectangle &bounds)
 	const Ship &ship = **shipIt;
 
 	// Cargo list: Show pooled cargo instead if the ship to display is landed together with the flagship.
-	const bool showPooled = (ship.GetSystem() == player.GetSystem() && player.Cargo().Used());
+	const bool showPooled = ship.GetPlanet() == player.GetPlanet() && player.Cargo().Used();
 	const CargoHold &cargo = (showPooled ? player.Cargo() : ship.Cargo());
 	Table table;
 	table.AddColumn(0, {COLUMN_WIDTH, Alignment::LEFT});

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -570,8 +570,9 @@ void ShipInfoPanel::DrawCargo(const Rectangle &bounds)
 	Color backColor = *GameData::Colors().Get("faint");
 	const Ship &ship = **shipIt;
 
-	// Cargo list.
-	const CargoHold &cargo = (player.Cargo().Used() ? player.Cargo() : ship.Cargo());
+	// Cargo list: Show pooled cargo instead if the ship to display is landed together with the flagship.
+	const bool showPooled = (ship.GetSystem() == player.GetSystem() && player.Cargo().Used());
+	const CargoHold &cargo = (showPooled ? player.Cargo() : ship.Cargo());
 	Table table;
 	table.AddColumn(0, {COLUMN_WIDTH, Alignment::LEFT});
 	table.AddColumn(COLUMN_WIDTH, {COLUMN_WIDTH, Alignment::RIGHT});


### PR DESCRIPTION
**Bug fix**

## Summary
The ship info display ("I" - click a ship) shows either the pooled cargo hold while landed or the individual ship's cargo hold. The decision is based on whether the pooled cargo is empty or not. This leads to the info being basically incorrect for escorts in other systems.

## Screenshots
<details>

After a farming run, where I accidentally captured one of the already plundered ships, so it stayed in Deneb:

Before:
![image](https://github.com/user-attachments/assets/46ed2603-4b1a-4791-97c6-6712ba4e33fe)

After:
![image](https://github.com/user-attachments/assets/c005c16a-76be-4895-926a-6cc465a6f9b2)

</details>

## Testing Done
See screenshots

## Performance Impact
Negligible
