### PR TITLE
Warn users that SCons is deprecated and point them to the CMake instructions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,3 +1,5 @@
+print('WARNING: Support for using SCons to build Endless Sky is deprecated and will be removed in the future. See "docs/readme-cmake.md" for instructions on configuring CMake.')
+
 import os
 import platform
 from SCons.Node.FS import Dir


### PR DESCRIPTION
**Documentation**

This PR is inspired by https://github.com/endless-sky/endless-sky/issues/10823#issuecomment-2506543588.

## Summary
Users who just pull & build and don't track the development actively may not notice that we are deprecating SCons and they should migrate to CMake. If we want to give them some time to figure out CMake, we need to tell them they should do it, instead of just removing SCons support one day and leaving these people in not quite nice situation.

## Screenshots
![image](https://github.com/user-attachments/assets/bdf1e84d-aef7-4a8b-8b0e-b33f673e6c8c)

## Testing Done
See the screenshot above.

## Wiki Update
N/A, the SCons readme already says it's deprecated.
