### PR TITLE
feat(ci): More aggressive timeouts for integration tests

### DIFF
--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -27,7 +27,7 @@ foreach(test ${INTEGRATION_TESTS_LIST})
 		set(SET_TEST_PROPS
 	"set_tests_properties([==[${test}]==] PROPERTIES
 		WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
-		TIMEOUT 15
+		TIMEOUT 30
 		LABELS integration)")
 
 	# Launches the integration tests in debug mode, so that they can be followed.

--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -27,6 +27,7 @@ foreach(test ${INTEGRATION_TESTS_LIST})
 		set(SET_TEST_PROPS
 	"set_tests_properties([==[${test}]==] PROPERTIES
 		WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
+		TIMEOUT 15
 		LABELS integration)")
 
 	# Launches the integration tests in debug mode, so that they can be followed.


### PR DESCRIPTION
**CI/CD/Testing**

This PR makes it easier to debug integration test failures by configuring their timeout.

## Summary
Our (non-debug) integration tests pass in less than10 seconds consistently. Their timeout is 1500 seconds however, which makes for a really long wait if they get hanged up on something.

This PR changes the timeout to 15 seconds, which shouldn't fail well-behaved tests, but should immediately alert us when things go wrong. It also allows for executing the remaining tests without running into github's runner timeouts.

## Testing Done
I tested that the tests now compute the timeout to 15 seconds.

## Performance Impact
Nothing for passing tests, and massively faster progression for hanging tests.