### PR TITLE
test(integration/ci): Option to print debug messages from integration tests

### DIFF
--- a/source/test/Test.cpp
+++ b/source/test/Test.cpp
@@ -485,7 +485,7 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 				break;
 			case TestStep::Type::DEBUG:
 				// Print debugging output directly to the terminal.
-				cout << stepToRun.nameOrLabel << '\n';
+				cout << stepToRun.nameOrLabel << endl;
 				cout.flush();
 				++(context.callstack.back().step);
 				break;

--- a/source/test/Test.cpp
+++ b/source/test/Test.cpp
@@ -29,6 +29,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <SDL2/SDL.h>
 
 #include <algorithm>
+#include <iostream>
 #include <map>
 #include <numeric>
 #include <set>
@@ -50,6 +51,7 @@ namespace {
 		{Test::TestStep::Type::ASSERT, "assert"},
 		{Test::TestStep::Type::BRANCH, "branch"},
 		{Test::TestStep::Type::CALL, "call"},
+		{Test::TestStep::Type::DEBUG, "debug"},
 		{Test::TestStep::Type::INJECT, "inject"},
 		{Test::TestStep::Type::INPUT, "input"},
 		{Test::TestStep::Type::LABEL, "label"},
@@ -239,6 +241,16 @@ void Test::LoadSequence(const DataNode &node)
 				{
 					status = Status::BROKEN;
 					child.PrintTrace("Error: Invalid use of \"call\" without name of called (sub)test:");
+					return;
+				}
+				else
+					step.nameOrLabel = child.Token(1);
+				break;
+			case TestStep::Type::DEBUG:
+				if(child.Size() < 2)
+				{
+					status = Status::BROKEN;
+					child.PrintTrace("Error: Invalid use of \"debug\" without an actual message to print:");
 					return;
 				}
 				else
@@ -470,6 +482,12 @@ void Test::Step(TestContext &context, PlayerInfo &player, Command &commandToGive
 					// Break the loop to switch to the test just pushed.
 				}
 				continueGameLoop = true;
+				break;
+			case TestStep::Type::DEBUG:
+				// Print debugging output directly to the terminal.
+				cout << stepToRun.nameOrLabel << '\n';
+				cout.flush();
+				++(context.callstack.back().step);
 				break;
 			case TestStep::Type::INJECT:
 				{

--- a/source/test/Test.h
+++ b/source/test/Test.h
@@ -62,6 +62,8 @@ public:
 			BRANCH,
 			// Step that calls another test to handle some generic common actions.
 			CALL,
+			// Step that prints a debug-message to the output.
+			DEBUG,
 			// Step that adds game-data, either in the config-directories or in the game directly.
 			INJECT,
 			// Step that performs input (key, mouse, command). Does cause the game to step (to process the inputs).

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_afterburn_flight.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_afterburn_flight.txt
@@ -109,6 +109,7 @@ test "Afterburner-flight - Simple depart land"
 		inject "burning flyers save"
 		call "Load First Savegame"
 		call "Depart"
+		debug "Departed from the planet"
 		# Wait for 10 seconds to drift away from the planet.
 		apply
 			"test: steps to wait" = 20
@@ -121,6 +122,8 @@ test "Afterburner-flight - Simple depart land"
 			"test: steps to wait" > 0
 		navigate
 			"travel destination" Ruin
+		debug "Start landing"
 		call "Land"
+		debug "Done landing"
 		assert
 			"flagship landed" == 1


### PR DESCRIPTION
**Feature**

This PR adds an option to the integration test framework to print messages to a terminal

## Summary
Integration tests running in CI were not very transparent, they either pass, fail or timeout, but it is not always clear why a test passes or fails. This PR adds an option to include debug-messages within integration tests to allow some more information about the internals of the test to be printed to the outside world.

## Screenshots
The output should look a bit like:
```
# Running test "Afterburner-flight - Simple depart land":
#     Departed from the planet
#     Start landing
#     Done landing
ok 2 Afterburner-flight - Simple depart land
```

## Usage examples
Add `debug` statements in integration tests, but please don't add them in long loops.

## Testing Done
Ran the integration test (in debug mode) and noticed the output messages appearing on the terminal.

## Wiki Update
I don't think the integration tests are documented on the wiki.

## Performance Impact
Test-code only. Should not impact the main game.