### PR TITLE
refactor(random): Move random from ConditionSet to on-demand auto-conditions

### DIFF
--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -19,7 +19,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "Logger.h"
-#include "Random.h"
 
 #include <algorithm>
 #include <cmath>
@@ -160,9 +159,7 @@ namespace {
 		for(const string &str : side)
 		{
 			int64_t value = 0;
-			if(str == "random")
-				value = Random::Int(100);
-			else if(DataNode::IsNumber(str))
+			if(DataNode::IsNumber(str))
 				value = static_cast<int64_t>(DataNode::Value(str));
 			else
 			{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3940,6 +3940,14 @@ void PlayerInfo::RegisterDerivedConditions()
 		return true;
 	});
 
+	// A condition for returning a random integer in the range [0, 100).
+	auto &&randomProvider = conditions.GetProviderNamed("random");
+	auto randomFun = [this](const string &name) -> int64_t
+	{
+		return Random::Int(100);
+	};
+	randomProvider.SetGetFunction(randomFun);
+
 	// A condition for returning a random integer in the range [0, input). Input may be a number,
 	// or it may be the name of a condition. For example, "roll: 100" would roll a random
 	// integer in the range [0, 100), but if you had a condition "max roll" with a value of 100,

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3942,7 +3942,7 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// A condition for returning a random integer in the range [0, 100).
 	auto &&randomProvider = conditions.GetProviderNamed("random");
-	auto randomFun = [this](const string &name) -> int64_t
+	auto randomFun = [](const string &name) -> int64_t
 	{
 		return Random::Int(100);
 	};


### PR DESCRIPTION
**Refactor**

This PR moves the random function, which is helpful for #10810 (since it avoids a special case there)

## Summary
The on-demand auto-conditions already have a `roll: [nr]` and `roll: [condition]` function, but the `random` function was implemented as a special case in ConditionSet (that code was from before on-demand auto-conditions existed) and not available as a generic condition.

This PR moves the random function to a read-only on-demand auto-condition, similar to how the `roll:` function works.

## Usage examples
Just use `random` as before. The change should not be visible externally.

## Testing Done
Integration tests `"Clear flagship model condition"` and `"Landing in a system with multiple planets"` have a very large change of failing when random is not really returning random numbers. See #10835 for details. Those tests currently however still have about 2% chance of still failing anyway.

## Save File
N/A (this moves a random function)

## Wiki Update
The `random` function still works as documented on the Wiki. But the test-framework can now also call random (and actually get a random number returned).

## Performance Impact
Running `random` now has an extra lookup, but regular conditions now have a comparison less. I expect no noticeable impact overall.