### PR TITLE
Outfitter: highlight differences in a group of same-model ships

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -51,6 +51,7 @@ color "logbook background" .125 .125 .125 1.
 color "logbook line" .2 .2 .2 1.
 color "message log background" .125 .125 .125 1.
 color "item selected" 0. 0. 0. .3
+color "outfitter difference highlight" 1. .5 0. 1.
 
 # Colors used to draw certain HUD elements in-flight.
 color "shields" .43 .55 .85 .8

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -169,7 +169,6 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 	const Font &font = FontSet::Get(14);
 	const Color &bright = *GameData::Colors().Get("bright");
 	const Color &highlight = *GameData::Colors().Get("outfitter difference highlight");
-	// Highlight outfit differences only if several ships of the same model are selected:
 	bool highlightDifferences = false;
 
 	if(playerShip || isLicense || mapSize)
@@ -186,6 +185,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 			string firstModelName;
 			for(const Ship *ship : playerShips)
 			{
+				// Highlight differences in installed outfit counts only when all selected ships are of the same model.
 				string modelName = ship->TrueModelName();
 				if(firstModelName.empty())
 					firstModelName = modelName;

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -168,6 +168,10 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 
 	const Font &font = FontSet::Get(14);
 	const Color &bright = *GameData::Colors().Get("bright");
+	const Color &highlight = *GameData::Colors().Get("outfitter difference highlight");
+	// Highlight outfit differences only if several ships of the same model are selected:
+	bool highlightDifferences = false;
+
 	if(playerShip || isLicense || mapSize)
 	{
 		int minCount = numeric_limits<int>::max();
@@ -178,8 +182,15 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 			minCount = maxCount = player.HasMapped(mapSize);
 		else
 		{
+			highlightDifferences = true;
+			string lastModelName;
 			for(const Ship *ship : playerShips)
 			{
+				string modelName = ship->TrueModelName();
+				if(lastModelName.empty())
+					lastModelName = modelName;
+				else
+					highlightDifferences = highlightDifferences && (modelName == lastModelName);
 				int count = ship->OutfitCount(outfit);
 				minCount = min(minCount, count);
 				maxCount = max(maxCount, count);
@@ -189,13 +200,19 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 		if(maxCount)
 		{
 			string label = "installed: " + to_string(minCount);
+			auto color = bright;
 			if(maxCount > minCount)
+			{
 				label += " - " + to_string(maxCount);
+				if(highlightDifferences)
+					color = highlight;
+			}
 
 			Point labelPos = point + Point(-OUTFIT_SIZE / 2 + 20, OUTFIT_SIZE / 2 - 38);
-			font.Draw(label, labelPos, bright);
+			font.Draw(label, labelPos, color);
 		}
 	}
+
 	// Don't show the "in stock" amount if the outfit has an unlimited stock.
 	int stock = 0;
 	if(!outfitter.Has(outfit))

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -183,14 +183,14 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 		else
 		{
 			highlightDifferences = true;
-			string lastModelName;
+			string firstModelName;
 			for(const Ship *ship : playerShips)
 			{
 				string modelName = ship->TrueModelName();
-				if(lastModelName.empty())
-					lastModelName = modelName;
+				if(firstModelName.empty())
+					firstModelName = modelName;
 				else
-					highlightDifferences = highlightDifferences && (modelName == lastModelName);
+					highlightDifferences &= (modelName == firstModelName);
 				int count = ship->OutfitCount(outfit);
 				minCount = min(minCount, count);
 				maxCount = max(maxCount, count);
@@ -200,7 +200,7 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 		if(maxCount)
 		{
 			string label = "installed: " + to_string(minCount);
-			auto color = bright;
+			Color color = bright;
 			if(maxCount > minCount)
 			{
 				label += " - " + to_string(maxCount);

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -169,8 +169,8 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 	const Font &font = FontSet::Get(14);
 	const Color &bright = *GameData::Colors().Get("bright");
 	const Color &highlight = *GameData::Colors().Get("outfitter difference highlight");
-	bool highlightDifferences = false;
 
+	bool highlightDifferences = false;
 	if(playerShip || isLicense || mapSize)
 	{
 		int minCount = numeric_limits<int>::max();


### PR DESCRIPTION
**Feature**

## Summary
I often find myself wanting to have a group of ships to be identical - model and outfits. In other words, a successful loadout might be worth having more ships of. To assemble one at a sufficiently stocked port, this is the simplest help I could think of.
This tiny change makes any differences more eye-catching by using a highlight colour for the "installed:" line, but only if all selected ships are of the same base model.

## Screenshots
<details>

![image](https://github.com/user-attachments/assets/d843d2b9-4619-4280-9712-faac3d50723c)
![image](https://github.com/user-attachments/assets/e3d329a1-dcca-472e-8808-4bea7c2e6476)

</details>

## Usage examples
If desired, the new colour "outfitter difference highlight", could be set to 1 1 1 0 in a mod to effectively disable this.

## Testing Done
Had this in my play-branch for three weeks, works fine.

## Save File
This save file can be used to test these changes:
[Gary from Vault 78.txt.zip](https://github.com/user-attachments/files/18027038/Gary.from.Vault.78.txt.zip)

## Performance Impact
irrelevant