### PR TITLE
fix(ui-bug): Fix mission waypoint/stopover/mark pointers disappearing

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1479,12 +1479,12 @@ void MapPanel::DrawMissions()
 			continue;
 
 		auto &&it = missionCount[system];
-		if(it.drawn >= MAX_MISSION_POINTERS_DRAWN - reserved)
-			continue;
-
-		pair<bool, bool> blink = BlinkMissionIndicator(player, mission, step);
-		bool isSatisfied = IsSatisfied(player, mission) && blink.second;
-		DrawPointer(system, it.drawn, blink.first ? black : isSatisfied ? currentColor : blockedColor, isSatisfied);
+		if(it.drawn < it.MaximumActive())
+		{
+			pair<bool, bool> blink = BlinkMissionIndicator(player, mission, step);
+			bool isSatisfied = IsSatisfied(player, mission) && blink.second;
+			DrawPointer(system, it.drawn, blink.first ? black : isSatisfied ? currentColor : blockedColor, isSatisfied);
+		}
 
 		for(const System *waypoint : mission.Waypoints())
 			DrawPointer(waypoint, missionCount[waypoint].drawn, waypointColor);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1468,6 +1468,7 @@ void MapPanel::DrawMissions()
 		else
 			++it.unavailable;
 	}
+	for_each(missionCount.begin(), missionCount.end(), [](auto &it) { it.second.Reserve(); });
 	for(const Mission &mission : player.Missions())
 	{
 		if(!mission.IsVisible())
@@ -1477,9 +1478,7 @@ void MapPanel::DrawMissions()
 		if(!system)
 			continue;
 
-		// Reserve a maximum of half of the slots for available missions.
 		auto &&it = missionCount[system];
-		int reserved = min(MAX_MISSION_POINTERS_DRAWN / 2, it.available + it.unavailable);
 		if(it.drawn >= MAX_MISSION_POINTERS_DRAWN - reserved)
 			continue;
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1483,7 +1483,8 @@ void MapPanel::DrawMissions()
 		{
 			pair<bool, bool> blink = BlinkMissionIndicator(player, mission, step);
 			bool isSatisfied = IsSatisfied(player, mission) && blink.second;
-			DrawPointer(system, it.drawn, it.MaximumActive(), blink.first ? black : isSatisfied ? currentColor : blockedColor, isSatisfied);
+			const Color &color = blink.first ? black : isSatisfied ? currentColor : blockedColor;
+			DrawPointer(system, it.drawn, it.MaximumActive(), color, isSatisfied);
 		}
 
 		for(const System *waypoint : mission.Waypoints())

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1478,7 +1478,7 @@ void MapPanel::DrawMissions()
 		if(!system)
 			continue;
 
-		auto &&it = missionCount[system];
+		auto &it = missionCount[system];
 		if(it.drawn < it.MaximumActive())
 		{
 			pair<bool, bool> blink = BlinkMissionIndicator(player, mission, step);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1483,15 +1483,19 @@ void MapPanel::DrawMissions()
 		{
 			pair<bool, bool> blink = BlinkMissionIndicator(player, mission, step);
 			bool isSatisfied = IsSatisfied(player, mission) && blink.second;
-			DrawPointer(system, it.drawn, blink.first ? black : isSatisfied ? currentColor : blockedColor, isSatisfied);
+			DrawPointer(system, it.drawn, it.MaximumActive(), blink.first ? black : isSatisfied ? currentColor : blockedColor, isSatisfied);
 		}
 
 		for(const System *waypoint : mission.Waypoints())
-			DrawPointer(waypoint, missionCount[waypoint].drawn, waypointColor);
+			DrawPointer(waypoint, missionCount[waypoint].drawn, missionCount[waypoint].MaximumActive(), waypointColor);
 		for(const Planet *stopover : mission.Stopovers())
-			DrawPointer(stopover->GetSystem(), missionCount[stopover->GetSystem()].drawn, waypointColor);
+		{
+			const System *stopoverSystem = stopover->GetSystem();
+			auto &counts = missionCount[stopoverSystem];
+			DrawPointer(stopoverSystem, counts.drawn, counts.MaximumActive(), waypointColor);
+		}
 		for(const System *mark : mission.MarkedSystems())
-			DrawPointer(mark, missionCount[mark].drawn, waypointColor);
+			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
 	}
 	// Draw the available and unavailable jobs.
 	for(auto &&it : missionCount)
@@ -1499,16 +1503,18 @@ void MapPanel::DrawMissions()
 		const auto &system = it.first;
 		auto &&counters = it.second;
 		for(unsigned i = 0; i < counters.available; ++i)
-			DrawPointer(system, counters.drawn, availableColor);
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, availableColor);
 		for(unsigned i = 0; i < counters.unavailable; ++i)
-			DrawPointer(system, counters.drawn, unavailableColor);
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, unavailableColor);
 	}
 }
 
 
 
-void MapPanel::DrawPointer(const System *system, unsigned &systemCount, const Color &color, bool bigger)
+void MapPanel::DrawPointer(const System *system, unsigned &systemCount, unsigned max, const Color &color, bool bigger)
 {
+	if(systemCount >= max)
+		return;
 	DrawPointer(Zoom() * (system->Position() + center), systemCount, color, true, bigger);
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -69,13 +69,27 @@ namespace {
 	const unsigned MAX_MISSION_POINTERS_DRAWN = 12;
 	const double MISSION_POINTERS_ANGLE_DELTA = 30.;
 
-	// Struct to track per system how many pointers are drawn and still
+	// Class to track per system how many pointers are drawn and still
 	// need to be drawn.
-	struct PointerDrawCount {
+	class PointerDrawCount {
+	public:
+		// Calculate and check the most number of pointer positions that should be available for active missions.
+		// This can be up to half the maximum number of pointers that can be drawn.
+		void Reserve()
+		{
+			maximumActive = max(MAX_MISSION_POINTERS_DRAWN / 2, MAX_MISSION_POINTERS_DRAWN - (available + unavailable));
+		}
+
+		unsigned MaximumActive() const { return maximumActive; }
+
+	public:
 		// Amount of systems already drawn.
 		unsigned drawn = 0;
 		unsigned available = 0;
 		unsigned unavailable = 0;
+
+	private:
+		unsigned maximumActive = MAX_MISSION_POINTERS_DRAWN;
 	};
 
 	// Struct for storing the ends of wormhole links and their colors.

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -75,12 +75,9 @@ namespace {
 	public:
 		// Calculate and check the most number of pointer positions that should be available for active missions.
 		// This can be up to half the maximum number of pointers that can be drawn.
-		void Reserve()
-		{
-			maximumActive = max(MAX_MISSION_POINTERS_DRAWN / 2, MAX_MISSION_POINTERS_DRAWN - (available + unavailable));
-		}
+		void Reserve();
 
-		unsigned MaximumActive() const { return maximumActive; }
+		unsigned MaximumActive() const;
 
 	public:
 		// Amount of systems already drawn.
@@ -91,6 +88,17 @@ namespace {
 	private:
 		unsigned maximumActive = MAX_MISSION_POINTERS_DRAWN;
 	};
+
+	void PointerDrawCount::Reserve()
+	{
+		maximumActive = max(MAX_MISSION_POINTERS_DRAWN / 2, MAX_MISSION_POINTERS_DRAWN - (available + unavailable));
+	}
+
+	unsigned PointerDrawCount::MaximumActive() const
+	{
+		return maximumActive;
+	}
+
 
 	// Struct for storing the ends of wormhole links and their colors.
 	struct WormholeArrow {

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -176,7 +176,7 @@ private:
 	void DrawSystems();
 	void DrawNames();
 	void DrawMissions();
-	void DrawPointer(const System *system, unsigned &systemCount, const Color &color, bool bigger = false);
+	void DrawPointer(const System *system, unsigned &systemCount, unsigned max, const Color &color, bool bigger = false);
 	static void DrawPointer(Point position, unsigned &systemCount, const Color &color,
 		bool drawBack = true, bool bigger = false);
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10840

## Summary
When drawing mission pointers on the map, they are drawn mission by mission (for active missions).
There is a check on if the destination system of the mission currently under consideration already has the maximum number of pointers allowed for active missions (some spaces my be reserved for available jobs).
If the destination already has enough pointers, drawing the waypoint, stopover, and mark pointers for this mission on other systems are also skipped, resulting in the behaviour where the waypoint pointer on Mimosa is not drawn because the destination pointer for that mission on Aludra is not being drawn because that system already has the maximum number of pointers.
This PR makes it so that pointers on other systems are not skipped even for missions where the destination pointer is skipped.

## Screenshots
before | after
-- | --
![image](https://github.com/user-attachments/assets/6267c714-51cf-4614-ba15-61bae85ff183) | ![image](https://github.com/user-attachments/assets/88544556-d36c-4499-8c33-637e15ddce13)

## Usage examples
N/A

## Testing Done
Checked the map with the attached save file.

## Save File
This save file can be used to test these changes:
[Lakna Byrdock mission marker testing.txt](https://github.com/user-attachments/files/18045874/Lakna.Byrdock.mission.marker.testing.txt)
Based on the save file provided in the linked issue by tekker2234.
Ignore the disabled plugin mission.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
`MapPanel::DrawMissions` is marginally slower; on my system, the Release build from clang 15 is about 10 microseconds slower, out of around 260-270 microseconds.
