### PR TITLE
Fix typo in Dangerou Games 2

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5205,7 +5205,7 @@ mission "Dangerous Games 2"
 			label east5
 			action
 				set "Jorma and Daciana dead"
-			`	Small schools of fish flit past as you guide your small fleet to the west. Minutes pass with no sign of danger, and finally Karengo broadcasts, "Good work, <first>. Looks like this is the way forward."`
+			`	Small schools of fish flit past as you guide your small fleet to the east. Minutes pass with no sign of danger, and finally Karengo broadcasts, "Good work, <first>. Looks like this is the way forward."`
 			`	"Last one there's a rotten fish eye!" shouts Jorma, and your screen shows her subpod leap forward and gain on you, followed quickly by Daciana's.`
 			`	Then, without warning, a proximity sensor goes off at the same time your outer lights show a wall directly in front, stretching for as far as you can see. "Stop!" shouts Karengo, "It's the end of the cavern! Stop and go back!"`
 			`	Shuddering, your ship comes to a halt mere meters from the endless stone face. With a sinking feeling that has nothing to do with the depth, you turn the ship around and head back the way you came.`


### PR DESCRIPTION
**Typo fix**

Thanks to Algaean on Discord for reporting this: https://discord.com/channels/251118043411775489/536900466655887360/1315020213850210304

## Summary
One of the "go east" choices leads to text that says you go west.
This PR changes that line to say "east".
