### PR TITLE
Improve GameData::GetProgress

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -105,7 +105,7 @@ namespace {
 
 	// Tracks the progress of loading the sprites when the game starts.
 	std::atomic<bool> queuedAllImages = false;
-	std::atomic<int> spriteLoadingProgress = 0;
+	std::atomic<int> spritesLoaded = 0;
 	std::atomic<int> totalSprites = 0;
 
 	// List of image sets that are waiting to be uploaded to the GPU.
@@ -140,7 +140,7 @@ namespace {
 			[image, &queue]
 			{
 				image->Upload(SpriteSet::Modify(image->Name()), !preventSpriteUpload);
-				++spriteLoadingProgress;
+				++spritesLoaded;
 
 				// Start loading the next image in the queue, if any.
 				lock_guard lock(imageQueueMutex);
@@ -298,7 +298,7 @@ double GameData::GetProgress()
 		if(!totalSprites)
 			spriteProgress = 1.;
 		else
-			spriteProgress = static_cast<double>(spriteLoadingProgress) / totalSprites;
+			spriteProgress = static_cast<double>(spritesLoaded) / totalSprites;
 	}
 	return min({spriteProgress, Audio::GetProgress(), objects.GetProgress()});
 }

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -292,7 +292,14 @@ void GameData::LoadShaders()
 
 double GameData::GetProgress()
 {
-	double spriteProgress = static_cast<double>(spriteLoadingProgress) / totalSprites;
+	double spriteProgress = 0.;
+	if(queuedAllImages)
+	{
+		if(!totalSprites)
+			spriteProgress = 1.;
+		else
+			spriteProgress = static_cast<double>(spriteLoadingProgress) / totalSprites;
+	}
 	return min({spriteProgress, Audio::GetProgress(), objects.GetProgress()});
 }
 

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -104,7 +104,7 @@ namespace {
 	bool preventSpriteUpload = false;
 
 	// Tracks the progress of loading the sprites when the game starts.
-	int spriteLoadingProgress = 0;
+	std::atomic<int> spriteLoadingProgress = 0;
 	std::atomic<int> totalSprites = 0;
 
 	// List of image sets that are waiting to be uploaded to the GPU.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -215,6 +215,7 @@ shared_future<void> GameData::BeginLoad(TaskQueue &queue, bool onlyLoadData, boo
 					++totalSprites;
 				}
 			}
+			queuedAllImages = true;
 
 			// Launch the tasks to actually load the images, making sure not to exceed the amount
 			// of tasks the main thread can handle in a single frame to limit peak memory usage.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -104,6 +104,7 @@ namespace {
 	bool preventSpriteUpload = false;
 
 	// Tracks the progress of loading the sprites when the game starts.
+	std::atomic<bool> queuedAllImages = false;
 	std::atomic<int> spriteLoadingProgress = 0;
 	std::atomic<int> totalSprites = 0;
 

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -206,9 +206,6 @@ void Audio::CheckReferences()
 // Report the progress of loading sounds.
 double Audio::GetProgress()
 {
-	if(!queuedAllSounds)
-		return 0.;
-
 	unique_lock<mutex> lock(audioMutex);
 
 	if(loadQueue.empty())

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -206,6 +206,9 @@ void Audio::CheckReferences()
 // Report the progress of loading sounds.
 double Audio::GetProgress()
 {
+	if(!queuedAllSounds)
+		return 0.;
+
 	unique_lock<mutex> lock(audioMutex);
 
 	if(loadQueue.empty())

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -166,7 +166,6 @@ void Audio::Init(const vector<string> &sources)
 			}
 		}
 	}
-	queuedAllSounds = true;
 	// Begin loading the files.
 	if(!loadQueue.empty())
 		loadThread = thread(&Load);

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -97,6 +97,7 @@ namespace {
 
 	// Queue and thread for loading sound files in the background.
 	map<string, string> loadQueue;
+	std::atomic<bool> queuedAllSounds = false;
 	thread loadThread;
 
 	// The current position of the "listener," i.e. the center of the screen.

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -166,6 +166,7 @@ void Audio::Init(const vector<string> &sources)
 			}
 		}
 	}
+	queuedAllSounds = true;
 	// Begin loading the files.
 	if(!loadQueue.empty())
 		loadThread = thread(&Load);

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -97,7 +97,6 @@ namespace {
 
 	// Queue and thread for loading sound files in the background.
 	map<string, string> loadQueue;
-	std::atomic<bool> queuedAllSounds = false;
 	thread loadThread;
 
 	// The current position of the "listener," i.e. the center of the screen.


### PR DESCRIPTION
**Refactor**

## Summary
A previous version of #10392 made a change that drastically increased the time taken by "GameData::FindImages" to finish. This function is run asynchronously, as is much of the image loading progress, and so does not block the loading of audio and game data.
Often, this was so long that the "GameLoadingPanel" would have been constructed before it was finished, and all audio and game data would be fully loaded. As a result, 2GameData::GetProgress" would be called which quantifies image loading progress as the ratio of the variables "spriteLoadingProgress" and "totalSprites", in the anonymous namespace of GameData.cpp.
Because "GameData::FindImages" has not finished yet, "totalSprites" is still zero (as is "spriteLoadingProgress").
Therefore, when "GameData::GetProgress" attempts to determine the sprite loading progress, it gets a nan due to the divide by zero.
In order to determine the overall loading progres, "GameData::GetProgress" returns the minimum of the sprite, audio, and game data loading progress values.
In clang 15, and apparently every version of gcc and Apple Clang we use, this seems to return the nan, or some other very small or negative value. But, in clang 18, the nan is absorbed by `std::min` and so the final result is the minimum of the other two values.
Consequently, once both sounds and game data have been fully loaded, "GameLoadingPanel" assumed images have been loaded, too, and proceeds with other operations, resulting in images never actually being available, which is problematic for many reasons.

The current version of #10392 does not extend the execution time of "GameData::FindImages" so significantly, and so this problem is unlikely to appear again, though a sufficiently large number of images would likely result in a reoccurrence.

This PR modifies the image and sound loading processes, as well as "GameData::GetProgress" to ensure that all items to be loaded have been discovered before it is considered to be fully loaded, even if, by the the "GameData::GetProgress" is called, the number of items to be loaded is zero (because they haven't all been discovered yet).

~I believe "Audio::Init" is called in the main thread, so it should block progress checks until the sound loading queue has been populated, but I have made changes there just to be sure, and in case someone decides to move it to its own thread.~

Apparently, those changes don't work, so are no longer present.

I've also made "spriteLoadingProgress" in the GameData.cpp anonymous namespace an "std::atomic<int>" instead of just an "int" because it can be read in one thread while another is writing to it and using "std::atomic" prevents undefined behaviour in such cases.

Also, renamed "spriteLoadingProgress" from the GameData.cpp anonymous namespace to "spritesLoaded".

## Screenshots
Not today.

## Usage examples
N/A

## Testing Done
Launch the game; it still loads. It might just be me, but the progress ring in the game loading panel actually seems a bit smoother, now.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Not noticeable.
