### PR TITLE
Missions that don't block minors

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1301,6 +1301,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	result.hasFailed = true;
 	result.isVisible = isVisible;
 	result.hasPriority = hasPriority;
+	result.isNonBlocking = isNonBlocking;
 	result.isMinor = isMinor;
 	result.autosave = autosave;
 	result.location = location;

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -589,6 +589,15 @@ bool Mission::HasPriority() const
 
 
 
+// Check if this mission is a "non-blocking" mission.
+// Such missions will not prevent minor missions from being offered alongside them.
+bool Mission::IsNonBlocking() const
+{
+	return isNonBlocking;
+}
+
+
+
 // Check if this mission is a "minor" mission. Minor missions will only be
 // offered if no other missions (minor or otherwise) are being offered.
 bool Mission::IsMinor() const

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -206,6 +206,8 @@ void Mission::Load(const DataNode &node)
 			isVisible = false;
 		else if(child.Token(0) == "priority")
 			hasPriority = true;
+		else if(child.Token(0) == "non-blocking")
+			isNonBlocking = true;
 		else if(child.Token(0) == "minor")
 			isMinor = true;
 		else if(child.Token(0) == "autosave")

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -374,6 +374,8 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("invisible");
 		if(hasPriority)
 			out.Write("priority");
+		if(isNonBlocking)
+			out.Write("non-blocking");
 		if(isMinor)
 			out.Write("minor");
 		if(autosave)

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -82,7 +82,7 @@ public:
 	// This is to be used for missions that are part of a series.
 	bool HasPriority() const;
 	// Check if this mission is a "minor" mission. Minor missions will only be
-	// offered if no other missions (minor or otherwise) are being offered.
+	// offered if no other non-blocking missions (minor or otherwise) are being offered.
 	bool IsMinor() const;
 
 	// Find out where this mission is offered.
@@ -204,6 +204,7 @@ private:
 	bool hasFailed = false;
 	bool isVisible = true;
 	bool hasPriority = false;
+	bool isNonBlocking = false;
 	bool isMinor = false;
 	bool autosave = false;
 	bool overridesCapture = false;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -81,6 +81,9 @@ public:
 	// are available, no others will be shown at landing or in the spaceport.
 	// This is to be used for missions that are part of a series.
 	bool HasPriority() const;
+	// Check if this mission is a "non-blocking" mission.
+	// Such missions will not prevent minor missions from being offered alongside them.
+	bool IsNonBlocking() const;
 	// Check if this mission is a "minor" mission. Minor missions will only be
 	// offered if no other non-blocking missions (minor or otherwise) are being offered.
 	bool IsMinor() const;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4009,6 +4009,7 @@ void PlayerInfo::CreateMissions()
 	// Check for available missions.
 	bool skipJobs = planet && !planet->GetPort().HasService(Port::ServicesType::JobBoard);
 	bool hasPriorityMissions = false;
+	int nonBlockingMissions = 0;
 	for(const auto &it : GameData::Missions())
 	{
 		if(it.second.IsAtLocation(Mission::BOARDING) || it.second.IsAtLocation(Mission::ASSISTING))
@@ -4025,7 +4026,10 @@ void PlayerInfo::CreateMissions()
 			if(missions.back().IsFailed(*this))
 				missions.pop_back();
 			else if(!it.second.IsAtLocation(Mission::JOB))
+			{
 				hasPriorityMissions |= missions.back().HasPriority();
+				nonBlockingMissions += missions.back().IsNonBlocking();
+			}
 		}
 	}
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4049,18 +4049,18 @@ void PlayerInfo::CreateMissions()
 				++it;
 		}
 	}
-	else if(availableMissions.size() > 1)
+	else if(availableMissions.size() > 1 + nonBlockingMissions)
 	{
 		// Minor missions only get offered if no other missions (including other
-		// minor missions) are competing with them. This is to avoid having two
-		// or three missions pop up as soon as you enter the spaceport.
+		// minor missions) are competing with them, except for "non-blocking" missions.
+		// This is to avoid having two or three missions pop up as soon as you enter the spaceport.
 		auto it = availableMissions.begin();
 		while(it != availableMissions.end())
 		{
 			if(it->IsMinor())
 			{
 				it = availableMissions.erase(it);
-				if(availableMissions.size() <= 1)
+				if(availableMissions.size() <= 1 + nonBlockingMissions)
 					break;
 			}
 			else

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4009,7 +4009,7 @@ void PlayerInfo::CreateMissions()
 	// Check for available missions.
 	bool skipJobs = planet && !planet->GetPort().HasService(Port::ServicesType::JobBoard);
 	bool hasPriorityMissions = false;
-	int nonBlockingMissions = 0;
+	unsigned nonBlockingMissions = 0;
 	for(const auto &it : GameData::Missions())
 	{
 		if(it.second.IsAtLocation(Mission::BOARDING) || it.second.IsAtLocation(Mission::ASSISTING))


### PR DESCRIPTION
**Feature**

## Summary
Currently, a mission marked "minor" can only offer one at a time and when no other mission is being offered.
That is, if any non-"minor" missions are being offered, no "minor" missions will be offered, and if multiple "minor" missions may be offered, and no non-"minor" missions, all but the last "minor" mission will be discarded, and only that mission will be offered.

This can be somewhat limiting, so this PR introduces a way to mark a mission as "non-blocking". Such missions will not prevent "minor" missions from being offered; "minor" missions can offer alongside them.

The most obvious use for this would be the spaceport reminder resetter.
The spaceport reminder missions currently work as follows:
1. The "Spaceport Reminder Setter" mission offers on landing (in practice, this will be when the pilot is first created) and sets conditions storing the current month and year values ("spaceport reminder month" and "spaceport reminder year").
2. The "AA Spaceport Reminder Resetter" mission is a "minor" spaceport mission. Because its name begins with "AA", it will not offer unless no other vanilla missions are going to offer; every vanilla "minor" mission will take precedence over this one and all non-"minor" missions will block it (because it is "minor"). (A plugin could define a new "minor" mission that would have a lower precedence than this one, if it really wanted.) When this mission is offered, it updates the conditions set in the previous mission with the current month and year. This mission will stop offering once the "Spaceport Reminder" mission has been offered or the player has "chosen sides" in the FW story.
3. The "Spaceport Reminder" mission will offer on landing approximately seven months after the last time the "Resetter" mission ran, or after the "Setter" mission, if the "Resetter" has never run. It does not offer once the player has "chosen sides" in the FW story.

The purpose of these missions is, as the name suggests, to remind the player to visit the spaceport (to pick up main story missions). The idea being that if you do not visit the spaceport very often or at all, or have not visited it recently, the "Resetter" mission will not have run recently, so the "Spaceport Reminder" mission will be offered, providing the reminder conversation.

However, the current implementation requires that you visit the spaceport and not be offered any other missions for the "Resetter" to run. This means that it will not be reset when you are offered a mission. It is perhaps unlikely that a player would be offered a mission on every visit to the spaceport in seven months of in game time, assuming they visit the spaceport every time they land, but even somewhat less frequent visitations probably don't merit a reminder.

The feature in this PR could be used to allow the "Resetter" mission to run every time the player visits the spaceport regardless of if the player is offered another mission and without blocking "minor" missions.

## Screenshots
N/A

## Usage examples
```
mission
    "non-blocking"
```

## Testing Done
Literally nothing. It might not even compile.

## Save File
This save file can be used to test these changes:
Maybe another time.

## Artwork Checklist
N/A

## Wiki Update
soon:tm:

## Performance Impact
Immeasurable, probably.
