### PR TITLE
feat(content): Revert `shrouded` from most Umbral Reach systems

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -11505,7 +11505,6 @@ system Durax
 			period 29.2266
 
 system E-4183
-	shrouded
 	pos 1042.97 -618.13
 	government Uninhabited
 	attributes "bright star" "giant star" "notable star" "umbral reach"
@@ -11561,7 +11560,6 @@ system E-4183
 			offset 240
 
 system E-9182
-	shrouded
 	pos 1167.2 -629
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"
@@ -15123,7 +15121,6 @@ system G-6183
 		offset 145
 
 system G-719
-	shrouded
 	pos 1162.19 -417.18
 	government Uninhabited
 	attributes "umbral reach"
@@ -15164,7 +15161,6 @@ system G-719
 			period 147.7
 
 system G-819
-	shrouded
 	pos 1186.97 -477.17
 	government Uninhabited
 	attributes "umbral reach"
@@ -16338,7 +16334,6 @@ system Gupta
 		period 1077.08
 
 system H-8188
-	shrouded
 	pos 1206.6 -506.5
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"
@@ -21548,7 +21543,6 @@ system Kursa
 		period 1517.13
 
 system L-118
-	shrouded
 	pos 1088.89 -408.306
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"
@@ -21588,7 +21582,6 @@ system L-118
 			period 434
 
 system L-6181
-	shrouded
 	pos 1139.93 -522.87
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"
@@ -22384,7 +22377,6 @@ system Luue-Saqru
 			period 32
 
 system M-1188
-	shrouded
 	pos 1124.66 -607.233
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"
@@ -22423,7 +22415,6 @@ system M-1188
 		period 38041.2
 
 system MC-42
-	shrouded
 	pos 1113.33 -500.68
 	government Uninhabited
 	attributes "iije" "umbral reach"
@@ -22460,7 +22451,6 @@ system MC-42
 		period 3186.04
 
 system MS-219
-	shrouded
 	pos 1075.13 -568.167
 	government Uninhabited
 	attributes "bright star" "iije" "notable star" "umbral reach"
@@ -25832,7 +25822,6 @@ system Nunki
 			period 66.2404
 
 system O-3184
-	shrouded
 	pos 1100.4 -646.047
 	government Uninhabited
 	attributes "umbral reach"
@@ -34283,7 +34272,6 @@ system Tuur-Kella
 		period 10000
 
 system U-5188
-	shrouded
 	pos 1084 -665.623
 	government Uninhabited
 	attributes "umbral reach"
@@ -35095,7 +35083,6 @@ system "Uwo Seija"
 		period 2910.75
 
 system V-2189
-	shrouded
 	pos 1135.9 -711.667
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"
@@ -35784,7 +35771,6 @@ system Vulcuja
 		period 1989.22
 
 system W-3197
-	shrouded
 	pos 1204.5 -400
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -16363,7 +16363,6 @@ system H-8188
 		period 5620.03
 
 system H-9187
-	shrouded
 	pos 1130.88 -455.97
 	government Uninhabited
 	attributes "bright star" "notable star" "umbral reach"

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -15082,7 +15082,6 @@ system G-3191
 		period 5084.55
 
 system G-6183
-	shrouded
 	pos 1019.4 -590.18
 	government Uninhabited
 	attributes "black hole" "notable star" "umbral reach"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
I gave the Umbral Reach the `shrouded` attribute to make the area more mysterious and considered it a good first use of the shrouded mechanic, though I wasn't entirely sure how I felt about it. After re-thinking it, I feel it is better that the area ultimately does not have the attribute - the UR is about there being an eerie silence and *lack* of something - for everything to be shrouded draws more attention than I feel the area should [currently] have.

Shrouded is a good mechanic for areas that have dynamic reasons for it to exist, such as Successor space and the upcoming Avgi area, where shrouded is a core mechanic for the region. There are actual things to find in those areas, as opposed to the UR, so it's more engaging there and makes more sense mechanically. I feel those areas feel better as the more explicit place to have the shrouded mechanic.

I did however elect to keep shrouded on the one black hole system in the UR; that system is unique compared to the others with the black hole, especially because that black hole was not naturally formed (TBA), so it makes sense something is going on there.

