### PR TITLE
feat(content): Allow "Gegno Suspicions" to offer sooner

### DIFF
--- a/data/gegno/gegno I corroboration.txt
+++ b/data/gegno/gegno I corroboration.txt
@@ -351,7 +351,7 @@ mission "Gegno Suspicions"
 	landing
 	source "Giaru Gegno"
 	to offer
-		"gegno: encounters" >= 3
+		"gegno: encounters" >= 1
 		"gegno: encounters" < 6
 		not "Gegno Intervention: offered"
 		not "Gegno Genocide Defense: offered"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
In https://github.com/endless-sky/endless-sky/discussions/10769, it was brought up that the chances of the player landing at the Quarg ringworld, following the Scin Encounter  and prior to Apprehension, could be low. Landing on the Quarg ring after only three encounters, and less than six, is meant to be a softer route of two paths, the other being more strict if you interact with the Gegno too much.

This PR lowers that softer threshold of encounters from three to just one so that the window to talk to the Quarg more calmly in this moment is a bit more accessible. For example, perhaps the player runs into their first Gegno encounter and immediately thinks to talk to the Quarg about it.

## Testing Done
None; I changed 1 number, we should be good.

## Save File
I can make one if it's really necessary.
