### PR TITLE
fix(typo): Efreti Distress Call: specify a noun in a blocked message

### DIFF
--- a/data/korath/korath missions.txt
+++ b/data/korath/korath missions.txt
@@ -439,7 +439,7 @@ mission "Efreti: Distress Call 5"
 	destination "Greenwater"
 	landing
 	passengers 66
-	blocked `You need <bunks> available to carry the salvage team.`
+	blocked `You will need <bunks> available bunks to carry the salvage team.`
 	
 	to offer
 		has "Efreti: Distress Call 4: done"

--- a/data/korath/korath missions.txt
+++ b/data/korath/korath missions.txt
@@ -439,7 +439,7 @@ mission "Efreti: Distress Call 5"
 	destination "Greenwater"
 	landing
 	passengers 66
-	blocked `You will need <bunks> available bunks to carry the salvage team.`
+	blocked `You need <bunks> available bunks to carry the salvage team.`
 	
 	to offer
 		has "Efreti: Distress Call 4: done"


### PR DESCRIPTION
**Typo Fix**

This PR addresses the typo described on [Discord](https://discord.com/channels/251118043411775489/308902312741568512/1317385103126827059)

## Summary
Otherwise it doesn't make sense.
See the before screenshot.

## Screenshots
Before:
![](https://cdn.discordapp.com/attachments/308902312741568512/1317385136760946728/Screenshot_2024-12-14_at_11.38.10_am.png?ex=675e7e04&is=675d2c84&hm=f601f7bf2f708b85ebbd7e4fa6991a5e09a7994018896d4d358d044906cb4eec&)
After:
Hasn't been tested.