### PR TITLE
fix(startup): Fix application directory query

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -88,7 +88,7 @@ void Files::Init(const char * const *argv)
 	{
 		// Find the path to the resource directory. This will depend on the
 		// operating system, and can be overridden by a command line argument.
-		resources = filesystem::current_path();
+		resources = SDL_GetBasePath();
 		if(resources.empty())
 			throw runtime_error("Unable to get path to resource directory!");
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [discord](https://discord.com/channels/251118043411775489/285540320823869441/1317756034961379328)

## Summary
Due to an oversight in the recent filesystem refactor, the game's resource path was based on the current working directory, instead of on the executable's directory. This broke certain application bundles when combined with some specific launchers. (Note: it was running fine in the CI and in local builds, as those have a compatible working directory.)

This PR reintroduces the previous SDL call, which should restore functionality even on the systems where I couldn't test it.

## Testing Done
I tested that it now works when launching the executable from a different directory in a specific case where it was broken.