### PR TITLE
fix(ui): Fix conversation height offset

### DIFF
--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -374,7 +374,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	const Sprite *top = SpriteSet::Get("ui/dialog top");
 	// If the dialog is too tall, then switch to wide mode.
 	int maxHeight = Screen::Height() * 3 / 4;
-	if(text->GetTextHeight() > maxHeight)
+	if(text->GetTextHeight(false) > maxHeight)
 	{
 		textRectSize.Y() = maxHeight;
 		isWide = true;
@@ -392,7 +392,7 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 		}
 	}
 	else
-		textRectSize.Y() = text->GetTextHeight();
+		textRectSize.Y() = text->GetTextHeight(false);
 
 	top = SpriteSet::Get(isWide ? "ui/dialog top wide" : "ui/dialog top");
 	const Sprite *middle = SpriteSet::Get(isWide ? "ui/dialog middle wide" : "ui/dialog middle");

--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -108,10 +108,10 @@ void TextArea::SetTruncate(Truncate t)
 
 
 
-int TextArea::GetTextHeight()
+int TextArea::GetTextHeight(bool trailingBreak)
 {
 	Validate();
-	return wrappedText.Height();
+	return wrappedText.Height(trailingBreak);
 }
 
 

--- a/source/TextArea.h
+++ b/source/TextArea.h
@@ -47,7 +47,7 @@ public:
 	void SetAlignment(Alignment a);
 	void SetTruncate(Truncate t);
 
-	int GetTextHeight();
+	int GetTextHeight(bool trailingBreak = true);
 	int GetLongestLineWidth();
 
 

--- a/source/text/WrappedText.cpp
+++ b/source/text/WrappedText.cpp
@@ -141,10 +141,11 @@ void WrappedText::Wrap(const char *str)
 
 
 
-// Get the height of the wrapped text.
-int WrappedText::Height() const
+/// Get the height of the wrapped text.
+/// With trailingBreak, include a paragraph break after the text.
+int WrappedText::Height(bool trailingBreak) const
 {
-	return height;
+	return height + trailingBreak * paragraphBreak;
 }
 
 

--- a/source/text/WrappedText.h
+++ b/source/text/WrappedText.h
@@ -67,8 +67,9 @@ public:
 	void Wrap(const std::string &str);
 	void Wrap(const char *str);
 
-	// Get the height of the wrapped text.
-	int Height() const;
+	/// Get the height of the wrapped text.
+	/// With trailingBreak, include a paragraph break after the text.
+	int Height(bool trailingBreak = true) const;
 
 	// Return the width of the longest line of the wrapped text.
 	int LongestLineWidth() const;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported by @Saugia

## Summary
Conversations would have a slight height offset following #10323. This PR makes that disappear by conditionally re-introducing the previous behaviour to panels that have yet to be refactored.

## Screenshots
After: 
![image](https://github.com/user-attachments/assets/cde08dc7-5105-4e55-97e5-d883d785cff8)
Before:
![image](https://github.com/user-attachments/assets/a73695b3-bcf6-4b1d-ba66-0357e319da35)


## Testing Done
See screenshots above.