### PR TITLE
refactor(conditions): Remove unused condition erase functionality

### DIFF
--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -47,13 +47,6 @@ void ConditionsStore::DerivedProvider::SetSetFunction(function<bool(const string
 
 
 
-void ConditionsStore::DerivedProvider::SetEraseFunction(function<bool(const string &)> newEraseFun)
-{
-	eraseFunction = std::move(newEraseFun);
-}
-
-
-
 ConditionsStore::ConditionEntry::operator int64_t() const
 {
 	if(!provider)
@@ -240,24 +233,6 @@ bool ConditionsStore::Set(const string &name, int64_t value)
 		return true;
 	}
 	return ce->provider->setFunction(name, value);
-}
-
-
-
-// Erase a condition completely, either the local value or by performing
-// an erase on the provider.
-bool ConditionsStore::Erase(const string &name)
-{
-	ConditionEntry *ce = GetEntry(name);
-	if(!ce)
-		return true;
-
-	if(!(ce->provider))
-	{
-		storage.erase(name);
-		return true;
-	}
-	return ce->provider->eraseFunction(name);
 }
 
 

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -52,7 +52,6 @@ public:
 		// Functions to set the lambda functions for accessing the conditions.
 		void SetGetFunction(std::function<int64_t(const std::string &)> newGetFun);
 		void SetSetFunction(std::function<bool(const std::string &, int64_t)> newSetFun);
-		void SetEraseFunction(std::function<bool(const std::string &)> newEraseFun);
 
 	public:
 		// This is intended as a private constructor, only to be called from within
@@ -69,7 +68,6 @@ public:
 		std::function<int64_t(const std::string &)> getFunction = [](const std::string &name) { return 0; };
 		std::function<bool(const std::string &, int64_t)> setFunction = [](const std::string &name, int64_t value) {
 			return false; };
-		std::function<bool(const std::string &)> eraseFunction = [](const std::string &name) { return false; };
 	};
 
 
@@ -114,11 +112,10 @@ public:
 	// connected provider).
 	int64_t Get(const std::string &name) const;
 
-	// Add a value to a condition, set a value for a condition or erase a
-	// condition completely. Returns true on success, false on failure.
+	// Add a value to a condition or set a value for a condition. Returns true on
+	// success, false on failure.
 	bool Add(const std::string &name, int64_t value);
 	bool Set(const std::string &name, int64_t value);
-	bool Erase(const std::string &name);
 
 	// Direct access to a specific condition (using the ConditionEntry as proxy).
 	ConditionEntry &operator[](const std::string &name);

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -112,8 +112,8 @@ public:
 	// connected provider).
 	int64_t Get(const std::string &name) const;
 
-	// Add a value to a condition or set a value for a condition. Returns true on
-	// success, false on failure.
+	// Add a value to a condition or set a value for a condition.
+	// Returns true on success, false on failure.
 	bool Add(const std::string &name, int64_t value);
 	bool Set(const std::string &name, int64_t value);
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3305,11 +3305,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		accounts.SetSalaryIncome(name.substr(strlen("salary: ")), value);
 		return true;
 	});
-	salaryIncomeProvider.SetEraseFunction([this](const string &name) -> bool
-	{
-		accounts.SetSalaryIncome(name.substr(strlen("salary: ")), 0);
-		return true;
-	});
 
 	auto &&tributeProvider = conditions.GetProviderPrefixed("tribute: ");
 	auto tributeHasGetFun = [this](const string &name) -> int64_t
@@ -3328,27 +3323,17 @@ void PlayerInfo::RegisterDerivedConditions()
 	tributeProvider.SetSetFunction([this](const string &name, int64_t value) -> bool {
 		return SetTribute(name.substr(strlen("tribute: ")), value);
 	});
-	tributeProvider.SetEraseFunction([this](const string &name) -> bool {
-		return SetTribute(name.substr(strlen("tribute: ")), 0);
-	});
 
 	auto &&licenseProvider = conditions.GetProviderPrefixed("license: ");
 	licenseProvider.SetGetFunction([this](const string &name) -> int64_t {
 		return HasLicense(name.substr(strlen("license: ")));
 	});
-
 	licenseProvider.SetSetFunction([this](const string &name, int64_t value) -> bool
 	{
 		if(!value)
 			RemoveLicense(name.substr(strlen("license: ")));
 		else
 			AddLicense(name.substr(strlen("license: ")));
-		return true;
-	});
-
-	licenseProvider.SetEraseFunction([this](const string &name) -> bool
-	{
-		RemoveLicense(name.substr(strlen("license: ")));
 		return true;
 	});
 
@@ -3991,11 +3976,6 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		string condition = name.substr(strlen("global: "));
 		return GameData::GlobalConditions().Set(condition, value);
-	});
-	globalProvider.SetEraseFunction([](const string &name) -> bool
-	{
-		string condition = name.substr(strlen("global: "));
-		return GameData::GlobalConditions().Erase(condition);
 	});
 }
 

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -197,7 +197,7 @@ SCENARIO( "Creating a ConditionsStore", "[ConditionsStore][Creation]" )
 	}
 }
 
-SCENARIO( "Setting and erasing conditions", "[ConditionStore][ConditionSetting]" )
+SCENARIO( "Setting conditions", "[ConditionStore][ConditionSetting]" )
 {
 	GIVEN( "An empty conditionsStore" )
 	{

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -59,11 +59,6 @@ public:
 			verifyAndStripPrefix(prefix, name);
 			return false;
 		});
-		conditionsProvider.SetEraseFunction([prefix](const std::string &name)
-		{
-			verifyAndStripPrefix(prefix, name);
-			return false;
-		});
 		conditionsProvider.SetGetFunction([this, prefix](const std::string &name)
 		{
 			verifyAndStripPrefix(prefix, name);
@@ -79,12 +74,6 @@ public:
 			values[name] = value;
 			return true;
 		});
-		conditionsProvider.SetEraseFunction([this, prefix](const std::string &name)
-		{
-			verifyAndStripPrefix(prefix, name);
-			values.erase(name);
-			return true;
-		});
 		conditionsProvider.SetGetFunction([this, prefix](const std::string &name)
 		{
 			verifyAndStripPrefix(prefix, name);
@@ -95,11 +84,6 @@ public:
 	{
 		auto &&conditionsProvider = store.GetProviderNamed(named);
 		conditionsProvider.SetSetFunction([named](const std::string &name, int64_t value)
-		{
-			verifyName(named, name);
-			return false;
-		});
-		conditionsProvider.SetEraseFunction([named](const std::string &name)
 		{
 			verifyName(named, name);
 			return false;
@@ -117,12 +101,6 @@ public:
 		{
 			verifyName(named, name);
 			values[name] = value;
-			return true;
-		});
-		conditionsProvider.SetEraseFunction([this, named](const std::string &name)
-		{
-			verifyName(named, name);
-			values.erase(name);
 			return true;
 		});
 		conditionsProvider.SetGetFunction([this, named](const std::string &name)
@@ -235,18 +213,16 @@ SCENARIO( "Setting and erasing conditions", "[ConditionStore][ConditionSetting]"
 				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store["myFirstVar"] == 10 );
 			}
-			THEN( "erasing the condition will make it disappear again" )
+			THEN( "erasing the condition is done by setting it to zero" )
 			{
 				REQUIRE( store.Get("myFirstVar") );
 				REQUIRE( store.PrimariesSize() == 1 );
 				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store.PrimariesSize() == 1 );
-				REQUIRE( store.Erase("myFirstVar") );
+				REQUIRE( store.Set("myFirstVar", 0) );
 				REQUIRE_FALSE( store.Get("myFirstVar") );
-				REQUIRE( store.PrimariesSize() == 0 );
 				REQUIRE( store.Get("myFirstVar") == 0 );
 				REQUIRE_FALSE( store.Get("myFirstVar") );
-				REQUIRE( store.PrimariesSize() == 0 );
 			}
 		}
 		WHEN( "non-existing conditions are queried" )
@@ -415,7 +391,7 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 			THEN( "readonly providers should not perform erase actions" )
 			{
 				mockProvNamed.SetRONamedProvider(store, "named1");
-				REQUIRE_FALSE( store.Erase("named1") );
+				REQUIRE_FALSE( store.Set("named1", 0) );
 				REQUIRE( mockProvNamed.values.size() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -60 );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
@@ -468,7 +444,7 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 			THEN( "read-only prefixed provider should reject erase" )
 			{
 				mockProvPrefixA.SetROPrefixProvider(store, "prefixA: ");
-				REQUIRE_FALSE( store.Erase("prefixA: test") );
+				REQUIRE_FALSE( store.Set("prefixA: test", 0) );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
 				REQUIRE( mockProvPrefixA.values["prefixA: test"] == -60 );
 				REQUIRE( mockProvNamed.values.size() == 1 );
@@ -513,7 +489,7 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 					REQUIRE( mockProvPrefixA.values["prefixA: test"] == -30 );
 					REQUIRE( store.Get("prefixA: test") == -30 );
 					REQUIRE( store.Get("myFirstVar") == 10 );
-					REQUIRE_FALSE( store.Erase("prefixA: test") );
+					REQUIRE_FALSE( store.Set("prefixA: test", 0) );
 					REQUIRE( mockProvPrefixA.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values["prefixA: test"] == -30 );
 					REQUIRE( store.Get("prefixA: test") == -30 );

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -213,16 +213,20 @@ SCENARIO( "Setting and erasing conditions", "[ConditionStore][ConditionSetting]"
 				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store["myFirstVar"] == 10 );
 			}
-			THEN( "erasing the condition is done by setting it to zero" )
+			THEN( "the condition can be set to another value" )
 			{
-				REQUIRE( store.Get("myFirstVar") );
+				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store.PrimariesSize() == 1 );
+				REQUIRE( store.Set("myFirstVar", 2000) );
+				REQUIRE( store.Get("myFirstVar") == 2000 );
+			}
+
+			THEN( "the condition can be set to zero" )
+			{
 				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store.PrimariesSize() == 1 );
 				REQUIRE( store.Set("myFirstVar", 0) );
-				REQUIRE_FALSE( store.Get("myFirstVar") );
 				REQUIRE( store.Get("myFirstVar") == 0 );
-				REQUIRE_FALSE( store.Get("myFirstVar") );
 			}
 		}
 		WHEN( "non-existing conditions are queried" )
@@ -388,10 +392,14 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 				REQUIRE( store.Get("named1") == -60 );
 				REQUIRE( store.Get("myFirstVar") == 10 );
 			}
-			THEN( "readonly providers should not perform erase actions" )
+			THEN( "readonly providers should not perform any set actions" )
 			{
 				mockProvNamed.SetRONamedProvider(store, "named1");
 				REQUIRE_FALSE( store.Set("named1", 0) );
+				REQUIRE( mockProvNamed.values.size() == 1 );
+				REQUIRE( mockProvNamed.values["named1"] == -60 );
+				REQUIRE( mockProvPrefixA.values.size() == 1 );
+				REQUIRE_FALSE( store.Set("named1", 40) );
 				REQUIRE( mockProvNamed.values.size() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -60 );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
@@ -440,20 +448,6 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 				store["prefixA: test"] -= 20;
 				REQUIRE( store.Get("prefixA: test") == -60 );
 				REQUIRE( store.Get("myFirstVar") == 10 );
-			}
-			THEN( "read-only prefixed provider should reject erase" )
-			{
-				mockProvPrefixA.SetROPrefixProvider(store, "prefixA: ");
-				REQUIRE_FALSE( store.Set("prefixA: test", 0) );
-				REQUIRE( mockProvPrefixA.values.size() == 1 );
-				REQUIRE( mockProvPrefixA.values["prefixA: test"] == -60 );
-				REQUIRE( mockProvNamed.values.size() == 1 );
-				REQUIRE( store.Get("prefixA: test") == -60 );
-				REQUIRE( store.Get("myFirstVar") == 10 );
-				REQUIRE( store.Get("prefixA: test") );
-				REQUIRE_FALSE( store.Get("prefixA: t") );
-				REQUIRE_FALSE( store.Get("prefixA: ") );
-				REQUIRE_FALSE( store.Get("prefixA:") );
 			}
 			THEN( "prefixed values from within provider should be available" )
 			{


### PR DESCRIPTION
**Refactor**

This PR removes complex condition-erase functionality that was never used

## Summary
ConditionsStore had an Erase function, but no code in ES  explicitly erases conditions. Erasing an condition is done implicitly by setting the condition to zero. (And conditions set to zero are never written out to savegames, thus effectively erasing them at save.)

Removing this unused functionality should make the codebase simpler.

## Usage examples
N/A

## Testing Done
Removed the affected functions and compiled the code. The code was never called.

## Wiki Update
N/A

## Performance Impact
This should have no impact. The functions were never used.