### PR TITLE
refactor(content): Give the Spaceport Resetter mission non-blocking

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4353,9 +4353,8 @@ mission "Spaceport Reminder Setter"
 		"spaceport reminder month" = "month"
 		fail
 
-# Use of "AA" at the start of the mission name is to make it offer only if no other missions have.
-mission "AA Spaceport Reminder Resetter"
-	minor
+mission "Spaceport Reminder Resetter"
+	non-blocking
 	invisible
 	repeat
 	to offer


### PR DESCRIPTION
**Refactor**

This PR addresses the bug described in pull request #10852.

## Summary
The Spaceport Reminder mission uses a hacky workaround in order to give a reminder to players to check the spaceport, and is described in the linked PR as follows:
> The "AA Spaceport Reminder Resetter" mission is a "minor" spaceport mission. Because its name begins with "AA", it will not offer unless no other vanilla missions are going to offer; every vanilla "minor" mission will take precedence over this one and all non-"minor" missions will block it (because it is "minor"). (A plugin could define a new "minor" mission that would have a lower precedence than this one, if it really wanted.) When this mission is offered, it updates the conditions set in the previous mission with the current month and year. This mission will stop offering once the "Spaceport Reminder" mission has been offered or the player has "chosen sides" in the FW story.

The issues with this implementation are that this mission can still block other plugin missions, as mentioned above, and that this mission will not offer if a different mission offers instead, meaning players could get the reminder when it is not necessary, wasting it. 

This was for a while the only way to make this work, however, with https://github.com/endless-sky/endless-sky/commit/934426fdbb76f6ca903d8199f824179a06d1566e, this is no longer necessary, and a better solution exists. This PR uses that better solution by replacing the `minor` tag in the Spaceport Reminder Resetter mission with the `non-blocking` tag, and removing the extra letters and associated comment as they are also no longer necessary.

EDIT: Spelling

## Testing Done
Made sure this mission and spaceport missions actually offered.

## Save File
This save file can be used to test these changes: [Yuri Nuttz~minor.txt](https://github.com/user-attachments/files/17896964/Yuri.Nuttz.minor.txt)