### PR TITLE
feat(balance): Balance the Pug Seeker's `missile strength` against human AMs

### DIFF
--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -102,7 +102,7 @@ outfit "Pug Seeker"
 		"shield damage" 24
 		"hull damage" 13
 		"hit force" 3
-		"missile strength" 40
+		"missile strength" 10
 	description "You have no idea how this weapon works. It requires no ammunition, but its energy-based projectiles have the ability to home in on a target ship."
 
 effect "seeker impact"


### PR DESCRIPTION
**Balance**

## Summary
Reduced the `missile strength` from 40 to 10.
This means one heavy anti-missile turret now expects to score about 4 kills/sec (blocking 2/3 of the incoming fire from a single seeker, or 1/3 of the fire from two), rather than the 1 kill/sec that would have been expected previously (blocking only 1/6 of the incoming fire from a single seeker, or 1/12 of the fire from two).

This should make AM much more useful during the FW pug fights, allowing the Seeker's incoming damage to be mitigated somewhat if you have invested in AM, rather than the current situation where AM becomes effectively dead weight because it doesn't significantly reduce incoming damage.
