### PR TITLE
feat(missions): Add an "offer precedence" token to Missions for controlling offer order

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -210,6 +210,8 @@ void Mission::Load(const DataNode &node)
 			isNonBlocking = true;
 		else if(child.Token(0) == "minor")
 			isMinor = true;
+		else if(child.Token(0) == "offer precedence" && child.Size() >= 2)
+			offerPrecedence = child.Value(1);
 		else if(child.Token(0) == "autosave")
 			autosave = true;
 		else if(child.Token(0) == "job")
@@ -378,6 +380,8 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("non-blocking");
 		if(isMinor)
 			out.Write("minor");
+		if(offerPrecedence)
+			out.Write("offer precedence", offerPrecedence);
 		if(autosave)
 			out.Write("autosave");
 		if(location == LANDING)
@@ -607,6 +611,13 @@ bool Mission::IsNonBlocking() const
 bool Mission::IsMinor() const
 {
 	return isMinor;
+}
+
+
+
+int Mission::OfferPrecedence() const
+{
+	return offerPrecedence;
 }
 
 
@@ -1303,6 +1314,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	result.hasPriority = hasPriority;
 	result.isNonBlocking = isNonBlocking;
 	result.isMinor = isMinor;
+	result.offerPrecedence = offerPrecedence;
 	result.autosave = autosave;
 	result.location = location;
 	result.overridesCapture = overridesCapture;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -87,6 +87,7 @@ public:
 	// Check if this mission is a "minor" mission. Minor missions will only be
 	// offered if no other non-blocking missions (minor or otherwise) are being offered.
 	bool IsMinor() const;
+	int OfferPrecedence() const;
 
 	// Find out where this mission is offered.
 	enum Location {SPACEPORT, LANDING, JOB, ASSISTING, BOARDING, SHIPYARD, OUTFITTER};
@@ -209,6 +210,12 @@ private:
 	bool hasPriority = false;
 	bool isNonBlocking = false;
 	bool isMinor = false;
+	// By default, missions are offered in alphabetical order.
+	// Using a non-zero offer precedence changes the order that missions are offered in.
+	// Missions with a higher offer precedence are offered before missions with a lower
+	// precedence. Where two missions have the same offer precedence, they continue to
+	// offer in alphabetical order.
+	int offerPrecedence = 0;
 	bool autosave = false;
 	bool overridesCapture = false;
 	Date deadline;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2138,8 +2138,8 @@ void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 
 
 // Look at the list of available missions and see if any of them can be offered
-// right now, in the given location (landing or spaceport). If there are no
-// missions that can be accepted, return a null pointer.
+// right now, in the given location. If there are no missions that can be accepted,
+// return a null pointer.
 Mission *PlayerInfo::MissionToOffer(Mission::Location location)
 {
 	if(ships.empty())
@@ -4013,6 +4013,19 @@ void PlayerInfo::CreateMissions()
 		}
 	}
 
+	if(availableMissions.empty())
+		return;
+
+	// This list is already in alphabetical order by virture of the way that the Set
+	// class stores objects, so stable sorting on the offer precedence will maintain
+	// the alphabetical ordering for missions with the same precedence.
+	stable_sort(availableMissions.begin(),
+				availableMissions.end(),
+				[](const Mission &a, const Mission &b)
+				{
+					return a.OfferPrecedence() > b.OfferPrecedence();
+				})
+
 	// If any of the available missions are "priority" missions, no other
 	// special missions will be offered in the spaceport.
 	if(hasPriorityMissions)
@@ -4034,6 +4047,8 @@ void PlayerInfo::CreateMissions()
 		// Minor missions only get offered if no other missions (including other
 		// minor missions) are competing with them, except for "non-blocking" missions.
 		// This is to avoid having two or three missions pop up as soon as you enter the spaceport.
+		// Note that the manner in which excess minor missions are discarded means that the
+		// minor mission with the lowest precedence is the one that will be offered.
 		auto it = availableMissions.begin();
 		while(it != availableMissions.end())
 		{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4019,12 +4019,10 @@ void PlayerInfo::CreateMissions()
 	// This list is already in alphabetical order by virture of the way that the Set
 	// class stores objects, so stable sorting on the offer precedence will maintain
 	// the alphabetical ordering for missions with the same precedence.
-	stable_sort(availableMissions.begin(),
-				availableMissions.end(),
-				[](const Mission &a, const Mission &b)
-				{
-					return a.OfferPrecedence() > b.OfferPrecedence();
-				});
+	availableMissions.sort([](const Mission &a, const Mission &b)
+		{
+			return a.OfferPrecedence() > b.OfferPrecedence();
+		});
 
 	// If any of the available missions are "priority" missions, no other
 	// special missions will be offered in the spaceport.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4024,7 +4024,7 @@ void PlayerInfo::CreateMissions()
 				[](const Mission &a, const Mission &b)
 				{
 					return a.OfferPrecedence() > b.OfferPrecedence();
-				})
+				});
 
 	// If any of the available missions are "priority" missions, no other
 	// special missions will be offered in the spaceport.


### PR DESCRIPTION
**Feature**

This PR is a reopening of #10828. This feature has uses outside of just the spaceport reminder mission, so it still makes sense to add to the game. The missions in FW Reconciliation where the Syndicate gives the player a jump drive, but the game checks if the player has a hyperdrive, scram drive, or already has a jump drive is another example of how this feature could have been used (the jump drive version of the mission was titled "A Jump Drive" to force it to offer first), although that case was actually already fixed by other means: https://github.com/endless-sky/endless-sky/commit/127faa20b0b5e44cea8970f08696f88e78dd3474. Had this case not been fixed by other means, this is not a case that the non-blocking tag from #10852 would have been able to address.

## Summary
Adds the following new token to `mission`:
* `"offer precedence" <x#>`: An integer value which can be used to change the order that missions are offered. Missions with a higher offer precedence will be offered first. The default precedence value is 0, and this value can be negative.
  * For missions with the same offer precedence, they will be offered in alphabetical order according to the identifier of the mission. This is the behavior that already exists currently, meaning that content creators may need to give missions odd names in order to manipulate their offer order (as could be seen with the spaceport reminder reset missions changes in #10883).
  * Note that the way that the game determines which `minor` missions should offer means that the minor mission with the lowest precedence will be the one to offer, and all higher precedence minor missions that could have also offered at the same time will be discarded.

## Usage examples
The following two non-minor missions have the same offer conditions, and therefore will offer at the same time. Without the usage of "offer precedence", "A Mission" will offer first, and then "B Mission" will offer. By giving "B Mission" an offer precedence greater than 0 (or "A Mission" an offer precedence less than 0), the offer order can be flipped so that "B Mission" offers first.
```
mission "A Mission"
	repeat
	to offer
		has "condition"
	on offer
		dialog `A Mission`

mission "B Mission"
	repeat
	"offer precedence" 1
	to offer
		has "condition"
	on offer
		dialog "B Mission"
```
In practice, these mission identifiers would be more descriptive of what the mission is actually for. Using "offer precedence" means that the content creator doesn't need to worry about the alphabetical ordering of the mission identifiers in order to alter the offer order.

## Testing Done
Tested using the missions in the usage example with no offer precedence set, with an offer precedence of 1 on "B Mission", and with an offer precedence of -1 on "A Mission." In the first case the offer order was A then B, and the other two cases caused the offer order to go B then A.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/84
