### PR TITLE
feat(content): Gegno "Unwelcoming" mission that stops `clearance` workarounds

### DIFF
--- a/data/gegno/gegno I corroboration.txt
+++ b/data/gegno/gegno I corroboration.txt
@@ -1016,6 +1016,7 @@ mission "Acquiescence"
 			has "Gegno Intervention: offered"
 		not "Gegno Anticipation: failed"
 		not "Gegno Intervention: failed"
+		not "Gegno Genocide Defense: offered"
 
 	destination "Tschyss"
 	on offer

--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -823,7 +823,7 @@ mission "Gegno Unwelcoming"
 			`You are greeted by a large group of Gegno on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons. As they do, countless ships belonging to both the Vi and Scin factions begin to descend in formations from the sky above.`
 				to display
 					has "Giaru Gegno: Quarg Contact: offered"
-			`	It probably wasn't the smartest plan to purposefully land here after assaulting civilians. There's no room for talk as they immediately begin to attack, and you do your best to fight as many off as you can. While you're able to fend off several with your pistol, you are eventually overwhelmed, and the last thing you experience is a cold, sharp pain through your upper body.`
+			`	It probably wasn't the smartest plan to purposefully land here after assaulting civilians. There's no room for talk as they immediately begin to attack, and you do your best to fight as many off as you can. While you are able to fend off several with your pistol, you are eventually overwhelmed, and the last thing you experience is a cold, sharp pain through your upper body.`
 				die
 
 

--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -801,6 +801,26 @@ mission "Gegno Genocide Defense"
 		ship "Augen" "Vytii Yrrlausei"
 
 
+
+# Mission for if the player has clearance on a Gegno world despite having provoked civilians.
+
+mission "Gegno Unwelcoming"
+	landing
+	invisible
+	source
+		or
+			government "Gegno"
+			government "Gegno Vi"
+			government "Gegno Scin"
+	to offer
+		"reputation: Gegno" < 0
+	on offer
+		conversation
+		`It seems there are more ships than normal in the sky as ships of both the Vi and Scin begin to descend in formations from above. Meanwhile, you are greeted by a large force of Gegno on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons.`
+		`	It wasn't the smartest plan to purposefully land here after assaulting their civilians, and the last thing you experience is a cold, sharp pain as you are overwhelmed by their ground forces.`
+			die
+
+
 # Gegno Hunter Fleets
 
 mission "Gegno Hunter Fleets"

--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -171,6 +171,8 @@ mission "First Contact: Gegno Vi"
 	on defer
 		set "First Contact: Gegno Vi: deferred"
 
+	on abort
+
 	to fail
 		"reputation: Gegno" < -100
 
@@ -747,6 +749,9 @@ mission "Gegno Genocide Defense"
 		fail "First Contact: Gegno Vi"
 		fail "Visit Quarg in Gegno Space"
 		fail "Vi Augen"
+		fail "Gegno Anticipation"
+		fail "Gegno Intervention"
+		fail "Acquiescence"
 		"reputation: Gegno" = -1000
 		"reputation: Gegno Vi" = -1000
 		"reputation: Gegno Scin" = -1000
@@ -801,23 +806,24 @@ mission "Gegno Genocide Defense"
 		ship "Augen" "Vytii Yrrlausei"
 
 
-
 # Mission for if the player has clearance on a Gegno world despite having provoked civilians.
 
 mission "Gegno Unwelcoming"
 	landing
 	invisible
 	source
-		or
-			government "Gegno"
-			government "Gegno Vi"
-			government "Gegno Scin"
+		government "Gegno" "Gegno Vi" "Gegno Scin"
 	to offer
 		"reputation: Gegno" < 0
 	on offer
 		conversation
-			`It seems there are more ships than normal in the sky as ships of both the Vi and Scin begin to descend in formations from above. Meanwhile, you are greeted by a large force of Gegno on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons.`
-			`	It wasn't the smartest plan to purposefully land here after assaulting their civilians, and the last thing you experience is a cold, sharp pain as you are overwhelmed by their ground forces.`
+			`You are greeted by a large force of aliens on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons. As they do, countless ships begin to descend in formations from the sky above.`
+				to display
+					not "Giaru Gegno: Quarg Contact: offered"
+			`You are greeted by a large group of Gegno on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons. As they do, countless ships belonging to both the Vi and Scin factions begin to descend in formations from the sky above.`
+				to display
+					has "Giaru Gegno: Quarg Contact: offered"
+			`	It probably wasn't the smartest plan to purposefully land here after assaulting civilians. There's no room for talk as they immediately begin to attack, and you do your best to fight as many off as you can. While you're able to fend off several with your pistol, you are eventually overwhelmed, and the last thing you experience is a cold, sharp pain through your upper body.`
 				die
 
 

--- a/data/gegno/gegno intro missions.txt
+++ b/data/gegno/gegno intro missions.txt
@@ -816,9 +816,9 @@ mission "Gegno Unwelcoming"
 		"reputation: Gegno" < 0
 	on offer
 		conversation
-		`It seems there are more ships than normal in the sky as ships of both the Vi and Scin begin to descend in formations from above. Meanwhile, you are greeted by a large force of Gegno on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons.`
-		`	It wasn't the smartest plan to purposefully land here after assaulting their civilians, and the last thing you experience is a cold, sharp pain as you are overwhelmed by their ground forces.`
-			die
+			`It seems there are more ships than normal in the sky as ships of both the Vi and Scin begin to descend in formations from above. Meanwhile, you are greeted by a large force of Gegno on the surface of the planet, though they don't seem too happy to welcome you on their world - in fact, several squads in numbers you can't quickly determine rush towards you, equipped with advanced looking combat gear and weapons.`
+			`	It wasn't the smartest plan to purposefully land here after assaulting their civilians, and the last thing you experience is a cold, sharp pain as you are overwhelmed by their ground forces.`
+				die
 
 
 # Gegno Hunter Fleets


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Currently, there is a way to circumvent the "Gegno Genocide Defense" mission in a way that allows the player to land on a Gegno world (mainly Dueyu Eitch) and outfit stolen ships after having provoked their civilians. The `clearance` tag found in some of the intro content is being used to land despite having killed/stolen civilian ships and aborting it after the fact. While most civilian ships are eventually going to be available to the player, the player should not be getting away with murdering civilians and stealing away ships aggressively as they must use a Gegno planet to outfit them.

The main problem with this is the player can actually obtain one of the large Gegno Protolith Generation ships, which were never intended to be obtainable in the first place - partly due to lore, and partly due to balance concerns. These ships, as they are ancient, don't have hyperdrives, but with the above method the player is able to land on a civilian world and outfit one with a hyperdrive despite having just captured it/murdered thousands of civilians.

To avoid this from happening, I've created a mission that offers if the player lands on a Gegno world after having triggered Genocide and leads the player to `die`. I'm not sure if `die` is the best option, but this is a niche case, and the player shouldn't have a Protolith, and it's a bit dumb to be landing on a species' world and get away with it after all the above as if nothing happened.

Any saves prior will still have one though; it is what it is, same thing happened with balance changes to ships in the past.

I've additionally added conditions that were missing for failing other `clearance` missions, and added an `on abort` to the first contact mission as you could have aborted it and died based on the `on fail` condition, which isn't related.

## Testing Done
Tested it and the mission offers properly.

## Save File
[Shin Tensus~Pre-Gegno.txt](https://github.com/user-attachments/files/18278567/Shin.Tensus.Pre-Gegno.txt)
Just start the Gegno story, and prior to landing on their world with `clearance`, kill or disable a civilian ship, and abort the mission.