### PR TITLE
Fix "can trigger after failure" mission action saving

### DIFF
--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -214,6 +214,8 @@ void MissionAction::SaveBody(DataWriter &out) const
 		// LocationFilter indentation is handled by its Save method.
 		systemFilter.Save(out);
 	}
+	if(runsWhenFailed)
+		out.Write("can trigger after failure");
 	if(!dialogText.empty())
 	{
 		out.Write("dialog");


### PR DESCRIPTION
**Bug fix**

## Summary
The recently added functionality for a missio naction to be allowed to trigger even after a mission has failed (but not yet erased) was not persisting across reloads because the "can trigger after failure" property of a mission action was not being written to the save file, and so after the reload, the mission action no longer had that property.

This PR updates mission actions saving to write that line to the save file if the action has the property.

## Testing Done
None
