### PR TITLE
[Bugfix] Enable Full Sprite Definition for Minables

### DIFF
--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -80,9 +80,9 @@ void Minable::Load(const DataNode &node)
 		else if(key == "sprite")
 		{
 			LoadSprite(child);
-			for(const auto &grand : child)
-				if(grand.Token(0) == "frame rate")
-					useRandomFramerate = false;
+			for(const DataNode &grand : child)
+				if(grand.Token(0) == "frame rate" || grand.Token(0) == "frame time")
+					useRandomFrameRate = false;
 		}
 		else if(key == "hull")
 			hull = child.Value(1);
@@ -183,7 +183,7 @@ void Minable::Place(double energy, double beltRadius)
 	// Start the object off with a random facing angle and spin rate.
 	angle = Angle::Random();
 	spin = Angle::Random(energy) - Angle::Random(energy);
-	if(useRandomFramerate)
+	if(useRandomFrameRate)
 		SetFrameRate(Random::Real() * 4. * energy + 5.);
 	// Choose a random direction for the angle of periapsis.
 	rotation = Random::Real() * 2. * PI;

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -130,6 +130,5 @@ private:
 	std::map<const Effect *, int> explosions;
 	// The expected value of the payload of this minable.
 	int64_t value = 0.;
-	// Whether to use a random frame rate.
-	bool useRandomFramerate = true;
+	bool useRandomFrameRate = true;
 };


### PR DESCRIPTION

**Bug fix**


Resolves #10898 

## Summary
Using my master coding skills I was able to painstakingly replace a single line in mineables.cpp after hours of hard labor. This allows minable sprite definitions to be given all the attributes typical of a sprite definition elsewhere, such as scale, frame rate, etc. Existing minable definitions still function properly (as far as I can tell).

## Screenshots
As you can guess a Yottrite asteroid does not typically look like this. With these changes however, adding `scale` 10 to the sprite definition allows you to ruin the Yottrite economy forever.
![489967c51c6f60986e947096716de840-1](https://github.com/user-attachments/assets/435d06be-84b6-4f4f-8956-3a08c11d4ef8)

## Usage examples
Minables can now be scaled, have their frame rate modified, use blending modes, etc.

## Testing Done
I crashed the Yottrite economy to get back at the Quarg. This was not sponsored by the Pug.

## Save File
Nah.


## Wiki Update
Probably needs one.

## Performance Impact
Maybe increases the load time for each defined minable/asteroid very slightly? Dunno.
