### PR TITLE
fix(regression): Notify to the system log when you are at the destination system, just like in 0.10.10

### DIFF
--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -42,9 +42,9 @@ public:
 	};
 
 	enum class NotificationSetting : int_fast8_t {
-		OFF = 0,
-		MESSAGE,
-		BOTH
+		MESSAGE = 0,
+		BOTH,
+		OFF
 	};
 
 	enum class OverlayState : int_fast8_t {


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10900 

## Summary

In v0.10.10 and earlier, you are notified when the system you are entering has missions with a destination planet in that system, along with the destination(s). However, this was changed to add the option of playing a sound, and as part of that, it was defaulted to OFF. This PR defaults it to MESSAGE so that the previous functionality persists.

## Screenshots
TBD

## Testing Done
TBD: Make sure messages cycle and work as expected.

## Save File
No need, just make a new save and tell James to go away if you don’t have one with jobs available.

## Performance Impact
This changes the default to a more performance intensive setting, but I don’t think adding an extra log message should be a problem to most systems, and if it is one, you can just change the setting to OFF.