### PR TITLE
fix(bug): fix an overindented `decline`

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -9185,7 +9185,7 @@ mission "Timothy Radrickson 7: Monk"
 			`	As you speak Timothy shakes his head slowly, tears streaming down his face. Finally, as you finish, he wraps his arms around you in an earnest, heartfelt hug.`
 			`	He tries to speak, but his voice fails him. Instead he just shakes his teary-eyed head at you and gives you a deep solemn bow.`
 			`	Timothy stays to watch as you begin your slow descent down the mountain, and back to civilization.`
-			decline
+				decline
 
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/308902312741568512/1326183397583749220)

## Summary
Adds a tab character.
