### PR TITLE
fix: Deallocate the SDL base path properly

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -92,7 +92,6 @@ void Files::Init(const char * const *argv)
 		if(!basePath)
 			throw runtime_error("Unable to get path to resource directory!");
 		resources = basePath;
-		// TODO: this SDL_free call should be removed when migrating to SDL3.
 		SDL_free(basePath);
 
 		if(Exists(resources))

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -88,9 +88,11 @@ void Files::Init(const char * const *argv)
 	{
 		// Find the path to the resource directory. This will depend on the
 		// operating system, and can be overridden by a command line argument.
-		resources = SDL_GetBasePath();
-		if(resources.empty())
+		char *basePath = SDL_GetBasePath();
+		if(!basePath)
 			throw runtime_error("Unable to get path to resource directory!");
+		resources = basePath;
+		SDL_free(basePath);
 
 		if(Exists(resources))
 			resources = filesystem::canonical(resources);

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -92,6 +92,7 @@ void Files::Init(const char * const *argv)
 		if(!basePath)
 			throw runtime_error("Unable to get path to resource directory!");
 		resources = basePath;
+		// TODO: this SDL_free call should be removed when migrating to SDL3.
 		SDL_free(basePath);
 
 		if(Exists(resources))


### PR DESCRIPTION
**Bug fix**

## Summary
https://github.com/endless-sky/endless-sky/commit/d67480c35f0984a902d507c698ecf11197fbc0df added an `SDL_GetBasePath` call which should have a corresponding `SDL_free`, as stated in the [docs](https://wiki.libsdl.org/SDL2/SDL_GetBasePath).

## Testing Done
yes™.
