### PR TITLE
fix(cmake): Use generic code for glew library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ else()
 		target_compile_definitions(EndlessSkyLib PUBLIC GL_SILENCE_DEPRECATION)
 	else()
 		# GLEW is only needed on Linux and Windows.
-		target_link_libraries(ExternalLibraries INTERFACE ${GLEW_LIBRARIES})
+		target_link_libraries(ExternalLibraries INTERFACE GLEW)
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ else()
 		target_compile_definitions(EndlessSkyLib PUBLIC GL_SILENCE_DEPRECATION)
 	else()
 		# GLEW is only needed on Linux and Windows.
-		target_link_libraries(ExternalLibraries INTERFACE GLEW::glew)
+		target_link_libraries(ExternalLibraries INTERFACE ${GLEW_LIBRARIES})
 	endif()
 endif()
 


### PR DESCRIPTION
**Bug fix**

This PR (hopefully) addresses the bug described in issue #10519 (closes #10519)

## Summary
The use of this older cmake syntax should be independent of whether the library is called GLEW::glew or GLEW::GLEW. I think.

## Testing Done
Builds on my system, but so did the old code.