### PR TITLE
Use some better default preferences

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -117,7 +117,7 @@ namespace {
 	const vector<string> OverlaySetting::OVERLAY_SETTINGS = {"off", "always on", "damaged", "--", "on hit"};
 
 	map<Preferences::OverlayType, OverlaySetting> statusOverlaySettings = {
-		{Preferences::OverlayType::ALL, Preferences::OverlayState::OFF},
+		{Preferences::OverlayType::ALL, Preferences::OverlayState::ON_HIT},
 		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::ON},
 		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::ON},
 		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::ON},
@@ -175,6 +175,8 @@ void Preferences::Load()
 	settings["Ship outlines in HUD"] = true;
 	settings["Extra fleet status messages"] = true;
 	settings["Target asteroid based on"] = true;
+	settings["Show missile overlays"] = true;
+	settings["Deadline blink by distance"] = true;
 
 	DataFile prefs(Files::Config() / "preferences.txt");
 	for(const DataNode &node : prefs)

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -117,7 +117,7 @@ namespace {
 	const vector<string> OverlaySetting::OVERLAY_SETTINGS = {"off", "always on", "damaged", "--", "on hit"};
 
 	map<Preferences::OverlayType, OverlaySetting> statusOverlaySettings = {
-		{Preferences::OverlayType::ALL, Preferences::OverlayState::ON_HIT},
+		{Preferences::OverlayType::ALL, Preferences::OverlayState::OFF},
 		{Preferences::OverlayType::FLAGSHIP, Preferences::OverlayState::ON},
 		{Preferences::OverlayType::ESCORT, Preferences::OverlayState::ON},
 		{Preferences::OverlayType::ENEMY, Preferences::OverlayState::ON},
@@ -175,7 +175,6 @@ void Preferences::Load()
 	settings["Ship outlines in HUD"] = true;
 	settings["Extra fleet status messages"] = true;
 	settings["Target asteroid based on"] = true;
-	settings["Show missile overlays"] = true;
 	settings["Deadline blink by distance"] = true;
 
 	DataFile prefs(Files::Config() / "preferences.txt");


### PR DESCRIPTION
## Summary
This PR edits a few settings' defaults:
- Status Overlays: Defaults to `on hit` (before: `off`)
    - A balance between visual clarity and gameplay usefulness.
- Missile Overlays: Defaults to `on` (before: `off`)
    - Most useful in the early-game, where dodging missiles can be necessary.
- Deadline Blink by Distance: Defaults to `on` (before: `off`)
    - Highlights urgency, a better representation than just a date.

These are intended to make the new player experience better, mostly by bringing harder-to-notice details into the foreground that would otherwise go unnoticed until much later.