### PR TITLE
feat(ui): Highlight name of selected system in map panel

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -874,6 +874,7 @@ void MapPanel::Find(const string &name)
 			{
 				bestIndex = index;
 				selectedSystem = &system;
+				UpdateCache();
 				CenterOnSystem(selectedSystem);
 				if(!index)
 				{
@@ -893,6 +894,7 @@ void MapPanel::Find(const string &name)
 			{
 				bestIndex = index;
 				selectedSystem = planet.GetSystem();
+				UpdateCache();
 				CenterOnSystem(selectedSystem);
 				if(!index)
 				{

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -804,7 +804,11 @@ void MapPanel::Select(const System *system)
 {
 	if(!system)
 		return;
+
 	selectedSystem = system;
+	// Update the cache to apply any visual changes needed after the selected system was changed.
+	UpdateCache();
+
 	vector<const System *> &plan = player.TravelPlan();
 	Ship *flagship = player.Flagship();
 	if(!flagship || (!plan.empty() && system == plan.front()))
@@ -1128,7 +1132,7 @@ void MapPanel::UpdateCache()
 		const bool canViewSystem = player.CanView(system);
 		nodes.emplace_back(system.Position(), color,
 			player.KnowsName(system) ? system.DisplayName() : "",
-			(&system == &playerSystem) ? closeNameColor : farNameColor,
+			(&system == &playerSystem || &system == selectedSystem) ? closeNameColor : farNameColor,
 			canViewSystem ? system.GetGovernment() : nullptr,
 			canViewSystem ? system.GetMapIcons() : unmappedSystem);
 	}

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -648,11 +648,13 @@ void MissionPanel::SetSelectedScrollAndCenter(bool immediate)
 	if(availableIt != available.end())
 	{
 		selectedSystem = availableIt->Destination()->GetSystem();
+		UpdateCache();
 		ScrollMissionList(available, availableIt, availableScroll, false);
 	}
 	else if(acceptedIt != accepted.end())
 	{
 		selectedSystem = acceptedIt->Destination()->GetSystem();
+		UpdateCache();
 		ScrollMissionList(accepted, acceptedIt, acceptedScroll, true);
 	}
 


### PR DESCRIPTION
**Feature**

## Summary
Makes the selected system on the map have a brighter name colour. Useful when there's lots of names clustered in an area.

## Screenshots
Clicked on Zubenelgenubi while in Ruticulus:
![image](https://github.com/user-attachments/assets/91ad004f-a257-4944-8f2f-657e04245fec)

## Performance Impact
This does have a slight performance impact, but it is way overshadowed by the DistanceMap route calculation cost.
