### PR TITLE
fix(audio): Use relative path for sounds

### DIFF
--- a/source/audio/Music.cpp
+++ b/source/audio/Music.cpp
@@ -53,7 +53,8 @@ void Music::Init(const vector<filesystem::path> &sources)
 			if(Format::LowerCase(path.extension().string()) != ".mp3")
 				continue;
 
-			paths[(path.parent_path() / path.stem()).generic_string()] = path;
+			string name = (path.parent_path() / path.stem()).lexically_relative(root).generic_string();
+			paths[name] = path;
 		}
 	}
 }


### PR DESCRIPTION
**Bug fix**

The paths for audio files were not made relative in the filesystem changes, causing them to not play.

## Summary
Makes the path relative and stuff plays now.

## Testing Done
Listened to it.