### PR TITLE
fix(audio): Re-add missing `alSourcef` line removed from Audio.ccp in #10862

### DIFF
--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -470,6 +470,7 @@ void Audio::Step(bool isFastForward)
 			recycledSources.pop_back();
 		}
 		// Begin playing this sound.
+		alSourcef(source, AL_GAIN, Volume(it.second.category));
 		sources.emplace_back(it.first, source, it.second.category, isFastForward);
 		sources.back().Move(it.second);
 		alSourcePlay(source);


### PR DESCRIPTION
**Bug fix**

## Summary
Adds back a line that was unnecessarily removed in #10862, in which its absence caused sound effects not to play properly.

## Testing Done
Tested before and after; sounds play properly again.

## Save File
N/A; Pick a ship that has a 3x sound and spam weapons/landing.