### PR TITLE
Disable all help messages in integration tests

### DIFF
--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -1,11 +1,14 @@
 "Automatic aiming" 1
 "Automatic firing" 1
 "help: bank" 1
+"help: bank advanced" 1
 "help: basics 1" 1
 "help: basics 2" 1
 "help: basics 3" 1
+"help: control ship with mouse" 1
 "help: dead" 1
 "help: disabled" 1
+"help: fighters transfer cargo" !
 "help: fleet asteroid mining shortcuts" 1
 "help: fleet asteroid mining" 1
 "help: fleet harvest tutorial" 1
@@ -21,8 +24,10 @@
 "help: lost 7" 1
 "help: map" 1
 "help: map advanced" 1
+"help: map advanced danger" 1
 "help: map advanced ports" 1
 "help: map advanced shops" 1
+"help: map advanced stars" 1
 "help: multiple ship controls" 1
 "help: multiple ships" 1
 "help: navigation" 1

--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -10,8 +10,8 @@
 "help: dead" 1
 "help: disabled" 1
 "help: fighters transfer cargo" 1
-"help: fleet asteroid mining shortcuts" 1
 "help: fleet asteroid mining" 1
+"help: fleet asteroid mining shortcuts" 1
 "help: fleet harvest tutorial" 1
 "help: friendly disabled" 1
 "help: hiring" 1

--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -5,6 +5,7 @@
 "help: basics 1" 1
 "help: basics 2" 1
 "help: basics 3" 1
+"help: cargo management" 1
 "help: control ship with mouse" 1
 "help: dead" 1
 "help: disabled" 1
@@ -33,10 +34,9 @@
 "help: navigation" 1
 "help: outfitter" 1
 "help: outfitter with multiple ships" 1
-"help: cargo management" 1
-"help: uninstalling and storage" 1
 "help: ship info" 1
 "help: shipyard" 1
 "help: stranded" 1
 "help: trading" 1
 "help: try out fighters transfer cargo" 1
+"help: uninstalling and storage" 1

--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -9,7 +9,7 @@
 "help: control ship with mouse" 1
 "help: dead" 1
 "help: disabled" 1
-"help: fighters transfer cargo" !
+"help: fighters transfer cargo" 1
 "help: fleet asteroid mining shortcuts" 1
 "help: fleet asteroid mining" 1
 "help: fleet harvest tutorial" 1


### PR DESCRIPTION
**CI/CD/Testing**

## Summary
Adds some new help messages that weren't marked as "seen" in the integration tests preferences file there so they cannot show up while running integration tests (unless they are requested).
Not currently an issue for any of our integration tests, but doing it now so that it doesn't become an issue later and give people headaches.

## Testing Done
Never.
