### PR TITLE
Update tactical icon copyright again

### DIFF
--- a/copyright
+++ b/copyright
@@ -3702,7 +3702,7 @@ Files:
  images/ui/tactical/energy*
  images/ui/tactical/fuel*
  images/ui/tactical/thermal*
-Copyright: Michael Zahniser
+Copyright: Michael Zahniser <mzahniser@gmail.com>
 License: CC-BY-SA-4.0
 Comment: Cropped and split into four new files by Zitchas (zitchas.jma@gmail.com)
 

--- a/copyright
+++ b/copyright
@@ -3698,6 +3698,15 @@ Copyright: Zitchas (zitchas.jma@gmail.com)
 License: CC-BY-SA-4.0
 
 Files:
+ images/ui/tactical/crew*
+ images/ui/tactical/energy*
+ images/ui/tactical/fuel*
+ images/ui/tactical/thermal*
+Copyright: Michael Zahniser
+License: CC-BY-SA-4.0
+Comment: Cropped by Zitchas (zitchas.jma@gmail.com)
+
+Files:
  images/_menu/haze-brown*
 Copyright: RisingLeaf (https://github.com/RisingLeaf)
 License: CC-BY-SA-4.0

--- a/copyright
+++ b/copyright
@@ -3704,7 +3704,7 @@ Files:
  images/ui/tactical/thermal*
 Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
-Comment: Cropped by Zitchas (zitchas.jma@gmail.com)
+Comment: Cropped and split into four new files by Zitchas (zitchas.jma@gmail.com)
 
 Files:
  images/_menu/haze-brown*


### PR DESCRIPTION
**Documentation**

## Summary
Following on from https://github.com/endless-sky/endless-sky/pull/10921, this PR modifies the copyright entry for those icons to include a description stating that they were cropped by Zitchas, while still indicating that the copyright owner is Michael Zahniser.
I'm not going to copy-paste the description and conversation on that PR here.

## Artwork Checklist
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: https://github.com/endless-sky/endless-sky-high-dpi/pull/440
