### PR TITLE
[Bugfix] Quick Aberrant Player Rep Fix + Windjammer Timer Typo

### DIFF
--- a/data/avgi/windjammers.txt
+++ b/data/avgi/windjammers.txt
@@ -160,7 +160,7 @@ ship "Windjammer"
 		"cooling" 30
 		"overheat damage threshold" 0.66
 		"overheat damage rate" -0.06
-		"disabled recovery timer" 720
+		"disabled recovery time" 720
 		"thrust" 44
 		"turn" 720
 		"hull repair rate" 3
@@ -316,7 +316,7 @@ ship "Bluejacket"
 		"cooling" 30
 		"overheat damage threshold" 0.66
 		"overheat damage rate" -0.06
-		"disabled recovery timer" 720
+		"disabled recovery time" 720
 		"thrust" 22
 		"turn" 1440
 		"hull repair rate" 3

--- a/data/governments.txt
+++ b/data/governments.txt
@@ -16,6 +16,7 @@ government "Aberrant"
 	language "Ka'het"
 	color 0.4 0.4 0.7
 
+	"player reputation" -1000
 	"default attitude" -.01
 	"attitude toward"
 		"Author" 0


### PR DESCRIPTION
**Bug fix**

## Summary
Restores the accidentally deleted player reputation line in the Aberrant government. Also corrects `disabled recovery timer` to `disabled recovery time` on the Windjammer ships.



# Testing done

Shot at Windjammers, watched them recover after being disabled. ~~Didn't actually test the player rep fix with the Aberrant.~~