### PR TITLE
fix(audio): Don't pause sound effects when audio is already paused

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -70,6 +70,8 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	GameData::Preload(queue, planet.Landscape());
 	queue.Wait();
 	queue.ProcessSyncTasks();
+
+	Audio::Pause();
 }
 
 

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -358,7 +358,9 @@ void Audio::Step(bool isFastForward)
 
 	if(pauseChangeCount > 0)
 	{
-		if(pauseCount += pauseChangeCount)
+		bool wasPaused = pauseCount;
+		pauseCount += pauseChangeCount;
+		if(pauseCount && !wasPaused)
 		{
 			ALint state;
 			for(const Source &source : sources)


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug where sound effects would get paused even if their playback started after the game paused.

## Summary
Imagine landing on a planet. The planet panel pauses audio (for reals, this time), and landing popups might also pause audio. This happens in the same frame as the landing sound, so it doesn't cause issues. However, if you visit the spaceport and get a popup there before the landing sound finishes playback, it would get paused. This is unintentional, and is fixed here.

## Testing Done
I tested that stuff still pauses and resumes fine.