### PR TITLE
fix(ui): Properly select the ShipInfoPanel's ship

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -324,7 +324,10 @@ void ShipInfoPanel::UpdateInfo()
 	const Ship &ship = **shipIt;
 	info.Update(ship, player);
 	if(player.Flagship() && ship.GetSystem() == player.GetSystem() && &ship != player.Flagship())
+	{
 		player.Flagship()->SetTargetShip(*shipIt);
+		player.SelectShip(shipIt->get(), false);
+	}
 
 	outfits.clear();
 	for(const auto &it : ship.Outfits())


### PR DESCRIPTION
As reported [on Discord](https://discord.com/channels/251118043411775489/308902312741568512/1331179187511496745).

## Summary
When opening the ship info panel, the ship is selected as the flagship's target, but not actually selected for the player as the target of orders.
This PR fixes the problem by properly selecting the ship.

## Testing Done
yes™

## Performance Impact
N/A
