### PR TITLE
fix(audio): Fix some paused sources not getting resumed properly

### DIFF
--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -32,7 +32,7 @@ class UI;
 class MenuPanel : public Panel {
 public:
 	MenuPanel(PlayerInfo &player, UI &gamePanels);
-	~MenuPanel();
+	virtual ~MenuPanel();
 
 	virtual void Step() override;
 	virtual void Draw() override;

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -384,6 +384,12 @@ void Audio::Step(bool isFastForward)
 				if(state == AL_PAUSED)
 					alSourcePlay(source.ID());
 			}
+			for(unsigned source : endingSources)
+			{
+				alGetSourcei(source, AL_SOURCE_STATE, &state);
+				if(state == AL_PAUSED)
+					alSourcePlay(source);
+			}
 		}
 	}
 	pauseChangeCount = 0;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10944

## Summary
Looping sources would sometimes get moved to the `endingSources` list in a paused state; this PR resumes them when appropriate.

## Testing Done
I can no longer reproduce the bug.