### PR TITLE
Don't allow "Paradise Job: Wilderness Retreat" to go to a station

### DIFF
--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -591,6 +591,7 @@ mission "Paradise Job: Wilderness Retreat"
 	destination
 		distance 6 20
 		attributes "frontier" "rim" "forest" "fishing"
+		not attributes "station"
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/308902312741568512/1333017595712110622)

## Summary
Don't allow the job `"Paradise Job: Wilderness Retreat"` to go to a station, as both the description and `on complete` dialog imply there is a planetside destination.
