### PR TITLE
fix(build): Add missing includes

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -39,6 +39,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "UI.h"
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 using namespace std;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -49,6 +49,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstring>
 #include <ctime>
 #include <functional>
 #include <iterator>

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -44,6 +44,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "UI.h"
 
 #include <algorithm>
+#include <cmath>
 #include <ranges>
 
 using namespace std;

--- a/source/ShipNameDialog.cpp
+++ b/source/ShipNameDialog.cpp
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "image/SpriteSet.h"
 #include "shader/SpriteShader.h"
 
+#include <cmath>
+
 using namespace std;
 
 


### PR DESCRIPTION
I'm not sure why (maybe a gcc update?), but some files failed to build without these includes.

Example errors:
```prolog
FAILED: source/CMakeFiles/EndlessSkyLib.dir/Debug/ShipNameDialog.cpp.o
/usr/bin/c++ -DCMAKE_INTDIR=\"Debug\" -isystem /usr/include/SDL2 -isystem /usr/include/AL -g -std=c++20 -fdiagnostics-color=always -Wall -pedantic-errors -Wold-style-cast -g -fsanitize=address,undefined,pointer-compare,pointer-subtract,unreachable,builtin,integer-divide-by-zero,vla-bound,null,return,signed-integer-overflow,bounds,alignment,bool,enum,pointer-overflow -fno-omit-frame-pointer -fsanitize=leak,vptr -MD -MT source/CMakeFiles/EndlessSkyLib.dir/Debug/ShipNameDialog.cpp.o -MF source/CMakeFiles/EndlessSkyLib.dir/Debug/ShipNameDialog.cpp.o.d -o source/CMakeFiles/EndlessSkyLib.dir/Debug/ShipNameDialog.cpp.o -c /home/koranir/src/cpp/endless-sky/source/ShipNameDialog.cpp
/home/koranir/src/cpp/endless-sky/source/ShipNameDialog.cpp: In member function ‘virtual bool ShipNameDialog::Click(int, int, int)’:
/home/koranir/src/cpp/endless-sky/source/ShipNameDialog.cpp:48:12: error: ‘fabs’ was not declared in this scope; did you mean ‘labs’?
   48 |         if(fabs(off.X()) < 40. && fabs(off.Y()) < 20.)
      |            ^~~~
      |            labs
[75/139] Building CXX object source/CMakeFiles/EndlessSkyLib.dir/Debug/PlayerInfo.cpp.o
FAILED: source/CMakeFiles/EndlessSkyLib.dir/Debug/PlayerInfo.cpp.o
/usr/bin/c++ -DCMAKE_INTDIR=\"Debug\" -isystem /usr/include/SDL2 -isystem /usr/include/AL -g -std=c++20 -fdiagnostics-color=always -Wall -pedantic-errors -Wold-style-cast -g -fsanitize=address,undefined,pointer-compare,pointer-subtract,unreachable,builtin,integer-divide-by-zero,vla-bound,null,return,signed-integer-overflow,bounds,alignment,bool,enum,pointer-overflow -fno-omit-frame-pointer -fsanitize=leak,vptr -MD -MT source/CMakeFiles/EndlessSkyLib.dir/Debug/PlayerInfo.cpp.o -MF source/CMakeFiles/EndlessSkyLib.dir/Debug/PlayerInfo.cpp.o.d -o source/CMakeFiles/EndlessSkyLib.dir/Debug/PlayerInfo.cpp.o -c /home/koranir/src/cpp/endless-sky/source/PlayerInfo.cpp
/home/koranir/src/cpp/endless-sky/source/PlayerInfo.cpp: In lambda function:
/home/koranir/src/cpp/endless-sky/source/PlayerInfo.cpp:3297:47: error: ‘strlen’ was not declared in this scope
 3297 |                 auto it = si.find(name.substr(strlen("salary: ")));
      |                                               ^~~~~~
/home/koranir/src/cpp/endless-sky/source/PlayerInfo.cpp:53:1: note: ‘strlen’ is defined in header ‘<cstring>’; this is probably fixable by adding ‘#include <cstring>’
   52 | #include <ctime>
  +++ |+#include <cstring>
   53 | #include <functional>
/home/koranir/src/cpp/endless-sky/source/PlayerInfo.cpp: In lambda function:
/home/koranir/src/cpp/endless-sky/source/PlayerInfo.cpp:3305:54: error: ‘strlen’ was not declared in this scope
 3305 |                 accounts.SetSalaryIncome(name.substr(strlen("salary: ")), value);
      |
```