### PR TITLE
fix(bug): two Avgi news fixes

### DIFF
--- a/data/avgi/avgi news.txt
+++ b/data/avgi/avgi news.txt
@@ -20,12 +20,12 @@ news "avgi siege civilian"
 		attributes "aberrant siege"
 	name
 		word
-			"Avgi "
+			"Avgi"
 		word
-			"civilian"
-			"citizen"
-			"bystander"
-			"onlooker"
+			" civilian"
+			" citizen"
+			" bystander"
+			" onlooker"
 			""
 	message
 		word
@@ -208,6 +208,8 @@ news "avgi safety advisory"
 			`Missing fleet reported; suspected lost in the Tangled Shroud."`
 			`The defensive cordon at Arche is not impenetrable. Remain vigilant."`
 			`Report all Aberration sightings as soon as possible."`
+	message
+		word
 			"The message board chirps in an Avgi language your translator does not appear to be compatible with."
 
 


### PR DESCRIPTION
**Bug fix**

## Summary
Fixes two bugs in the way Avgi news are displayed.

The first change fixes instances of "Avgi :" and the second fixes `"Caution. The message bird chirps in a language your translator is not compatible with.`

I don't have screenshots and haven't tested.