### PR TITLE
Improve Dangerous Games source location filters

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4930,7 +4930,7 @@ mission "Dangerous Games 1"
 	passengers 9
 	source
 		attributes "frontier" "pirate"
-		government "Republic" "Free Worlds" "Syndicate" "Pirate"
+		near "Hadar" 1 100
 	stopover "Skymoot"
 	to offer
 		random < 15

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5026,6 +5026,7 @@ mission "Dangerous Games 2"
 	description `The adventurer Karengo and five others are traveling with you as part of his "Galactic Adventures." Bring Karengo and crew to <destination> for <payment>.`
 	source
 		attributes "frontier" "pirate" "rim"
+		near "Izar" 1 100
 	destination "Poseidos"
 	cargo "subpods" 6
 	passengers 6


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described on Discord by phil_4: https://discord.com/channels/251118043411775489/536900466655887360/1333794593040367649

## Summary
Adjusts the source location filters of the two Dangerous Games missions so they only choose systems between 1 and 100 hyperspace links from the stopover/destination system.
Without this, the second mission can choose Avgi planets as the source. The first mission cannot only because its location filter was adjusted when the Avgi were added to only offer from Republic, Free Worlds, Syndicate, or Pirate worlds. That part of the filter is now gone because the "near" filtering makes it redundant.

## Testing Done
None.

## Save File
This save file can be used to test these changes:
No.
