### PR TITLE
Fix conversation endpoint indentation in "Skadenga Call 5

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -3695,7 +3695,7 @@ mission "Skadenga Call 5"
 		payment 27
 		conversation
 			`You receive a message from the Census and Culture Bureau of the Deep. The Deep Citizen known as Hjlod has died. The cause of death appeared to be related to heavy substance abuse. The Bureau has determined that you are her closest relation and has forwarded you her entire inheritance: <payment>.`
-			decline
+				decline
 
 
 mission "Home for Skadenga 8"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described on Discord by dariusjenai: https://discord.com/channels/251118043411775489/536900466655887360/1333805486428127284

## Summary
Indents the "decline" so it is a child of the text node above it and treated as an endpoint instead of being used like its own text node.

## Testing Done
No.

## Save File
This save file can be used to test these changes:
No.
