### PR TITLE
Fix tooltip boxes being drawn when there is no tooltip text

### DIFF
--- a/source/text/WrappedText.cpp
+++ b/source/text/WrappedText.cpp
@@ -145,7 +145,7 @@ void WrappedText::Wrap(const char *str)
 /// With trailingBreak, include a paragraph break after the text.
 int WrappedText::Height(bool trailingBreak) const
 {
-	return height + trailingBreak * paragraphBreak;
+	return height + (height && trailingBreak) * paragraphBreak;
 }
 
 

--- a/source/text/WrappedText.cpp
+++ b/source/text/WrappedText.cpp
@@ -145,7 +145,9 @@ void WrappedText::Wrap(const char *str)
 /// With trailingBreak, include a paragraph break after the text.
 int WrappedText::Height(bool trailingBreak) const
 {
-	return height + (height && trailingBreak) * paragraphBreak;
+	if(!height)
+		return 0;
+	return height + trailingBreak * paragraphBreak;
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described by phil_4 on Discord:
https://discord.com/channels/251118043411775489/536900466655887360/1333860535535665326

## Summary
The tooltip code in ItemInfoDisplay expects the height of its WrappedText object to be "0" when there is no text.
This was originally the case, and remained the case when WrappedText::Wrap was adjusted to not incorporate a final paragraph break into the height of the text (this code was not reached if there was no text so no text = no final paragraph break) but this broke other things so the paragraph break height was optionally added in WrappedText::Height. But, this didn't account for how the paragraph break would not have been included if there was no text initially.
So, ItemInfoDisplay::DrawTooltips expected:
- no text: height = 0, no paragraph break.
- text: height != 0, includes paragraph break
But, it is now getting a value that always includes the paragraph break.

This PR modifies WrappedText::Height to only include the paragraph break if the height is not zero to begin with and the passed parameter asking for a paragraph break is "true" (which it is by default). This means the game no longer draws tooltip boxes without tooltip text in the ItemInfoDisplay (used by OutfitInfoDisplay and ShipInfoDisplay, in the shop panels for the selected item and player ships, and in the ship info panel).

The same issue also resulted in items without descriptions having the description collapse/expand click zone generated in the shop panels even if there is no description text. This is also fixed by this PR.

## Screenshots
No.

## Testing Done
Open the outfitter, select an outfit with an attribute without an associated tooltip, such as ammunition or hand to hand weapons (the ammuniition capacity attribute won't have a tooltip) and hover over it.
Without this PR, an empty tooltip box will be drawn.
With this PR, no tooltip box is drawn.
