### PR TITLE
Fix some issues with escorts jumping around on their own

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -921,6 +921,11 @@ void AI::Step(Command &activeCommands)
 					|| shipToAssist->GetGovernment()->IsEnemy(gov)
 					|| (!shipToAssist->IsDisabled() && !shipToAssist->NeedsFuel() && !shipToAssist->NeedsEnergy()))
 			{
+				if(target == shipToAssist)
+				{
+					target.reset();
+					it->SetTargetShip(nullptr);
+				}
 				shipToAssist.reset();
 				it->SetShipToAssist(nullptr);
 			}


### PR DESCRIPTION
**Bug fix**

Thank you to various people who have reported this on Discord, and in particular admitus who found a reliable reproduction method.

## Summary
It is possible for a ship to be recruited to help another ship, usually because that ship has insufficient fuel to jump to another system, and set that ship as its target, but for that ship to no longer need help by a later "step" before the helper has reached it. This would usually be through the use of a ramscoop. It is particularly noticeable when the ship is using afterburners or, I expect, other outfits that consume fuel at a relatively low, but sustained rate, as the ship may only be slightly below the threshold of being able to jump when it asks for help, and so will not take long to accumulate sufficient fuel to no longer consider itself stranded.
However, while the helper's "shipToAssist", that is, the ship it is planning to assist, pointer is cleared at this point, it will retain that ship as its target.
In the case of a player escort, it is not expected that it will be targeting a ship it is friendly with but not be planning to assist it. As a result, the ship will end up in the "MoveIndependent" method, the assumption having been that it is planning to either attack or scan its target. The player escort doesn't actually want to do either of these things to the target, though, and so it ends up in code for choosing a planet or system to travel to, and travels there.
This is not something we want player ships to be doing.

This PR adds a step to the process of clearing a ship's "shipToAssist" pointer if the target no longer needs assistance by also checking if the"target" pointer refers to the same ship and clearing that as well.

## Testing Done
admitus said they checked and the issue is no longer present.

## Save File
No.

## Performance Impact
Minimal if any.
