### PR TITLE
feat(balance): Buff the bastion and bulwark

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -435,13 +435,13 @@ ship "Bastion"
 	attributes
 		category "Medium Warship"
 		"cost" 3860000
-		"shields" 7500
-		"hull" 4700
+		"shields" 9000
+		"hull" 5500
 		"required crew" 17
 		"bunks" 40
-		"mass" 1210
-		"drag" 16.5
-		"heat dissipation" .32
+		"mass" 950
+		"drag" 12.8
+		"heat dissipation" .4
 		"fuel capacity" 500
 		"cargo space" 110
 		"outfit space" 470

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -812,13 +812,13 @@ ship "Bulwark"
 	attributes
 		category "Medium Warship"
 		"cost" 4360000
-		"shields" 7000
-		"hull" 5600
+		"shields" 8000
+		"hull" 6500
 		"required crew" 19
 		"bunks" 31
-		"mass" 1722
-		"drag" 21
-		"heat dissipation" .27
+		"mass" 1582
+		"drag" 20.1
+		"heat dissipation" .28
 		"fuel capacity" 500
 		"cargo space" 12
 		"outfit space" 521

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -435,13 +435,13 @@ ship "Bastion"
 	attributes
 		category "Medium Warship"
 		"cost" 3860000
-		"shields" 9000
-		"hull" 5500
+		"shields" 8600
+		"hull" 5300
 		"required crew" 17
 		"bunks" 40
-		"mass" 950
-		"drag" 12.8
-		"heat dissipation" .4
+		"mass" 1100
+		"drag" 15.5
+		"heat dissipation" .34
 		"fuel capacity" 500
 		"cargo space" 110
 		"outfit space" 470


### PR DESCRIPTION
**Balance**

This PR addresses the bug described on [today’s campfire chat](https://discord.com/channels/251118043411775489/1136144420681560064/1335336094895444070).

## Summary
Multiple people have noted that the Bastion was too slow for a medium warship. This PR starts the process of buffing it by reducing mass and drag, increasing HP, and increasing heat dissipation to account for the reduced mass.
EDIT: Also buffed the Bulwark as recommended by Quantumshark

## Testing Done
None. 