### PR TITLE
Fix Remnant Rescue 1 through 3 location filters FOR THE LAST TIME

### DIFF
--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -507,7 +507,8 @@ mission "Remnant: Rescue 2B"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			not near "Arculus" 3
+			near "Arculus" 3 100
+				"all wormholes"
 		personality staying heroic nemesis unconstrained
 		government "Test Dummy"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -545,7 +545,8 @@ mission "Remnant: Rescue 3"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			not near "Arculus" 3
+			near "Arculus" 3 100
+				"all wormholes"
 		personality derelict timid plunders
 		government "Remnant"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -429,7 +429,8 @@ mission "Remnant: Rescue 1B"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			not near "Arculus" 3
+			near "Arculus" 3 100
+				"all wormholes"
 		personality staying heroic nemesis unconstrained
 		government "Test Dummy"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -583,7 +583,8 @@ mission "Remnant: Rescue 3B"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			not near "Arculus" 3
+			near "Arculus" 3 100
+				"all wormholes"
 		personality staying heroic nemesis unconstrained
 		government "Test Dummy"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -467,7 +467,8 @@ mission "Remnant: Rescue 2"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			not near "Arculus" 3
+			near "Arculus" 3 100
+				"all wormholes"
 		personality derelict timid plunders
 		government "Remnant"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -361,7 +361,8 @@ mission "Remnant: Rescue"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			not near "Arculus" 3
+			near "Arculus" 3 100
+				"all wormholes"
 		personality derelict timid plunders
 		government "Remnant"
 		fleet

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -361,7 +361,8 @@ mission "Remnant: Rescue"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			near "Arculus" 3 100
+			not near "Arculus" 3
+			near "Arculus" 30
 				"all wormholes"
 		personality derelict timid plunders
 		government "Remnant"
@@ -429,7 +430,8 @@ mission "Remnant: Rescue 1B"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			near "Arculus" 3 100
+			not near "Arculus" 3
+			near "Arculus" 30
 				"all wormholes"
 		personality staying heroic nemesis unconstrained
 		government "Test Dummy"
@@ -467,7 +469,8 @@ mission "Remnant: Rescue 2"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			near "Arculus" 3 100
+			not near "Arculus" 3
+			near "Arculus" 30
 				"all wormholes"
 		personality derelict timid plunders
 		government "Remnant"
@@ -507,7 +510,8 @@ mission "Remnant: Rescue 2B"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			near "Arculus" 3 100
+			not near "Arculus" 3
+			near "Arculus" 30
 				"all wormholes"
 		personality staying heroic nemesis unconstrained
 		government "Test Dummy"
@@ -545,7 +549,8 @@ mission "Remnant: Rescue 3"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			near "Arculus" 3 100
+			not near "Arculus" 3
+			near "Arculus" 30
 				"all wormholes"
 		personality derelict timid plunders
 		government "Remnant"
@@ -583,7 +588,8 @@ mission "Remnant: Rescue 3B"
 			not attributes "inaccessible"
 			not attributes "graveyard"
 			not government "Remnant"
-			near "Arculus" 3 100
+			not near "Arculus" 3
+			near "Arculus" 30
 				"all wormholes"
 		personality staying heroic nemesis unconstrained
 		government "Test Dummy"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10974

## Summary
The filters these jobs currently use to select the starting location of their NPC can currently select some systems beyond what is reachable from the core Remnant worlds without a jump drive. Since the NPCs don't have jump drives, this leads to them being unable to follow the player back to the destination.
Additionally, these systems contain Aberrant fleets. This seems out of scope for these jobs which explicitly do not select graveyard systems wher the Ka'het are present.

This PR modifies the filters in these jobs so they will only select systems that can be reached from the Arculus system by wormhole or hyperspace link and are at least 

## Testing Done
<details> <summary>The current filters can select any of:</summary>

- Aescolanus
- Antevorta
- Caeculus
- Cardea
- Coluber
- Convector
- Duet
- Insitor
- Levana
- Lucina
- Nenia
- Nonet
- Octet
- Ossipago
- Parca
- Peragenor
- Quartet
- Quintet
- Segesta
- Septet
- Sextet
- Stercutus
- Trio

</details>

<details> <summary>The new filters can select any of:</summary>

- Aescolanus
- Antevorta
- Caeculus
- Cardea
- Coluber
- Convector
- Insitor
- Levana
- Lucina
- Nenia
- Ossipago
- Parca
- Peragenor
- Segesta
- Stercutus

</details>

<details> <summary>That is, all the same systems minus:</summary>

- Duet
- Trio
- Quartet
- Quintet
- Sextet
- Septet
- Octet
- Nonet

Which are the new systems that ought not be included.

</details>

## Save File
No.

## Performance Impact
Immeasurable, probably.
