### PR TITLE
feat(balance): Make Korath raids in human space `frugal`

### DIFF
--- a/data/korath/korath.txt
+++ b/data/korath/korath.txt
@@ -370,7 +370,7 @@ fleet "Korath Large Raid"
 		names "korath"
 	cargo 1
 	personality
-		disables plunders opportunistic harvests
+		disables plunders opportunistic frugal harvests
 	variant 5
 		"Palavret" 2
 		"'olofez" 4

--- a/data/korath/korath.txt
+++ b/data/korath/korath.txt
@@ -210,7 +210,7 @@ fleet "Korath Raid"
 		names "korath"
 	cargo 1
 	personality
-		disables plunders opportunistic harvests
+		disables plunders opportunistic frugal harvests
 	variant 4
 		"Palavret"
 		"'olofez" 2


### PR DESCRIPTION
**Balance**

This PR implements the change suggested by Ravenshining [here](https://github.com/endless-sky/endless-sky/pull/10923#discussion_r1935252449)

## Summary
Adds frugal to `Korath Raid` and `Korath Large Raid` fleets (the two that raid human space).
This should reduce the frequency with which these extremely powerful weapons are used against players in human ships that have no way to effectively deal with them.
This also makes more sense in-universe - it doesn't make sense for the severely resource-limited Korath to use these expensive missiles to blow up flimsy human ships that could be disabled and plundered without using them.

## Testing Done
Took some small human ships (a Clipper and a Corvette) into systems with Korath raids with and without the change, observed that without the changes I died repeatedly to firelights I could neither dodge nor outrun, whereas with the changes I was only having to deal with attacks from the 'olofezes, which were more survivable.

## Save File
This save file can be used to test these changes:
[Phillip Head.txt](https://github.com/user-attachments/files/18656740/Phillip.Head.txt)
Corvette in Polaris, with 10M credits with which to buy other ships to try out.
Or, alternatively, you can just go there with your ships on your save.