### PR TITLE
feat(mechanics): Turret turn multipliers

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1042,6 +1042,9 @@ tip "shots / second:"
 tip "turret turn rate:"
 	`Degrees this turret can turn per second.`
 
+tip "turret turn multiplier:"
+	`Modifies the turret turn rate on this ship by the given factor.`
+
 tip "arc:"
 	`The angular range of protection provided by this weapon, in degrees.`
 

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -225,10 +225,10 @@ set<const Outfit *> Armament::RestockableAmmo() const
 
 
 // Adjust the aim of the turrets.
-void Armament::Aim(const FireCommand &command)
+void Armament::Aim(const Ship &ship, const FireCommand &command)
 {
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
-		hardpoints[i].Aim(command.Aim(i));
+		hardpoints[i].Aim(ship, command.Aim(i));
 }
 
 

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -71,7 +71,7 @@ public:
 	std::set<const Outfit *> RestockableAmmo() const;
 
 	// Adjust the aim of the turrets.
-	void Aim(const FireCommand &command);
+	void Aim(const Ship &ship, const FireCommand &command);
 	// Fire the given weapon, if it is ready.
 	void Fire(unsigned index, Ship &ship, std::vector<Projectile> &projectiles, std::vector<Visual> &visuals, bool jammed);
 	// Fire the given anti-missile system.

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -125,6 +125,16 @@ Angle Hardpoint::HarmonizedAngle() const
 
 
 
+double Hardpoint::TurnRate(const Ship &ship) const
+{
+	if(!outfit)
+		return 0.;
+	return outfit->TurretTurn()
+		* (1. + ship.Attributes().Get("turret turn multiplier") + baseAttributes.turnMultiplier);
+}
+
+
+
 // Find out if this is a turret hardpoint (whether or not it has a turret installed).
 bool Hardpoint::IsTurret() const
 {
@@ -171,9 +181,9 @@ bool Hardpoint::IsSpecial() const
 
 
 
-bool Hardpoint::CanAim() const
+bool Hardpoint::CanAim(const Ship &ship) const
 {
-	return outfit && outfit->TurretTurn();
+	return TurnRate(ship);
 }
 
 
@@ -227,12 +237,12 @@ void Hardpoint::Step()
 
 // Adjust this weapon's aim by the given amount, relative to its maximum
 // "turret turn" rate. Up to its angle limit.
-void Hardpoint::Aim(double amount)
+void Hardpoint::Aim(const Ship &ship, double amount)
 {
 	if(!outfit)
 		return;
 
-	const double add = outfit->TurretTurn() * amount;
+	const double add = TurnRate(ship) * amount;
 	if(isOmnidirectional)
 		angle += add;
 	else

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -46,6 +46,8 @@ public:
 		// (directional turret only)
 		Angle minArc;
 		Angle maxArc;
+		// This attribute is added to the turret turn multiplier of the ship.
+		double turnMultiplier;
 	};
 
 
@@ -71,6 +73,8 @@ public:
 	const Angle &GetMaxArc() const;
 	// Get the angle this weapon ought to point at for ideal gun harmonization.
 	Angle HarmonizedAngle() const;
+	// Get the turret turn rate of this hardpoint, considering all applicable multipliers.
+	double TurnRate(const Ship &ship) const;
 	// Shortcuts for querying weapon characteristics.
 	bool IsTurret() const;
 	bool IsParallel() const;
@@ -78,7 +82,7 @@ public:
 	bool IsUnder() const;
 	bool IsHoming() const;
 	bool IsSpecial() const;
-	bool CanAim() const;
+	bool CanAim(const Ship &ship) const;
 
 	// Check if this weapon is ready to fire.
 	bool IsReady() const;
@@ -91,7 +95,7 @@ public:
 
 	// Adjust this weapon's aim by the given amount, relative to its maximum
 	// "turret turn" rate.
-	void Aim(double amount);
+	void Aim(const Ship &ship, double amount);
 	// Fire this weapon. If it is a turret, it automatically points toward
 	// the given ship's target. If the weapon requires ammunition, it will
 	// be subtracted from the given ship.

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -171,7 +171,8 @@ namespace {
 		{"shield fuel multiplier", -1.},
 		{"shield heat multiplier", -1.},
 		{"acceleration multiplier", -1.},
-		{"turn multiplier", -1.}
+		{"turn multiplier", -1.},
+		{"turret turn multiplier", -1.}
 	};
 
 	void AddFlareSprites(vector<pair<Body, int>> &thisFlares, const pair<Body, int> &it, int count)

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -352,6 +352,7 @@ void Ship::Load(const DataNode &node)
 			attributes.baseAngle = Angle(0.);
 			attributes.isParallel = false;
 			attributes.isOmnidirectional = true;
+			attributes.turnMultiplier = 0.;
 			bool drawUnder = (key == "gun");
 			if(child.HasChildren())
 			{
@@ -376,6 +377,8 @@ void Ship::Load(const DataNode &node)
 						if(!Angle(0.).IsInRange(attributes.minArc, attributes.maxArc))
 							grand.PrintTrace("Warning: Minimum arc is higher than maximum arc. Might not work as expected.");
 					}
+					else if(grand.Token(0) == "turret turn multiplier")
+						attributes.turnMultiplier = grand.Value(1);
 					else if(grand.Token(0) == "under")
 						drawUnder = true;
 					else if(grand.Token(0) == "over")
@@ -1081,6 +1084,8 @@ void Ship::Save(DataWriter &out) const
 					out.Write("parallel");
 				if(!attributes.isOmnidirectional)
 					out.Write("arc", firstArc, secondArc);
+				if(attributes.turnMultiplier)
+					out.Write("turret turn multiplier", attributes.turnMultiplier);
 				if(hardpoint.IsUnder())
 					out.Write("under");
 				else
@@ -1666,7 +1671,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 
 		// Move the turrets.
 		if(!isDisabled)
-			armament.Aim(firingCommands);
+			armament.Aim(*this, firingCommands);
 
 		DoInitializeMovement();
 		StepPilot();


### PR DESCRIPTION
**Feature**

## Summary
Added a multiplier attribute for turret turn rates (additive, like all other multipliers). It can be set on the whole ship (by adding it as an attribute of the ship or its outfits) or directly on a particular hardpoint. As there's no UI for viewing the detailed attributes of hardpoints, it should be mentioned somewhere else (for example in the ship's description) if we want the player to know about it.

As usual, no data changes in this PR, just the engine feature.

## Usage examples
`"turret turn multiplier" <value#>` can be a child of the hardpoint, and a standard attribute of the ship (or its outfits).

## Testing Done
yes.

## Wiki Update
soon

## Performance Impact
most likely none.
