### PR TITLE
fix(mechanics): Fix blast damage not affecting minables

### DIFF
--- a/source/AsteroidField.cpp
+++ b/source/AsteroidField.cpp
@@ -162,6 +162,14 @@ void AsteroidField::CollideMinables(const Projectile &projectile, vector<Collisi
 
 
 
+// Get a list of minables affected by an explosion with blast radius.
+void AsteroidField::MinablesCollisionsCircle(const Point &center, double radius, vector<Body *> &result) const
+{
+	minableCollisions.Circle(center, radius, result);
+}
+
+
+
 // Get the list of minable asteroids.
 const list<shared_ptr<Minable>> &AsteroidField::Minables() const
 {

--- a/source/AsteroidField.h
+++ b/source/AsteroidField.h
@@ -63,6 +63,8 @@ public:
 	void CollideAsteroids(const Projectile &projectile, std::vector<Collision> &result) const;
 	// Check if the given projectile collides with any minables.
 	void CollideMinables(const Projectile &projectile, std::vector<Collision> &result) const;
+	// Get a list of minables affected by an explosion with blast radius.
+	void MinablesCollisionsCircle(const Point &center, double radius, std::vector<Body *> &result) const;
 
 	// Get the list of minable asteroids.
 	const std::list<std::shared_ptr<Minable>> &Minables() const;

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -182,6 +182,7 @@ target_sources(EndlessSkyLib PRIVATE
 	Messages.h
 	Minable.cpp
 	Minable.h
+	MinableDamageDealt.h
 	Mission.cpp
 	Mission.h
 	MissionAction.cpp

--- a/source/DamageProfile.h
+++ b/source/DamageProfile.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Weather.h"
 
 class DamageDealt;
+class Minable;
 class Ship;
 class Weapon;
 
@@ -37,14 +38,15 @@ public:
 
 	// Calculate the damage dealt to the given ship.
 	DamageDealt CalculateDamage(const Ship &ship, bool ignoreBlast = false) const;
+	MinableDamageDealt CalculateDamage(const Minable &minable) const;
 
 
 private:
 	// Calculate the shared k and rSquared variables for
 	// any ship hit by a blast.
 	void CalculateBlast();
-	// Determine the damage scale for the given ship.
-	double Scale(double scale, const Ship &ship, bool blast) const;
+	// Determine the damage scale for the given body.
+	double Scale(double scale, const Body &body, bool blast) const;
 	// Populate the given DamageDealt object with values.
 	void PopulateDamage(DamageDealt &damage, const Ship &ship) const;
 

--- a/source/DamageProfile.h
+++ b/source/DamageProfile.h
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class DamageDealt;
 class Minable;
+class MinableDamageDealt;
 class Ship;
 class Weapon;
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2345,9 +2345,8 @@ void Engine::DoCollisions(Projectile &projectile)
 
 		const DamageProfile damage(projectile.GetInfo(range));
 
-		// If this projectile has a blast radius, find all ships within its
+		// If this projectile has a blast radius, find all ships and minables within its
 		// radius. Otherwise, only one is damaged.
-		// TODO: Also deal blast damage to minables?
 		double blastRadius = weapon.BlastRadius();
 		if(blastRadius)
 		{
@@ -2372,6 +2371,10 @@ void Engine::DoCollisions(Projectile &projectile)
 				if(eventType)
 					eventQueue.emplace_back(gov, ship->shared_from_this(), eventType);
 			}
+			blastCollisions.clear();
+			asteroids.MinablesCollisionsCircle(hitPos, blastRadius, blastCollisions);
+			for(Body *body : blastCollisions)
+				reinterpret_cast<Minable *>(body)->TakeDamage(projectile);
 		}
 		else if(hit)
 		{

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -43,6 +43,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "image/Mask.h"
 #include "Messages.h"
 #include "Minable.h"
+#include "MinableDamageDealt.h"
 #include "Mission.h"
 #include "NPC.h"
 #include "shader/OutlineShader.h"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2374,7 +2374,10 @@ void Engine::DoCollisions(Projectile &projectile)
 			blastCollisions.clear();
 			asteroids.MinablesCollisionsCircle(hitPos, blastRadius, blastCollisions);
 			for(Body *body : blastCollisions)
-				reinterpret_cast<Minable *>(body)->TakeDamage(projectile);
+			{
+				auto minable = reinterpret_cast<Minable *>(body);
+				minable->TakeDamage(damage.CalculateDamage(*minable));
+			}
 		}
 		else if(hit)
 		{
@@ -2385,7 +2388,10 @@ void Engine::DoCollisions(Projectile &projectile)
 					eventQueue.emplace_back(gov, shipHit, eventType);
 			}
 			else if(collisionType == CollisionType::MINABLE)
-				reinterpret_cast<Minable *>(hit)->TakeDamage(projectile);
+			{
+				auto minable = reinterpret_cast<Minable *>(hit);
+				minable->TakeDamage(damage.CalculateDamage(*minable));
+			}
 		}
 
 		if(shipHit)

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Flotsam.h"
 #include "text/Format.h"
 #include "GameData.h"
+#include "MinableDamageDealt.h"
 #include "Outfit.h"
 #include "pi.h"
 #include "Projectile.h"
@@ -258,10 +259,10 @@ bool Minable::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 
 
 // Damage this object (because a projectile collided with it).
-void Minable::TakeDamage(const Projectile &projectile)
+void Minable::TakeDamage(const MinableDamageDealt &damage)
 {
-	hull -= projectile.GetWeapon().MinableDamage() + projectile.GetWeapon().RelativeMinableDamage() * maxHull;
-	prospecting += projectile.GetWeapon().Prospecting();
+	hull -= damage.hullDamage;
+	prospecting += damage.prospecting;
 }
 
 
@@ -269,6 +270,13 @@ void Minable::TakeDamage(const Projectile &projectile)
 double Minable::Hull() const
 {
 	return min(1., hull / maxHull);
+}
+
+
+
+double Minable::MaxHull() const
+{
+	return maxHull;
 }
 
 

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class DataNode;
 class Effect;
 class Flotsam;
+class MinableDamageDealt;
 class Outfit;
 class Projectile;
 class Visual;
@@ -79,7 +80,7 @@ public:
 	bool Move(std::vector<Visual> &visuals, std::list<std::shared_ptr<Flotsam>> &flotsam);
 
 	// Damage this object (because a projectile collided with it).
-	void TakeDamage(const Projectile &projectile);
+	void TakeDamage(const MinableDamageDealt &damage);
 
 	// Determine what flotsam this asteroid will create.
 	const std::vector<Payload> &GetPayload() const;
@@ -89,6 +90,8 @@ public:
 
 	// Get hull remaining of this asteroid, as a fraction between 0 and 1.
 	double Hull() const;
+	// Get max hull of this asteroid.
+	double MaxHull() const;
 
 
 private:

--- a/source/Minable.h
+++ b/source/Minable.h
@@ -90,7 +90,7 @@ public:
 
 	// Get hull remaining of this asteroid, as a fraction between 0 and 1.
 	double Hull() const;
-	// Get max hull of this asteroid.
+	// Get the maximum hull value of this asteroid.
 	double MaxHull() const;
 
 

--- a/source/MinableDamageDealt.h
+++ b/source/MinableDamageDealt.h
@@ -1,0 +1,24 @@
+/* MinableDamageDealt.h
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+
+
+class MinableDamageDealt {
+public:
+	double hullDamage = 0.;
+	double prospecting = 0.;
+};


### PR DESCRIPTION
**Bug fix**

This PR fixes #9785.

## Summary
Implemented blast damage for minables.

## Testing Done
yes™.

## Wiki Update
N/A

## Performance Impact
hopefully none.
