### PR TITLE
Check that a weapon actually consumes a resource before requiring that the resource amount exceed some minimum value

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3565,26 +3565,28 @@ bool Ship::CanFire(const Weapon *weapon) const
 			return false;
 	}
 
-	if(energy < weapon->FiringEnergy() + weapon->RelativeFiringEnergy() * attributes.Get("energy capacity"))
+	if(weapon->ConsumesEnergy()
+			&& energy < weapon->FiringEnergy() + weapon->RelativeFiringEnergy() * attributes.Get("energy capacity"))
 		return false;
-	if(fuel < weapon->FiringFuel() + weapon->RelativeFiringFuel() * attributes.Get("fuel capacity"))
+	if(weapon->ConsumesFuel()
+			&& fuel < weapon->FiringFuel() + weapon->RelativeFiringFuel() * attributes.Get("fuel capacity"))
 		return false;
 	// We do check hull, but we don't check shields. Ships can survive with all shields depleted.
 	// Ships should not disable themselves, so we check if we stay above minimumHull.
-	if(hull - MinimumHull() < weapon->FiringHull() + weapon->RelativeFiringHull() * MaxHull())
+	if(weapon->ConsumesHull() && hull - MinimumHull() < weapon->FiringHull() + weapon->RelativeFiringHull() * MaxHull())
 		return false;
 
 	// If a weapon requires heat to fire, (rather than generating heat), we must
 	// have enough heat to spare.
-	if(heat < -(weapon->FiringHeat() + (!weapon->RelativeFiringHeat()
+	if(weapon->ConsumesHeat() && heat < -(weapon->FiringHeat() + (!weapon->RelativeFiringHeat()
 			? 0. : weapon->RelativeFiringHeat() * MaximumHeat())))
 		return false;
 	// Repeat this for various effects which shouldn't drop below 0.
-	if(ionization < -weapon->FiringIon())
+	if(weapon->ConsumesIonization() && ionization < -weapon->FiringIon())
 		return false;
-	if(disruption < -weapon->FiringDisruption())
+	if(weapon->ConsumesDisruption() && disruption < -weapon->FiringDisruption())
 		return false;
-	if(slowness < -weapon->FiringSlowing())
+	if(weapon->ConsumesSlowing() && slowness < -weapon->FiringSlowing())
 		return false;
 
 	return true;

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -196,6 +196,14 @@ public:
 	// weapon is not a provocation (even if you push or pull it).
 	bool DoesDamage() const;
 
+	bool ConsumesHull() const;
+	bool ConsumesFuel() const;
+	bool ConsumesHeat() const;
+	bool ConsumesEnergy() const;
+	bool ConsumesIonization() const;
+	bool ConsumesDisruption() const;
+	bool ConsumesSlowing() const;
+
 	double Piercing() const;
 
 	double Prospecting() const;
@@ -468,5 +476,13 @@ inline double Weapon::RelativeHeatDamage() const { return TotalDamage(RELATIVE_H
 inline double Weapon::RelativeEnergyDamage() const { return TotalDamage(RELATIVE_ENERGY_DAMAGE); }
 
 inline bool Weapon::DoesDamage() const { if(!calculatedDamage) TotalDamage(0); return doesDamage; }
+
+inline bool Weapon::ConsumesHull() const { return FiringHull() > 0. || RelativeFiringHull() > 0.; }
+inline bool Weapon::ConsumesFuel() const { return FiringFuel() > 0. || RelativeFiringFuel() > 0.; }
+inline bool Weapon::ConsumesHeat() const { return FiringHeat() < 0. || RelativeFiringHeat() > 0.; }
+inline bool Weapon::ConsumesEnergy() const { return FiringEnergy() > 0. || RelativeFiringEnergy() > 0.; }
+inline bool Weapon::ConsumesIonization() const { return FiringIon() < 0.; }
+inline bool Weapon::ConsumesDisruption() const { return FiringDisruption() < 0.; }
+inline bool Weapon::ConsumesSlowing() const { return FiringSlowing() < 0.; }
 
 inline bool Weapon::HasDamageDropoff() const { return hasDamageDropoff; }


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue https://github.com/endless-sky/endless-sky/issues/8041#issuecomment-2638094966

## Summary
In the situation described, the equipped afterburner lowers the firing ship's "slowness" below zero. Then, when checking if the weapon can fire, it is concluded that it cannot because the available "slowness" is lower than the amount of slowness the weapon consumes, even though the weapon consumes zero "slowness" upon firing.
This PR adds an additional check for each quantity checked in "Ship::CanFire" to ensure that the weapon actualy consumes that quantity.
I note that there are some things, such as shields, discharge, corrosion, burn, and leak, which are not checked in this manner, but I'm not doing anything about that in this PR.

## Testing Done
Use the ship in the plugin attached to the linked issue.
Without this PR, the primary weapons will not fire while the afterburner is in use, with this PR they will.

## Save File
Use the plugin attached to the linked issue.

## Performance Impact
Possibly meaningful in extreme situations; i haven't checked.
