### PR TITLE
feat(fix): Removing reference to the Free Worlds in Pact Questioning

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -224,7 +224,7 @@ mission "Pact Questioning"
 			`	"Am I correct that you have been assisting the Southern Mutual Defense Pact?"`
 				goto start
 			label free
-			`	"Am I correct that you performed some missions for the Southern Mutual Defense Pact, back before they became the Free Worlds?"`
+			`	"Am I correct that you performed some missions for the Southern Mutual Defense Pact recently?"`
 			label start
 			`	His voice is very friendly, and he is not armed or accompanied by any other officers that you can see, so it doesn't seem like you are in trouble or in danger of being arrested - especially since your work for the Pact was perfectly legal.`
 			choice


### PR DESCRIPTION
## Credit

Thanks to RecursiveParadox for spotting this anachronism!

## Summary

Pact Questioning can be received before the war has started, and thus before the Free Worlds exist. As such, this removes the reference to them becoming the Free Worlds.

## Alternate

An additional mission requirement could be added to this mission to restrict it to triggering after the war has started. This would make it a much tighter timeline, and thus less likely for players to ever see this mission.