### PR TITLE
[Bugfix] Add missing `flotsam chance` tooltip

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -252,6 +252,9 @@ tip "energy protection:"
 tip "fighter bays:"
 	`The number of ships from the "Fighter" category that this ship can carry.`
 
+tip "flotsam chance:"
+	`The chance that this outfit will drop as flotsam when the ship it is installed on is destroyed.`
+
 tip "force protection:"
 	`Protection provided against hit force. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in hit force, while a total value of 11 only results in a 10 percent reduction.`
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on discord

## Summary
Whoever added the flotsam chance attribute in #7942 was incompetent and didn't include a tooltip description for `flotsam chance.` Obviously, this person has no business adding features to Endless Sky, so I took it upon myself to fix their bug-riddled feature and do the work they were clearly too lazy to do.

## Screenshots
That would require me to open the game and verify that this works.

## Testing Done
haha

## Save File
Really?

## Performance Impact
Critical
