### PR TITLE
fix(crash): Handle snapshot file errors properly

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -296,7 +296,7 @@ time_t Files::Timestamp(const filesystem::path &filePath)
 
 
 
-void Files::Copy(const filesystem::path &from, const filesystem::path &to)
+bool Files::Copy(const filesystem::path &from, const filesystem::path &to)
 {
 #ifdef _WIN32
 	// Due to a mingw bug, the overwrite_existing flag is not respected on Windows.
@@ -304,7 +304,14 @@ void Files::Copy(const filesystem::path &from, const filesystem::path &to)
 	if(Exists(to))
 		Delete(to);
 #endif
-	copy(from, to, filesystem::copy_options::overwrite_existing);
+	try {
+		copy(from, to, filesystem::copy_options::overwrite_existing);
+	}
+	catch(...)
+	{
+		return false;
+	}
+	return true;
 }
 
 

--- a/source/Files.h
+++ b/source/Files.h
@@ -55,7 +55,7 @@ public:
 
 	static bool Exists(const std::filesystem::path &filePath);
 	static std::time_t Timestamp(const std::filesystem::path &filePath);
-	static void Copy(const std::filesystem::path &from, const std::filesystem::path &to);
+	static bool Copy(const std::filesystem::path &from, const std::filesystem::path &to);
 	static void Move(const std::filesystem::path &from, const std::filesystem::path &to);
 	static void Delete(const std::filesystem::path &filePath);
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -584,17 +584,14 @@ void LoadPanel::SnapshotCallback(const string &name)
 void LoadPanel::WriteSnapshot(const filesystem::path &sourceFile, const filesystem::path &snapshotName)
 {
 	// Copy the autosave to a new, named file.
-	try {
-		Files::Copy(sourceFile, snapshotName);
-	}
-	catch(const filesystem::filesystem_error &)
+	if(Files::Copy(sourceFile, snapshotName))
 	{
-		GetUI()->Push(new Dialog("Error: unable to create the file \"" + snapshotName.string() + "\"."));
-		return;
+		UpdateLists();
+		selectedFile = Files::Name(snapshotName);
+		loadedInfo.Load(Files::Saves() / selectedFile);
 	}
-	UpdateLists();
-	selectedFile = Files::Name(snapshotName);
-	loadedInfo.Load(Files::Saves() / selectedFile);
+	else
+		GetUI()->Push(new Dialog("Error: unable to create the file \"" + snapshotName.string() + "\"."));
 }
 
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -584,15 +584,17 @@ void LoadPanel::SnapshotCallback(const string &name)
 void LoadPanel::WriteSnapshot(const filesystem::path &sourceFile, const filesystem::path &snapshotName)
 {
 	// Copy the autosave to a new, named file.
-	Files::Copy(sourceFile, snapshotName);
-	if(Files::Exists(snapshotName))
-	{
-		UpdateLists();
-		selectedFile = Files::Name(snapshotName);
-		loadedInfo.Load(Files::Saves() / selectedFile);
+	try {
+		Files::Copy(sourceFile, snapshotName);
 	}
-	else
+	catch(const filesystem::filesystem_error &)
+	{
 		GetUI()->Push(new Dialog("Error: unable to create the file \"" + snapshotName.string() + "\"."));
+		return;
+	}
+	UpdateLists();
+	selectedFile = Files::Name(snapshotName);
+	loadedInfo.Load(Files::Saves() / selectedFile);
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported somewhere on Discord.

## Bug details
Trying to create a snapshot with illegal characters in the file name crashes the game, because a runtime error is thrown before our custom error checking code has a chance to respond.

## Testing Done
Tested on Linux with the `/` char.