### PR TITLE
refactor(ui): Move the unexplored systems color to the interfaces

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -199,6 +199,7 @@ color "map wormhole" .5 .2 .9 1.
 color "map orbits fleet destination" 1. 1. 1. 1.
 color "map danger none" .1 .6 0. .4
 color "map system ring" .4 .4 .4 .6
+color "map system ring unexplored" .1 .1 .1 0.
 
 # Colors used for the routing issue text in the map panel when
 # a route to the selected system cannot be determined.

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -797,7 +797,7 @@ Color MapPanel::UninhabitedColor()
 
 Color MapPanel::UnexploredColor()
 {
-	return Color(.1, 0.);
+	return *GameData::Colors().Get("map system ring unexplored");
 }
 
 


### PR DESCRIPTION
**Refactor**

This PR resolves #5127.

## Summary
The color used for rendering map rings for unexplored systems is now defined as an interface color.

## Testing Done
Looks the same (as it should).