### PR TITLE
fix(content): Correctly redefine Giftbringer Carrier variant

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1168,6 +1168,7 @@ mission "Wanderers: Alpha Surveillance C (Pug)"
 
 
 ship "Carrier" "Carrier (Alpha)"
+	"display name" "Modified Carrier"
 	sprite "ship/modified carrier"
 	thumbnail "thumbnail/modified carrier"
 	add attributes
@@ -1201,6 +1202,26 @@ ship "Carrier" "Carrier (Alpha)"
 	turret 0 14 "Husk-Slice Turret"
 	turret -22 22 "Shield Disruptor Turret"
 	turret 22 22 "Husk-Slice Turret"
+	bay "Fighter" -38.5 -64.5
+		"launch effect" "human internal"
+	bay "Fighter" 38.5 -64.5
+		"launch effect" "human internal"
+	bay "Fighter" -50 40.5
+		"launch effect" "human internal"
+	bay "Fighter" 50 40.5
+		"launch effect" "human internal"
+	bay "Drone" -71.5 -49.5
+		"launch effect" "human internal"
+	bay "Drone" 71.5 -49.5
+		"launch effect" "human internal"
+	bay "Drone" -115 55
+		"launch effect" "human internal"
+	bay "Drone" 115 55
+		"launch effect" "human internal"
+	bay "Drone" -85 55
+		"launch effect" "human internal"
+	bay "Drone" 85 55
+		"launch effect" "human internal"
 
 mission "Wanderers: Alpha Surveillance D"
 	name "Find the Alphas"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**
**Bug fix**

This PR addresses the bug/feature reported by Midnightplugins in Discord.

## Summary
In the Carrier update, the Giftbringer was decided not to be adjusted as it is sufficiently strong as-is. However, it did not get redefined bay hardpoints, so on top of the old Carrier weapon configuration, it also has the buffed bay count, which is meant to be an offset of a loss of weapons, not an additive buff.

This PR defines the Giftbringer's bay count to the original 4 fighter bays, as well as gives it a display name since it is now considered a "Modified Carrier" (the sprite name being different than the original sprite was more my concern, but it does make sense to make it visible).

## Save File
This save file can be used to test these changes:
Will get one soon, or if anyone else has one, feel free to submit it.
