### PR TITLE
fix(content): Make the Coalition Intros easier to find

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -17,11 +17,10 @@ mission "Heliarch Investigation 1"
 	description "Bring <bunks> Heliarch agents to <destination>."
 	passengers 3
 	source
-		near "Quaru" 4 10
+		near "Quaru" 2 10
 	destination "Ring of Friendship"
 	to offer
 		random < 65
-		"coalition jobs" >= 70
 		has "license: Coalition"
 		not "joined the lunarium"
 		not "assisting lunarium"
@@ -557,7 +556,6 @@ mission "Heliarch Recon 1"
 	destination "Ring of Wisdom"
 	to offer
 		"reputation: Quarg" >= 0
-		"coalition jobs" >= 55
 		has "outfit: Jump Drive"
 		has "visited planet: Lagrange"
 		has "visited planet: Alta Hai"
@@ -809,7 +807,6 @@ mission "Heliarch Recon 3-A"
 		has "event: rim archaeology results"
 		not "joined the lunarium"
 		not "assisting lunarium"
-		"coalition jobs" >= 65
 	on offer
 		conversation
 			`Upon landing, you're contacted by the Heliarch agents who have had you scan Quarg worlds and ships. "Hello again, Captain <last>!" the Kimek greets you. "Thank you again, we must, for your latest service. Much more detailed than what we had, your scans are."`
@@ -1286,15 +1283,14 @@ mission "Heliarch Containment 1"
 	cargo "military supplies" 25
 	deadline
 	source
-		near "3 Spring Rising" 2 5
+		near "3 Spring Rising" 1 5
 	destination "Fourth Shadow"
 	to offer
 		has "license: Coalition"
 		has "main plot completed"
 		not "joined the lunarium"
 		not "assisting lunarium"
-		"coalition jobs" >= 60
-		random > 25
+		random < 75
 	on offer
 		conversation
 			`The spaceport on <origin> is in quite a lot of turmoil, as dozens of Heliarch agents march around at an accelerated pace. Some prepare to board their own ships, and others speak with some of the captains here. It's no different with you, as a Kimek agent approaches you after noticing you watching.`
@@ -1344,7 +1340,7 @@ mission "Heliarch Containment 2"
 	name "Pick Up Injured Soldiers"
 	description "Land on <stopovers>, to pick up the <bunks> Heliarch soldiers in need of medical attention, and transport them to <destination> by <date>."
 	source
-		near "Bloptab" 1 3
+		near "Bloptab" 1 4
 	stopover "Delve of Bloptab"
 	destination "Ahr"
 	passengers 21
@@ -1353,7 +1349,7 @@ mission "Heliarch Containment 2"
 		has "Heliarch Containment 1: done"
 		not "joined the lunarium"
 		not "assisting lunarium"
-		random > 35
+		random < 65
 	on offer
 		conversation
 			`You're stopped by a group of Heliarch agents as you enter the spaceport, most of them Arachi.`
@@ -1620,7 +1616,7 @@ mission "Heliarch Drills 1"
 		has "license: Coalition"
 		not "joined the lunarium"
 		not "assisting lunarium"
-		random < 11
+		random < 15
 		"combat rating" >= 8104
 	on offer
 		conversation
@@ -2062,10 +2058,10 @@ mission "Heliarch License 1"
 		or
 			"assisted heliarch" >= 5
 			and
-				"coalition jobs" >= 90
+				"coalition jobs" >= 70
 				"assisted heliarch" == 4
 			and
-				"coalition jobs" >= 120
+				"coalition jobs" >= 100
 				"assisted heliarch" == 3
 		not "joined the lunarium"
 		not "assisting heliarchy"

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1616,7 +1616,7 @@ mission "Heliarch Drills 1"
 		has "license: Coalition"
 		not "joined the lunarium"
 		not "assisting lunarium"
-		random < 15
+		random < 30
 		"combat rating" >= 8104
 	on offer
 		conversation

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -26,11 +26,11 @@ mission "Lunarium: Smuggling: Charity 1"
 	minor
 	cargo "charity supplies" 22
 	source
-		near "3 Spring Rising" 2 6
+		near "3 Spring Rising" 1 6
 		not government "Heliarch"
 	destination "Fourth Shadow"
 	to offer
-		random < 40
+		random < 55
 		has "Coalition: First Contact: done"
 		not "joined the heliarchs"
 		not "Lunarium: Questions: active"
@@ -96,10 +96,10 @@ mission "Lunarium: Smuggling: Charity 2"
 	passengers 5
 	cargo "charity supplies" 39
 	source
-		near "5 Winter Above" 1 3
+		near "5 Winter Above" 1 4
 	destination "Into White"
 	to offer
-		random < 50
+		random < 60
 		has "Lunarium: Smuggling: Charity 1: done"
 		not "joined the heliarchs"
 		not "Lunarium: Questions: active"
@@ -156,10 +156,10 @@ mission "Lunarium: Smuggling: Charity 3"
 	description "Bring <cargo> to <destination>"
 	cargo "charity supplies" 46
 	source
-		near "14 Pole" 3 5
+		near "14 Pole" 3 7
 	destination "Remote Blue"
 	to offer
-		random < 70
+		random < 80
 		has "Lunarium: Smuggling: Charity 2: done"
 		not "joined the heliarchs"
 		not "Lunarium: Questions: active"
@@ -284,7 +284,7 @@ mission "Lunarium: Smuggling: AM"
 	destination "Fourth Shadow"
 	to offer
 		has "Lunarium: Smuggling: Grenades: done"
-		random < 15 + 3 * "assisted lunarium" * "assisted lunarium"
+		random < 25 + 4 * "assisted lunarium" * "assisted lunarium"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 	on offer
@@ -329,7 +329,7 @@ mission "Lunarium: Smuggling: Torpedoes"
 	to offer
 		has "Lunarium: Smuggling: AM: done"
 		has "event: deep sky tech available"
-		random < 20 + 3 * "assisted lunarium" * "assisted lunarium"
+		random < 30 + 4 * "assisted lunarium" * "assisted lunarium"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 	on offer
@@ -380,7 +380,7 @@ mission "Lunarium: Smuggling: Heat"
 	to offer
 		has "Lunarium: Smuggling: Torpedoes: done"
 		has "event: flamethrower available"
-		random < 25 + 3 * "assisted lunarium" * "assisted lunarium"
+		random < 30 + 4 * "assisted lunarium" * "assisted lunarium"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 	on offer
@@ -436,7 +436,7 @@ mission "Lunarium: Smuggling: Reactors"
 	destination "Mebla's Portion"
 	to offer
 		has "Lunarium: Smuggling: Heat: done"
-		random < 40 + 3 * "assisted lunarium" * "assisted lunarium"
+		random < 40 + 4 * "assisted lunarium" * "assisted lunarium"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 	on offer
@@ -487,7 +487,7 @@ mission "House Bebliss 1-A"
 	description "Head to <destination>, where members of House Bebliss wish to discuss a job offer."
 	minor
 	to offer
-		random < 10
+		random < 15
 		has "license: Coalition"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
@@ -539,7 +539,7 @@ mission "House Bebliss 1-B"
 	name "Meet with House Bebliss"
 	description "Head to <destination>, where representatives from an Arach House that supports the Lunarium wish to discuss a job offer."
 	to offer
-		random < 40
+		random < 75
 		has "House Bebliss 1-A: declined"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
@@ -938,10 +938,11 @@ mission "Lunarium: Evacuation 1"
 	passengers 35
 	"apparent payment" 386730
 	source
-		near "3 Spring Rising" 1 4
+		not government "Heliarch"
+		near "3 Spring Rising" 1 5
 	destination "Fourth Shadow"
 	to offer
-		random < 40
+		random < 55
 		has "Coalition: First Contact: done"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
@@ -1060,10 +1061,10 @@ mission "Lunarium: Evacuation 3"
 	"apparent payment" 748300
 	source
 		not government "Heliarch"
-		near "Silver Bell" 2 3
+		near "Silver Bell" 1 4
 	destination "Chosen Nexus"
 	to offer
-		random < 50
+		random < 60
 		has "Lunarium: Evacuation 2: done"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
@@ -1185,10 +1186,10 @@ mission "Lunarium: Evacuation 5"
 	passengers 116
 	landing
 	source
-		near "Ablub"
+		near "Ablub" 1 3
 	destination "Cool Forest"
 	to offer
-		random < 80
+		random < 85
 		has "Lunarium: Evacuation 4: done"
 		has "outfit: Jump Drive"
 		not "joined the heliarchs"
@@ -1329,10 +1330,10 @@ mission "Lunarium: Propaganda 1"
 	passengers 1
 	cargo "promotional posters" 1
 	source
-		near "Ancient Hope" 2 4
+		near "Ancient Hope" 2 5
 	destination "Bright Echo"
 	to offer
-		random < 25
+		random < 50
 		has "Coalition: First Contact: done"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
@@ -1602,7 +1603,7 @@ mission "Lunarium: Combat Training 1"
 		attributes arach
 	destination "Zug"
 	to offer
-		random < 20
+		random < 65
 		has "outfit: Jump Drive"
 		or
 			has "Lunarium: Propaganda 4: done"
@@ -1847,10 +1848,10 @@ mission "Lunarium: Questions"
 		or
 			"assisted lunarium" >= 5
 			and
-				"coalition jobs" >= 80
+				"coalition jobs" >= 70
 				"assisted lunarium" == 4
 			and
-				"coalition jobs" >= 110
+				"coalition jobs" >= 100
 				"assisted lunarium" == 3
 		"reputation: Quarg" >= 0
 		not "joined the heliarchs"


### PR DESCRIPTION
**Content (Mission Tweaks)**

This PR makes several changes to the `to offer` requirements of the Coalition Intro mission chains, in an effort to make them easier to find and complete, as per the results of the following poll that ran over the course of 2 weeks on the Discord server:

![image](https://github.com/user-attachments/assets/dffa2937-5438-42d5-b13c-7c283da08694)

## Summary

The difficulty in finding and completing the Coalition Intros mission chains has been a recurring topic of discussion on the Discord server, so this PR aims to reduce the need to go into the game files to figure out where exactly to land for XYZ mission.

Changes are as follows:

- Increased the effective offer range for missions that rely on the `near` keyword;
- General increase to the random % chance of offering missions;
- Completely removed the arbitrary number of `"coalition jobs"` required for some mission chains to offer;
- For the Heliarch Intro, swapped the `>` sign for `<`, altering the random % chance accordingly (no increases to those as they were already pretty high) for the sake of being consistent;
- Lowered the # of `"coalition jobs"` needed to join either side, assuming one hasn't completed all 5 chains, and also made that # equal between both Intros (0, 70 and 100 respectively if you've completed 5, 4 and 3 mission chains).
