### PR TITLE
Fix Timothy Radrickson 1a being given inappropriately

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7573,6 +7573,8 @@ mission "Timothy Radrickson 1: Stowaway"
 				decline
 
 			label somewhere
+			action
+				set "timothy radrickson: agreed"
 			`	Timothy looks at you, his eyes wide and full of tears. "Rand," he whispers. "Rand. I can make good money there. I can turn my life around. B-b-but I'd be okay with anywhere. You d-d-don't have to.."`
 			`	You cut him off. "It's fine, Timothy. I'll take you to Rand."`
 			`	Timothy breaks down in tears. "Thank you. Thank you. Thank you..." he mumbles over and over again.`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7595,7 +7595,7 @@ mission "Timothy Radrickson 1a: Accepted"
 	description "You found a man named Timothy on your ship stowed away in a foodstuff crate, on the run from somebody. He would like you to bring him to <destination>, where he can find work."
 	destination "Rand"
 	to offer
-		has "Timothy Radrickson 1: Stowaway: active"
+		has "timothy radrickson: agreed"
 	on abort
 		fail "Timothy Radrickson 1: Stowaway"
 


### PR DESCRIPTION
**Bug fix**

Thanks to @Saugia for reporting this on Twitch.

## Summary
The first mission in this chain, "Timothy Radrickson 1: Stowaway" is invisible. On the second time of entering a system after it has been received, it shows a conversation where you have the option to ignore Timothy, allowing him to die, murder him, agree to drop him off on the next spaceport you reach, or agree to take him to his desired destination (Rand in the Zeta Aquilae system).
There is a second, visible mission that is supposed to offer the next time you land, only if this first mission is still active (which is only the case if you agreed to take him to Rand), reminding you of this objective.
However, if you take off and then land again without travelling to another system, you can receive the second mission before the conversation in the first mission. This is a problem because you're being told you have a mission to take this Timothy guy to Rand and that he was a stowaway on your ship, but you never heard of this.
Additionally, when you do take off, you will be shown the conversation from the first mission. If you agree to transport him, there is no further problem, however, if, like @Saugia, you choose to murder him, the visible mission persists even though there is no one to transport anymore.

This PR fixes this by setting a condition in the conversation you should see first if you agree to transport Timothy to Rand and then only offering the second, visible mission if you have this condition, instead of only requiring that the first mission is active. This ensures that you have actually agreed to transport Timothy to Rand before giving you the mission saying you have.

## Testing Done
Take off after receiving the first, invisible mission and then land without leaving the system. Without this PR, I am given the visible mission, with this PR, I am not.

## Save File
This save file can be used to test these changes:
[Timothy Test~3013-12-18-Stowaway aboard.txt](https://github.com/user-attachments/files/18774065/Timothy.Test.3013-12-18-Stowaway.aboard.txt)
[Timothy Test~3013-12-19-Mission visible.txt](https://github.com/user-attachments/files/18774066/Timothy.Test.3013-12-19-Mission.visible.txt)
