### PR TITLE
fix(ci): Increase timeout for integration tests

### DIFF
--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -27,7 +27,7 @@ foreach(test ${INTEGRATION_TESTS_LIST})
 		set(SET_TEST_PROPS
 	"set_tests_properties([==[${test}]==] PROPERTIES
 		WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
-		TIMEOUT 30
+		TIMEOUT 60
 		LABELS integration)")
 
 	# Launches the integration tests in debug mode, so that they can be followed.


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug found in PR #9089.

## Summary
The PR adding a timer also added an integration test making sure the timer works. Due to the nature of this test, it is expected to take 20 seconds longer than most other tests. Therefore, I have bumped the timeout by 30 seconds to add some cushion, and to make sure the test isn’t creating false positives.

## Testing Done
Automatic

## Performance Impact
May make tests take longer, but not by too much, and this should hopefully reduce random test failure due to timeouts.