### PR TITLE
feat(ui): Support for reversing the draw order of HUD messages

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1251,6 +1251,7 @@ interface "hud"
 	box "messages"
 		from 120 0 bottom left
 		to -110 -200 bottom right
+	value "messages reversed" 0
 	box "ammo"
 		from -110 450 top right
 		to 0 0 bottom right

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1202,18 +1202,30 @@ void Engine::Draw() const
 	const Font &font = FontSet::Get(14);
 	const vector<Messages::Entry> &messages = Messages::Get(step);
 	Rectangle messageBox = hud->GetBox("messages");
+	bool messagesReversed = hud->GetValue("messages reversed");
 	WrappedText messageLine(font);
 	messageLine.SetWrapWidth(messageBox.Width());
 	messageLine.SetParagraphBreak(0.);
-	Point messagePoint = Point(messageBox.Left(), messageBox.Bottom());
+	Point messagePoint{messageBox.Left(), messagesReversed ? messageBox.Top() : messageBox.Bottom()};
 	for(auto it = messages.rbegin(); it != messages.rend(); ++it)
 	{
 		messageLine.Wrap(it->message);
-		messagePoint.Y() -= messageLine.Height();
-		if(messagePoint.Y() < messageBox.Top())
-			break;
+		int height = messageLine.Height();
+		if(messagesReversed)
+		{
+			if(messagePoint.Y() + height > messageBox.Bottom())
+				break;
+		}
+		else
+		{
+			messagePoint.Y() -= height;
+			if(messagePoint.Y() < messageBox.Top())
+				break;
+		}
 		float alpha = (it->step + 1000 - step) * .001f;
 		messageLine.Draw(messagePoint, Messages::GetColor(it->importance, false)->Additive(alpha));
+		if(messagesReversed)
+			messagePoint.Y() += height;
 	}
 
 	// Draw crosshairs around anything that is targeted.


### PR DESCRIPTION
**Feature**

## Summary
The messages on the main panel can now be drawn in reversed order and alignment: newer messages above older, starting from the top edge of the box. It's controlled by an interface value set to 0 by default - it's backward-compatible, so outdated interfaces file won't be a problem here.

## Screenshots
<details>
<summary>
Example (I haven't changed the box dimensions, so it looks a bit odd, but it works)
</summary>

![reversed](https://github.com/user-attachments/assets/d99efe46-7ec4-4232-b3de-15df81a5d2ba)

</details>

## Testing Done
See the screenshot above.

## Wiki Update
N/A
