### PR TITLE
feat(UI): Change "disabled fighters dodge projectiles" from a gamerule to a setting

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1455,7 +1455,7 @@ tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
 tip "Disabled fighter immunity"
-	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeted. "Player only" means that this setting applies to only the player's fighters.`
+	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeted. The "player" option makes this setting apply to only the player's fighters.`
 
 tip "Extra fleet status messages"
 	`Display extra status messages about escorts in your fleet, such as when they are under-crewed or collect flotsam.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1454,6 +1454,9 @@ tip "Clickable radar display"
 tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
+tip "Disabled fighters dodge projectiles"
+	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeting. "Player only" means that this setting applies to only the player's fighters.`
+
 tip "Extra fleet status messages"
 	`Display extra status messages about escorts in your fleet, such as when they are under-crewed or collect flotsam.`
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1454,7 +1454,7 @@ tip "Clickable radar display"
 tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
-tip "Disabled fighters dodge projectiles"
+tip "Disabled fighters avoid projectiles"
 	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeting. "Player only" means that this setting applies to only the player's fighters.`
 
 tip "Extra fleet status messages"

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1455,7 +1455,7 @@ tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
 tip "Disabled fighters avoid projectiles"
-	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeting. "Player only" means that this setting applies to only the player's fighters.`
+	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeted. "Player only" means that this setting applies to only the player's fighters.`
 
 tip "Extra fleet status messages"
 	`Display extra status messages about escorts in your fleet, such as when they are under-crewed or collect flotsam.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1454,7 +1454,7 @@ tip "Clickable radar display"
 tip "Alert indicator"
 	`Indicate when hostile ships enter your current system. Audio plays a siren. Visual displays an alert icon by the in-system radar.`
 
-tip "Disabled fighters avoid projectiles"
+tip "Disabled fighter immunity"
 	`Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeted. "Player only" means that this setting applies to only the player's fighters.`
 
 tip "Extra fleet status messages"

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -51,11 +51,6 @@ gamerules
 	# ALLOWABLE VALUES: any value between 0. and 1.
 	"universal frugal threshold" 0.75
 
-	# Controls which fighters, when disabled, will not be hit by projectiles unless they are directly targeting.
-	# DEFAULT: all
-	# ALLOWABLE VALUES: all, none, only player
-	"disabled fighters avoid projectiles" "all"
-
 	# Depreciation related game rules:
 
 	# The depreciated value of an item that is "age" days old is calculated with the following equation:

--- a/source/FighterHitHelper.h
+++ b/source/FighterHitHelper.h
@@ -15,8 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "GameData.h"
-#include "Gamerules.h"
+#include "Preferences.h"
 #include "Ship.h"
 
 
@@ -29,11 +28,11 @@ public:
 	{
 		if(!ship->CanBeCarried() || !ship->IsDisabled())
 			return true;
-		switch(GameData::GetGamerules().FightersHitWhenDisabled())
+		switch(Preferences::FightersHitWhenDisabled())
 		{
-			case Gamerules::FighterDodgePolicy::ALL: return false;
-			case Gamerules::FighterDodgePolicy::NONE: return true;
-			case Gamerules::FighterDodgePolicy::ONLY_PLAYER: return !ship->IsYours();
+			case Preferences::FighterDodgePolicy::ALL: return false;
+			case Preferences::FighterDodgePolicy::NONE: return true;
+			case Preferences::FighterDodgePolicy::ONLY_PLAYER: return !ship->IsYours();
 		}
 		return false;
 	}

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -54,18 +54,6 @@ void Gamerules::Load(const DataNode &node)
 			depreciationGracePeriod = max<int>(0, child.Value(1));
 		else if(key == "depreciation max age")
 			depreciationMaxAge = max<int>(0, child.Value(1));
-		else if(key == "disabled fighters avoid projectiles")
-		{
-			const string &value = child.Token(1);
-			if(value == "all")
-				fighterHitPolicy = FighterDodgePolicy::ALL;
-			else if(value == "none")
-				fighterHitPolicy = FighterDodgePolicy::NONE;
-			else if(value == "only player")
-				fighterHitPolicy = FighterDodgePolicy::ONLY_PLAYER;
-			else
-				child.PrintTrace("Skipping unrecognized value for gamerule:");
-		}
 		else
 			child.PrintTrace("Skipping unrecognized gamerule:");
 	}
@@ -135,8 +123,3 @@ int Gamerules::DepreciationMaxAge() const
 }
 
 
-
-Gamerules::FighterDodgePolicy Gamerules::FightersHitWhenDisabled() const
-{
-	return fighterHitPolicy;
-}

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -45,7 +45,6 @@ public:
 	double DepreciationDaily() const;
 	int DepreciationGracePeriod() const;
 	int DepreciationMaxAge() const;
-	FighterDodgePolicy FightersHitWhenDisabled() const;
 
 
 private:
@@ -58,5 +57,4 @@ private:
 	double depreciationDaily = 0.997;
 	int depreciationGracePeriod = 7;
 	int depreciationMaxAge = 1000;
-	FighterDodgePolicy fighterHitPolicy = FighterDodgePolicy::ALL;
 };

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -245,7 +245,7 @@ void Preferences::Load()
 			settings["Control ship with mouse"] = (node.Size() == 1 || node.Value(1));
 		else if(node.Token(0) == "notification settings")
 			notifOptionsIndex = max<int>(0, min<int>(node.Value(1), NOTIF_OPTIONS.size() - 1));
-		else if(node.Token(0) == "Disabled fighters avoid projectiles")
+		else if(node.Token(0) == "Disabled fighter immunity")
 			disabledFighterIndex = max<int>(0, min<int>(node.Value(1), DISABLED_FIGHTER_SETTINGS.size() - 1));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -163,7 +163,7 @@ namespace {
 
 	int previousSaveCount = 3;
 
-	const vector<string> DISABLED_FIGHTER_SETTINGS = {"always", "never", "player only"};
+	const vector<string> DISABLED_FIGHTER_SETTINGS = {"always", "never", "player"};
 	int disabledFighterIndex = 0;
 }
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -162,6 +162,11 @@ namespace {
 	int alertIndicatorIndex = 3;
 
 	int previousSaveCount = 3;
+
+
+	// These were the exact strings used by the old gamerule
+	const vector<string> DISABLED_FIGHTER_SETTINGS = {"NONE", "ONLY_PLAYER", "ALL"};
+	int disabledFighterIndex = 2;
 }
 
 
@@ -190,7 +195,6 @@ void Preferences::Load()
 	settings["Ship outlines in HUD"] = true;
 	settings["Extra fleet status messages"] = true;
 	settings["Target asteroid based on"] = true;
-	settings["Disabled fighters avoid projectiles"] = true;
 
 	DataFile prefs(Files::Config() / "preferences.txt");
 	for(const DataNode &node : prefs)
@@ -243,6 +247,8 @@ void Preferences::Load()
 			settings["Control ship with mouse"] = (node.Size() == 1 || node.Value(1));
 		else if(node.Token(0) == "notification settings")
 			notifOptionsIndex = max<int>(0, min<int>(node.Value(1), NOTIF_OPTIONS.size() - 1));
+		else if(node.Token(0) == "Disabled fighters avoid projectiles")
+			disabledFighterIndex = max<int>(0, min<int>(node.Value(1), DISABLED_FIGHTER_SETTINGS.size() - 1));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
@@ -723,7 +729,15 @@ const string &Preferences::FlotsamSetting()
 	return FLOTSAM_SETTINGS[flotsamIndex];
 }
 
+void Preferences::ToggleFighterDodgePolicy()
+{
+	disabledFighterIndex = (disabledFighterIndex + 1) % DISABLED_FIGHTER_SETTINGS.size();
+}
 
+Preferences::FighterDodgePolicy Preferences::FightersHitWhenDisabled() const
+{
+	return DISABLED_FIGHTER_SETTINGS[disabledFighterIndex];
+}
 
 void Preferences::ToggleAlert()
 {

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -162,6 +162,9 @@ namespace {
 	int alertIndicatorIndex = 3;
 
 	int previousSaveCount = 3;
+
+	const vector<string> DISABLED_FIGHTER_SETTING = {"off", "player", "on"};
+	int disabledFighterIndex = 2;
 }
 
 
@@ -190,6 +193,7 @@ void Preferences::Load()
 	settings["Ship outlines in HUD"] = true;
 	settings["Extra fleet status messages"] = true;
 	settings["Target asteroid based on"] = true;
+	settings["Disabled fighters avoid projectiles"] = true;
 
 	DataFile prefs(Files::Config() / "preferences.txt");
 	for(const DataNode &node : prefs)

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -163,9 +163,7 @@ namespace {
 
 	int previousSaveCount = 3;
 
-
-	// These were the exact strings used by the old gamerule
-	const vector<string> DISABLED_FIGHTER_SETTINGS = {"ALL", "NONE", "ONLY_PLAYER"};
+	const vector<string> DISABLED_FIGHTER_SETTINGS = {"always", "never", "player only"};
 	int disabledFighterIndex = 0;
 }
 
@@ -735,6 +733,12 @@ void Preferences::ToggleFighterDodgePolicy()
 }
 
 Preferences::FighterDodgePolicy Preferences::FightersHitWhenDisabled() const
+{
+	return DISABLED_FIGHTER_SETTINGS[disabledFighterIndex];
+}
+
+
+const std::string &Preferences::DisabledFighterSetting()
 {
 	return DISABLED_FIGHTER_SETTINGS[disabledFighterIndex];
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -165,8 +165,8 @@ namespace {
 
 
 	// These were the exact strings used by the old gamerule
-	const vector<string> DISABLED_FIGHTER_SETTINGS = {"NONE", "ONLY_PLAYER", "ALL"};
-	int disabledFighterIndex = 2;
+	const vector<string> DISABLED_FIGHTER_SETTINGS = {"ALL", "NONE", "ONLY_PLAYER"};
+	int disabledFighterIndex = 0;
 }
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -734,7 +734,7 @@ void Preferences::ToggleFighterDodgePolicy()
 
 Preferences::FighterDodgePolicy Preferences::FightersHitWhenDisabled() const
 {
-	return DISABLED_FIGHTER_SETTINGS[disabledFighterIndex];
+	return static_cast<FighterDodgePolicy>(disabledFighterIndex);
 }
 
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -732,7 +732,7 @@ void Preferences::ToggleFighterDodgePolicy()
 	disabledFighterIndex = (disabledFighterIndex + 1) % DISABLED_FIGHTER_SETTINGS.size();
 }
 
-Preferences::FighterDodgePolicy Preferences::FightersHitWhenDisabled() const
+Preferences::FighterDodgePolicy Preferences::FightersHitWhenDisabled()
 {
 	return static_cast<FighterDodgePolicy>(disabledFighterIndex);
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -162,9 +162,6 @@ namespace {
 	int alertIndicatorIndex = 3;
 
 	int previousSaveCount = 3;
-
-	const vector<string> DISABLED_FIGHTER_SETTING = {"off", "player", "on"};
-	int disabledFighterIndex = 2;
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -109,7 +109,9 @@ public:
 	};
 
 	enum class FighterDodgePolicy {
-		ALL, NONE, ONLY_PLAYER
+		ALL = 0, 
+		NONE,
+		ONLY_PLAYER
 	};
 
 public:

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -109,7 +109,7 @@ public:
 	};
 
 	enum class FighterDodgePolicy {
-		ALL = 0, 
+		ALL = 0,
 		NONE,
 		ONLY_PLAYER
 	};

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -195,6 +195,7 @@ public:
 	// Disabled fighter setting, "NONE", "ONLY_PLAYER", or "ALL".
 	static void ToggleFighterDodgePolicy();
 	static FighterDodgePolicy FightersHitWhenDisabled() const;
+	static const std::string &DisabledFighterSetting();
 
 	/// Red alert siren and symbol
 	static void ToggleAlert();

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -194,7 +194,7 @@ public:
 
 	// Disabled fighter setting, "NONE", "ONLY_PLAYER", or "ALL".
 	static void ToggleFighterDodgePolicy();
-	static FighterDodgePolicy FightersHitWhenDisabled() const;
+	static FighterDodgePolicy FightersHitWhenDisabled();
 	static const std::string &DisabledFighterSetting();
 
 	/// Red alert siren and symbol

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -108,6 +108,9 @@ public:
 		BOTH
 	};
 
+	enum class FighterDodgePolicy {
+		ALL, NONE, ONLY_PLAYER
+	};
 
 public:
 	static void Load();
@@ -186,6 +189,10 @@ public:
 	static void ToggleFlotsam();
 	static FlotsamCollection GetFlotsamCollection();
 	static const std::string &FlotsamSetting();
+
+	// Disabled fighter setting, "NONE", "ONLY_PLAYER", or "ALL".
+	static void ToggleFighterDodgePolicy();
+	static FighterDodgePolicy FightersHitWhenDisabled() const;
 
 	/// Red alert siren and symbol
 	static void ToggleAlert();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -753,7 +753,8 @@ void PreferencesPanel::DrawSettings()
 		SCROLL_SPEED,
 		DATE_FORMAT,
 		"Show parenthesis",
-		NOTIFY_ON_DEST
+		NOTIFY_ON_DEST,
+		"Disabled fighters avoid projectiles"
 	};
 
 	bool isCategory = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -81,7 +81,7 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
-	const string FIGHTER_DODGE_POLICY = "Disabled fighters dodge projectiles";
+	const string FIGHTER_DODGE_POLICY = "Disabled fighters avoid projectiles";
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -81,6 +81,7 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
+	const string FIGHTER_DODGE_POLICY = "Disabled fighters dodge projectiles";
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;
@@ -754,7 +755,7 @@ void PreferencesPanel::DrawSettings()
 		DATE_FORMAT,
 		"Show parenthesis",
 		NOTIFY_ON_DEST,
-		"Disabled fighters avoid projectiles"
+		FIGHTER_DODGE_POLICY
 	};
 
 	bool isCategory = true;
@@ -967,6 +968,11 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = Preferences::GetAlertIndicator() != Preferences::AlertIndicator::NONE;
 			text = Preferences::AlertSetting();
+		}
+		else if(setting == FIGHTER_DODGE_POLICY)
+		{
+			isOn = Preferences::FighterDodgePolicy() != Preferences::FighterDodgePolicy::NONE;
+			text = Preferences::DisabledFighterSetting();
 		}
 		else
 			text = isOn ? "on" : "off";
@@ -1310,6 +1316,8 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleNotificationSetting();
 	else if(str == ALERT_INDICATOR)
 		Preferences::ToggleAlert();
+	else if(str == FIGHTER_DODGE_POLICY)
+		Preferences::ToggleFighterDodgePolicy();
 	// All other options are handled by just toggling the boolean state.
 	else
 		Preferences::Set(str, !Preferences::Has(str));

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -81,7 +81,7 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
-	const string FIGHTER_DODGE_POLICY = "Disabled fighters avoid projectiles";
+	const string FIGHTER_DODGE_POLICY = "Disabled fighter immunity";
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;


### PR DESCRIPTION
**Refactor**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/251125349109202944/1341084875695853588) (only visible to core members).

## Summary
I have replaced the "disabled fighters dodge projectiles" gamerule with a setting. In order to fit inside the boundaries, it now says “disabled fighter immunity,” but I think this is fine, as the tooltip explains what this means.

## Screenshots
![image](https://github.com/user-attachments/assets/62be9725-7c89-4069-bcda-1f3f281563bf)
![image](https://github.com/user-attachments/assets/3fe7d80f-f4cb-487c-8cd7-0e3c520226bc)
![image](https://github.com/user-attachments/assets/30f32278-3c39-4049-a7b2-4aa71d7bf6ff)
![image](https://github.com/user-attachments/assets/5814c7d1-9b60-4191-8b29-c6f8ced19bb6)

## Testing Done
Made sure that the setting worked and fit inside the boundaries.

## Save File
[Test Pilot~Fighters.txt](https://github.com/user-attachments/files/18832444/Test.Pilot.Fighters.txt)

## Performance Impact
Hopefully none