### PR TITLE
feat(mechanics): Gamerule overriding

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1531,3 +1531,15 @@ tip "Show parenthesis"
 
 tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
+
+tip `Override "universal ramscoop"`
+	`Replace the "universal ramscoop" gamerule provided by the game and plugins with a custom value.`
+
+tip `"universal ramscoop" value`
+	`The value replacing the default "universal ramscoop" gamerule.`
+
+tip `Override "disabled fighters..."`
+	`Replace the "disabled fighters avoid projectiles" gamerule provided by the game and plugins with a custom value.`
+
+tip `"disabled fighters..." value`
+	`The value replacing the default "disabled fighters avoid projectiles" gamerule.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1532,14 +1532,6 @@ tip "Show parenthesis"
 tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
 
-tip `Override "universal ramscoop"`
-	`Replace the "universal ramscoop" gamerule provided by the game and plugins with a custom value.`
-
-tip `"universal ramscoop" value`
-	`The value replacing the default "universal ramscoop" gamerule.`
-
-tip `Override "disabled fighters..."`
-	`Replace the "disabled fighters avoid projectiles" gamerule provided by the game and plugins with a custom value.`
-
-tip `"disabled fighters..." value`
-	`The value replacing the default "disabled fighters avoid projectiles" gamerule.`
+#
+# TODO
+#

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -196,6 +196,7 @@ target_sources(EndlessSkyLib PRIVATE
 	NPCAction.h
 	News.cpp
 	News.h
+	OptionalPreference.h
 	Outfit.cpp
 	Outfit.h
 	OutfitInfoDisplay.cpp

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -16,8 +16,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Gamerules.h"
 
 #include "DataNode.h"
+#include "Preferences.h"
 
 #include <algorithm>
+#include <optional>
 
 using namespace std;
 
@@ -75,68 +77,68 @@ void Gamerules::Load(const DataNode &node)
 
 bool Gamerules::UniversalRamscoopActive() const
 {
-	return universalRamscoop;
+	return Preferences::GetGameruleRamscoop().value_or(universalRamscoop);
 }
 
 
 
 int Gamerules::PersonSpawnPeriod() const
 {
-	return personSpawnPeriod;
+	return Preferences::GetGamerulePersonPeriod().value_or(personSpawnPeriod);
 }
 
 
 
 int Gamerules::NoPersonSpawnWeight() const
 {
-	return noPersonSpawnWeight;
+	return Preferences::GetGamerulePersonWeight().value_or(noPersonSpawnWeight);
 }
 
 
 
 int Gamerules::NPCMaxMiningTime() const
 {
-	return npcMaxMiningTime;
+	return Preferences::GetGameruleMiningTime().value_or(npcMaxMiningTime);
 }
 
 
 
 double Gamerules::UniversalFrugalThreshold() const
 {
-	return universalFrugalThreshold;
+	return Preferences::GetGameruleFrugalThreshold().value_or(universalFrugalThreshold);
 }
 
 
 
 double Gamerules::DepreciationMin() const
 {
-	return depreciationMin;
+	return Preferences::GetGameruleDepreciationMin().value_or(depreciationMin);
 }
 
 
 
 double Gamerules::DepreciationDaily() const
 {
-	return depreciationDaily;
+	return Preferences::GetGameruleDepreciationDaily().value_or(depreciationDaily);
 }
 
 
 
 int Gamerules::DepreciationGracePeriod() const
 {
-	return depreciationGracePeriod;
+	return Preferences::GetGameruleDepreciationGracePeriod().value_or(depreciationGracePeriod);
 }
 
 
 
 int Gamerules::DepreciationMaxAge() const
 {
-	return depreciationMaxAge;
+	return Preferences::GetGameruleDepreciationMaxAge().value_or(depreciationMaxAge);
 }
 
 
 
 Gamerules::FighterDodgePolicy Gamerules::FightersHitWhenDisabled() const
 {
-	return fighterHitPolicy;
+	return Preferences::GetGameruleFighters().value_or(fighterHitPolicy);
 }

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Gamerules.h"
 
 #include "DataNode.h"
+#include "OptionalPreference.h"
 #include "Preferences.h"
 
 #include <algorithm>
@@ -84,56 +85,56 @@ bool Gamerules::UniversalRamscoopActive() const
 
 int Gamerules::PersonSpawnPeriod() const
 {
-	return Preferences::GetGamerulePersonPeriod().value_or(personSpawnPeriod);
+	return Preferences::GamerulePersonPeriod().Get().value_or(personSpawnPeriod);
 }
 
 
 
 int Gamerules::NoPersonSpawnWeight() const
 {
-	return Preferences::GetGamerulePersonWeight().value_or(noPersonSpawnWeight);
+	return Preferences::GamerulePersonWeight().Get().value_or(noPersonSpawnWeight);
 }
 
 
 
 int Gamerules::NPCMaxMiningTime() const
 {
-	return Preferences::GetGameruleMiningTime().value_or(npcMaxMiningTime);
+	return Preferences::GameruleMiningTime().Get().value_or(npcMaxMiningTime);
 }
 
 
 
 double Gamerules::UniversalFrugalThreshold() const
 {
-	return Preferences::GetGameruleFrugalThreshold().value_or(universalFrugalThreshold);
+	return Preferences::GameruleFrugalThreshold().Get().value_or(universalFrugalThreshold);
 }
 
 
 
 double Gamerules::DepreciationMin() const
 {
-	return Preferences::GetGameruleDepreciationMin().value_or(depreciationMin);
+	return Preferences::GameruleDepreciationMin().Get().value_or(depreciationMin);
 }
 
 
 
 double Gamerules::DepreciationDaily() const
 {
-	return Preferences::GetGameruleDepreciationDaily().value_or(depreciationDaily);
+	return Preferences::GameruleDepreciationDaily().Get().value_or(depreciationDaily);
 }
 
 
 
 int Gamerules::DepreciationGracePeriod() const
 {
-	return Preferences::GetGameruleDepreciationGracePeriod().value_or(depreciationGracePeriod);
+	return Preferences::GameruleDepreciationGracePeriod().Get().value_or(depreciationGracePeriod);
 }
 
 
 
 int Gamerules::DepreciationMaxAge() const
 {
-	return Preferences::GetGameruleDepreciationMaxAge().value_or(depreciationMaxAge);
+	return Preferences::GameruleDepreciationMaxAge().Get().value_or(depreciationMaxAge);
 }
 
 

--- a/source/OptionalPreference.h
+++ b/source/OptionalPreference.h
@@ -1,0 +1,127 @@
+/* OptionalPreference.h
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "DataNode.h"
+#include "DataWriter.h"
+
+#include <optional>
+
+
+
+// A preference that may have a numerical value, or be in a default no-value state.
+template<class T>
+class OptionalPreference {
+public:
+	OptionalPreference(T minValue, T step, int numberOfSteps, std::string (&stringFun)(T));
+
+	void Load(const DataNode &node, T minLimit = std::numeric_limits<T>::lowest(),
+		T maxLimit = std::numeric_limits<T>::max());
+	void Save(DataWriter &out, const std::string &name) const;
+
+	void Toggle(bool backwards = false);
+	const std::optional<T> &Get() const;
+	std::string Setting() const;
+
+
+private:
+	std::optional<T> value;
+	// The index doesn't have any meaningful information for the value.
+	// It's only used for the settings UI that doesn't allow arbitrary numerical input.
+	int currentIndex = 0;
+	// The constraints controlling changing the value via the settings UI.
+	const T minValue{};
+	const T step{};
+	const int maxIndex = 0;
+	// The function used to construct a string from the value.
+	std::string (&stringFun)(T);
+};
+
+
+
+template<class T>
+OptionalPreference<T>::OptionalPreference(T minValue, T step, int numberOfSteps, std::string (&stringFun)(T))
+	: minValue{minValue}, step{step}, maxIndex{numberOfSteps - 1}, stringFun{stringFun}
+{
+}
+
+
+
+template<class T>
+void OptionalPreference<T>::Load(const DataNode &node, T minLimit, T maxLimit)
+{
+	// The first element is used to check if the value has been set,
+	// while the second one contains the value.
+	if(node.Size() < 3 || !node.BoolValue(1))
+		return;
+
+	value = std::clamp<T>(node.Value(2), minLimit, maxLimit);
+	// Choose the index corresponding to the step closest to the actual value.
+	currentIndex = (*value - minValue) / step;
+}
+
+
+
+template<class T>
+void OptionalPreference<T>::Save(DataWriter &out, const std::string &name) const
+{
+	out.Write(name, value.has_value(), value.value_or(0));
+}
+
+
+
+template<class T>
+void OptionalPreference<T>::Toggle(bool backwards)
+{
+	if(value.has_value())
+	{
+		if(backwards ? --currentIndex > 0 : ++currentIndex <= maxIndex)
+			// Change the value to the next full step.
+			*value = minValue + step * currentIndex;
+		else
+		{
+			// Reset to "default".
+			currentIndex = 0;
+			value.reset();
+		}
+	}
+	else
+	{
+		if(backwards)
+		{
+			currentIndex = maxIndex;
+			value = minValue + step * currentIndex;
+		}
+		else
+			value = minValue;
+	}
+}
+
+
+
+template<class T>
+const std::optional<T> &OptionalPreference<T>::Get() const
+{
+	return value;
+}
+
+
+
+template<class T>
+std::string OptionalPreference<T>::Setting() const
+{
+	return value.has_value() ? stringFun(*value) : "default";
+}

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -162,6 +162,30 @@ namespace {
 	int alertIndicatorIndex = 3;
 
 	int previousSaveCount = 3;
+
+	bool gameruleRamscoop = false;
+	const vector<string> GAMERULE_RAMSCOOP_SETTINGS = {"true", "false"};
+	int gameruleRamscoopIndex = 0;
+
+	optional<int> gamerulePersonPeriod;
+
+	optional<int> gamerulePersonWeight;
+
+	optional<int> gameruleMiningTime;
+
+	optional<double> gameruleFrugalThreshold;
+
+	bool gameruleFighters = false;
+	const vector<string> GAMERULE_FIGHTERS_SETTINGS = {"all", "none", "only player"};
+	int gameruleFightersIndex = 0;
+
+	optional<double> gameruleDepreciationMin;
+
+	optional<int> gameruleDepreciationGracePeriod;
+
+	optional<double> gameruleDepreciationDaily;
+
+	optional<int> gameruleDepreciationMaxAge;
 }
 
 
@@ -242,6 +266,57 @@ void Preferences::Load()
 			settings["Control ship with mouse"] = (node.Size() == 1 || node.Value(1));
 		else if(node.Token(0) == "notification settings")
 			notifOptionsIndex = max<int>(0, min<int>(node.Value(1), NOTIF_OPTIONS.size() - 1));
+		else if(node.Token(0) == "universal ramscoop")
+		{
+			gameruleRamscoop = node.BoolValue(1);
+			gameruleRamscoopIndex = clamp<int>(node.Value(2), 0, GAMERULE_RAMSCOOP_SETTINGS.size() - 1);
+		}
+		else if(node.Token(0) == "person spawn period")
+		{
+			if(node.BoolValue(1))
+				gamerulePersonPeriod = max<int>(1, node.Value(2));
+		}
+		else if(node.Token(0) == "no person spawn weight")
+		{
+			if(node.BoolValue(1))
+				gamerulePersonWeight = max<int>(0, node.Value(2));
+		}
+		else if(node.Token(0) == "npc max mining time")
+		{
+			if(node.BoolValue(1))
+				gameruleMiningTime = max<int>(0, node.Value(2));
+		}
+		else if(node.Token(0) == "universal frugal threshold")
+		{
+			if(node.BoolValue(1))
+				gameruleFrugalThreshold = clamp(node.Value(2), 0., 1.);
+		}
+		else if(node.Token(0) == "disabled fighters avoid projectiles")
+		{
+			gameruleFighters = node.BoolValue(1);
+			gameruleFightersIndex = clamp<int>(node.Value(2), 0, GAMERULE_FIGHTERS_SETTINGS.size() - 1);
+		}
+
+		else if(node.Token(0) == "depreciation min")
+		{
+			if(node.BoolValue(1))
+				gameruleDepreciationMin = clamp(node.Value(2), 0., 1.);
+		}
+		else if(node.Token(0) == "depreciation grace period")
+		{
+			if(node.BoolValue(1))
+				gameruleDepreciationGracePeriod = max<int>(0, node.Value(2));
+		}
+		else if(node.Token(0) == "depreciation daily")
+		{
+			if(node.BoolValue(1))
+				gameruleDepreciationDaily = clamp(node.Value(2), 0., 1.);
+		}
+		else if(node.Token(0) == "depreciation max age")
+		{
+			if(node.BoolValue(1))
+				gameruleDepreciationMaxAge = max<int>(0, node.Value(2));
+		}
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
 	}
@@ -306,6 +381,18 @@ void Preferences::Save()
 	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
 	out.Write("previous saves", previousSaveCount);
+	out.Write("universal ramscoop", gameruleRamscoop, gameruleRamscoopIndex);
+	out.Write("person spawn period", gamerulePersonPeriod.has_value(), gamerulePersonPeriod.value_or(72000));
+	out.Write("no person spawn weight", gamerulePersonWeight.has_value(), gamerulePersonWeight.value_or(1000));
+	out.Write("npc max mining time", gameruleMiningTime.has_value(), gameruleMiningTime.value_or(3600));
+	out.Write("universal frugal threshold", gameruleFrugalThreshold.has_value(), gameruleFrugalThreshold.value_or(.75));
+	out.Write("disabled fighters avoid projectiles", gameruleFighters, gameruleFightersIndex);
+	out.Write("depreciation min", gameruleDepreciationMin.has_value(), gameruleDepreciationMin.value_or(.25));
+	out.Write("depreciation grace period", gameruleDepreciationGracePeriod.has_value(),
+		gameruleDepreciationGracePeriod.value_or(7));
+	out.Write("depreciation daily", gameruleDepreciationDaily.has_value(), gameruleDepreciationDaily.value_or(.997));
+	out.Write("depreciation max age", gameruleDepreciationMaxAge.has_value(),
+		gameruleDepreciationMaxAge.value_or(1000));
 
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);
@@ -775,4 +862,117 @@ bool Preferences::DoAlertHelper(Preferences::AlertIndicator toDo)
 int Preferences::GetPreviousSaveCount()
 {
 	return previousSaveCount;
+}
+
+
+
+void Preferences::ToggleGameruleRamscoop()
+{
+	gameruleRamscoop = !gameruleRamscoop;
+}
+
+
+
+void Preferences::ToggleGameruleRamscoopValue()
+{
+	gameruleRamscoopIndex = !gameruleRamscoopIndex;
+}
+
+
+
+optional<bool> Preferences::GetGameruleRamscoop()
+{
+	return gameruleRamscoop ? optional<bool>{gameruleRamscoopIndex} : nullopt;
+}
+
+
+
+const string &Preferences::GameruleRamscoopSetting()
+{
+	return GAMERULE_RAMSCOOP_SETTINGS[gameruleRamscoopIndex];
+}
+
+
+
+const optional<int> &Preferences::GetGamerulePersonPeriod()
+{
+	return gamerulePersonPeriod;
+}
+
+
+
+const optional<int> &Preferences::GetGamerulePersonWeight()
+{
+	return gamerulePersonWeight;
+}
+
+
+
+const optional<int> &Preferences::GetGameruleMiningTime()
+{
+	return gameruleMiningTime;
+}
+
+
+
+const optional<double> &Preferences::GetGameruleFrugalThreshold()
+{
+	return gameruleFrugalThreshold;
+}
+
+
+
+void Preferences::ToggleGameruleFighters()
+{
+	gameruleFighters = !gameruleFighters;
+}
+
+
+
+void Preferences::ToggleGameruleFightersValue()
+{
+	if(++gameruleFightersIndex >= static_cast<int>(GAMERULE_FIGHTERS_SETTINGS.size()))
+		gameruleFightersIndex = 0;
+}
+
+
+
+optional<Gamerules::FighterDodgePolicy> Preferences::GetGameruleFighters()
+{
+	return gameruleFighters ? optional{static_cast<Gamerules::FighterDodgePolicy>(gameruleFightersIndex)} : nullopt;
+}
+
+
+
+const std::string &Preferences::GameruleFightersSetting()
+{
+	return GAMERULE_FIGHTERS_SETTINGS[gameruleFightersIndex];
+}
+
+
+
+const optional<double> &Preferences::GetGameruleDepreciationMin()
+{
+	return gameruleDepreciationMin;
+}
+
+
+
+const optional<int> &Preferences::GetGameruleDepreciationGracePeriod()
+{
+	return gameruleDepreciationGracePeriod;
+}
+
+
+
+const optional<double> &Preferences::GetGameruleDepreciationDaily()
+{
+	return gameruleDepreciationDaily;
+}
+
+
+
+const optional<int> &Preferences::GetGameruleDepreciationMaxAge()
+{
+	return gameruleDepreciationMaxAge;
 }

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -15,7 +15,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "Gamerules.h"
+
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -196,4 +199,32 @@ public:
 	static bool DoAlertHelper(AlertIndicator toDo);
 
 	static int GetPreviousSaveCount();
+
+	/// Gamerule override settings.
+	
+	static void ToggleGameruleRamscoop();
+	static void ToggleGameruleRamscoopValue();
+	static std::optional<bool> GetGameruleRamscoop();
+	static const std::string &GameruleRamscoopSetting();
+
+	static const std::optional<int> &GetGamerulePersonPeriod();
+
+	static const std::optional<int> &GetGamerulePersonWeight();
+
+	static const std::optional<int> &GetGameruleMiningTime();
+
+	static const std::optional<double> &GetGameruleFrugalThreshold();
+
+	static void ToggleGameruleFighters();
+	static void ToggleGameruleFightersValue();
+	static std::optional<Gamerules::FighterDodgePolicy> GetGameruleFighters();
+	static const std::string &GameruleFightersSetting();
+
+	static const std::optional<double> &GetGameruleDepreciationMin();
+
+	static const std::optional<int> &GetGameruleDepreciationGracePeriod();
+
+	static const std::optional<double> &GetGameruleDepreciationDaily();
+
+	static const std::optional<int> &GetGameruleDepreciationMaxAge();
 };

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -201,7 +201,7 @@ public:
 	static int GetPreviousSaveCount();
 
 	/// Gamerule override settings.
-	
+
 	static void ToggleGameruleRamscoop();
 	static void ToggleGameruleRamscoopValue();
 	static std::optional<bool> GetGameruleRamscoop();

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -22,6 +22,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+template<class T>
+class OptionalPreference;
+
 
 
 class Preferences {
@@ -201,30 +204,18 @@ public:
 	static int GetPreviousSaveCount();
 
 	/// Gamerule override settings.
-
 	static void ToggleGameruleRamscoop();
-	static void ToggleGameruleRamscoopValue();
-	static std::optional<bool> GetGameruleRamscoop();
+	static const std::optional<bool> &GetGameruleRamscoop();
 	static const std::string &GameruleRamscoopSetting();
-
-	static const std::optional<int> &GetGamerulePersonPeriod();
-
-	static const std::optional<int> &GetGamerulePersonWeight();
-
-	static const std::optional<int> &GetGameruleMiningTime();
-
-	static const std::optional<double> &GetGameruleFrugalThreshold();
-
+	static OptionalPreference<int> &GamerulePersonPeriod();
+	static OptionalPreference<int> &GamerulePersonWeight();
+	static OptionalPreference<int> &GameruleMiningTime();
+	static OptionalPreference<double> &GameruleFrugalThreshold();
 	static void ToggleGameruleFighters();
-	static void ToggleGameruleFightersValue();
-	static std::optional<Gamerules::FighterDodgePolicy> GetGameruleFighters();
+	static const std::optional<Gamerules::FighterDodgePolicy> &GetGameruleFighters();
 	static const std::string &GameruleFightersSetting();
-
-	static const std::optional<double> &GetGameruleDepreciationMin();
-
-	static const std::optional<int> &GetGameruleDepreciationGracePeriod();
-
-	static const std::optional<double> &GetGameruleDepreciationDaily();
-
-	static const std::optional<int> &GetGameruleDepreciationMaxAge();
+	static OptionalPreference<double> &GameruleDepreciationMin();
+	static OptionalPreference<int> &GameruleDepreciationGracePeriod();
+	static OptionalPreference<double> &GameruleDepreciationDaily();
+	static OptionalPreference<int> &GameruleDepreciationMaxAge();
 };

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -81,6 +81,10 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
+	const string GAMERULE_RAMSCOOP = "Override \"universal ramscoop\"";
+	const string GAMERULE_RAMSCOOP_VALUE = "\"universal ramscoop\" value";
+	const string GAMERULE_FIGHTERS = "Override \"disabled fighters...\"";
+	const string GAMERULE_FIGHTERS_VALUE = "\"disabled fighters...\" value";
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;
@@ -753,7 +757,13 @@ void PreferencesPanel::DrawSettings()
 		SCROLL_SPEED,
 		DATE_FORMAT,
 		"Show parenthesis",
-		NOTIFY_ON_DEST
+		NOTIFY_ON_DEST,
+		"",
+		"Gamerules",
+		GAMERULE_RAMSCOOP,
+		GAMERULE_RAMSCOOP_VALUE,
+		GAMERULE_FIGHTERS,
+		GAMERULE_FIGHTERS_VALUE
 	};
 
 	bool isCategory = true;
@@ -966,6 +976,26 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = Preferences::GetAlertIndicator() != Preferences::AlertIndicator::NONE;
 			text = Preferences::AlertSetting();
+		}
+		else if(setting == GAMERULE_RAMSCOOP)
+		{
+			isOn = Preferences::GetGameruleRamscoop().has_value();
+			text = isOn ? "on" : "off";
+		}
+		else if(setting == GAMERULE_RAMSCOOP_VALUE)
+		{
+			isOn = Preferences::GetGameruleRamscoop().has_value();
+			text = Preferences::GameruleRamscoopSetting();
+		}
+		else if(setting == GAMERULE_FIGHTERS)
+		{
+			isOn = Preferences::GetGameruleFighters().has_value();
+			text = isOn ? "on" : "off";
+		}
+		else if(setting == GAMERULE_FIGHTERS_VALUE)
+		{
+			isOn = Preferences::GetGameruleFighters().has_value();
+			text = Preferences::GameruleFightersSetting();
 		}
 		else
 			text = isOn ? "on" : "off";
@@ -1309,6 +1339,14 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleNotificationSetting();
 	else if(str == ALERT_INDICATOR)
 		Preferences::ToggleAlert();
+	else if(str == GAMERULE_RAMSCOOP)
+		Preferences::ToggleGameruleRamscoop();
+	else if(str == GAMERULE_RAMSCOOP_VALUE)
+		Preferences::ToggleGameruleRamscoopValue();
+	else if(str == GAMERULE_FIGHTERS)
+		Preferences::ToggleGameruleFighters();
+	else if(str == GAMERULE_FIGHTERS_VALUE)
+		Preferences::ToggleGameruleFightersValue();
 	// All other options are handled by just toggling the boolean state.
 	else
 		Preferences::Set(str, !Preferences::Has(str));

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -26,6 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Information.h"
 #include "Interface.h"
+#include "OptionalPreference.h"
 #include "Plugins.h"
 #include "shader/PointerShader.h"
 #include "Preferences.h"
@@ -81,10 +82,16 @@ namespace {
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
-	const string GAMERULE_RAMSCOOP = "Override \"universal ramscoop\"";
-	const string GAMERULE_RAMSCOOP_VALUE = "\"universal ramscoop\" value";
-	const string GAMERULE_FIGHTERS = "Override \"disabled fighters...\"";
-	const string GAMERULE_FIGHTERS_VALUE = "\"disabled fighters...\" value";
+	const string GAMERULE_RAMSCOOP = "\"universal ramscoop\"";
+	const string GAMERULE_PERSON_PERIOD = "\"person spawn period\"";
+	const string GAMERULE_PERSON_WEIGHT = "\"no person spawn weight\"";
+	const string GAMERULE_MINING_TIME = "\"npc max mining time\"";
+	const string GAMERULE_FRUGAL_THRESHOLD = "\"universal frugal...\"";
+	const string GAMERULE_FIGHTERS = "\"disabled fighters...\"";
+	const string GAMERULE_DEPRECIATION_MIN = "\"depreciation min\"";
+	const string GAMERULE_DEPRECIATION_GRACE_PERIOD = "\"depreciation grace period\"";
+	const string GAMERULE_DEPRECIATION_DAILY = "\"depreciation daily\"";
+	const string GAMERULE_DEPRECIATION_MAX_AGE = "\"depreciation max age\"";
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;
@@ -424,6 +431,22 @@ bool PreferencesPanel::Scroll(double dx, double dy)
 				speed = min(60, speed + 10);
 			Preferences::SetScrollSpeed(speed);
 		}
+		else if(hoverItem == GAMERULE_PERSON_PERIOD)
+			Preferences::GamerulePersonPeriod().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_PERSON_WEIGHT)
+			Preferences::GamerulePersonWeight().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_MINING_TIME)
+			Preferences::GameruleMiningTime().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_FRUGAL_THRESHOLD)
+			Preferences::GameruleFrugalThreshold().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_DEPRECIATION_MIN)
+			Preferences::GameruleDepreciationMin().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_DEPRECIATION_GRACE_PERIOD)
+			Preferences::GameruleDepreciationGracePeriod().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_DEPRECIATION_DAILY)
+			Preferences::GameruleDepreciationDaily().Toggle(dy < 0);
+		else if(hoverItem == GAMERULE_DEPRECIATION_MAX_AGE)
+			Preferences::GameruleDepreciationMaxAge().Toggle(dy < 0);
 		return true;
 	}
 	else if(page == 'p')
@@ -761,9 +784,15 @@ void PreferencesPanel::DrawSettings()
 		"",
 		"Gamerules",
 		GAMERULE_RAMSCOOP,
-		GAMERULE_RAMSCOOP_VALUE,
+		GAMERULE_PERSON_PERIOD,
+		GAMERULE_PERSON_WEIGHT,
+		GAMERULE_MINING_TIME,
+		GAMERULE_FRUGAL_THRESHOLD,
 		GAMERULE_FIGHTERS,
-		GAMERULE_FIGHTERS_VALUE
+		GAMERULE_DEPRECIATION_MIN,
+		GAMERULE_DEPRECIATION_GRACE_PERIOD,
+		GAMERULE_DEPRECIATION_DAILY,
+		GAMERULE_DEPRECIATION_MAX_AGE
 	};
 
 	bool isCategory = true;
@@ -980,22 +1009,52 @@ void PreferencesPanel::DrawSettings()
 		else if(setting == GAMERULE_RAMSCOOP)
 		{
 			isOn = Preferences::GetGameruleRamscoop().has_value();
-			text = isOn ? "on" : "off";
-		}
-		else if(setting == GAMERULE_RAMSCOOP_VALUE)
-		{
-			isOn = Preferences::GetGameruleRamscoop().has_value();
 			text = Preferences::GameruleRamscoopSetting();
+		}
+		else if(setting == GAMERULE_PERSON_PERIOD)
+		{
+			isOn = Preferences::GamerulePersonPeriod().Get().has_value();
+			text = Preferences::GamerulePersonPeriod().Setting();
+		}
+		else if(setting == GAMERULE_PERSON_WEIGHT)
+		{
+			isOn = Preferences::GamerulePersonWeight().Get().has_value();
+			text = Preferences::GamerulePersonWeight().Setting();
+		}
+		else if(setting == GAMERULE_MINING_TIME)
+		{
+			isOn = Preferences::GameruleMiningTime().Get().has_value();
+			text = Preferences::GameruleMiningTime().Setting();
+		}
+		else if(setting == GAMERULE_FRUGAL_THRESHOLD)
+		{
+			isOn = Preferences::GameruleFrugalThreshold().Get().has_value();
+			text = Preferences::GameruleFrugalThreshold().Setting();
 		}
 		else if(setting == GAMERULE_FIGHTERS)
 		{
 			isOn = Preferences::GetGameruleFighters().has_value();
-			text = isOn ? "on" : "off";
-		}
-		else if(setting == GAMERULE_FIGHTERS_VALUE)
-		{
-			isOn = Preferences::GetGameruleFighters().has_value();
 			text = Preferences::GameruleFightersSetting();
+		}
+		else if(setting == GAMERULE_DEPRECIATION_MIN)
+		{
+			isOn = Preferences::GameruleDepreciationMin().Get().has_value();
+			text = Preferences::GameruleDepreciationMin().Setting();
+		}
+		else if(setting == GAMERULE_DEPRECIATION_GRACE_PERIOD)
+		{
+			isOn = Preferences::GameruleDepreciationGracePeriod().Get().has_value();
+			text = Preferences::GameruleDepreciationGracePeriod().Setting();
+		}
+		else if(setting == GAMERULE_DEPRECIATION_DAILY)
+		{
+			isOn = Preferences::GameruleDepreciationDaily().Get().has_value();
+			text = Preferences::GameruleDepreciationDaily().Setting();
+		}
+		else if(setting == GAMERULE_DEPRECIATION_MAX_AGE)
+		{
+			isOn = Preferences::GameruleDepreciationMaxAge().Get().has_value();
+			text = Preferences::GameruleDepreciationMaxAge().Setting();
 		}
 		else
 			text = isOn ? "on" : "off";
@@ -1341,12 +1400,24 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleAlert();
 	else if(str == GAMERULE_RAMSCOOP)
 		Preferences::ToggleGameruleRamscoop();
-	else if(str == GAMERULE_RAMSCOOP_VALUE)
-		Preferences::ToggleGameruleRamscoopValue();
+	else if(str == GAMERULE_PERSON_PERIOD)
+		Preferences::GamerulePersonPeriod().Toggle();
+	else if(str == GAMERULE_PERSON_WEIGHT)
+		Preferences::GamerulePersonWeight().Toggle();
+	else if(str == GAMERULE_MINING_TIME)
+		Preferences::GameruleMiningTime().Toggle();
+	else if(str == GAMERULE_FRUGAL_THRESHOLD)
+		Preferences::GameruleFrugalThreshold().Toggle();
 	else if(str == GAMERULE_FIGHTERS)
 		Preferences::ToggleGameruleFighters();
-	else if(str == GAMERULE_FIGHTERS_VALUE)
-		Preferences::ToggleGameruleFightersValue();
+	else if(str == GAMERULE_DEPRECIATION_MIN)
+		Preferences::GameruleDepreciationMin();
+	else if(str == GAMERULE_DEPRECIATION_GRACE_PERIOD)
+		Preferences::GameruleDepreciationGracePeriod().Toggle();
+	else if(str == GAMERULE_DEPRECIATION_DAILY)
+		Preferences::GameruleDepreciationDaily().Toggle();
+	else if(str == GAMERULE_DEPRECIATION_MAX_AGE)
+		Preferences::GameruleDepreciationMaxAge().Toggle();
 	// All other options are handled by just toggling the boolean state.
 	else
 		Preferences::Set(str, !Preferences::Has(str));


### PR DESCRIPTION
**Feature**

## Summary
Gamerules can now be overriden by special settings. Each setting can be in a "default" state, in which case the values defined in the data (or plugins) will be used. The UI is limited to predefined values, but the settings are forwards-compatible, so you can set arbitrary values by editing the preferences.txt file (they still must be within the limits defined for gamerule values). Most of the new settings can also be scrolled for quicker modification with lots of possible values.

## UI Screenshots
![gamerules](https://github.com/user-attachments/assets/3237b632-86a7-494d-8a0c-cf40a0273e1b)

## Testing Done
Haven't fully tested after the change to how the settings work, yet.

## Performance Impact
probably N/A