### PR TITLE
feat(ui): Double clicking selecting similar ships in shops

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4974,31 +4974,5 @@ double Ship::CalculateDeterrence() const
 
 bool Ship::Immitates(const Ship &other) const
 {
-	// Some early return checks.
-	if(other.DisplayModelName() != DisplayModelName())
-		return false;
-
-	for(auto oit : outfits)
-		if(other.OutfitCount(oit.first) != OutfitCount(oit.first))
-			return false;
-
-	// We have to test this in both directions to avoid false positives when the right hand side
-	//  includes attributes not present on the left hand side of the first loop.
-	// Testing size() wouldn't work because attributes are incremented (created if necessary) when
-	//  outfits are installed, but are only decremented to zero (not deleted from the Dictionary)
-	//  when outfits are uninstalled, thus lengths can differ for identical configurations.
-	// We would need to filter the vectors for non-zero values before comparing their sizes.
-
-	const Dictionary &myAttributes = attributes.Attributes();
-	const Dictionary &otherAttributes = other.Attributes().Attributes();
-
-	for(auto &it : myAttributes)
-		if(otherAttributes.Get(it.first) != it.second)
-			return false;
-
-	for(auto &it : otherAttributes)
-		if(myAttributes.Get(it.first) != it.second)
-			return false;
-
-	return true;
+	return DisplayModelName() == other.DisplayModelName() && outfits == other.Outfits();
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4974,6 +4974,14 @@ double Ship::CalculateDeterrence() const
 
 bool Ship::Immitates(const Ship &other) const
 {
+	// Some early return checks.
+	if(other.DisplayModelName() != DisplayModelName())
+		return false;
+
+	for(auto oit : outfits)
+		if(other.OutfitCount(oit.first) != OutfitCount(oit.first))
+			return false;
+
 	// We have to test this in both directions to avoid false positives when the right hand side
 	//  includes attributes not present on the left hand side of the first loop.
 	// Testing size() wouldn't work because attributes are incremented (created if necessary) when

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4969,3 +4969,14 @@ double Ship::CalculateDeterrence() const
 		}
 	return tempDeterrence;
 }
+
+
+
+bool Ship::Immitates(const Ship &other) const
+{
+	for(auto &it : attributes.Attributes())
+		if(other.Attributes().Get(it.first) != it.second)
+			return false;
+
+	return true;
+}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4974,8 +4974,22 @@ double Ship::CalculateDeterrence() const
 
 bool Ship::Immitates(const Ship &other) const
 {
-	for(auto &it : attributes.Attributes())
-		if(other.Attributes().Get(it.first) != it.second)
+	// We have to test this in both directions to avoid false positives when the right hand side
+	//  includes attributes not present on the left hand side of the first loop.
+	// Testing size() wouldn't work because attributes are incremented (created if necessary) when
+	//  outfits are installed, but are only decremented to zero (not deleted from the Dictionary)
+	//  when outfits are uninstalled, thus lengths can differ for identical configurations.
+	// We would need to filter the vectors for non-zero values before comparing their sizes.
+
+	const Dictionary &myAttributes = attributes.Attributes();
+	const Dictionary &otherAttributes = other.Attributes().Attributes();
+
+	for(auto &it : myAttributes)
+		if(otherAttributes.Get(it.first) != it.second)
+			return false;
+
+	for(auto &it : otherAttributes)
+		if(myAttributes.Get(it.first) != it.second)
 			return false;
 
 	return true;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4974,5 +4974,5 @@ double Ship::CalculateDeterrence() const
 
 bool Ship::Immitates(const Ship &other) const
 {
-	return DisplayModelName() == other.DisplayModelName() && outfits == other.Outfits();
+	return displayModelName == other.DisplayModelName() && outfits == other.Outfits();
 }

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -488,6 +488,9 @@ public:
 	// The AI wants the ship to linger for one AI step.
 	void Linger();
 
+	// Does this ship look the same as another? (except for name, uuid)
+	bool Immitates(const Ship &other) const;
+
 
 private:
 	// Various steps of Ship::Move:

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -440,7 +440,7 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
-bool ShopPanel::Click(int x, int y, int /* clicks */)
+bool ShopPanel::Click(int x, int y, int clicks)
 {
 	dragShip = nullptr;
 	// Handle clicks on the buttons.
@@ -530,7 +530,7 @@ bool ShopPanel::Click(int x, int y, int /* clicks */)
 				{
 					dragShip = ship.get();
 					dragPoint.Set(x, y);
-					SideSelect(dragShip);
+					SideSelect(dragShip, clicks);
 					break;
 				}
 
@@ -1154,7 +1154,7 @@ void ShopPanel::SideSelect(int count)
 
 
 
-void ShopPanel::SideSelect(Ship *ship)
+void ShopPanel::SideSelect(Ship *ship, int clicks)
 {
 	bool shift = (SDL_GetModState() & KMOD_SHIFT);
 	bool control = (SDL_GetModState() & (KMOD_CTRL | KMOD_GUI));
@@ -1176,7 +1176,16 @@ void ShopPanel::SideSelect(Ship *ship)
 		}
 	}
 	else if(!control)
+	{
 		playerShips.clear();
+		if(clicks > 1)
+			for(const shared_ptr<Ship> &it : player.Ships())
+			{
+				Ship *itShip = it.get();
+				if(itShip != ship && itShip->Immitates(*ship))
+					playerShips.insert(itShip);
+			}
+	}
 	else if(playerShips.count(ship))
 	{
 		playerShips.erase(ship);

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -196,7 +196,7 @@ private:
 	bool SetScrollToTop();
 	bool SetScrollToBottom();
 	void SideSelect(int count);
-	void SideSelect(Ship *ship);
+	void SideSelect(Ship *ship, int clicks = 1);
 	void MainAutoScroll(const std::vector<Zone>::const_iterator &selected);
 	void MainLeft();
 	void MainRight();


### PR DESCRIPTION
**Feature**

## Summary
Re-PR of #10200. You can now double click a ship in the shipyard/outfitter to select all ships _similar_ to it.

## Screenshots
N/A

## Testing Done
IIRC I've tested the original PR and it worked.

## Performance Impact
N/A
