### PR TITLE
fix(audio): Pause audio on the Ship Info panel

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ShipInfoPanel.h"
 
 #include "text/alignment.hpp"
+#include "audio/Audio.h"
 #include "CategoryList.h"
 #include "CategoryTypes.h"
 #include "Command.h"
@@ -63,6 +64,7 @@ ShipInfoPanel::ShipInfoPanel(PlayerInfo &player, InfoPanelState state)
 	: player(player), panelState(std::move(state))
 {
 	shipIt = this->panelState.Ships().begin();
+	Audio::Pause();
 	SetInterruptible(false);
 
 	// If a valid ship index was given, show that ship.
@@ -77,6 +79,13 @@ ShipInfoPanel::ShipInfoPanel(PlayerInfo &player, InfoPanelState state)
 	}
 
 	UpdateInfo();
+}
+
+
+
+ShipInfoPanel::~ShipInfoPanel()
+{
+	Audio::Resume();
 }
 
 

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -42,6 +42,7 @@ class ShipInfoPanel : public Panel {
 public:
 	explicit ShipInfoPanel(PlayerInfo &player);
 	explicit ShipInfoPanel(PlayerInfo &player, InfoPanelState state);
+	virtual ~ShipInfoPanel() override;
 
 	virtual void Step() override;
 	virtual void Draw() override;


### PR DESCRIPTION
**Bug fix**

## Summary
To reproduce the bug:
1. Open the game.
2. When the sound starts playing, quickly enter the game and open Player Info. Notice that the sound pauses.
3. Select a ship to open Ship Info. The sound unpauses.

## Testing Done
yes™.
