### PR TITLE
feat(balance): Remove ammo racks from Lances

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2479,8 +2479,7 @@ ship "Lance"
 	outfits
 		"Energy Blaster"
 		"Sidewinder Missile Pod" 2
-		"Sidewinder Missile Rack"
-		"Sidewinder Missile" 35
+		"Sidewinder Missile" 12
 		
 		"nGVF-AA Fuel Cell"
 		"Supercapacitor" 4


### PR DESCRIPTION
**Balance**

## Summary
Following the Carrier rework, the now twice as many Lances flying around Carriers with Sidewinder Pods can get a bit unruly in Free Worlds combat missions. Not only do they have the Pods, but they also have ammo racks, so after their initial burst, if you don't seek them out right away, their follow-up missiles can start to put a lot of pressure on you or other ships.

This PR removes their ammo racks, reducing their Sidewinder count from 35 to the original 12. Since these are pods, it kind of makes sense these aren't full-blown launchers with consistent damage and more-so focused around their initial attack. This is also likely more healthy for fights as the ammo rack is a sort of "min-maxing" Lances here, which we probably shouldn't try to min-max everything. The Carrier still has extra ammunition for Lances to restock on, and having to return to it reduces their uptime and proves more shots to kill them instead of them shooting ~3 bursts over time from far away.

## Testing Done
Playtested the Zeta fight as the primary enemies are two Carriers. Made note that the Lances run out of their missiles after the first moments in the fight and go in for energy blaster attacks, instead of going on burst reload for 2 more cycles and continuing to provide fire from afar.

## Save File
This save is the fight already instantiated with the PR's changes:
[Shin Tensus~Zeta Aquilae.txt](https://github.com/user-attachments/files/18913652/Shin.Tensus.Zeta.Aquilae.txt)
This save is before the attack mission is instantiated: 
[Shin Tensus~FW Pre Zeta Invade.txt](https://github.com/user-attachments/files/18913653/Shin.Tensus.FW.Pre.Zeta.Invade.txt)
