### PR TITLE
feat(balance): Replace missiles with Particle Cannons on Reconciliation's Cruiser (Jump) Variant

### DIFF
--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1282,10 +1282,7 @@ ship "Cruiser" "Cruiser (Heavy)"
 
 ship "Cruiser" "Cruiser (Jump)"
 	outfits
-		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
-		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Particle Cannon" 4
 		"Electron Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Laser Rifle" 20
@@ -1302,10 +1299,10 @@ ship "Cruiser" "Cruiser (Jump)"
 		"A520 Atomic Thruster"
 		"A525 Atomic Steering"
 		"Jump Drive"
-	gun "Sidewinder Missile Launcher"
-	gun "Sidewinder Missile Launcher"
-	gun "Typhoon Launcher"
-	gun "Typhoon Launcher"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
+	gun "Particle Cannon"
 	gun
 	gun
 	turret "Electron Turret"


### PR DESCRIPTION
**Balance**

## Summary
With the Carrier rework removing the Carrier's main four Particle Cannons and replacing them with more Fighters and stronger munitions, Carrier variants lost their strict forward weapon power. While this is a plus for its role, its a minus for certain situations.

In FW Reconciliation, the Jump variant Carriers no longer have their Particle Cannons, meaning none of the ships escorting the player in these fights, Cruiser or Carrier, have Particle Cannons, which are decent at providing constant fire on ships in Pug fights. The replacements on the Carriers being reliant on munitions means they're susceptible to Pug AM, whereas Particle Cannons are not, so this can spike the fight's difficulty.

This PR replaces the munitions on the Cruiser variants with Particle Cannons. This brings back the Particle Cannon damage the Carriers once had, since the Typhoons and Missiles removed from the Cruiser variants are now found on the Carrier variants.

## Testing Done
The fight's current balance aside, using the save below, over the course of a few tests between PR and not, there is a not-insignificant amount of Pug ships remaining without the PR, than with, at the end of the fight.

## Save File
[Shin Tensus~FW Pre Pug Fight.txt](https://github.com/user-attachments/files/18913836/Shin.Tensus.FW.Pre.Pug.Fight.txt)

