### PR TITLE
Add fleet jump description

### DIFF
--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -62,7 +62,7 @@ const Command Command::BOARD(ONE << 11, "Board selected ship");
 const Command Command::HAIL(ONE << 12, "Talk to selected ship");
 const Command Command::SCAN(ONE << 13, "Scan selected ship");
 const Command Command::JUMP(ONE << 14, "Initiate hyperspace jump");
-const Command Command::FLEET_JUMP(ONE << 15, "");
+const Command Command::FLEET_JUMP(ONE << 15, "Fleet jump");
 const Command Command::TARGET(ONE << 16, "Select next ship");
 const Command Command::NEAREST(ONE << 17, "Select nearest hostile ship");
 const Command Command::NEAREST_ASTEROID(ONE << 18, "Select nearest asteroid");

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -62,7 +62,7 @@ const Command Command::BOARD(ONE << 11, "Board selected ship");
 const Command Command::HAIL(ONE << 12, "Talk to selected ship");
 const Command Command::SCAN(ONE << 13, "Scan selected ship");
 const Command Command::JUMP(ONE << 14, "Initiate hyperspace jump");
-const Command Command::FLEET_JUMP(ONE << 15, "Fleet jump");
+const Command Command::FLEET_JUMP(ONE << 15, "Initiate fleet jump");
 const Command Command::TARGET(ONE << 16, "Select next ship");
 const Command Command::NEAREST(ONE << 17, "Select nearest hostile ship");
 const Command Command::NEAREST_ASTEROID(ONE << 18, "Select nearest asteroid");


### PR DESCRIPTION
Add a fleet jump description. This allows endless-mobile to trigger this command from a button.

**Feature**

This PR addresses the bug/feature described in issue #11012

## Summary
This just adds a description to the `FLEET_JUMP` command, which can be used as a key for endless-mobile buttons. 

## Testing Done
Checked that existing shift+`JUMP` still works as designed.
Checked that `keys.txt` is not affected (since no key is bound to `FLEET_JUMP` by default, and it does not show up in preferences)

## Performance Impact
N/A
