### PR TITLE
feat(balance): Make firelights jammable, slightly slower, smaller radius

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -947,7 +947,7 @@ outfit "Firelight Missile Bank"
 		"firing heat" 151
 		"acceleration" 0.6
 		"drag" .1
-		"optical tracking" .9
+		"optical tracking" .7
 		"homing" 4
 		"blast radius" 48
 		"hit force" 150

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -947,7 +947,6 @@ outfit "Firelight Missile Bank"
 		"firing heat" 151
 		"acceleration" 0.6
 		"drag" .1
-		"infrared tracking" .7
 		"optical tracking" .9
 		"homing" 4
 		"trigger radius" 30
@@ -970,8 +969,7 @@ outfit "Firelight Turning"
 		"acceleration" -0.1
 		"turn" 4.6
 		"homing" 4
-		"infrared tracking" .7
-		"optical tracking" .9
+		"tracking" .9
 		"trigger radius" 30
 		"blast radius" 60
 		"hit force" 90

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -949,8 +949,7 @@ outfit "Firelight Missile Bank"
 		"drag" .1
 		"optical tracking" .9
 		"homing" 4
-		"trigger radius" 30
-		"blast radius" 60
+		"blast radius" 48
 		"hit force" 150
 		"missile strength" 30
 		submunition "Firelight Turning"
@@ -970,8 +969,8 @@ outfit "Firelight Turning"
 		"turn" 4.6
 		"homing" 4
 		"tracking" .9
-		"trigger radius" 30
-		"blast radius" 60
+		"trigger radius" 20
+		"blast radius" 48
 		"hit force" 90
 		"missile strength" 30
 		"submunition" "Firelight Activated"

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -951,7 +951,7 @@ outfit "Firelight Missile Bank"
 		"homing" 4
 		"blast radius" 48
 		"hit force" 150
-		"missile strength" 30
+		"missile strength" 33
 		submunition "Firelight Turning"
 		"stream"
 	description "As the Firestorm Torpedo does not require full reactor shielding or safety interlocks, Korath engineers were able to create the Firelight by further scaling down the reactor element to fit in a missile casing for use on and against smaller vessels."
@@ -997,7 +997,7 @@ outfit "Firelight Activated"
 		"burn damage" 10
 		"corrosion damage" 2
 		"hit force" 600
-		"missile strength" 36
+		"missile strength" 33
 
 effect "firelight ring"
 	sprite "effect/firestorm ring"

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -986,22 +986,21 @@ outfit "Firelight Activated"
 		"hit effect" "firelight ring" 20
 		"die effect" "small explosion"
 		"velocity" 3
-		"lifetime" 140
+		"lifetime" 168
 		"acceleration" 1.6
-		"drag" .1
+		"drag" .12
 		"turn" 1.7
 		"homing" 4
-		"infrared tracking" .5
 		"optical tracking" .7
-		"trigger radius" 30
-		"blast radius" 60
+		"trigger radius" 24
+		"blast radius" 48
 		"shield damage" 950
 		"hull damage" 950
 		"heat damage" 1800
 		"burn damage" 10
 		"corrosion damage" 2
 		"hit force" 600
-		"missile strength" 30
+		"missile strength" 36
 
 effect "firelight ring"
 	sprite "effect/firestorm ring"

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -938,7 +938,7 @@ outfit "Firelight Missile Bank"
 		"hit effect" "firelight ring" 20
 		"die effect" "piercer fire"
 		"velocity" 4
-		"velocity override" 16
+		"velocity override" 13
 		"lifetime" 10
 		"reload" 120
 		"burst reload" 30
@@ -992,7 +992,7 @@ outfit "Firelight Activated"
 		"turn" 1.7
 		"homing" 4
 		"optical tracking" .7
-		"trigger radius" 24
+		"trigger radius" 20
 		"blast radius" 48
 		"shield damage" 950
 		"hull damage" 950
@@ -1099,7 +1099,6 @@ outfit "Firestorm Battery"
 		"drag" .12
 		"turn" 1.6
 		"homing" 4
-		"infrared tracking" .7
 		"optical tracking" .9
 		"trigger radius" 40
 		"blast radius" 95

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -948,7 +948,7 @@ outfit "Firelight Missile Bank"
 		"acceleration" 0.6
 		"drag" .1
 		"optical tracking" .7
-		"homing" 4
+		"homing" 3
 		"blast radius" 48
 		"hit force" 150
 		"missile strength" 33
@@ -987,7 +987,7 @@ outfit "Firelight Activated"
 		"acceleration" 1.6
 		"drag" .12
 		"turn" 1.7
-		"homing" 4
+		"homing" 3
 		"optical tracking" .7
 		"trigger radius" 20
 		"blast radius" 48


### PR DESCRIPTION
**Balance**

This PR addresses concerns raised by @Quantumshark regarding the strength of the Firelight missile

## Summary

This slightly reduces Firelight missile speed and blast radius, removes its IR tracking ability, and downgrades its homing behaviour.

There is a balancing act to be danced with speed and anti-missile strength.  If speed is reduced too much, AM becomes too effective.  The design goal is that one out of every three shots (note how they fire in threes) should be able to get through a PDT, given the Korath use these offensively against the Remnant.  Or, at least one in six, given these are equipped in pairs.  Increasing drag beyond the .12 given here would give a PDT a third shot, requiring a dramatic increase in missile strength.

Blast radius has been reduced to match the scale of the effect sprite, to bring it in line with the Firestorm.

Given that Korath ships tend to be the hottest things in the sky, it doesn't make a lot of sense for them to fire heat-seeking missiles, so IR tracking has been removed.  Removing IR tracking allows optical jamming to be an effective countermeasure.  This should encourage players to visit the Hai before taking on the Korath, and helps explain why the Unfettered have powerful optical jamming.

As a bonus, that and the move to `homing 3` should also make it easier for very small ships to evade, without adversely affecting its role as a missile.

<!---## Screenshots--->

<!---## Testing Done--->

<!---## Save File--->