### PR TITLE
refactor(audio): Decouple playback, decoding and effects into separate classes

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -330,6 +330,21 @@ target_sources(EndlessSkyLib PRIVATE
 	audio/Sound.cpp
 	audio/Sound.h
 	audio/SoundCategory.h
+    audio/player/AudioPlayer.cpp
+    audio/player/AudioPlayer.h
+    audio/player/MusicPlayer.cpp
+    audio/player/MusicPlayer.h
+    audio/player/VolumeFadePlayer.cpp
+    audio/player/VolumeFadePlayer.h
+    audio/supplier/AudioDataSupplier.h
+    audio/supplier/AudioSupplier.cpp
+    audio/supplier/AudioSupplier.h
+    audio/supplier/Mp3Supplier.cpp
+    audio/supplier/Mp3Supplier.h
+    audio/supplier/WavSupplier.cpp
+    audio/supplier/WavSupplier.h
+    audio/supplier/effect/Fade.cpp
+    audio/supplier/effect/Fade.h
 	comparators/ByGivenOrder.h
 	comparators/ByName.h
 	comparators/BySeriesAndIndex.h

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -296,7 +296,6 @@ void Audio::PlayMusic(const string &name)
 		musicPlayer = shared_ptr<AudioPlayer>(new MusicPlayer(unique_ptr<AudioDataSupplier>{fade}));
 		musicPlayer->Init();
 		musicPlayer->SetVolume(Volume(SoundCategory::MUSIC));
-		musicPlayer->Move(0., 0., 0.);
 		musicPlayer->Play();
 		players.emplace_back(musicPlayer);
 	}

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -25,7 +25,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "../Files.h"
 #include "../Logger.h"
 #include "../Point.h"
-#include "../Random.h"
 
 #include <AL/al.h>
 #include <AL/alc.h>
@@ -34,7 +33,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cmath>
 #include <map>
 #include <mutex>
-#include <set>
 #include <stdexcept>
 #include <thread>
 #include <vector>

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -288,11 +288,11 @@ void Audio::PlayMusic(const string &name)
 	// by the main thread.
 	currentTrack = name;
 	if(musicPlayer && !musicPlayer->IsFinished())
-		reinterpret_cast<Fade *>(musicPlayer->Supplier())->AddSource(Music::CreateSupplier(name));
+		reinterpret_cast<Fade *>(musicPlayer->Supplier())->AddSource(Music::CreateSupplier(name, true));
 	else
 	{
 		Fade *fade = new Fade();
-		fade->AddSource(Music::CreateSupplier(name));
+		fade->AddSource(Music::CreateSupplier(name, true));
 		musicPlayer = shared_ptr<AudioPlayer>(new MusicPlayer(unique_ptr<AudioDataSupplier>{fade}));
 		musicPlayer->Init();
 		musicPlayer->SetVolume(Volume(SoundCategory::MUSIC));
@@ -335,7 +335,10 @@ void Audio::Step(bool isFastForward)
 			cachedVolume[category] = expected;
 			if(category == SoundCategory::MASTER)
 				alListenerf(AL_GAIN, expected);
-
+			else
+				for(const auto &player : players)
+					if(player->Category() == category)
+						player->SetVolume(expected);
 		}
 
 	if(pauseChangeCount > 0)

--- a/source/audio/Music.cpp
+++ b/source/audio/Music.cpp
@@ -53,12 +53,12 @@ void Music::Init(const vector<filesystem::path> &sources)
 
 
 
-unique_ptr<AudioDataSupplier> Music::CreateSupplier(const string &name)
+unique_ptr<AudioDataSupplier> Music::CreateSupplier(const string &name, bool looping)
 {
 	// TODO: After Files is refactored with std::iostream, just use Files::Open() to get the stream.
 	if(paths.contains(name))
 		return unique_ptr<AudioDataSupplier>{
 				new Mp3Supplier(shared_ptr<iostream>{
-						new fstream(paths[name], fstream::in | fstream::binary)})};
+						new fstream(paths[name], fstream::in | fstream::binary)}, looping)};
 	return {};
 }

--- a/source/audio/Music.cpp
+++ b/source/audio/Music.cpp
@@ -16,24 +16,16 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Music.h"
 
 #include "../Files.h"
-
 #include "../text/Format.h"
 
-#include <mad.h>
+#include "supplier/Mp3Supplier.h"
 
-#include <algorithm>
-#include <cstring>
+#include <fstream>
 #include <map>
 
 using namespace std;
 
 namespace {
-	// How many bytes to read from the file at a time:
-	const size_t INPUT_CHUNK = 65536;
-	// How many samples to put in each output block. Because the output is in
-	// stereo, the duration of the sample is half this amount:
-	const size_t OUTPUT_CHUNK = 32768;
-
 	map<string, filesystem::path> paths;
 }
 
@@ -61,227 +53,12 @@ void Music::Init(const vector<filesystem::path> &sources)
 
 
 
-// Music constructor, which starts the decoding thread. Initially, the thread
-// has no file to read, so it will sleep until a file is specified.
-Music::Music()
-	: silence(OUTPUT_CHUNK, 0)
+unique_ptr<AudioDataSupplier> Music::CreateSupplier(const string &name)
 {
-	// Don't start the thread until this object is fully constructed.
-	thread = std::thread(&Music::Decode, this);
-}
-
-
-
-// Destructor, which waits for the thread to stop.
-Music::~Music()
-{
-	// Tell the decoding thread to stop.
-	{
-		unique_lock<mutex> lock(decodeMutex);
-		done = true;
-	}
-	condition.notify_all();
-	thread.join();
-
-	// If the decode thread has not yet taken possession of the next file, it is
-	// our job to close it.
-	if(nextFile)
-		fclose(nextFile);
-}
-
-
-
-// Set the source of music. If the path is empty, this music will be silent.
-void Music::SetSource(const string &name)
-{
-	// Find a file that provides this music.
-	auto it = paths.find(name);
-	filesystem::path path = (it == paths.end() ? "" : it->second);
-
-	// Do nothing if this is the same file we're playing.
-	if(path == previousPath)
-		return;
-	currentSource = name;
-	previousPath = path;
-
-	// Inform the decoding thread that it should switch to decoding a new file.
-	unique_lock<mutex> lock(decodeMutex);
-	if(path.empty())
-		nextFile = nullptr;
-	else
-		nextFile = Files::Open(path);
-	hasNewFile = true;
-
-	// Also clear any decoded data left over from the previous file.
-	next.clear();
-
-	// Notify the decoding thread that it can start.
-	lock.unlock();
-	condition.notify_all();
-}
-
-
-
-// Get the name of the current music source playing.
-const string &Music::GetSource() const
-{
-	return currentSource;
-}
-
-
-
-// Get the next audio buffer to play.
-const vector<int16_t> &Music::NextChunk()
-{
-	// Check whether the "next" buffer is ready.
-	unique_lock<mutex> lock(decodeMutex);
-	if(next.size() < OUTPUT_CHUNK)
-		return silence;
-
-	// If the next buffer is ready, move a chunk of data into the output buffer.
-	// All output buffers need to be the same size so that we can fade between
-	// two different sources.
-	current.clear();
-	current.insert(current.begin(), next.begin(), next.begin() + OUTPUT_CHUNK);
-	next.erase(next.begin(), next.begin() + OUTPUT_CHUNK);
-
-	// Once the lock is unlocked, notify the decoding thread to continue.
-	lock.unlock();
-	condition.notify_all();
-
-	// Return the buffer.
-	return current;
-
-}
-
-
-
-// Entry point for the decoding thread.
-void Music::Decode()
-{
-	// This vector will store the input from the file.
-	vector<unsigned char> input(INPUT_CHUNK, 0);
-	// Objects for MP3 decoding:
-	mad_stream stream;
-	mad_frame frame;
-	mad_synth synth;
-	// Loop until the thread is told to quit.
-	while(true)
-	{
-		// First, wait until a new file has been specified or we're done.
-		FILE *file = nullptr;
-		while(!file)
-		{
-			unique_lock<mutex> lock(decodeMutex);
-			while(!done && !hasNewFile)
-				condition.wait(lock);
-
-			// If the "done" variable has been set, exit this thread.
-			if(done)
-				return;
-
-			// The new file now belongs to us, and it's our job to close it.
-			file = nextFile;
-			nextFile = nullptr;
-			hasNewFile = false;
-		}
-
-		// Now, we have a file to read. Initialize the decoder.
-		mad_stream_init(&stream);
-		mad_frame_init(&frame);
-		mad_synth_init(&synth);
-
-		// Loop until we are asked to switch files.
-		while(true)
-		{
-			// If the "next" buffer has filled up, wait until it is retrieved.
-			// Generally try to queue up two chunks worth of samples in it, just
-			// in case NextChunk() gets called twice in rapid succession.
-			unique_lock<mutex> lock(decodeMutex);
-			while(!done && next.size() >= 2 * OUTPUT_CHUNK)
-				condition.wait(lock);
-			// Check if we're done or if we need to switch files.
-			if(done || hasNewFile)
-				break;
-
-			// The lock can be freed until we start filling the output buffer.
-			lock.unlock();
-
-			// See if any input data is left undecoded in the stream. Typically
-			// this is because the last block of input contained a fraction of a
-			// full MP3 frame.
-			size_t remainder = 0;
-			if(stream.next_frame && stream.next_frame < stream.bufend)
-				remainder = stream.bufend - stream.next_frame;
-			if(remainder)
-				memcpy(&input.front(), stream.next_frame, remainder);
-
-			// Now, read a chunk of data from the file.
-			size_t read = fread(&input.front() + remainder, 1, INPUT_CHUNK - remainder, file);
-			// If you get the end of the file, loop around to the beginning.
-			if(!read || feof(file))
-				rewind(file);
-			// If there is nothing to decode, return to the top of this loop.
-			if(!(read + remainder))
-				continue;
-
-			// Hand the input to the stream decoder.
-			mad_stream_buffer(&stream, &input.front(), read + remainder);
-
-			// Loop through the decoded result for that input block.
-			while(true)
-			{
-				// Decode the next frame, and check if there is an error.
-				if(mad_frame_decode(&frame, &stream))
-				{
-					// For recoverable errors, keep going.
-					if(MAD_RECOVERABLE(stream.error))
-						continue;
-					else
-						break;
-				}
-				// Convert the decoded audio into a PCM signal.
-				mad_synth_frame(&synth, &frame);
-
-				// If the source is mono, read both output channels from the left input.
-				// Otherwise, read two separate input channels.
-				mad_fixed_t *channels[2] = {
-					synth.pcm.samples[0],
-					synth.pcm.samples[synth.pcm.channels > 1]
-				};
-
-				// For this part, we need access to the output buffer.
-				lock.lock();
-				if(done || hasNewFile)
-					break;
-
-				// We'll alternate what channel we read from each time through the loop.
-				bool channel = false;
-				for(unsigned i = 0; i < 2 * synth.pcm.length; ++i)
-				{
-					// Read the next sample from the next channel.
-					mad_fixed_t sample = *channels[channel]++;
-					channel = !channel;
-
-					// Clip and scale the sample to 16 bits.
-					sample += (1L << (MAD_F_FRACBITS - 16));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-					sample = max(-MAD_F_ONE, min(MAD_F_ONE - 1, sample));
-#pragma GCC diagnostic pop
-					next.push_back(sample >> (MAD_F_FRACBITS + 1 - 16));
-				}
-				// Now, the "next" buffer can be used by others. In theory, the
-				// NextChunk() function could take what's in that buffer while
-				// we are right in the middle of this decoding cycle.
-				lock.unlock();
-			}
-		}
-
-		// Clean up.
-		mad_synth_finish(&synth);
-		mad_frame_finish(&frame);
-		mad_stream_finish(&stream);
-		fclose(file);
-	}
+	// TODO: After Files is refactored with std::iostream, just use Files::Open() to get the stream.
+	if(paths.contains(name))
+		return unique_ptr<AudioDataSupplier>{
+				new Mp3Supplier(shared_ptr<iostream>{
+						new fstream(paths[name], fstream::in | fstream::binary)})};
+	return {};
 }

--- a/source/audio/Music.h
+++ b/source/audio/Music.h
@@ -15,16 +15,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <condition_variable>
-#include <cstdint>
-#include <cstdio>
+#include "supplier/AudioDataSupplier.h"
+
 #include <filesystem>
-#include <mutex>
-#include <string>
-#include <thread>
-#include <vector>
-
-
+#include <memory>
 
 // The Music class streams mp3 audio from a file and delivers it to the program
 // on "block" at a time, so it never needs to hold the entire decoded file in
@@ -35,41 +29,7 @@ class Music {
 public:
 	static void Init(const std::vector<std::filesystem::path> &sources);
 
+	static std::unique_ptr<AudioDataSupplier> CreateSupplier(const std::string &name);
 
-public:
-	Music();
-	~Music();
-
-	// Set the source of music. If the path is empty, this music will be silent.
-	void SetSource(const std::string &name = "");
-	// Get the name of the current music source playing.
-	const std::string &GetSource() const;
-	// Get the next audio buffer to play.
-	const std::vector<int16_t> &NextChunk();
-
-
-private:
-	// This is the entry point for the decoding thread.
-	void Decode();
-
-
-private:
-	// Buffers for storing the decoded audio sample. The "silence" buffer holds
-	// a block of silence to be returned if nothing was read from the file.
-	std::vector<int16_t> silence;
-	std::vector<int16_t> next;
-	std::vector<int16_t> current;
-
-	std::string currentSource;
-	std::filesystem::path previousPath;
-	// This pointer holds the file for as long as it is owned by the main
-	// thread. When the decode thread takes possession of it, it sets this
-	// pointer to null.
-	FILE *nextFile = nullptr;
-	bool hasNewFile = false;
-	bool done = false;
-
-	std::thread thread;
-	std::mutex decodeMutex;
-	std::condition_variable condition;
+	Music() = delete;
 };

--- a/source/audio/Music.h
+++ b/source/audio/Music.h
@@ -29,7 +29,7 @@ class Music {
 public:
 	static void Init(const std::vector<std::filesystem::path> &sources);
 
-	static std::unique_ptr<AudioDataSupplier> CreateSupplier(const std::string &name);
+	static std::unique_ptr<AudioDataSupplier> CreateSupplier(const std::string &name, bool looping);
 
 	Music() = delete;
 };

--- a/source/audio/Sound.cpp
+++ b/source/audio/Sound.cpp
@@ -15,6 +15,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Sound.h"
 
+#include "supplier/WavSupplier.h"
+#include "supplier/effect/Fade.h"
+
 #include "../File.h"
 
 #include <AL/al.h>
@@ -91,6 +94,13 @@ unsigned Sound::Buffer3x() const
 bool Sound::IsLooping() const
 {
 	return isLooped;
+}
+
+
+
+unique_ptr<AudioSupplier> Sound::CreateSupplier() const
+{
+	return unique_ptr<AudioSupplier>{new WavSupplier(*this, false,IsLooping())};
 }
 
 

--- a/source/audio/player/AudioPlayer.cpp
+++ b/source/audio/player/AudioPlayer.cpp
@@ -1,0 +1,247 @@
+/* AudioPlayer.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "AudioPlayer.h"
+
+#include "../../Random.h"
+
+#include <algorithm>
+
+using namespace std;
+
+
+
+std::vector<ALuint> AudioPlayer::availableSources{};
+
+
+
+AudioPlayer::AudioPlayer(SoundCategory category, unique_ptr<AudioSupplier> supplier)
+	: category(category), audioSupplier(std::move(supplier))
+{
+}
+
+
+
+AudioPlayer::~AudioPlayer()
+{
+	// Maintenance note: this does not delete the buffers.
+	// Make sure playback has stopped and the buffers were released appropriately.
+	// (This can't be enforced as the game may exit at any point, even with audio playing.)
+	ReleaseSource();
+}
+
+
+
+void AudioPlayer::Update()
+{
+	if(!alSource)
+		return;
+
+	ALint buffersDone = 0;
+	alGetSourcei(alSource, AL_BUFFERS_PROCESSED, &buffersDone);
+
+	if(!audioSupplier->MaxChunkCount() || shouldStop) // no chunks left to play
+	{
+		ALint buffersQueued = 0;
+		alGetSourcei(alSource, AL_BUFFERS_QUEUED, &buffersQueued);
+
+		if(buffersDone == buffersQueued)
+		{
+			// All queued buffers finished, and we don't have any others left. Playback has finished.
+			// Unqueue all buffers and return them, then release the source.
+			std::vector<ALuint> buffers(buffersQueued);
+			alSourceUnqueueBuffers(alSource, buffersQueued, buffers.data());
+
+			for(ALuint buffer : buffers)
+				audioSupplier->ReturnBuffer(buffer);
+
+			ReleaseSource();
+
+			done = true;
+		}
+	}
+	else
+	{
+		// Queue as many buffers as possible.
+		for(int i = 0; i < buffersDone && audioSupplier->AvailableChunks(); i++)
+		{
+			ALuint buffer = 0;
+			alSourceUnqueueBuffers(alSource, 1, &buffer);
+
+			if(audioSupplier->IsSynchronous())
+			{
+				audioSupplier->ReturnBuffer(buffer);
+				buffer = audioSupplier->AwaitNextChunk();
+			}
+			else
+			{
+				audioSupplier->NextChunk(buffer);
+			}
+
+			alSourceQueueBuffers(alSource, 1, &buffer);
+		}
+	}
+}
+
+
+
+bool AudioPlayer::IsFinished() const
+{
+	return done;
+}
+
+
+
+double AudioPlayer::Volume() const
+{
+	if(!alSource)
+		return 0.;
+
+	ALfloat value;
+	alGetSourcef(alSource, AL_GAIN, &value);
+	return value;
+}
+
+
+
+void AudioPlayer::SetVolume(double level) const
+{
+	if(!alSource)
+		return;
+
+	alSourcef(alSource, AL_GAIN, level);
+}
+
+
+
+void AudioPlayer::Move(double x, double y, double z) const
+{
+	alSource3f(alSource, AL_POSITION, x, y, z);
+}
+
+
+
+SoundCategory AudioPlayer::Category() const
+{
+	return category;
+}
+
+
+
+void AudioPlayer::Pause() const
+{
+	if(!alSource)
+		return;
+
+	alSourcePause(alSource);
+}
+
+
+
+void AudioPlayer::Play() const
+{
+	if(!alSource)
+		return;
+
+	ALint state;
+	alGetSourcei(alSource, AL_SOURCE_STATE, &state);
+	if(state != AL_PLAYING)
+		alSourcePlay(alSource);
+}
+
+
+
+void AudioPlayer::Init()
+{
+	if(shouldStop)
+		return;
+
+	if(!alSource)
+	{
+		if(!ClaimSource())
+			return;
+	}
+
+	int bufferCount = clamp(audioSupplier->MaxChunkCount(), 1, MAX_INITIAL_BUFFERS);
+
+	std::vector<ALuint> realBuffers(bufferCount);
+	for(int i = 0; i < bufferCount; ++i)
+		realBuffers.emplace_back(audioSupplier->AwaitNextChunk());
+
+	// Queue the actual audio buffers
+	alSourceQueueBuffers(alSource, realBuffers.size(), realBuffers.data());
+}
+
+
+
+void AudioPlayer::Stop(bool stop)
+{
+	shouldStop = stop;
+}
+
+
+
+AudioSupplier *AudioPlayer::Supplier()
+{
+	return audioSupplier.get();
+}
+
+
+
+bool AudioPlayer::ClaimSource()
+{
+	if(alSource)
+		return true;
+
+	if(!availableSources.empty())
+	{
+		alSource = availableSources.back();
+		availableSources.pop_back();
+		ConfigureSource();
+		return true;
+	}
+	else
+	{
+		alGenSources(1, &alSource);
+		ConfigureSource();
+
+		return alSource;
+	}
+}
+
+
+
+void AudioPlayer::ConfigureSource()
+{
+	if(!alSource)
+		return;
+
+	alSourcef(alSource, AL_PITCH, 1. + (Random::Real() - Random::Real()) * .04);
+	alSourcef(alSource, AL_REFERENCE_DISTANCE, 1.);
+	alSourcef(alSource, AL_ROLLOFF_FACTOR, 1.);
+	alSourcei(alSource, AL_LOOPING, 0);
+	alSourcef(alSource, AL_MAX_DISTANCE, 100.);
+}
+
+
+
+void AudioPlayer::ReleaseSource()
+{
+	if(!alSource)
+		return;
+
+	availableSources.emplace_back(alSource);
+	alSource = 0;
+}

--- a/source/audio/player/AudioPlayer.h
+++ b/source/audio/player/AudioPlayer.h
@@ -42,13 +42,15 @@ public:
 	/// and should not be stored.
 	bool IsFinished() const;
 
-	/// The volume of the playback, or 0 if the player has not started yet.
+	/// The volume of the playback, or 0 if the player is not initialized.
 	double Volume() const;
-	///
+	/// Sets the volume of the player, if it is initialized.
 	void SetVolume(double level) const;
 
+	/// Moves the sound to the specified point in 3D. Ignored if the player is not initialized.
 	virtual void Move(double x, double y, double z) const;
 
+	/// The category of the sound being played
 	SoundCategory Category() const;
 
 	virtual void Pause() const;
@@ -60,29 +62,38 @@ public:
 	/// Until the player is marked finished, calling this function with 'false' can undo its effect.
 	void Stop(bool stop = true);
 
+	/// The supplier of the player. Never null.
 	AudioSupplier *Supplier();
 
 
 protected:
+	/// Acquires a new source, if there isn't one already.
 	bool ClaimSource();
+	/// Releases the current source, making it available for other audio players.
 	void ReleaseSource();
 
+	/// Configures a source for the first time after being claimed.
 	virtual void ConfigureSource();
 
 
 protected:
+	/// The maximum number of buffers to queue up synchronously when the player is initialized
 	static constexpr int MAX_INITIAL_BUFFERS = 3;
 
 	SoundCategory category;
 
 	/// The configured source, or 0
 	ALuint alSource = 0;
+	/// The data supplier; never null
 	std::unique_ptr<AudioSupplier> audioSupplier;
 
+	/// Whether the player has terminated
 	bool done = false;
+	/// Whether the player should stop queueing up more buffers (and terminate, once they all run out)
 	bool shouldStop = false;
 
 
 private:
+	/// The currently unclaimed OpenAL sources for reuse.
 	static std::vector<ALuint> availableSources;
 };

--- a/source/audio/player/AudioPlayer.h
+++ b/source/audio/player/AudioPlayer.h
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 
+
 /// Audio players can play audio from a single supplier at a varying volume, supporting pause/resume functionality.
 /// This class contains a base implementation suitable for playback of sound effects;
 /// it is meant to be inherited by specialized classes for other purposes.

--- a/source/audio/player/AudioPlayer.h
+++ b/source/audio/player/AudioPlayer.h
@@ -1,0 +1,88 @@
+/* AudioPlayer.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../supplier/AudioSupplier.h"
+#include "../SoundCategory.h"
+
+#include <AL/al.h>
+#include <AL/alc.h>
+
+#include <memory>
+#include <vector>
+
+
+/// Audio players can play audio from a single supplier at a varying volume, supporting pause/resume functionality.
+/// This class contains a base implementation suitable for playback of sound effects;
+/// it is meant to be inherited by specialized classes for other purposes.
+class AudioPlayer {
+public:
+	/// Creates a new audio player with the given audio.
+	/// Please note that the audio isn't loaded from the supplier until the Play() call.
+	AudioPlayer(SoundCategory category, std::unique_ptr<AudioSupplier> audioSupplier);
+	virtual ~AudioPlayer();
+
+	/// Updates the queued music of the player. This step may also mark the player as finished.
+	virtual void Update();
+
+	/// Checks whether the player is finished. Finished players will not be able to play audio again,
+	/// and should not be stored.
+	bool IsFinished() const;
+
+	/// The volume of the playback, or 0 if the player has not started yet.
+	double Volume() const;
+	///
+	void SetVolume(double level) const;
+
+	virtual void Move(double x, double y, double z) const;
+
+	SoundCategory Category() const;
+
+	virtual void Pause() const;
+	virtual void Play() const;
+
+	/// Acquires the source for this player, and loads the initial buffers. Does not begin playback.
+	virtual void Init();
+	/// Instructs the player to stop. No new buffers will be queued, but queued buffers will finish playback.
+	/// Until the player is marked finished, calling this function with 'false' can undo its effect.
+	void Stop(bool stop = true);
+
+	AudioSupplier *Supplier();
+
+
+protected:
+	bool ClaimSource();
+	void ReleaseSource();
+
+	virtual void ConfigureSource();
+
+
+protected:
+	static constexpr int MAX_INITIAL_BUFFERS = 3;
+
+	SoundCategory category;
+
+	/// The configured source, or 0
+	ALuint alSource = 0;
+	std::unique_ptr<AudioSupplier> audioSupplier;
+
+	bool done = false;
+	bool shouldStop = false;
+
+
+private:
+	static std::vector<ALuint> availableSources;
+};

--- a/source/audio/player/MusicPlayer.cpp
+++ b/source/audio/player/MusicPlayer.cpp
@@ -36,12 +36,6 @@ void MusicPlayer::Pause() const
 
 
 
-void MusicPlayer::Play() const
-{
-}
-
-
-
 void MusicPlayer::ConfigureSource()
 {
 	alSourcef(alSource, AL_PITCH, 1.);

--- a/source/audio/player/MusicPlayer.cpp
+++ b/source/audio/player/MusicPlayer.cpp
@@ -42,6 +42,7 @@ void MusicPlayer::ConfigureSource()
 	alSourcef(alSource, AL_REFERENCE_DISTANCE, 1.);
 	alSourcef(alSource, AL_ROLLOFF_FACTOR, 1.);
 	alSourcef(alSource, AL_MAX_DISTANCE, 100.);
+	AudioPlayer::Move(0, 0, 0);
 }
 
 

--- a/source/audio/player/MusicPlayer.cpp
+++ b/source/audio/player/MusicPlayer.cpp
@@ -1,0 +1,55 @@
+/* MusicPlayer.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "MusicPlayer.h"
+
+
+
+MusicPlayer::MusicPlayer(std::unique_ptr<AudioSupplier> audioSupplier)
+	: AudioPlayer(SoundCategory::MUSIC, std::move(audioSupplier))
+{
+}
+
+
+
+void MusicPlayer::Move(double x, double y, double z) const
+{
+}
+
+
+
+void MusicPlayer::Pause() const
+{
+}
+
+
+
+void MusicPlayer::Play() const
+{
+}
+
+
+
+void MusicPlayer::ConfigureSource()
+{
+	alSourcef(alSource, AL_PITCH, 1.);
+	alSourcef(alSource, AL_REFERENCE_DISTANCE, 1.);
+	alSourcef(alSource, AL_ROLLOFF_FACTOR, 1.);
+	alSourcef(alSource, AL_MAX_DISTANCE, 100.);
+}
+
+
+
+

--- a/source/audio/player/MusicPlayer.h
+++ b/source/audio/player/MusicPlayer.h
@@ -26,8 +26,10 @@ public:
 	/// Please note that the audio isn't loaded from the supplier until the Play() call.
 	explicit MusicPlayer(std::unique_ptr<AudioSupplier> audioSupplier);
 
+	/// Music is always centered on the listener; it can't be moved.
 	void Move(double x, double y, double z) const override;
 
+	/// Music is always playing; it can't be paused.
 	void Pause() const override;
 
 

--- a/source/audio/player/MusicPlayer.h
+++ b/source/audio/player/MusicPlayer.h
@@ -1,5 +1,5 @@
-/* Sound.h
-Copyright (c) 2014 by Michael Zahniser
+/* MusicPlayer.h
+Copyright (c) 2025 by tibetiroka
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -15,32 +15,23 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "supplier/AudioSupplier.h"
-
-#include <filesystem>
-#include <memory>
-#include <string>
+#include "AudioPlayer.h"
 
 
 
-// This is a sound that can be played. The sound's file name will determine
-// whether it is looping (ends in '~') or not.
-class Sound {
+/// Music players are audio players that are always centered, and can't be paused/resumed.
+class MusicPlayer : public AudioPlayer {
 public:
-	bool Load(const std::filesystem::path &path, const std::string &name);
+	/// Creates a new audio player with the given audio.
+	/// Please note that the audio isn't loaded from the supplier until the Play() call.
+	explicit MusicPlayer(std::unique_ptr<AudioSupplier> audioSupplier);
 
-	const std::string &Name() const;
+	void Move(double x, double y, double z) const override;
 
-	unsigned Buffer() const;
-	unsigned Buffer3x() const;
-	bool IsLooping() const;
-
-	std::unique_ptr<AudioSupplier> CreateSupplier() const;
+	void Pause() const override;
+	void Play() const override;
 
 
-private:
-	std::string name;
-	unsigned buffer = 0;
-	unsigned buffer3x = 0;
-	bool isLooped = false;
+protected:
+	void ConfigureSource() override;
 };

--- a/source/audio/player/MusicPlayer.h
+++ b/source/audio/player/MusicPlayer.h
@@ -29,7 +29,6 @@ public:
 	void Move(double x, double y, double z) const override;
 
 	void Pause() const override;
-	void Play() const override;
 
 
 protected:

--- a/source/audio/player/VolumeFadePlayer.cpp
+++ b/source/audio/player/VolumeFadePlayer.cpp
@@ -1,0 +1,53 @@
+/* VolumeFadePlayer.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "VolumeFadePlayer.h"
+
+
+
+VolumeFadePlayer::VolumeFadePlayer(SoundCategory category, std::unique_ptr<AudioSupplier> audioSupplier)
+	: AudioPlayer(category, std::move(audioSupplier))
+{
+}
+
+
+
+void VolumeFadePlayer::Update()
+{
+	if(isFading && !IsFinished())
+	{
+		double newVolume = Volume() - VOLUME_DECREASE;
+		if(newVolume >= 0.)
+			SetVolume(newVolume);
+		else
+		{
+			SetVolume(0.);
+			Stop();
+		}
+	}
+
+	AudioPlayer::Update();
+}
+
+
+
+void VolumeFadePlayer::FadeOut()
+{
+	isFading = true;
+}
+
+
+
+

--- a/source/audio/player/VolumeFadePlayer.h
+++ b/source/audio/player/VolumeFadePlayer.h
@@ -17,15 +17,19 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "AudioPlayer.h"
 
+/// A specialized audio player that can fade out the audio gradually before ending.
+/// This fade effect is implemented with volume changes, unlike the cross-fade effect in Fade.
 class VolumeFadePlayer : public AudioPlayer {
 public:
 	VolumeFadePlayer(SoundCategory category, std::unique_ptr<AudioSupplier> audioSupplier);
 
 	void Update() override;
 
+	/// Begins fading out the audio. The player stops when the volume reaches 0.
 	void FadeOut();
 
 private:
+	/// How much to decrease the volume per frame.
 	static constexpr float VOLUME_DECREASE = 0.05;
 
 	bool isFading = false;

--- a/source/audio/player/VolumeFadePlayer.h
+++ b/source/audio/player/VolumeFadePlayer.h
@@ -17,6 +17,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "AudioPlayer.h"
 
+
+
 /// A specialized audio player that can fade out the audio gradually before ending.
 /// This fade effect is implemented with volume changes, unlike the cross-fade effect in Fade.
 class VolumeFadePlayer : public AudioPlayer {

--- a/source/audio/player/VolumeFadePlayer.h
+++ b/source/audio/player/VolumeFadePlayer.h
@@ -1,5 +1,5 @@
-/* Sound.h
-Copyright (c) 2014 by Michael Zahniser
+/* VolumeFadePlayer.h
+Copyright (c) 2025 by tibetiroka
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -15,32 +15,18 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "supplier/AudioSupplier.h"
+#include "AudioPlayer.h"
 
-#include <filesystem>
-#include <memory>
-#include <string>
-
-
-
-// This is a sound that can be played. The sound's file name will determine
-// whether it is looping (ends in '~') or not.
-class Sound {
+class VolumeFadePlayer : public AudioPlayer {
 public:
-	bool Load(const std::filesystem::path &path, const std::string &name);
+	VolumeFadePlayer(SoundCategory category, std::unique_ptr<AudioSupplier> audioSupplier);
 
-	const std::string &Name() const;
+	void Update() override;
 
-	unsigned Buffer() const;
-	unsigned Buffer3x() const;
-	bool IsLooping() const;
-
-	std::unique_ptr<AudioSupplier> CreateSupplier() const;
-
+	void FadeOut();
 
 private:
-	std::string name;
-	unsigned buffer = 0;
-	unsigned buffer3x = 0;
-	bool isLooped = false;
+	static constexpr float VOLUME_DECREASE = 0.05;
+
+	bool isFading = false;
 };

--- a/source/audio/supplier/AudioDataSupplier.h
+++ b/source/audio/supplier/AudioDataSupplier.h
@@ -20,6 +20,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cstdint>
 #include <vector>
 
+
+
 /// An audio data supplier can provide the raw samples as well as the OpenAL buffers.
 /// All data suppliers use the same chunk size for easier post-processing.
 class AudioDataSupplier : public AudioSupplier {

--- a/source/audio/supplier/AudioDataSupplier.h
+++ b/source/audio/supplier/AudioDataSupplier.h
@@ -1,0 +1,36 @@
+/* AudioDataSupplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "AudioSupplier.h"
+
+#include <cstdint>
+#include <vector>
+
+/// An audio data supplier can provide the raw samples as well as the OpenAL buffers.
+/// All data suppliers use the same chunk size for easier post-processing.
+class AudioDataSupplier : public AudioSupplier {
+public:
+	virtual std::vector<int16_t> NextDataChunk() = 0;
+
+
+protected:
+	// How many samples to put in each output block. Because the output is in
+	// stereo, the duration of the sample is half this amount, divided by the sample rate:
+	static constexpr size_t OUTPUT_CHUNK = 32768;
+	// How many bytes to read from a file at a time:
+	static constexpr size_t INPUT_CHUNK = sizeof(int16_t) * 65536;
+};

--- a/source/audio/supplier/AudioDataSupplier.h
+++ b/source/audio/supplier/AudioDataSupplier.h
@@ -24,13 +24,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 /// All data suppliers use the same chunk size for easier post-processing.
 class AudioDataSupplier : public AudioSupplier {
 public:
+	/// Gets the next, fixed-size chunk of audio samples.
 	virtual std::vector<int16_t> NextDataChunk() = 0;
 
 
 protected:
-	// How many samples to put in each output block. Because the output is in
-	// stereo, the duration of the sample is half this amount, divided by the sample rate:
+	/// How many samples to put in each output chunk. Because the output is in
+	/// stereo, the duration of the sample is half this amount, divided by the sample rate.
 	static constexpr size_t OUTPUT_CHUNK = 32768;
-	// How many bytes to read from a file at a time:
+	/// How many bytes to read from a file at a time
 	static constexpr size_t INPUT_CHUNK = sizeof(int16_t) * 65536;
 };

--- a/source/audio/supplier/AudioSupplier.cpp
+++ b/source/audio/supplier/AudioSupplier.cpp
@@ -1,0 +1,38 @@
+/* AudioSupplier.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "AudioSupplier.h"
+
+#include <cstring>
+
+
+AudioSupplier::AudioSupplier(bool is3x)
+	: is3x(is3x)
+{
+}
+
+
+
+void AudioSupplier::Set3x(bool is3x)
+{
+	this->is3x = is3x;
+}
+
+
+void AudioSupplier::SetSilence(ALuint buffer, size_t frames)
+{
+	std::vector<int16_t> data(frames);
+	alBufferData(buffer, AL_FORMAT_STEREO16, data.data(), 2 * frames, 44100);
+}

--- a/source/audio/supplier/AudioSupplier.h
+++ b/source/audio/supplier/AudioSupplier.h
@@ -25,7 +25,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 /// There are two main ways they operate: synchronously or asynchronously.
 /// Synchronous suppliers provide audio samples on the fly, via AwaitNextChunk().
 /// Asynchronous suppliers generate audio in the background, which can be requested via NextChunk().
-/// Though both supplier types fully support both interfaces, the most efficient use is as described above.
+/// Though both supplier types support both interfaces, the most efficient use is as described above.
+/// Mixed usage may result in extra chunks of silence.
 class AudioSupplier {
 public:
 	explicit AudioSupplier(bool is3x = false);
@@ -43,15 +44,17 @@ public:
 	/// Configures 3x audio playback. Some suppliers may choose to ignore this setting.
 	void Set3x(bool is3x);
 
+	/// Whether the preferred chunk acquisition is AwaitNextChunk() or NextChunk().
 	virtual bool IsSynchronous() const = 0;
 
 	/// Puts the next queued audio chunk into the buffer, removing it from the supplier's queue.
 	/// If there is no queued audio, the buffer is filled with silence.
 	/// The buffer must be a buffer returned by the AwaitNextChunk() call of this supplier.
+	/// A sync supplier without caching may return a silent buffer.
 	/// This method should not be called if MaxChunkCount() is 0.
 	/// Returns true if real sound was provided instead of silence.
 	virtual bool NextChunk(ALuint buffer) = 0;
-	/// Returns an audio chunk in a buffer. For an async supplier, a silent buffer is returned.
+	/// Returns an audio chunk in a buffer. For an async supplier, a silent buffer may be returned.
 	/// This method should not be called if MaxChunkCount() is 0.
 	virtual ALuint AwaitNextChunk() = 0;
 	/// Returns a buffer to the supplier, for reuse in AwaitNextChunk().

--- a/source/audio/supplier/AudioSupplier.h
+++ b/source/audio/supplier/AudioSupplier.h
@@ -21,6 +21,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <cstdint>
 #include <vector>
 
+
+
 /// An audio supplier provides chunks of audio over time.
 /// There are two main ways they operate: synchronously or asynchronously.
 /// Synchronous suppliers provide audio samples on the fly, via AwaitNextChunk().

--- a/source/audio/supplier/AudioSupplier.h
+++ b/source/audio/supplier/AudioSupplier.h
@@ -1,0 +1,72 @@
+/* AudioSupplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <AL/al.h>
+#include <AL/alc.h>
+
+#include <cstdint>
+#include <vector>
+
+/// An audio supplier provides chunks of audio over time.
+/// There are two main ways they operate: synchronously or asynchronously.
+/// Synchronous suppliers provide audio samples on the fly, via AwaitNextChunk().
+/// Asynchronous suppliers generate audio in the background, which can be requested via NextChunk().
+/// Though both supplier types fully support both interfaces, the most efficient use is as described above.
+class AudioSupplier {
+public:
+	explicit AudioSupplier(bool is3x = false);
+	virtual ~AudioSupplier() = default;
+
+	AudioSupplier(const AudioSupplier&) = delete;
+	AudioSupplier(AudioSupplier&&) = default;
+
+	/// The estimated number of non-silent chunks that can be supplied by further NextChunk() or AwaitNextChunk() calls.
+	/// Never less than AvailableChunks(), and is always zero when the supplier can't provide new chunks anymore.
+	virtual ALsizei MaxChunkCount() const = 0;
+	/// The number of chunks currently ready for access via NextChunk() or AwaitNextChunk().
+	virtual int AvailableChunks() const = 0;
+
+	/// Configures 3x audio playback. Some suppliers may choose to ignore this setting.
+	void Set3x(bool is3x);
+
+	virtual bool IsSynchronous() const = 0;
+
+	/// Puts the next queued audio chunk into the buffer, removing it from the supplier's queue.
+	/// If there is no queued audio, the buffer is filled with silence.
+	/// The buffer must be a buffer returned by the AwaitNextChunk() call of this supplier.
+	/// This method should not be called if MaxChunkCount() is 0.
+	/// Returns true if real sound was provided instead of silence.
+	virtual bool NextChunk(ALuint buffer) = 0;
+	/// Returns an audio chunk in a buffer. For an async supplier, a silent buffer is returned.
+	/// This method should not be called if MaxChunkCount() is 0.
+	virtual ALuint AwaitNextChunk() = 0;
+	/// Returns a buffer to the supplier, for reuse in AwaitNextChunk().
+	/// The caller may not use this buffer in NextChunk() afterwards.
+	virtual void ReturnBuffer(ALuint buffer) = 0;
+
+
+protected:
+	/// Sets the buffer to silence for the given number of frames.
+	void SetSilence(ALuint buffer, size_t frames);
+
+
+protected:
+	static constexpr int SAMPLE_RATE = 44100;
+	static constexpr ALenum FORMAT = AL_FORMAT_STEREO16;
+
+	bool is3x = false;
+};

--- a/source/audio/supplier/Mp3Supplier.cpp
+++ b/source/audio/supplier/Mp3Supplier.cpp
@@ -1,0 +1,243 @@
+/* Mp3Supplier.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Mp3Supplier.h"
+
+#include <mad.h>
+
+#include <cmath>
+#include <cstring>
+#include <thread>
+#include <utility>
+
+using namespace std;
+
+
+
+Mp3Supplier::Mp3Supplier(std::shared_ptr<std::iostream> data, bool looping)
+	: data(std::move(data)), looping(looping)
+{
+	// Don't start the thread until this object is fully constructed.
+	thread = std::thread(&Mp3Supplier::Decode, this);
+}
+
+
+
+Mp3Supplier::~Mp3Supplier()
+{
+	// Tell the decoding thread to stop.
+	{
+		lock_guard<mutex> lock(decodeMutex);
+		done = true;
+	}
+	condition.notify_all();
+	thread.join();
+}
+
+
+
+ALsizei Mp3Supplier::MaxChunkCount() const
+{
+	if(done && buffer.size() < OUTPUT_CHUNK)
+		return 0;
+
+	return AvailableChunks();
+}
+
+
+
+int Mp3Supplier::AvailableChunks() const
+{
+	return buffer.size() / OUTPUT_CHUNK;
+}
+
+
+
+bool Mp3Supplier::IsSynchronous() const
+{
+	return false;
+}
+
+
+
+bool Mp3Supplier::NextChunk(ALuint alBuffer)
+{
+	if(AvailableChunks())
+	{
+		lock_guard<mutex> lock(decodeMutex);
+		alBufferData(alBuffer, FORMAT, buffer.data(), sizeof(int16_t) * OUTPUT_CHUNK, SAMPLE_RATE);
+		buffer.erase(buffer.begin(), buffer.begin() + OUTPUT_CHUNK);
+		return true;
+	}
+	else
+	{
+		SetSilence(alBuffer, OUTPUT_CHUNK);
+		return false;
+	}
+}
+
+
+vector<int16_t> Mp3Supplier::NextDataChunk()
+{
+	if(AvailableChunks())
+	{
+		lock_guard<mutex> lock(decodeMutex);
+
+		vector<int16_t> temp{buffer.begin(), buffer.begin() + OUTPUT_CHUNK};
+		buffer.erase(buffer.begin(), buffer.begin() + OUTPUT_CHUNK);
+		return temp;
+	}
+	else
+	{
+		return vector<int16_t>(OUTPUT_CHUNK);
+	}
+}
+
+
+
+ALuint Mp3Supplier::AwaitNextChunk()
+{
+	// This is an async supplier, so return a silent buffer here.
+	ALuint buffer;
+	alGenBuffers(1, &buffer);
+
+	vector<int16_t> temp(OUTPUT_CHUNK);
+	alBufferData(buffer, FORMAT, temp.data(), OUTPUT_CHUNK, SAMPLE_RATE);
+
+	return buffer;
+}
+
+
+
+void Mp3Supplier::ReturnBuffer(ALuint buffer)
+{
+	alDeleteBuffers(1, &buffer);
+}
+
+
+
+void Mp3Supplier::Decode()
+{
+	// This vector will store the input from the file.
+	vector<unsigned char> input(INPUT_CHUNK, 0);
+	// Objects for MP3 decoding:
+	mad_stream stream;
+	mad_frame frame;
+	mad_synth synth;
+
+	// Initialize the decoder.
+	mad_stream_init(&stream);
+	mad_frame_init(&frame);
+	mad_synth_init(&synth);
+
+	// Loop until we are done.
+	while(true)
+	{
+		// If the "next" buffer has filled up, wait until it is retrieved.
+		// Generally try to queue up two chunks worth of samples in it, just
+		// in case NextChunk() gets called twice in rapid succession.
+		unique_lock<mutex> lock(decodeMutex);
+		while(!done && buffer.size() >= BUFFER_CHUNK_SIZE * OUTPUT_CHUNK)
+			condition.wait(lock);
+		// Check if we're done.
+		if(done)
+			break;
+
+		// The lock can be freed until we start filling the output buffer.
+		lock.unlock();
+
+		// See if any input data is left undecoded in the stream. Typically
+		// this is because the last block of input contained a fraction of a
+		// full MP3 frame.
+		size_t remainder = 0;
+		if(stream.next_frame && stream.next_frame < stream.bufend)
+			remainder = stream.bufend - stream.next_frame;
+		if(remainder)
+			memcpy(input.data(), stream.next_frame, remainder);
+
+		// Now, read a chunk of data from the file.
+		data->read(reinterpret_cast<char *>(input.data() + remainder), INPUT_CHUNK - remainder);
+		// If you get the end of the file, loop around to the beginning.
+		if(data->eof() && looping)
+			data->seekg(0, iostream::beg);
+		else
+		{
+			done = true;
+			// Make sure there are full chunks of data available
+			buffer.resize(OUTPUT_CHUNK * ceil(static_cast<double>(buffer.size()) / static_cast<double>(OUTPUT_CHUNK)));
+		}
+
+		// If there is nothing to decode, return to the top of this loop.
+		if(!(remainder || !data->eof()))
+			continue;
+
+		// Hand the input to the stream decoder.
+		mad_stream_buffer(&stream, &input.front(), INPUT_CHUNK);
+
+		// Loop through the decoded result for that input block.
+		while(true)
+		{
+			// Decode the next frame, and check if there is an error.
+			if(mad_frame_decode(&frame, &stream))
+			{
+				// For recoverable errors, keep going.
+				if(MAD_RECOVERABLE(stream.error))
+					continue;
+				else
+					break;
+			}
+			// Convert the decoded audio into a PCM signal.
+			mad_synth_frame(&synth, &frame);
+
+			// If the source is mono, read both output channels from the left input.
+			// Otherwise, read two separate input channels.
+			mad_fixed_t *channels[2] = {
+					synth.pcm.samples[0],
+					synth.pcm.samples[synth.pcm.channels > 1]
+			};
+
+			// For this part, we need access to the output buffer.
+			lock.lock();
+			if(done)
+				break;
+
+			// We'll alternate what channel we read from each time through the loop.
+			bool channel = false;
+			for(unsigned i = 0; i < 2 * synth.pcm.length; ++i)
+			{
+				// Read the next sample from the next channel.
+				mad_fixed_t sample = *channels[channel]++;
+				channel = !channel;
+
+				// Clip and scale the sample to 16 bits.
+				sample += (1L << (MAD_F_FRACBITS - 16));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+				sample = max(-MAD_F_ONE, min(MAD_F_ONE - 1, sample));
+#pragma GCC diagnostic pop
+				buffer.emplace_back(sample >> (MAD_F_FRACBITS + 1 - 16));
+			}
+			// Now, the buffer can be used by others. In theory, the
+			// NextChunk() function could take what's in that buffer while
+			// we are right in the middle of this decoding cycle.
+			lock.unlock();
+		}
+	}
+
+	// Clean up.
+	mad_synth_finish(&synth);
+	mad_frame_finish(&frame);
+	mad_stream_finish(&stream);
+}

--- a/source/audio/supplier/Mp3Supplier.h
+++ b/source/audio/supplier/Mp3Supplier.h
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <thread>
 
+/// Streams audio from an MP3 file. This is an async data supplier.
 class Mp3Supplier : public AudioDataSupplier {
 public:
 	explicit Mp3Supplier(std::shared_ptr<std::iostream> data, bool looping = false);
@@ -39,15 +40,16 @@ public:
 
 
 private:
-	// This is the entry point for the decoding thread.
+	/// This is the entry point for the decoding thread.
 	void Decode();
 
 private:
-	// The number of chunks to queue up in the buffer
+	/// The number of chunks to queue up in the buffer
 	static constexpr size_t BUFFER_CHUNK_SIZE = 2;
-	// The decoded data
+	/// The decoded data
 	std::vector<int16_t> buffer;
 
+	/// The MP3 input stream
 	std::shared_ptr<std::iostream> data;
 
 	bool done = false;

--- a/source/audio/supplier/Mp3Supplier.h
+++ b/source/audio/supplier/Mp3Supplier.h
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <thread>
 
+
+
 /// Streams audio from an MP3 file. This is an async data supplier.
 class Mp3Supplier : public AudioDataSupplier {
 public:

--- a/source/audio/supplier/Mp3Supplier.h
+++ b/source/audio/supplier/Mp3Supplier.h
@@ -1,0 +1,59 @@
+/* Mp3Supplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "AudioSupplier.h"
+#include "AudioDataSupplier.h"
+
+#include <condition_variable>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+class Mp3Supplier : public AudioDataSupplier {
+public:
+	explicit Mp3Supplier(std::shared_ptr<std::iostream> data, bool looping = false);
+	~Mp3Supplier();
+
+	// Inherited pure virtual methods
+	ALsizei MaxChunkCount() const override;
+	int AvailableChunks() const override;
+	bool IsSynchronous() const override;
+	bool NextChunk(ALuint buffer) override;
+	std::vector<int16_t> NextDataChunk() override;
+	ALuint AwaitNextChunk() override;
+	void ReturnBuffer(ALuint buffer) override;
+
+
+private:
+	// This is the entry point for the decoding thread.
+	void Decode();
+
+private:
+	// The number of chunks to queue up in the buffer
+	static constexpr size_t BUFFER_CHUNK_SIZE = 2;
+	// The decoded data
+	std::vector<int16_t> buffer;
+
+	std::shared_ptr<std::iostream> data;
+
+	bool done = false;
+	bool looping;
+
+	std::thread thread;
+	std::mutex decodeMutex;
+	std::condition_variable condition;
+};

--- a/source/audio/supplier/WavSupplier.cpp
+++ b/source/audio/supplier/WavSupplier.cpp
@@ -1,0 +1,75 @@
+/* WavSupplier.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "WavSupplier.h"
+
+#include "../Sound.h"
+
+
+WavSupplier::WavSupplier(const Sound &sound, bool is3x, bool looping)
+		: AudioSupplier(is3x), sound(sound), looping(looping), wasBufferGiven(false)
+{
+}
+
+
+
+ALsizei WavSupplier::MaxChunkCount() const
+{
+	if(looping)
+		return 1;
+	return !wasBufferGiven;
+}
+
+
+
+int WavSupplier::AvailableChunks() const
+{
+	return MaxChunkCount();
+}
+
+
+
+bool WavSupplier::IsSynchronous() const
+{
+	return true;
+}
+
+
+
+bool WavSupplier::NextChunk(ALuint buffer)
+{
+	// This function must receive the buffer from AwaitNextChunk(),
+	// which returns the audio buffer backing this sound. No action needed.
+	// Note: Unlike the sync use via AwaitNextChunk(),
+	// this will not change 3x mode.
+	return true;
+}
+
+
+
+ALuint WavSupplier::AwaitNextChunk()
+{
+	wasBufferGiven = true;
+	if(is3x && sound.Buffer3x())
+		return sound.Buffer3x();
+	return sound.Buffer();
+}
+
+
+
+void WavSupplier::ReturnBuffer(ALuint buffer)
+{
+	// This is the audio buffer backing this sound. No action needed.
+}

--- a/source/audio/supplier/WavSupplier.cpp
+++ b/source/audio/supplier/WavSupplier.cpp
@@ -28,7 +28,7 @@ WavSupplier::WavSupplier(const Sound &sound, bool is3x, bool looping)
 ALsizei WavSupplier::MaxChunkCount() const
 {
 	if(looping)
-		return 1;
+		return 2;
 	return !wasBufferGiven;
 }
 

--- a/source/audio/supplier/WavSupplier.h
+++ b/source/audio/supplier/WavSupplier.h
@@ -19,7 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class Sound;
 
-/// A buffered supplier for waveform files. The audio is supplied in a single chunk.
+/// A sync buffered supplier for waveform files. The audio is supplied in a single chunk.
 class WavSupplier : public AudioSupplier {
 public:
 	WavSupplier(const Sound& sound, bool is3x, bool looping = false);

--- a/source/audio/supplier/WavSupplier.h
+++ b/source/audio/supplier/WavSupplier.h
@@ -19,6 +19,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class Sound;
 
+
+
 /// A sync buffered supplier for waveform files. The audio is supplied in a single chunk.
 class WavSupplier : public AudioSupplier {
 public:

--- a/source/audio/supplier/WavSupplier.h
+++ b/source/audio/supplier/WavSupplier.h
@@ -1,5 +1,5 @@
-/* Sound.h
-Copyright (c) 2014 by Michael Zahniser
+/* WavSupplier.h
+Copyright (c) 2025 by tibetiroka
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -15,32 +15,25 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "supplier/AudioSupplier.h"
+#include "AudioSupplier.h"
 
-#include <filesystem>
-#include <memory>
-#include <string>
+class Sound;
 
-
-
-// This is a sound that can be played. The sound's file name will determine
-// whether it is looping (ends in '~') or not.
-class Sound {
+/// A buffered supplier for waveform files. The audio is supplied in a single chunk.
+class WavSupplier : public AudioSupplier {
 public:
-	bool Load(const std::filesystem::path &path, const std::string &name);
+	WavSupplier(const Sound& sound, bool is3x, bool looping = false);
 
-	const std::string &Name() const;
-
-	unsigned Buffer() const;
-	unsigned Buffer3x() const;
-	bool IsLooping() const;
-
-	std::unique_ptr<AudioSupplier> CreateSupplier() const;
-
+	// Inherited pure virtual methods
+	ALsizei MaxChunkCount() const override;
+	int AvailableChunks() const override;
+	bool IsSynchronous() const override;
+	bool NextChunk(ALuint buffer) override;
+	ALuint AwaitNextChunk() override;
+	void ReturnBuffer(ALuint buffer) override;
 
 private:
-	std::string name;
-	unsigned buffer = 0;
-	unsigned buffer3x = 0;
-	bool isLooped = false;
+	const Sound& sound;
+	const bool looping;
+	bool wasBufferGiven;
 };

--- a/source/audio/supplier/effect/Fade.cpp
+++ b/source/audio/supplier/effect/Fade.cpp
@@ -82,7 +82,7 @@ vector<int16_t> Fade::NextDataChunk()
 		{
 			vector<int16_t> other = fadeProgress[i].first->NextDataChunk();
 			CrossFade(faded, other, fadeProgress[i - 1].second);
-			faded = other;
+			faded = std::move(other);
 		}
 
 		// Get the foreground data
@@ -126,7 +126,7 @@ void Fade::CrossFade(const vector<int16_t> &fadeOut, vector<int16_t> &fadeIn, si
 {
 	for(size_t i = 0; i < fadeIn.size() && fade; ++i)
 	{
-		fadeIn[i] = (fadeOut[i] * fade + (fadeIn[i] * (MAX_FADE - fade))) / fade;
+		fadeIn[i] = (fadeOut[i] * fade + (fadeIn[i] * (MAX_FADE - fade))) / MAX_FADE;
 		--fade;
 	}
 }

--- a/source/audio/supplier/effect/Fade.cpp
+++ b/source/audio/supplier/effect/Fade.cpp
@@ -1,0 +1,132 @@
+/* Fade.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Fade.h"
+
+using namespace std;
+
+
+
+void Fade::AddSource(unique_ptr<AudioDataSupplier> source, size_t fade)
+{
+	fade = min(fade, MAX_FADE); // don't allow a slower fade than the default
+
+	if(primarySource && fade)
+		fadeProgress.emplace_back(std::move(primarySource), fade);
+	primarySource = std::move(source);
+}
+
+
+ALsizei Fade::MaxChunkCount() const
+{
+	int count = primarySource ? primarySource->MaxChunkCount() : 1;
+	for(const auto &[supplier, fade] : fadeProgress)
+		count = max(supplier->MaxChunkCount(), count);
+
+	return max(1, count);
+}
+
+
+
+int Fade::AvailableChunks() const
+{
+	int count = primarySource ? primarySource->AvailableChunks() : MaxChunkCount();
+	for(const auto &[supplier, fade] : fadeProgress)
+		count = min(supplier->AvailableChunks(), count);
+
+	return count;
+}
+
+
+
+bool Fade::IsSynchronous() const
+{
+	return false;
+}
+
+
+
+bool Fade::NextChunk(ALuint buffer)
+{
+	vector<int16_t> next = NextDataChunk();
+	alBufferData(buffer, FORMAT, next.data(), OUTPUT_CHUNK, SAMPLE_RATE);
+	return true;
+}
+
+
+
+vector<int16_t> Fade::NextDataChunk()
+{
+	vector<int16_t> result;
+	if(!primarySource && fadeProgress.empty()) // no sources -> silence
+		result = vector<int16_t>(OUTPUT_CHUNK);
+	else if(primarySource && fadeProgress.empty()) // only primary -> primary
+		result = primarySource->NextDataChunk();
+	else
+	{
+		// Generate the faded background
+		vector<int16_t> faded = fadeProgress[0].first->NextDataChunk();
+		for(size_t i = 1; i < fadeProgress.size(); i++)
+		{
+			vector<int16_t> other = fadeProgress[i].first->NextDataChunk();
+			CrossFade(faded, other, fadeProgress[i - 1].second);
+			faded = other;
+		}
+
+		// Get the foreground data
+		if(primarySource)
+			result = primarySource->NextDataChunk();
+		else
+			result.resize(OUTPUT_CHUNK); // silence
+
+		// final blend
+		CrossFade(faded, result, fadeProgress.back().second);
+	}
+
+	// Clean up the finished sources.
+	if(primarySource && !primarySource->MaxChunkCount())
+		primarySource.reset();
+	erase_if(fadeProgress, [](const auto &pair){return !pair.second || !pair.first->MaxChunkCount();});
+
+	return result;
+}
+
+
+
+ALuint Fade::AwaitNextChunk()
+{
+	ALuint buffer;
+	alGenBuffers(1, &buffer);
+
+	NextChunk(buffer);
+	return buffer;
+}
+
+
+void Fade::ReturnBuffer(ALuint buffer)
+{
+	alDeleteBuffers(1, &buffer);
+}
+
+
+
+void Fade::CrossFade(const vector<int16_t> &fadeOut, vector<int16_t> &fadeIn, size_t &fade)
+{
+	for(size_t i = 0; i < fadeIn.size() && fade; ++i)
+	{
+		fadeIn[i] = (fadeOut[i] * fade + (fadeIn[i] * (MAX_FADE - fade))) / fade;
+		--fade;
+	}
+}

--- a/source/audio/supplier/effect/Fade.h
+++ b/source/audio/supplier/effect/Fade.h
@@ -46,8 +46,11 @@ private:
 
 
 private:
+	/// The number of samples to fade over; smaller values mean faster fade
 	static constexpr size_t MAX_FADE = 65536;
 
+	/// The fading sources, with their fade values
 	std::vector<std::pair<std::unique_ptr<AudioDataSupplier>, size_t>> fadeProgress;
+	/// The primary source; this one is not faded out by itself, but can be cross-faded with the other sources.
 	std::unique_ptr<AudioDataSupplier> primarySource;
 };

--- a/source/audio/supplier/effect/Fade.h
+++ b/source/audio/supplier/effect/Fade.h
@@ -1,0 +1,53 @@
+/* Fade.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../AudioDataSupplier.h"
+
+#include <memory>
+#include <vector>
+
+/// Cross-fades any number of sources into a single source.
+/// There is usually a "primary" source that is not being faded,
+/// which then gets replaced by another source. That's when they are
+/// cross-faded.
+class Fade : public AudioDataSupplier {
+public:
+	Fade() = default;
+
+	void AddSource(std::unique_ptr<AudioDataSupplier> source, size_t fade = MAX_FADE);
+
+	// Inherited pure virtual methods
+	ALsizei MaxChunkCount() const override;
+	int AvailableChunks() const override;
+	bool IsSynchronous() const override;
+	bool NextChunk(ALuint buffer) override;
+	std::vector<int16_t> NextDataChunk() override;
+	ALuint AwaitNextChunk() override;
+	void ReturnBuffer(ALuint buffer) override;
+
+
+private:
+	/// Cross-fades two sources. The faded result is stored in the fadeIn input.
+	void CrossFade(const std::vector<int16_t> &fadeOut, std::vector<int16_t> &fadeIn, size_t &fade);
+
+
+private:
+	static constexpr size_t MAX_FADE = 65536;
+
+	std::vector<std::pair<std::unique_ptr<AudioDataSupplier>, size_t>> fadeProgress;
+	std::unique_ptr<AudioDataSupplier> primarySource;
+};

--- a/source/audio/supplier/effect/Fade.h
+++ b/source/audio/supplier/effect/Fade.h
@@ -20,6 +20,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <vector>
 
+
+
 /// Cross-fades any number of sources into a single source.
 /// There is usually a "primary" source that is not being faded,
 /// which then gets replaced by another source. That's when they are


### PR DESCRIPTION
**Refactor**

This PR separates the various aspects of audio management into separate classes with a unified interface. This will make it much easier to add support for new audio formats, and to do more complex audio processing.

## Summary
This PR introduces two new interfaces for managing audio. This does come with some boilerplate, which is the vast majoriy of the lines in this PR; the actual changes are fairly small.

- `AudioPlayer`: plays audio on an OpenAL stream. The acquisition and recycling of the stream is handled internally, and so are the volume and play/pause options.
  - This is subclassed by `MusicPlayer`, which cannot be paused or moved.
  - Another subclass is `VolumeFadePlayer`, which can fade out the sound gradually before ending.
- `AudioSupplier`: provides audio for an `AudioPlayer`, or to another `AudioSupplier` for further processing. This class only works with OpenAL buffers, and supports either sync or async decoding.
  - The `AudioDataSupplier` class can also provide the raw audio samples, as well as the OpenAL buffers. This is required for most post-processing steps.
  - The `WavSupplier` and `Mp3Supplier` classes provide the audio for these formats. The wav data is still cached, and the mp3 data is still streamed, as before. (Unlike `Music`, `Mp3Supplier` only streams a single file. You have to create a new supplier to play another file, and then cross-fade them via `Fade`.)
  - The `Fade` supplier provides a cross-fade effect between any number of audio data suppliers. This is an example of how post-processing audio can be done in a 'drop-in' manner with this API.

Overall, the goal was to unify the audio interface to remove format-specific handling wherever possible. The engine would now be capable of playing MP3 sound effects or WAV music if desired; though the data parser was not updated, so the Sound/Music assumptions are still present in Audio.cpp. An AudioPlayer does not care about what kind of AudioSupplier it gets, though.

## Changes to audio behaviour
Though these changes are generally hidden from players, there are a couple details that might be interesting:
- Looping sounds no longer loop; instead, they stream the same data indefinitely.
  - If someone had a 3x looping sound, that will now switch dynamically when the sound restarts. (Not used in vanilla.)
  - Looping sounds are somewhat more susceptible to stutters at low frame rates, though that was already an issue with non-looping sounds.
- Multiple music tracks can now be cross-faded.
  - Previously, only the current track would be cross-faded with the previous track. This limit was removed; rapid music changes will have all tracks fade in / out.
- The music source is not used when there is no music, so running out of sources is somewhat less likely.

## Usage examples
Adding FLAC support, removing the WAV/MP3 differentiation, various audio effects, dynamic audio buffering, you name it.

## Testing Done
I tested that sounds play, react to volume controls, looping sounds loop and don't duplicate, mp3 playback works and can loop (and not loop), and I tested 3x and 1x sounds as well.

## Performance Impact
Should be minimal.
