### PR TITLE
feat(enhancement): Allow afterburner effects to scale with engine zoom

### DIFF
--- a/source/Effect.cpp
+++ b/source/Effect.cpp
@@ -62,6 +62,8 @@ void Effect::Load(const DataNode &node)
 	{
 		if(child.Token(0) == "sprite")
 			LoadSprite(child);
+		else if(child.Token(0) == "zooms")
+			respectsEngineZoom = true;
 		else if(child.Token(0) == "sound" && child.Size() >= 2)
 			sound = Audio::Get(child.Token(1));
 		else if(child.Token(0) == "sound category" && child.Size() >= 2)
@@ -98,4 +100,11 @@ void Effect::Load(const DataNode &node)
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
+}
+
+
+
+bool Effect::RespectsEngineZoom() const
+{
+	return respectsEngineZoom;
 }

--- a/source/Effect.h
+++ b/source/Effect.h
@@ -47,6 +47,8 @@ public:
 
 	void Load(const DataNode &node);
 
+	bool RespectsEngineZoom() const;
+
 
 private:
 	std::string name;
@@ -70,6 +72,9 @@ private:
 
 	int lifetime = 0;
 	int randomLifetime = 0;
+
+	// If set, this effect scales with the zoom of the ship engines bay that placed it.
+	bool respectsEngineZoom = false;
 
 	// Allow the Visual class to access all these private members.
 	friend class Visual;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4940,7 +4940,8 @@ void Ship::DoEngineVisuals(vector<Visual> &visuals, bool isUsingAfterburner)
 			Point effectVelocity = velocity - 6. * afterburnerAngle.Unit();
 			for(auto &&it : Attributes().AfterburnerEffects())
 				for(int i = 0; i < it.second; ++i)
-					visuals.emplace_back(*it.first, pos, effectVelocity, afterburnerAngle);
+					visuals.emplace_back(*it.first, pos, effectVelocity, afterburnerAngle, Point{},
+						it.first->RespectsEngineZoom() ? point.zoom : 1.);
 		}
 	}
 }

--- a/source/Visual.cpp
+++ b/source/Visual.cpp
@@ -24,8 +24,8 @@ using namespace std;
 
 
 // Generate a visual based on the given Effect.
-Visual::Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity)
-	: Body(effect, pos, vel, effect.hasAbsoluteAngle ? effect.absoluteAngle : facing),
+Visual::Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity, double zoom)
+	: Body(effect, pos, vel, effect.hasAbsoluteAngle ? effect.absoluteAngle : facing, zoom),
 	lifetime(effect.lifetime)
 {
 	if(effect.randomLifetime > 0)

--- a/source/Visual.h
+++ b/source/Visual.h
@@ -29,7 +29,8 @@ class Effect;
 class Visual : public Body {
 public:
 	Visual() = default;
-	Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity = Point());
+	Visual(const Effect &effect, Point pos, Point vel, Angle facing, Point hitVelocity = Point(),
+		double zoom = 1.);
 
 	// Functions provided by the Body base class:
 	// Frame GetFrame(int step = -1) const;


### PR DESCRIPTION
**Feature**

This PR resolves #11064.

## Summary
Afterburner effects can now have an attribute that tells them to respect the `zoom` of the engine bay that spawns the effect.

## Usage examples
```
effect <name>
	zooms
	...
```

## Testing Done
yes.™

## Wiki Update
soon

## Performance Impact
nah
