### PR TITLE
Reduce the maximum fuel capacity at which the fuel bar will be drawn segmented

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -215,7 +215,7 @@ namespace {
 	}
 
 	const double RADAR_SCALE = .025;
-	const double MAX_FUEL_DISPLAY = 5000.;
+	const double MAX_FUEL_DISPLAY = 3000.;
 
 	const double CAMERA_VELOCITY_TRACKING = 0.1;
 	const double CAMERA_POSITION_CENTERING = 0.01;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #10688

## Summary
Reduces the maximum fuel capacity for which the fuel bar will be drawn with segments from 5000 to 3000 so it doesn't exhibit the issue described in the linked issue.
I considered making the limit dynamic, so that it could account for custom interfaces using a bigger or smaller bar length, but I haven't come up with a way to do that that I like.

## Screenshots
Seems like effort.

## Testing Done
None.
