### PR TITLE
fix(graphics): Temporarily reduce scale of Z-3600 to prevent visual impairment

### DIFF
--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -540,6 +540,7 @@ outfit `Z-3600 "Beam" Amat Torch`
 	"thrusting fuel" 0.3
 	"drag reduction" 9
 	"flare sprite" "effect/avgi flare/antimatter"
+		"scale" 0.25
 		"frame rate" 15
 	"flare sound" "fusion torch"
 	"turn" 6000

--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -525,6 +525,7 @@ outfit "R-720 RCS Thrusters"
 	description "This large set of 'teakettle' style reaction control thrusters can allow even the largest of Avgi starships to maneuver with ease, or even reverse course without needing to fully turn around. They also can be used to reject considerable amounts of waste heat by expelling superheated water vapor, boosted by an electromagnetic accelerator."
 
 
+# Flare sprite temporarily scaled down due to visual impairment concerns.
 outfit `Z-3600 "Beam" Amat Torch`
 	category "Engines"
 	series "Avgi: Thrusters"


### PR DESCRIPTION
**Graphic Fix**

## Summary
This PR temporarily adds a `scale` factor to the Tachytia's engines, scaling them down to a quarter of what they currently are. This is because with how the game's engine and AI currently work, engine flares flicker during adjustment. Currently they fill the entire screen and go pass it considerably, and halving them still fills up a majority of the screen. This can be concerning visually and possibly cause problems for players up to a point that may cause visual impairment or seizure-inducing conditions. They are still longer than any other Avgi flare 

Once functionality to have engine flares "scale outward" visually when thrusting is added (it is a desired feature), such as from https://github.com/endless-sky/endless-sky/pull/9019, the scale change can be removed.

## Screenshots
![image](https://github.com/user-attachments/assets/3ca31079-0213-428f-a8bc-b0f238a4581c)

## Testing Done
Spammed my thrust with the new size and it's not as hard on the eyes for now.
