### PR TITLE
Correct debug mode pause key

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -314,7 +314,7 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 			if(event.type == SDL_MOUSEMOTION)
 				cursorTime = 0;
 
-			if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_9)
+			if(debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
 			{
 				isPaused = !isPaused;
 				if(isPaused)


### PR DESCRIPTION
**Bug fix**

## Summary
They key used to trigger the debug mode pause was erroneously changed in a previous PR. This changes it back.
