### PR TITLE
fix(style): Minor code style fixes and cleanup for conditions

### DIFF
--- a/source/ConditionAssignments.cpp
+++ b/source/ConditionAssignments.cpp
@@ -28,13 +28,13 @@ using namespace std;
 
 namespace {
 	const auto ASSIGN_OP_TO_TEXT = map<ConditionAssignments::AssignOp, const string> {
-		{ConditionAssignments::AssignOp::AO_ASSIGN, "="},
-		{ConditionAssignments::AssignOp::AO_ADD, "+="},
-		{ConditionAssignments::AssignOp::AO_SUB, "-="},
-		{ConditionAssignments::AssignOp::AO_MUL, "*="},
-		{ConditionAssignments::AssignOp::AO_DIV, "/="},
-		{ConditionAssignments::AssignOp::AO_LT, "<?="},
-		{ConditionAssignments::AssignOp::AO_GT, ">?="},
+		{ConditionAssignments::AssignOp::ASSIGN, "="},
+		{ConditionAssignments::AssignOp::ADD, "+="},
+		{ConditionAssignments::AssignOp::SUB, "-="},
+		{ConditionAssignments::AssignOp::MUL, "*="},
+		{ConditionAssignments::AssignOp::DIV, "/="},
+		{ConditionAssignments::AssignOp::LT, "<?="},
+		{ConditionAssignments::AssignOp::GT, ">?="},
 	};
 }
 
@@ -100,25 +100,25 @@ void ConditionAssignments::Apply(ConditionsStore &conditions) const
 		int64_t newValue = assignment.expressionToEvaluate.Evaluate(conditions);
 		switch(assignment.assignOperator)
 		{
-			case AssignOp::AO_ASSIGN:
+			case AssignOp::ASSIGN:
 				ce = newValue;
 				break;
-			case AssignOp::AO_ADD:
+			case AssignOp::ADD:
 				ce += newValue;
 				break;
-			case AssignOp::AO_SUB:
+			case AssignOp::SUB:
 				ce -= newValue;
 				break;
-			case AssignOp::AO_MUL:
+			case AssignOp::MUL:
 				ce = static_cast<int64_t>(ce) * newValue;
 				break;
-			case AssignOp::AO_DIV:
+			case AssignOp::DIV:
 				ce = newValue ? static_cast<int64_t>(ce) / newValue : numeric_limits<int64_t>::max();
 				break;
-			case AssignOp::AO_LT:
+			case AssignOp::LT:
 				ce = min(static_cast<int64_t>(ce), newValue);
 				break;
-			case AssignOp::AO_GT:
+			case AssignOp::GT:
 				ce = max(static_cast<int64_t>(ce), newValue);
 				break;
 		}
@@ -143,7 +143,7 @@ set<string> ConditionAssignments::RelevantConditions() const
 
 void ConditionAssignments::AddSetCondition(const std::string &name)
 {
-	assignments.emplace_back(name, AssignOp::AO_ASSIGN, ConditionSet(1));
+	assignments.emplace_back(name, AssignOp::ASSIGN, ConditionSet(1));
 }
 
 
@@ -157,7 +157,7 @@ void ConditionAssignments::Add(const DataNode &node)
 			node.PrintTrace("Parse error; " + node.Token(0) + " keyword requires a single valid condition:");
 			return;
 		}
-		assignments.emplace_back(node.Token(1), AssignOp::AO_ASSIGN, ConditionSet(node.Token(0) == "set" ? 1 : 0));
+		assignments.emplace_back(node.Token(1), AssignOp::ASSIGN, ConditionSet(node.Token(0) == "set" ? 1 : 0));
 	}
 	else if(node.Size() == 2 && (node.Token(1) == "++" || node.Token(1) == "--"))
 	{
@@ -166,13 +166,13 @@ void ConditionAssignments::Add(const DataNode &node)
 			node.PrintTrace("Parse error; " + node.Token(1) + " operator requires a single valid condition:");
 			return;
 		}
-		assignments.emplace_back(node.Token(0), node.Token(1) == "++" ? AssignOp::AO_ADD : AssignOp::AO_SUB,
+		assignments.emplace_back(node.Token(0), node.Token(1) == "++" ? AssignOp::ADD : AssignOp::SUB,
 			ConditionSet(1));
 	}
 	else if(node.Size() >= 3)
 	{
 		// Parse the assignment operator.
-		AssignOp ao = AssignOp::AO_ASSIGN;
+		AssignOp ao = AssignOp::ASSIGN;
 		const string assignOpString = node.Token(1);
 		auto it = find_if(ASSIGN_OP_TO_TEXT.begin(), ASSIGN_OP_TO_TEXT.end(),
 			[&assignOpString](const std::pair<AssignOp, const string> &e) {

--- a/source/ConditionAssignments.h
+++ b/source/ConditionAssignments.h
@@ -31,6 +31,20 @@ class DataWriter;
 // "conditions" to modify them.
 class ConditionAssignments {
 public:
+	/// Possible assignment operators.
+	enum class AssignOp
+	{
+		ASSIGN, /// Used for =, set (with 1 as expression), clear ((with 0 as expression)
+		ADD, /// Used for +=, ++ (with 1 as expression)
+		SUB, /// Used for -=, -- (with 1 as expression)
+		MUL, /// Used for *=
+		DIV, /// Used for /= (integer division)
+		LT,  /// Used for <?=
+		GT  /// Used for >?=
+	};
+
+
+public:
 	ConditionAssignments() = default;
 
 	// Construct and Load() at the same time.
@@ -57,20 +71,6 @@ public:
 
 	// Add an extra condition assignment from a data node.
 	void Add(const DataNode &node);
-
-
-public:
-	/// Possible assignment operators.
-	enum class AssignOp
-	{
-		AO_ASSIGN, /// Used for =, set (with 1 as expression), clear ((with 0 as expression)
-		AO_ADD, /// Used for +=, ++ (with 1 as expression)
-		AO_SUB, /// Used for -=, -- (with 1 as expression)
-		AO_MUL, /// Used for *=
-		AO_DIV, /// Used for /= (integer division)
-		AO_LT,  /// Used for <?=
-		AO_GT  /// Used for >?=
-	};
 
 
 private:

--- a/source/ConditionAssignments.h
+++ b/source/ConditionAssignments.h
@@ -32,8 +32,7 @@ class DataWriter;
 class ConditionAssignments {
 public:
 	/// Possible assignment operators.
-	enum class AssignOp
-	{
+	enum class AssignOp {
 		ASSIGN, /// Used for =, set (with 1 as expression), clear ((with 0 as expression)
 		ADD, /// Used for +=, ++ (with 1 as expression)
 		SUB, /// Used for -=, -- (with 1 as expression)

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -41,17 +41,17 @@ namespace
 		// "Apply" operators return the value that the condition should have
 		// after applying the expression.
 		static const map<ConditionSet::ExpressionOp, BinFun> opMap = {
-			{ConditionSet::ExpressionOp::OP_EQ, [](int64_t a, int64_t b) -> int64_t { return a == b; }},
-			{ConditionSet::ExpressionOp::OP_NE, [](int64_t a, int64_t b) -> int64_t { return a != b; }},
-			{ConditionSet::ExpressionOp::OP_LT, [](int64_t a, int64_t b) -> int64_t { return a < b; }},
-			{ConditionSet::ExpressionOp::OP_GT, [](int64_t a, int64_t b) -> int64_t { return a > b; }},
-			{ConditionSet::ExpressionOp::OP_LE, [](int64_t a, int64_t b) -> int64_t { return a <= b; }},
-			{ConditionSet::ExpressionOp::OP_GE, [](int64_t a, int64_t b) -> int64_t { return a >= b; }},
-			{ConditionSet::ExpressionOp::OP_MOD, [](int64_t a, int64_t b) { return b ? a % b : a; }},
-			{ConditionSet::ExpressionOp::OP_MUL, [](int64_t a, int64_t b) { return a * b; }},
-			{ConditionSet::ExpressionOp::OP_ADD, [](int64_t a, int64_t b) { return a + b; }},
-			{ConditionSet::ExpressionOp::OP_SUB, [](int64_t a, int64_t b) { return a - b; }},
-			{ConditionSet::ExpressionOp::OP_DIV, [](int64_t a, int64_t b) { return b ? a / b : numeric_limits<int64_t>::max(); }}
+			{ConditionSet::ExpressionOp::EQ, [](int64_t a, int64_t b) -> int64_t { return a == b; }},
+			{ConditionSet::ExpressionOp::NE, [](int64_t a, int64_t b) -> int64_t { return a != b; }},
+			{ConditionSet::ExpressionOp::LT, [](int64_t a, int64_t b) -> int64_t { return a < b; }},
+			{ConditionSet::ExpressionOp::GT, [](int64_t a, int64_t b) -> int64_t { return a > b; }},
+			{ConditionSet::ExpressionOp::LE, [](int64_t a, int64_t b) -> int64_t { return a <= b; }},
+			{ConditionSet::ExpressionOp::GE, [](int64_t a, int64_t b) -> int64_t { return a >= b; }},
+			{ConditionSet::ExpressionOp::MOD, [](int64_t a, int64_t b) { return b ? a % b : a; }},
+			{ConditionSet::ExpressionOp::MUL, [](int64_t a, int64_t b) { return a * b; }},
+			{ConditionSet::ExpressionOp::ADD, [](int64_t a, int64_t b) { return a + b; }},
+			{ConditionSet::ExpressionOp::SUB, [](int64_t a, int64_t b) { return a - b; }},
+			{ConditionSet::ExpressionOp::DIV, [](int64_t a, int64_t b) { return b ? a / b : numeric_limits<int64_t>::max(); }}
 		};
 
 		auto it = opMap.find(op);
@@ -61,22 +61,22 @@ namespace
 	/// Map string tokens to precedence and internal operators.
 	const auto CS_TOKEN_CONVERSION = map<const string, ConditionSet::ExpressionOp>{
 		// Infix arithmetic multiply, divide and modulo have a higher precedence than add and subtract.
-		{ "*", ConditionSet::ExpressionOp::OP_MUL },
-		{ "/", ConditionSet::ExpressionOp::OP_DIV },
-		{ "%", ConditionSet::ExpressionOp::OP_MOD },
+		{ "*", ConditionSet::ExpressionOp::MUL },
+		{ "/", ConditionSet::ExpressionOp::DIV },
+		{ "%", ConditionSet::ExpressionOp::MOD },
 		// Infix arithmetic operators add and subtract have the same precedence.
-		{ "+", ConditionSet::ExpressionOp::OP_ADD },
-		{ "-", ConditionSet::ExpressionOp::OP_SUB },
+		{ "+", ConditionSet::ExpressionOp::ADD },
+		{ "-", ConditionSet::ExpressionOp::SUB },
 		// Infix boolean equality operators have a lower precedence than their arithmetic counterparts.
-		{ "==", ConditionSet::ExpressionOp::OP_EQ },
-		{ "!=", ConditionSet::ExpressionOp::OP_NE },
-		{ ">", ConditionSet::ExpressionOp::OP_GT },
-		{ "<", ConditionSet::ExpressionOp::OP_LT },
-		{ ">=", ConditionSet::ExpressionOp::OP_GE },
-		{ "<=", ConditionSet::ExpressionOp::OP_LE },
+		{ "==", ConditionSet::ExpressionOp::EQ },
+		{ "!=", ConditionSet::ExpressionOp::NE },
+		{ ">", ConditionSet::ExpressionOp::GT },
+		{ "<", ConditionSet::ExpressionOp::LT },
+		{ ">=", ConditionSet::ExpressionOp::GE },
+		{ "<=", ConditionSet::ExpressionOp::LE },
 		// Parent-type operators have a low precedence in Endless-Sky, because they are on outer parent/child sections.
-		{ "and", ConditionSet::ExpressionOp::OP_AND },
-		{ "or", ConditionSet::ExpressionOp::OP_OR },
+		{ "and", ConditionSet::ExpressionOp::AND },
+		{ "or", ConditionSet::ExpressionOp::OR },
 	};
 
 
@@ -85,27 +85,27 @@ namespace
 	{
 		switch(op)
 		{
-			case ConditionSet::ExpressionOp::OP_INVALID:
+			case ConditionSet::ExpressionOp::INVALID:
 				return 9;
-			case ConditionSet::ExpressionOp::OP_LIT:
-			case ConditionSet::ExpressionOp::OP_VAR:
+			case ConditionSet::ExpressionOp::LIT:
+			case ConditionSet::ExpressionOp::VAR:
 				return 8;
-			case ConditionSet::ExpressionOp::OP_MUL:
-			case ConditionSet::ExpressionOp::OP_DIV:
-			case ConditionSet::ExpressionOp::OP_MOD:
+			case ConditionSet::ExpressionOp::MUL:
+			case ConditionSet::ExpressionOp::DIV:
+			case ConditionSet::ExpressionOp::MOD:
 				return 6;
-			case ConditionSet::ExpressionOp::OP_ADD:
-			case ConditionSet::ExpressionOp::OP_SUB:
+			case ConditionSet::ExpressionOp::ADD:
+			case ConditionSet::ExpressionOp::SUB:
 				return 5;
-			case ConditionSet::ExpressionOp::OP_EQ:
-			case ConditionSet::ExpressionOp::OP_NE:
-			case ConditionSet::ExpressionOp::OP_GT:
-			case ConditionSet::ExpressionOp::OP_LT:
-			case ConditionSet::ExpressionOp::OP_GE:
-			case ConditionSet::ExpressionOp::OP_LE:
+			case ConditionSet::ExpressionOp::EQ:
+			case ConditionSet::ExpressionOp::NE:
+			case ConditionSet::ExpressionOp::GT:
+			case ConditionSet::ExpressionOp::LT:
+			case ConditionSet::ExpressionOp::GE:
+			case ConditionSet::ExpressionOp::LE:
 				return 3;
 			default:
-				// Precedence for OP_AND, OP_OR
+				// Precedence for AND, OR
 				return 0;
 		}
 	}
@@ -117,8 +117,8 @@ namespace
 		if(it != CS_TOKEN_CONVERSION.end())
 			return it->second;
 
-		// If nothing matches, then we get the default OP_INVALID value.
-		return ConditionSet::ExpressionOp::OP_INVALID;
+		// If nothing matches, then we get the default INVALID value.
+		return ConditionSet::ExpressionOp::INVALID;
 	}
 }
 
@@ -135,7 +135,7 @@ ConditionSet::ConditionSet(const DataNode &node)
 // Construct a terminal with a literal value;
 ConditionSet::ConditionSet(int64_t newLiteral)
 {
-	expressionOperator = ExpressionOp::OP_LIT;
+	expressionOperator = ExpressionOp::LIT;
 	literal = newLiteral;
 }
 
@@ -189,7 +189,7 @@ ConditionSet &ConditionSet::operator=(const ConditionSet &other)
 void ConditionSet::Load(const DataNode &node)
 {
 	// The top-node is always an 'and' node, without the keyword.
-	expressionOperator = ExpressionOp::OP_AND;
+	expressionOperator = ExpressionOp::AND;
 	ParseBooleanChildren(node);
 }
 
@@ -199,8 +199,8 @@ void ConditionSet::Load(const DataNode &node)
 void ConditionSet::Save(DataWriter &out) const
 {
 	// Default should be AND, so if it is, then just write the subsets.
-	// If this condition got optimized beyond OP_AND, then re-add the OP_AND by writing the current condition in full.
-	if(expressionOperator == ExpressionOp::OP_AND)
+	// If this condition got optimized beyond AND, then re-add the AND by writing the current condition in full.
+	if(expressionOperator == ExpressionOp::AND)
 		for(const auto &child : children)
 		{
 			child.SaveSubset(out);
@@ -239,26 +239,26 @@ void ConditionSet::SaveSubset(DataWriter &out) const
 
 	switch(expressionOperator)
 	{
-	case ExpressionOp::OP_INVALID:
+	case ExpressionOp::INVALID:
 		out.WriteToken("never");
 		break;
-	case ExpressionOp::OP_VAR:
+	case ExpressionOp::VAR:
 		out.WriteToken(conditionName);
 		break;
-	case ExpressionOp::OP_LIT:
+	case ExpressionOp::LIT:
 		out.WriteToken(literal);
 		break;
-	case ExpressionOp::OP_ADD:
-	case ExpressionOp::OP_SUB:
-	case ExpressionOp::OP_MUL:
-	case ExpressionOp::OP_DIV:
-	case ExpressionOp::OP_MOD:
-	case ExpressionOp::OP_EQ:
-	case ExpressionOp::OP_NE:
-	case ExpressionOp::OP_LE:
-	case ExpressionOp::OP_GE:
-	case ExpressionOp::OP_LT:
-	case ExpressionOp::OP_GT:
+	case ExpressionOp::ADD:
+	case ExpressionOp::SUB:
+	case ExpressionOp::MUL:
+	case ExpressionOp::DIV:
+	case ExpressionOp::MOD:
+	case ExpressionOp::EQ:
+	case ExpressionOp::NE:
+	case ExpressionOp::LE:
+	case ExpressionOp::GE:
+	case ExpressionOp::LT:
+	case ExpressionOp::GT:
 		if(children.empty())
 		{
 			out.WriteToken("never");
@@ -271,8 +271,8 @@ void ConditionSet::SaveSubset(DataWriter &out) const
 			SaveChild(i, out);
 		}
 		break;
-	case ExpressionOp::OP_AND:
-	case ExpressionOp::OP_OR:
+	case ExpressionOp::AND:
+	case ExpressionOp::OR:
 		out.Write(opTxt);
 		out.BeginChild();
 		for(const auto &child : children)
@@ -282,8 +282,8 @@ void ConditionSet::SaveSubset(DataWriter &out) const
 		}
 		out.EndChild();
 		break;
-	case ExpressionOp::OP_NOT:
-	case ExpressionOp::OP_HAS:
+	case ExpressionOp::NOT:
+	case ExpressionOp::HAS:
 		if(children.empty())
 		{
 			out.WriteToken("never");
@@ -303,7 +303,7 @@ void ConditionSet::SaveSubset(DataWriter &out) const
 void ConditionSet::MakeNever()
 {
 	children.clear();
-	expressionOperator = ExpressionOp::OP_LIT;
+	expressionOperator = ExpressionOp::LIT;
 	literal = 0;
 }
 
@@ -313,11 +313,11 @@ void ConditionSet::MakeNever()
 // Invalid ConditionSets are also considered empty.
 bool ConditionSet::IsEmpty() const
 {
-	// OP_AND is the default toplevel operator for any condition, so whenever we encounter OP_AND without any children
+	// AND is the default toplevel operator for any condition, so whenever we encounter AND without any children
 	// then there was nothing under the toplevel to parse, thus the condition was empty.
 	return
-		(expressionOperator == ExpressionOp::OP_AND && children.size() == 0) ||
-		(expressionOperator == ExpressionOp::OP_INVALID);
+		(expressionOperator == ExpressionOp::AND && children.size() == 0) ||
+		(expressionOperator == ExpressionOp::INVALID);
 }
 
 
@@ -325,7 +325,7 @@ bool ConditionSet::IsEmpty() const
 // Check if the conditionset contains valid data
 bool ConditionSet::IsValid() const
 {
-	return expressionOperator != ExpressionOp::OP_INVALID;
+	return expressionOperator != ExpressionOp::INVALID;
 }
 
 
@@ -342,11 +342,11 @@ int64_t ConditionSet::Evaluate(const ConditionsStore &conditionsStore) const
 {
 	switch(expressionOperator)
 	{
-		case ExpressionOp::OP_VAR:
+		case ExpressionOp::VAR:
 			return conditionsStore.Get(conditionName);
-		case ExpressionOp::OP_LIT:
+		case ExpressionOp::LIT:
 			return literal;
-		case ExpressionOp::OP_AND:
+		case ExpressionOp::AND:
 		{
 			// An empty AND section returns true.
 			if(children.empty())
@@ -364,7 +364,7 @@ int64_t ConditionSet::Evaluate(const ConditionsStore &conditionsStore) const
 			}
 			return result;
 		}
-		case ExpressionOp::OP_OR:
+		case ExpressionOp::OR:
 			for(const ConditionSet &child : children)
 			{
 				int64_t childResult = child.Evaluate(conditionsStore);
@@ -396,7 +396,7 @@ set<string> ConditionSet::RelevantConditions() const
 {
 	set<string> result;
 	// Add the name from this set, if it is a VAR type operator.
-	if(expressionOperator == ExpressionOp::OP_VAR)
+	if(expressionOperator == ExpressionOp::VAR)
 		result.emplace(conditionName);
 	// Add the names from the children.
 	for(const auto &child : children)
@@ -413,12 +413,12 @@ bool ConditionSet::ParseNode(const DataNode &node)
 	{
 		if(node.Token(0) == "and")
 		{
-			expressionOperator = ExpressionOp::OP_AND;
+			expressionOperator = ExpressionOp::AND;
 			return ParseBooleanChildren(node);
 		}
 		if(node.Token(0) == "or")
 		{
-			expressionOperator = ExpressionOp::OP_OR;
+			expressionOperator = ExpressionOp::OR;
 			return ParseBooleanChildren(node);
 		}
 	}
@@ -433,7 +433,7 @@ bool ConditionSet::ParseNode(const DataNode &node)
 		if(node.Size() > 1)
 			return FailParse(node, "tokens found after never keyword");
 
-		expressionOperator = ExpressionOp::OP_LIT;
+		expressionOperator = ExpressionOp::LIT;
 		literal = 0;
 		return true;
 	}
@@ -443,7 +443,7 @@ bool ConditionSet::ParseNode(const DataNode &node)
 			return FailParse(node, "has keyword requires a single condition");
 
 		// Convert has keyword directly to the variable.
-		expressionOperator = ExpressionOp::OP_VAR;
+		expressionOperator = ExpressionOp::VAR;
 		conditionName = node.Token(1);
 		return true;
 	}
@@ -453,9 +453,9 @@ bool ConditionSet::ParseNode(const DataNode &node)
 			return FailParse(node, "not keyword requires a single condition");
 
 		// Create `conditionName == 0` expression.
-		expressionOperator = ExpressionOp::OP_EQ;
+		expressionOperator = ExpressionOp::EQ;
 		children.emplace_back();
-		children.back().expressionOperator = ExpressionOp::OP_VAR;
+		children.back().expressionOperator = ExpressionOp::VAR;
 		children.back().conditionName = node.Token(1);
 		children.emplace_back(0);
 		return true;
@@ -485,7 +485,7 @@ bool ConditionSet::ParseNode(const DataNode &node, int &tokenNr)
 		return true;
 
 	// If there are more tokens, then we need to have an infix operator here.
-	if(!ParseFromInfix(node, tokenNr, ExpressionOp::OP_AND))
+	if(!ParseFromInfix(node, tokenNr, ExpressionOp::AND))
 		return FailParse();
 
 	// Parsing from infix should have consumed and parsed all tokens.
@@ -507,42 +507,42 @@ bool ConditionSet::Optimize(const DataNode &node)
 
 	switch(expressionOperator)
 	{
-		case ExpressionOp::OP_AND:
-		case ExpressionOp::OP_OR:
+		case ExpressionOp::AND:
+		case ExpressionOp::OR:
 			// If we only have a single element, then replace the current OP/AND by its child.
 			if(children.size() == 1)
 				*this = children[0];
 
 			break;
 
-		case ExpressionOp::OP_EQ:
-		case ExpressionOp::OP_NE:
-		case ExpressionOp::OP_LE:
-		case ExpressionOp::OP_GE:
-		case ExpressionOp::OP_LT:
-		case ExpressionOp::OP_GT:
+		case ExpressionOp::EQ:
+		case ExpressionOp::NE:
+		case ExpressionOp::LE:
+		case ExpressionOp::GE:
+		case ExpressionOp::LT:
+		case ExpressionOp::GT:
 			// TODO: Optimize boolean equality operators.
 			break;
 
-		case ExpressionOp::OP_ADD:
-		case ExpressionOp::OP_SUB:
-		case ExpressionOp::OP_MUL:
-		case ExpressionOp::OP_DIV:
-		case ExpressionOp::OP_MOD:
+		case ExpressionOp::ADD:
+		case ExpressionOp::SUB:
+		case ExpressionOp::MUL:
+		case ExpressionOp::DIV:
+		case ExpressionOp::MOD:
 			// TODO: Optimize arithmetic operators.
 			break;
 
-		case ExpressionOp::OP_HAS:
+		case ExpressionOp::HAS:
 			// Optimize away HAS, we can directly use the expression below it.
 			if(children.size() == 1)
 				*this = children[0];
 
 			break;
 
-		case ExpressionOp::OP_NOT:
-		case ExpressionOp::OP_LIT:
-		case ExpressionOp::OP_VAR:
-		case ExpressionOp::OP_INVALID:
+		case ExpressionOp::NOT:
+		case ExpressionOp::LIT:
+		case ExpressionOp::VAR:
+		case ExpressionOp::INVALID:
 			break;
 	}
 	return returnValue;
@@ -561,7 +561,7 @@ bool ConditionSet::ParseBooleanChildren(const DataNode &node)
 		children.emplace_back();
 		children.back().ParseNode(child);
 
-		if(children.back().expressionOperator == ExpressionOp::OP_INVALID)
+		if(children.back().expressionOperator == ExpressionOp::INVALID)
 			return FailParse();
 	}
 
@@ -594,13 +594,13 @@ bool ConditionSet::ParseMini(const DataNode &node, int &tokenNr)
 
 	if(node.IsNumber(tokenNr))
 	{
-		expressionOperator = ExpressionOp::OP_LIT;
+		expressionOperator = ExpressionOp::LIT;
 		literal = node.Value(tokenNr);
 		++tokenNr;
 	}
 	else if(DataNode::IsConditionName(node.Token(tokenNr)))
 	{
-		expressionOperator = ExpressionOp::OP_VAR;
+		expressionOperator = ExpressionOp::VAR;
 		conditionName = node.Token(tokenNr);
 		++tokenNr;
 	}
@@ -630,7 +630,7 @@ bool ConditionSet::ParseMini(const DataNode &node, int &tokenNr)
 		else
 			// If there are more tokens, then we need to have an infix operator here.
 			// Use the precedence of the AND operator, since we want to parse to the closing bracket.
-			if(!ParseFromInfix(node, tokenNr, ExpressionOp::OP_AND))
+			if(!ParseFromInfix(node, tokenNr, ExpressionOp::AND))
 				return FailParse();
 	}
 	return true;
@@ -657,17 +657,17 @@ bool ConditionSet::ParseFromInfix(const DataNode &node, int &tokenNr, Expression
 		ExpressionOp infixOp = ParseOperator(node.Token(tokenNr));
 		switch(infixOp)
 		{
-			case ExpressionOp::OP_ADD:
-			case ExpressionOp::OP_SUB:
-			case ExpressionOp::OP_MUL:
-			case ExpressionOp::OP_DIV:
-			case ExpressionOp::OP_MOD:
-			case ExpressionOp::OP_EQ:
-			case ExpressionOp::OP_NE:
-			case ExpressionOp::OP_LE:
-			case ExpressionOp::OP_GE:
-			case ExpressionOp::OP_LT:
-			case ExpressionOp::OP_GT:
+			case ExpressionOp::ADD:
+			case ExpressionOp::SUB:
+			case ExpressionOp::MUL:
+			case ExpressionOp::DIV:
+			case ExpressionOp::MOD:
+			case ExpressionOp::EQ:
+			case ExpressionOp::NE:
+			case ExpressionOp::LE:
+			case ExpressionOp::GE:
+			case ExpressionOp::LT:
+			case ExpressionOp::GT:
 			{
 				if(tokenNr + 1 >= node.Size())
 					return FailParse(node, "expected terminal after infix operator \"" + node.Token(tokenNr) + "\"");
@@ -727,7 +727,7 @@ bool ConditionSet::PushDownFull(const DataNode &node)
 	ConditionSet ce(*this);
 	children.clear();
 	children.push_back(std::move(ce));
-	expressionOperator = ExpressionOp::OP_AND;
+	expressionOperator = ExpressionOp::AND;
 
 	return true;
 }
@@ -756,7 +756,7 @@ bool ConditionSet::PushDownLast(const DataNode &node)
 
 bool ConditionSet::FailParse()
 {
-	expressionOperator = ExpressionOp::OP_INVALID;
+	expressionOperator = ExpressionOp::INVALID;
 	children.clear();
 	return false;
 }

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -32,6 +32,39 @@ class DataWriter;
 // conditions.
 class ConditionSet {
 public:
+	enum class ExpressionOp {
+		INVALID, ///< Expression is invalid.
+
+		// Direct access operators
+		VAR, ///< Direct access to condition variable, no other operations.
+		LIT, ///< Direct access to literal, no other operations).
+
+		// Arithmetic operators
+		ADD, ///< Adds ( + ) the values from all sub-expressions.
+		SUB, ///< Subtracts ( - ) all later sub-expressions from the first one.
+		MUL, ///< Multiplies ( * ) all sub-expressions with each-other.
+		DIV, ///< (Integer) Divides ( / ) the first sub-expression by all later ones.
+		MOD, ///< Modulo ( % ) by the second and later sub-expressions on the first one.
+
+		// Boolean equality operators, return 0 or 1
+		EQ, ///< Tests for equality ( == ).
+		NE, ///< Tests for not equal to ( != ).
+		LE, ///< Tests for less than or equal to ( <= ).
+		GE, ///< Tests for greater than or equal to ( >= ).
+		LT, ///< Tests for less than ( < ).
+		GT, ///< Tests for greater than ( > ).
+
+		// Boolean combination operators, return 0 or 1
+		AND, ///< Boolean 'and' operator; returns 0 on first 0 subcondition, value of first sub-condition otherwise.
+		OR, ///< Boolean 'or' operator; returns value of first non-zero sub-condition, or zero if all are zero.
+
+		// Single boolean operators
+		NOT, ///< Single boolean 'not' operator.
+		HAS ///< Single boolean 'has' operator.
+	};
+
+
+public:
 	ConditionSet() = default;
 	ConditionSet(const ConditionSet &) = default;
 
@@ -77,56 +110,19 @@ public:
 	std::set<std::string> RelevantConditions() const;
 
 
-public:
-	enum class ExpressionOp
-	{
-		OP_INVALID, ///< Expression is invalid.
-
-		// Direct access operators
-		OP_VAR, ///< Direct access to condition variable, no other operations.
-		OP_LIT, ///< Direct access to literal, no other operations).
-
-		// Arithmetic operators
-		OP_ADD, ///< Adds ( + ) the values from all sub-expressions.
-		OP_SUB, ///< Subtracts ( - ) all later sub-expressions from the first one.
-		OP_MUL, ///< Multiplies ( * ) all sub-expressions with each-other.
-		OP_DIV, ///< (Integer) Divides ( / ) the first sub-expression by all later ones.
-		OP_MOD, ///< Modulo ( % ) by the second and later sub-expressions on the first one.
-
-		// Boolean equality operators, return 0 or 1
-		OP_EQ, ///< Tests for equality ( == ).
-		OP_NE, ///< Tests for not equal to ( != ).
-		OP_LE, ///< Tests for less than or equal to ( <= ).
-		OP_GE, ///< Tests for greater than or equal to ( >= ).
-		OP_LT, ///< Tests for less than ( < ).
-		OP_GT, ///< Tests for greater than ( > ).
-
-		// Boolean combination operators, return 0 or 1
-		OP_AND, ///< Boolean 'and' operator; returns 0 on first 0 subcondition, value of first sub-condition otherwise.
-		OP_OR, ///< Boolean 'or' operator; returns value of first non-zero sub-condition, or zero if all are zero.
-
-		// Single boolean operators
-		OP_NOT, ///< Single boolean 'not' operator.
-		OP_HAS ///< Single boolean 'has' operator.
-	};
-
-
 private:
 	/// Parse a node completely into this expression; all tokens on the line and all children if there are any.
 	bool ParseNode(const DataNode &node);
 
-
 	/// Parse the children under 'and'-nodes, 'or'-nodes, or the toplevel-node (which acts as and-node). The
 	/// expression-operator should already have been set before calling this function.
 	bool ParseBooleanChildren(const DataNode &node);
-
 
 	/// Parse a minimal complete expression from the tokens into the (empty) expression.
 	///
 	/// @param node The node to report parse-errors on, if any occur.
 	/// @param lineTokens Tokens to use (and pop from) for parsing.
 	bool ParseMini(const DataNode &node, int &tokenNr);
-
 
 	/// Helper function to parse an infix operator and the subexpression after it.
 	/// Should be called on ConditionSets that already have at least 1 sub-expression in them.
@@ -135,7 +131,6 @@ private:
 	/// @param lineTokens Tokens to use (and pop from) for parsing.
 	bool ParseFromInfix(const DataNode &node, int &tokenNr, ExpressionOp parentOp);
 
-
 	/// Push sub-expressions and the operator from the current expression one level down into a new single
 	/// sub-expression.
 	///
@@ -143,22 +138,19 @@ private:
 	/// @param node Node on which to report the failures (using node.PrintTrace()).
 	bool PushDownFull(const DataNode &node);
 
-
 	/// Push the last sub-expression from the current expression one level down into a new sub-expression.
 	///
 	/// To be used when the next infix-operator has precedence over the current operators being processed.
 	/// @param node Node on which to report the failures (using node.PrintTrace()).
 	bool PushDownLast(const DataNode &node);
 
-
 	/// Handles a failure in parsing of lower-level nodes, for higher-level nodes;
-	/// - Clears the sub-expressions and sets the operator to OP_INVALID.
+	/// - Clears the sub-expressions and sets the operator to INVALID.
 	bool FailParse();
-
 
 	/// Handles a failure in parsing;
 	/// - Reports the failure using PrintTrace() in the given DataNode.
-	/// - Clears the sub-expressions and sets the operator to OP_INVALID.
+	/// - Clears the sub-expressions and sets the operator to INVALID.
 	///
 	/// @param node Node on which to report the failures (using node.PrintTrace()).
 	/// @param failText The reason why parsing is failing. (Will be used as output for node.PrintTrace()).
@@ -171,7 +163,7 @@ private:
 	/// combined using the expression operator that determines how the nested
 	/// sets are to be combined.
 	/// Using an `and`-operator with no sub-expressions as safe initial value.
-	ExpressionOp expressionOperator = ExpressionOp::OP_AND;
+	ExpressionOp expressionOperator = ExpressionOp::AND;
 	/// Literal part of the expression, if this is a literal terminal.
 	int64_t literal = 0;
 	/// Condition variable that is used in this expression, if this is a condition variable.


### PR DESCRIPTION
## Summary
1. public enums go before everything else
2. no space between functions in the header or a single blank line
3. removed unnecessary prefixes
4. `{` on new line only after `)`