### PR TITLE
Fix adding minables and asteroids error detection and reporting

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -253,6 +253,9 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			}
 			else if(child.Size() > valueIndex + 2)
 				asteroids.emplace_back(value, child.Value(valueIndex + 1), child.Value(valueIndex + 2));
+			else
+				child.PrintTrace("Error: expected " + to_string(valueIndex + 3)
+					+ " tokens. Found " + to_string(child.Size()) + ":");
 		}
 		else if(key == "minables")
 		{
@@ -268,6 +271,9 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 			}
 			else if(child.Size() > valueIndex + 2)
 				asteroids.emplace_back(type, child.Value(valueIndex + 1), child.Value(valueIndex + 2));
+			else
+				child.PrintTrace("Error: expected " + to_string(valueIndex + 3)
+					+ " tokens. Found " + to_string(child.Size()) + ":");
 		}
 		else if(key == "fleet")
 		{

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -251,7 +251,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 						break;
 					}
 			}
-			else if(child.Size() >= 4)
+			else if(child.Size() > valueIndex + 2)
 				asteroids.emplace_back(value, child.Value(valueIndex + 1), child.Value(valueIndex + 2));
 		}
 		else if(key == "minables")
@@ -266,7 +266,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets)
 						break;
 					}
 			}
-			else if(child.Size() >= 4)
+			else if(child.Size() > valueIndex + 2)
 				asteroids.emplace_back(type, child.Value(valueIndex + 1), child.Value(valueIndex + 2));
 		}
 		else if(key == "fleet")


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11016

## Summary
As described in the linked issue, the game currently checks that an "(add) minables" or "(add) asteroids" node has at least four tokens before trying to add a new asteroid object to the system.
The expected tokens are:
- Literal "minables" or "asteroids",
- Name of the minable or asteroid to use,
- A "count" value, and
- An "energy" value.

This is four tokens, explaining why it requires at least four tokens. However, when using "add" to avoid deleting whatever asteroids the system already has and instead only add new asteroids to the end of the list, the required number of tokens is five: the previously listed four plus the "add" token itself.

Since the game only requires four tokens, however, this means that a node missing the "energy" value may still be passed. In this case, the game will attempt to retrieve a value from the fifth token, which will produce an error, and return a value of zero.

This PR modifies the check on the number of tokens in the node to require there be at least two tokens after the token at "valueIndex".
It also adds error reporting where, if insufficient tokens are found, the expected number (four or five) will be provided as well as the number found. No asteroid object will be added to the system based on this node.

## Testing Done
Tried something like:
```
system "Sol"
    add minables "lead" 3
    add asteroids "small rock" 5
```

Without this PR, got errors about accessing an out of bounds index.
With this PR, get told that five tokens were expected, but only four were found.

## Wiki Update
N/A, I think.
