### PR TITLE
feat(error-handling): Include image name and frame number in collision mask error message

### DIFF
--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -187,13 +187,14 @@ void ImageSet::Load() noexcept(false)
 	// to be in separate locations on the disk. Create masks if needed.
 	for(size_t i = 0; i < frames; ++i)
 	{
+		const string fileName = "\"" + name + "\" frame #" + to_string(i);
 		if(!buffer[0].Read(paths[0][i], i))
-			Logger::LogError("Failed to read image data for \"" + name + "\" frame #" + to_string(i));
+			Logger::LogError("Failed to read image data for " + fileName);
 		else if(makeMasks)
 		{
-			masks[i].Create(buffer[0], i);
+			masks[i].Create(buffer[0], i, fileName);
 			if(!masks[i].IsLoaded())
-				Logger::LogError("Failed to create collision mask for \"" + name + "\" frame #" + to_string(i));
+				Logger::LogError("Failed to create collision mask for " + fileName);
 		}
 	}
 

--- a/source/image/Mask.cpp
+++ b/source/image/Mask.cpp
@@ -26,17 +26,17 @@ using namespace std;
 
 namespace {
 	// Trace out outlines from an image frame.
-	void Trace(const ImageBuffer &image, int frame, vector<vector<Point>> &raw)
+	void Trace(const ImageBuffer &image, int frame, vector<vector<Point>> &raw, const string &fileName)
 	{
 		const uint32_t on = 0xFF000000;
 		const int width = image.Width();
 		const int height = image.Height();
 		const int numPixels = width * height;
 		const uint32_t *begin = image.Pixels() + frame * numPixels;
-		auto LogError = [width, height](string reason)
+		auto LogError = [width, height, fileName](string reason)
 		{
 			Logger::LogError("Unable to create mask for " + to_string(width) + "x" + to_string(height)
-				+ " px image: " + std::move(reason));
+				+ " px image " + fileName + ": " + std::move(reason));
 		};
 		raw.clear();
 
@@ -281,13 +281,13 @@ namespace {
 
 
 // Construct a mask from the alpha channel of an RGBA-formatted image.
-void Mask::Create(const ImageBuffer &image, int frame)
+void Mask::Create(const ImageBuffer &image, int frame, const string &fileName)
 {
 	outlines.clear();
 	radius = 0.;
 
 	vector<vector<Point>> raw;
-	Trace(image, frame, raw);
+	Trace(image, frame, raw, fileName);
 	if(raw.empty())
 		return;
 

--- a/source/image/Mask.h
+++ b/source/image/Mask.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "../Angle.h"
 #include "../Point.h"
 
+#include <string>
 #include <vector>
 
 class ImageBuffer;
@@ -32,7 +33,7 @@ class ImageBuffer;
 class Mask {
 public:
 	// Construct a mask from the alpha channel of an RGBA-formatted image.
-	void Create(const ImageBuffer &image, int frame = 0);
+	void Create(const ImageBuffer &image, int frame, const std::string &fileName);
 
 	// Check whether a mask was successfully generated from the image.
 	bool IsLoaded() const;


### PR DESCRIPTION
**Feature**

## Summary
Currently, if there are lone floating pixels in a ship or asteroid image, the game will output an error about that causing problems while creating the collision mask, but it will only include the dimensions of hte image nad the coordinates of the problematic pixels.
This PR adds the name of the image and the frame number to this message, to make it easier to find the offending file.

## Testing Done
Use a bad image.
Without this PR, get a message like:
`Unable to create mask for 60x60 px image: lone point found at (49, 27)`
With this PR, get a message like:
`Unable to create mask for 60x60 px image "ship/asteroid young 3" frame #0: lone point found at (49, 27)`
