### PR TITLE
feat(Balance): Reducing Autumn Leaf peacetime utility

### DIFF
--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -154,7 +154,7 @@ ship "Autumn Leaf"
 		"mass" 228
 		"drag" 3.5
 		"heat dissipation" .67
-		"fuel capacity" 600
+		"fuel capacity" 800
 		"cargo space" 35
 		"outfit space" 361
 		"weapon capacity" 103

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -150,12 +150,12 @@ ship "Autumn Leaf"
 		"shields" 18700
 		"hull" 7400
 		"required crew" 8
-		"bunks" 16
+		"bunks" 13
 		"mass" 228
 		"drag" 3.5
 		"heat dissipation" .67
-		"fuel capacity" 1000
-		"cargo space" 45
+		"fuel capacity" 600
+		"cargo space" 35
 		"outfit space" 361
 		"weapon capacity" 103
 		"engine capacity" 117


### PR DESCRIPTION
**Balance**

This PR addresses the bug/feature described in Discord by me.

## Summary
The Autumn Leaf is described as a wartime conversion of the Summer Leaf, but the Autumn Leaf currently functions better in a peacetime capacity than the Summer Leaf, with greater bunk, cargo, and fuel capacity than its less warlike counterpart. This PR makes the wartime conversion have logical drawbacks similar to [what has been proposed for the Heavy Gust](https://github.com/endless-sky/endless-sky/pull/10672).

This change better fits the Autumn Leaf into its lore as a warlike version of the Summer Leaf, and balance-wise gives the peacetime utility niche back to the Summer Leaf and introduces tradeoffs to this ship, which could otherwise make the Summer Leaf redundant in its role.

This PR changes:

1. Bunks to be slightly lower than the Summer Leaf (13 vs 15)
2. Fuel capacity to be the same as the Summer Leaf (800)
3. Cargo space to be less than the Summer Leaf (35 vs 41)
