### PR TITLE
fix(bug): remove duplicate log entry in mission `Boarding Ka'het`

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -31,7 +31,6 @@ mission "Disabled Ka'het"
 		government "Ka'het" "Ka'het (Infighting)"
 	destination "Earth"
 	on offer
-		log "Successfully boarded a Ka'het. It appears to be a single, ship-sized organism that can travel in space using a special exoskeleton."
 		conversation
 
 			branch "boarded aberrant"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on Discord

## Summary
See the title.

## Testing Done
None.