### PR TITLE
fix(code): Fix a misplaced bracket in AI::MoveToAttack

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2825,7 +2825,7 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 	if(facing < -.75 && ship.Attributes().Get("reverse thrust"))
 		command |= Command::BACK;
 	// Only apply thrust if either:
-	// This ship is within 90° degrees of facing towards its target and far enough away not to overshoot
+	// This ship is within 90 degrees of facing towards its target and far enough away not to overshoot
 	// if it accelerates while needing to turn further, or:
 	// This ship is moving away from its target but facing mostly towards it.
 	else if((facing >= 0. && direction.Length() > diameter)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2826,8 +2826,7 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 		command |= Command::BACK;
 	// This isn't perfect, but it works well enough.
 	else if((facing >= 0. && direction.Length() > diameter)
-			|| (ship.Velocity().Dot(direction) < 0. &&
-				facing) >= .9)
+			|| (ship.Velocity().Dot(direction) < 0. && facing >= .9))
 		command |= Command::FORWARD;
 
 	// Use an equipped afterburner if possible.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2824,7 +2824,10 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 	// use them to reach the target more quickly.
 	if(facing < -.75 && ship.Attributes().Get("reverse thrust"))
 		command |= Command::BACK;
-	// This isn't perfect, but it works well enough.
+	// Only apply thrust if either:
+	// This ship is within 90° degrees of facing towards its target and far enough away not to overshoot
+	// if it accelerates while needing to turn further, or:
+	// This ship is moving away from its target but facing mostly towards it.
 	else if((facing >= 0. && direction.Length() > diameter)
 			|| (ship.Velocity().Dot(direction) < 0. && facing >= .9))
 		command |= Command::FORWARD;


### PR DESCRIPTION
**Bug fix**

Thanks to @TomGoodIdea for pointing this out on Discord.

## Summary
This expression currently compares a boolean value to 0.9, which is fairly non-sensical.
This is the result of a bracket being misplaced in a previous modification of this code.
This PR moves the bracket to the correct position so that the value compared to 0.9 is the dot product of this ship's current facing direction and the direction to the target, that is, it is checking if this ship is facing mostly towards its target (within approximately 26°).
I don't know how much of an impact this will have on actual AI behaviour, but I expect it might help some ships turn back towards their targets faster, instead of potentially accelerating away from their target after flying past it, which the current code allows.

I've also combined two lines because they come in well below even 80 characters and it is much easier to read this way.

Also, updates a comment to provide a description of what is happening because it might be difficult to figure out if you don't know maths, or even if you do.

## Testing Done
None.

## Performance Impact
Immeasurable, I expect.
