### PR TITLE
fix(jobs-code): Allow jobs to fail themselves on offer or accept

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2127,10 +2127,12 @@ void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 		if(&*it == &mission)
 		{
 			cargo.AddMissionCargo(&mission);
-			it->Do(Mission::OFFER, *this);
-			it->Do(Mission::ACCEPT, *this, ui);
 			auto spliceIt = it->IsUnique() ? missions.begin() : missions.end();
 			missions.splice(spliceIt, availableJobs, it);
+			it->Do(Mission::OFFER, *this);
+			it->Do(Mission::ACCEPT, *this, ui);
+			if(it->IsFailed(*this))
+				RemoveMission(Mission::Trigger::FAIL, *it, ui);
 			SortAvailable(); // Might not have cargo anymore, so some jobs can be sorted to end
 			break;
 		}


### PR DESCRIPTION
**Bug fix**

Thanks to etherdais for reporting this on Discord.

## Summary
The Heliarch jump drive jobs expect to fail themselves upon being acceptance, thus not appearing in the mission list.
However, the way a mission failing itself works, it only occurs if the mission is already in the player's active missions list.
A job being accepted is not there until the offer and accept actions have been executed, and therefore, when the job tries to fail itself, it does not succeed because it does not appear to be active.
This PR modifies this process so that a job being accepted is moved to the active missions list before these two actions are executed. Immediately after these actions have been executed, the game will check if hte job is failed and, if it is, removes it.

## Usage examples
```
mission "Whatever"
    job
    on offer
        fail
mission "Whateverer"
    job
    on accept
        fail
```

## Testing Done
With the attached save file, visit the job board and accept the job to sell a jump drive to the Heliarchs.
Without this PR, after closing the pop up dialog, the mission appears in the active mission list, unfailed. This is not the intended effect. You will need to take off and land here again to get it to disappear, or abort it.
With this PR, the mission is not in the list.

## Save File
This save file can be used to test these changes:
[warpest core heliarch jump drive testing~3021-04-01.txt](https://github.com/user-attachments/files/18987618/warpest.core.heliarch.jump.drive.testing.3021-04-01.txt)

## Wiki Update
Probably not necessary.

## Performance Impact
Immeasurable
