### PR TITLE
Hai Legacy: tweak according to player feedback

### DIFF
--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -95,7 +95,7 @@ mission "Hai Legacy 1"
 					decline
 			label first
 			`As you're browsing the shipyard, you are discreetly approached by a hooded figure. When you stop to see what they want to say, they grab and pull on your arm to follow them. "Keep walking," the stranger hisses. After pointing at and commenting on random ships, as if to mimic the actions of a regular passerby, they address you again.`
-			`	"My associates and I have a lucrative business proposition for you. If you are interested, come find us at these coordinates." Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`
+			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates." Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`
 			branch continue
 				"credits" >= 10000000
 			`	However, the paper also mentions you need to have at least ten million credits in cash! You'll have to save up or take a loan and then come back another day before heading to the specified location.`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -98,7 +98,7 @@ mission "Hai Legacy 1"
 			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates."`
 			`	Glancing over at your fleet on the nearby landing pad, they add, "It's a solitary affair -- make sure you can park most of your ships."`
 				to display
-					has "total ships" > 1
+					"total ships" > 1
 			`	Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`
 			branch continue
 				"credits" >= 10000000

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -363,7 +363,7 @@ mission "Hai Legacy 3"
 			`As you enter the system you can see your challenger is indeed waiting for you, and they promptly send you a hail. "Show us what you've got, monkey! Show us that you control your weapons well, as any warrior should! Prove to us that you have the strength to disable our ships, yet still have the restraint not to destroy them!"`
 				accept
 			label "too many ships"
-			`As you take off to join your fleet in orbit, you receive a hail from the Unfettered. "If you can't even count how many ships you have, you're not worthy of our time, monkey! Dishonor will get you nowhere with us True Hai!"`
+			`As you arrive with your fleet in this system, you receive a hail from the Unfettered. "If you can't even count how many ships you have, you're not worthy of our time, monkey! Dishonor will get you nowhere with us True Hai!"`
 				goto failed
 			label anomaly
 			`You are hailed by the Unfettered as soon as you reach orbit. "You think us blind, monkey? That is not the relic! You're not even worth a launch sequence."`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -96,7 +96,7 @@ mission "Hai Legacy 1"
 			label first
 			`As you're browsing the shipyard, you are discreetly approached by a hooded figure. When you stop to see what they want to say, they grab and pull on your arm to follow them. "Keep walking," the stranger hisses. After pointing at and commenting on random ships, as if to mimic the actions of a regular passerby, they address you again.`
 			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates."`
-			`	"We note you operate multiple ships, however, this is a solitary affair; make sure you can park most of your ships."`
+			`	"We note you operate multiple ships. However, this is a solitary affair; make sure you can park most of your ships."`
 				to display
 					"total ships" > 1
 			`	Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -96,7 +96,7 @@ mission "Hai Legacy 1"
 			label first
 			`As you're browsing the shipyard, you are discreetly approached by a hooded figure. When you stop to see what they want to say, they grab and pull on your arm to follow them. "Keep walking," the stranger hisses. After pointing at and commenting on random ships, as if to mimic the actions of a regular passerby, they address you again.`
 			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates."`
-			`	"We note you operate multiple ships. However, this is a solitary affair; make sure you can park most of your ships."`
+			`	Just before leaving they add, "We note you operate multiple ships. However, this is a solitary affair; make sure you can park most of your ships."`
 				to display
 					"total ships" > 1
 			`	Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`
@@ -227,6 +227,7 @@ mission "Hai Legacy 1"
 		clear "unfettered: ocean dialog"
 		clear "unfettered: pilot dialog"
 		log "Accepted a somewhat shady deal for an old Hai ship called an Anomalocaris. It seems to still be in a good enough state to fly."
+		fail
 
 
 

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -74,7 +74,7 @@ mission "Hai Legacy 1"
 	invisible
 	shipyard
 	source "Hai-home"
-	destination "Firelode"
+	destination "Darkcloak"
 	clearance
 	to offer
 		has "First Contact: Unfettered: offered"
@@ -239,12 +239,12 @@ mission "Hai Legacy 2"
 	deadline 7
 	cargo "food (aid)" 121
 	source "Hai-home"
-	destination "Firelode"
+	destination "Darkcloak"
 	to offer
 		not "Hai Legacy 1: declined"
 		has "First Contact: Unfettered: offered"
 		"reputation: Hai (Unfettered)" < 0
-		not "Unfettered Jump Drive 1: offered"
+		not "Unfettered Jump Drive 2: offered"
 		"credits" >= 10000000
 	to accept
 		has "ship model: Anomalocaris"
@@ -278,9 +278,11 @@ mission "Hai Legacy 2"
 
 mission "Hai Legacy 3"
 	landing
+	deadline 2
 	name "Ancient Claim"
-	description "Defeat the Unfettered challenger in combat. You only have one day, and becoming disabled will result in losing the fight."
-	source "Firelode"
+	description "Defeat the Unfettered challenger in combat in the system of <system>. You only have 2 days, and becoming disabled will result in losing the fight."
+	source "Darkcloak"
+	destination "Firelode"
 	to offer
 		has "Hai Legacy 2: done"
 		has "ship model: Anomalocaris"
@@ -322,7 +324,7 @@ mission "Hai Legacy 3"
 			`	He then looks at you intensely, straight in the eyes. "We sometimes bend the rules for our friends, but that is not the case with you."`
 				to display
 					"reputation: Hai (Unfettered)" < -1500
-			`	Mera starts to look a bit impatient. "Are you going to talk all day, or are you going to fight?" The Unfettered pilots immediately head to their ships, but Mera pulls you in close once they are far enough away. "I want this done by the end of the day, so do not try my patience. You are lucky I offered this deal in the first place, as they were planning to take the relic by force. Now, quick, get to your ship!"`
+			`	Mera starts to look a bit impatient. "Are you going to talk all day, or are you going to fight? Head to Ehma Ti already!" The Unfettered immediately head to their ships, but Mera pulls you in close once they are far enough away. "I want this done by the end of the day, so do not try my patience. You are lucky I offered this deal in the first place, as they were planning to take the relic by force. Now, quick, get to your ship! Make any last minute modifications you may need, and then come fight us."`
 			`	You see the Unfettered have already begun their launching procedures, so you should prepare for takeoff in your Anomalocaris, and no other ships, as soon as you can.`
 				accept
 			label fleeing
@@ -339,13 +341,27 @@ mission "Hai Legacy 3"
 				"total ships" > 1
 			branch anomaly
 				not "flagship model: Anomalocaris"
-			`As you leave the planet's atmosphere, you see your challenger already waiting for you in the system, and they send you a hail as soon as you are in space. "Show us what you've got, monkey! Show us that you control your weapons well, as any warrior should! Prove to us that you have the strength to disable our ships, yet still have the restraint not to destroy them!"`
+			`As you leave the planet's atmosphere, you receive a short message. "We are waiting for you in Ehma Ti today, do not disapoint us."`
 				accept
 			label fleeing
 			action
 				fail
 			`The Unfettered don't seem too pleased to see you leaving with their prize. The challenger is already waiting for you in orbit, and hails you. "Where do you think you're going, monkey?"`
 				decline
+			label "too many ships"
+			`As you take off to join your fleet in orbit, you receive a hail from the Unfettered. "You must leave your fleet on hold here. If they help you, the duel will be forfeit!"`
+				decline
+			label anomaly
+			`You are hailed by the Unfettered as soon as you reach orbit. "You think us blind, monkey? That is not the relic! You're not even worth a launch sequence."`
+			action
+				"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
+				fail
+	on enter "Ehma Ti"
+		conversation
+			branch "too many ships"
+				"total ships" > 1
+			`As you enter the system you can see your challenger is indeed waiting for you, and they promptly send you a hail. "Show us what you've got, monkey! Show us that you control your weapons well, as any warrior should! Prove to us that you have the strength to disable our ships, yet still have the restraint not to destroy them!"`
+				accept
 			label "too many ships"
 			`As you take off to join your fleet in orbit, you receive a hail from the Unfettered. "If you can't even count how many ships you have, you're not worthy of our time, monkey! Dishonor will get you nowhere with us True Hai!"`
 				goto failed
@@ -355,10 +371,10 @@ mission "Hai Legacy 3"
 			action
 				"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
 				fail
-	on enter
+	on enter "Hi Yahr" "Wah Ki" "Zuba Zub" "Bore Fah"
 		"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
 		fail
-		dialog `You receive a hail from the Unfettered. "You failed to complete the duel, and as such, you will not enjoy unwarranted respect any longer! It would be in your best interest to return the ship to us should we ever find you on our worlds again!`
+		dialog `You receive a hail from the Unfettered. "You ran away and failed to complete the duel. As such, you will not enjoy unwarranted respect any longer! It would be in your best interest to return the ship to us should we ever find you on our worlds again!`
 	on disabled
 		fail
 		dialog
@@ -379,6 +395,7 @@ mission "Hai Legacy 3"
 			"old reputation: Hai (Unfettered)" >= -1500
 		personality disables heroic plunders staying target unconstrained
 		ship "Sea Scorpion (Ionic Blasters)" "Thunder Struck"
+		system "Ehma Ti"
 		on kill
 			dialog `You receive a hail from Mera, who sounds quite angry. "Destroying the ship can only be due to either incompetence or evil intent, and we will not tolerate either!"`
 			"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
@@ -393,6 +410,7 @@ mission "Hai Legacy 3"
 			"old reputation: Hai (Unfettered)" < -1500
 		personality heroic mute plunders target unconstrained
 		ship "Shield Beetle (Tripulse Ionic Turret)" "Requiem"
+		system "Ehma Ti"
 		on kill
 			dialog `You receive a hail from Mera, who sounds quite angry. "Destroying the ship can only be due to either incompetence or evil intent, and we will not tolerate either!"`
 			"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
@@ -403,6 +421,7 @@ mission "Hai Legacy 3"
 		to spawn
 			not "unfettered: fled with the relic"
 		ship "Lightning Bug (Unfettered Shipyards)" "Dungeon Master"
+		system "Ehma Ti"
 		personality launching pacifist staying uninterested
 		on disable
 			dialog `Mera hails you. "Stop! I am only here as an observer. If you destroy my ship, the deal is off!"`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -341,7 +341,7 @@ mission "Hai Legacy 3"
 				"total ships" > 1
 			branch anomaly
 				not "flagship model: Anomalocaris"
-			`As you leave the planet's atmosphere, you receive a short message. "We are waiting for you in Ehma Ti today, do not disapoint us."`
+			`As you leave the planet's atmosphere, you receive a short message. "We are waiting for you in Ehma Ti today, do not disappoint us."`
 				accept
 			label fleeing
 			action

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -400,7 +400,7 @@ mission "Hai Legacy 3"
 			dialog `You receive a hail from Mera, who sounds quite angry. "Destroying the ship can only be due to either incompetence or evil intent, and we will not tolerate either!"`
 			"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
 			fail
-		dialog `You receive a message from the Unfettered ship. "We surrender. If you land now, you will receive your reward."`
+		dialog `You receive a message from the Unfettered ship. "We surrender. Land on Firelode to receive your reward."`
 	npc disable
 		government "Hai (Unfettered Challenger)"
 		to spawn
@@ -415,7 +415,7 @@ mission "Hai Legacy 3"
 			dialog `You receive a hail from Mera, who sounds quite angry. "Destroying the ship can only be due to either incompetence or evil intent, and we will not tolerate either!"`
 			"reputation: Hai (Unfettered)" = "old reputation: Hai (Unfettered)"
 			fail
-		dialog `You have managed to defeat the Unfettered challenger. Now it's time to land and claim your reward.`
+		dialog `You have managed to defeat the Unfettered challenger. Now it's time to land on Firelode and claim your reward.`
 	npc
 		government "Hai (Unfettered)"
 		to spawn

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -341,7 +341,7 @@ mission "Hai Legacy 3"
 				"total ships" > 1
 			branch anomaly
 				not "flagship model: Anomalocaris"
-			`As you leave the planet's atmosphere, you receive a short message. "We are waiting for you in Ehma Ti today, do not disappoint us."`
+			`As you leave the planet's atmosphere, you receive a short message. "We are waiting for you in Ehma Ti today. Do not disappoint us."`
 				accept
 			label fleeing
 			action

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -95,7 +95,11 @@ mission "Hai Legacy 1"
 					decline
 			label first
 			`As you're browsing the shipyard, you are discreetly approached by a hooded figure. When you stop to see what they want to say, they grab and pull on your arm to follow them. "Keep walking," the stranger hisses. After pointing at and commenting on random ships, as if to mimic the actions of a regular passerby, they address you again.`
-			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates." Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`
+			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates."`
+			`	Glancing over at your fleet on the nearby landing pad, they add, "It's a solitary affair -- make sure you can park most of your ships."`
+				to display
+					has "total ships" > 1
+			`	Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`
 			branch continue
 				"credits" >= 10000000
 			`	However, the paper also mentions you need to have at least ten million credits in cash! You'll have to save up or take a loan and then come back another day before heading to the specified location.`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -96,7 +96,7 @@ mission "Hai Legacy 1"
 			label first
 			`As you're browsing the shipyard, you are discreetly approached by a hooded figure. When you stop to see what they want to say, they grab and pull on your arm to follow them. "Keep walking," the stranger hisses. After pointing at and commenting on random ships, as if to mimic the actions of a regular passerby, they address you again.`
 			`	"My associates and I have a lucrative business proposition for you. It will require your undivided attention, so you would do well to finish any ongoing business first. If you are interested, come find us at these coordinates."`
-			`	Glancing over at your fleet on the nearby landing pad, they add, "It's a solitary affair -- make sure you can park most of your ships."`
+			`	"We note you operate multiple ships, however, this is a solitary affair; make sure you can park most of your ships."`
 				to display
 					"total ships" > 1
 			`	Without waiting for a response, they fold a piece of paper into your hand before quickly fading into the crowd. It lists only a location, and if you cross-reference it with the local maps, it appears to point towards a beach on the other side of the planet.`


### PR DESCRIPTION
**Content (Mission Addition)**

This PR addresses an issue mentioned on discord.

## Summary
Hai Legacy is a unique mission in that it requires you to not have your fleet with you for the fight.
Considering that, I think it makes sense to add a small warning at the start to make sure players don't take it with a full cargo hold and many passengers.

~~Note that they could always make their fleets hold position in another system but that's a bit much to ask.~~
I updated the fight to still happen in Ehma Ti but have you land on Darkcloak to reoutfit the ships and leave the fleet on hold there.

## Save file
Launch, land and go to the shipyard to start the mission.
[Intrepid.Enterprise.txt](https://github.com/user-attachments/files/19151752/Intrepid.Enterprise.txt)