### PR TITLE
fix(bug): add missing passenger to Remnant: Cognizance 21

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -782,7 +782,7 @@ mission "Remnant: Cognizance 21"
 		government "Remnant"
 		attributes "remnant primary"
 	stopover "Ssil Vida"
-	blocked "You need 10 free space and a Research Laboratory for this mission."
+	blocked "You need 10 free space, five free bunks, and a Research Laboratory for this mission."
 	passengers 5
 	cargo "supplies" 10
 	to offer

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -783,6 +783,7 @@ mission "Remnant: Cognizance 21"
 		attributes "remnant primary"
 	stopover "Ssil Vida"
 	blocked "You need 10 free space and a Research Laboratory for this mission."
+	passengers 5
 	cargo "supplies" 10
 	to offer
 		has "Remnant: Cognizance 20: done"


### PR DESCRIPTION
**Bug fix**

Fixes #10608.

## Summary
Added a missing `passengers` line to `Remnant: Cognizance 21`
This number (5) was inferred from a mission or two before.