### PR TITLE
feat(content): Culture Conversation for native life on Glaze

### DIFF
--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -846,29 +846,32 @@ mission "Republic 300 Year Anniversary"
 			`	Web comments and news anchors seem to be particularly excited to comment on the recent victory of the Navy over the mysterious armada of robotic warships that invaded the Far North. Though at a great cost to the northern fleet garrisons, the invading fleets were successfully stopped at the Farpoint base, preventing the ships from causing any further harm. Veterans of the Farpoint battle seem to be hoarding the spotlight, giving emotional reports of their memory of the fight, and of the sacrifices they went through to achieve victory.`
 				goto end
 
-mission "Exotic Animals - Glaze"
+mission "Exotic Life: Glaze"
 	minor
 	source Glaze
 	to offer
 		random < 10
+		or
+			not "chosen sides"
+			has "main plot completed"
 	on offer
 		conversation
-			`You step to the edge of the mesa from the spaceport, the wind blowing as you take in the view. The canyons stretch out before you, a maze of red and gold stone, their depths lost in shadow. Far in the distance, something moves -- small figures, barely more than specks, making their way through one of the ravines. You squint, but the details remain elusive.`
-			`	Nearby, a weathered set of credit-operated binoculars stands bolted to the ground, a faded sign above them reading: 5 credits per use.`
+			`You step to the edge of the mesa from the spaceport, the wind blowing as you take in the view. The canyons stretch out before you, a maze of red and gold stone, their depths lost in shadow. Far in the distance, something moves - small figures, barely more than specks, making their way through one of the ravines. You squint, but the details remain elusive.`
+			`	Nearby, a weathered set of credit-operated binoculars stands bolted to the ground, a faded sign above them reading: 1 credit per use.`
 			choice
-				`	(Take a closer look for 5 credits.)`
+				`	(Take a closer look for 1 credits.)`
 					to display
-						credits >= 5
+						credits >= 1
 				`	(Ignore the specks and return to your ship.)`
 					to display
-						credits >= 5
+						credits >= 1
 					goto closing
-				`	(Pat your empty pockets. Return to your ship as you can't even afford the 5 credits.)`
+				`	(Pat your empty pockets. Return to your ship as you can't even afford the 1 credit fee.)`
 					to display
-						credits < 5
+						credits < 1
 					goto closing
 			action
-				payment -5
+				payment -1
 			branch norareapes
 				random > 20
 			`	The binoculars hum as you focus in on the figures, expecting hikers. But what you see is something else entirely. A small group of shaggy, long-limbed creatures moves carefully through the canyon. Their fur is the same hue as the sandstone, blending almost perfectly with the terrain. They walk on two legs, but with a hunched, cautious gait, pausing often to glance around before continuing.`
@@ -878,7 +881,7 @@ mission "Exotic Animals - Glaze"
 				`	(Return to your ship.)`
 					goto closing
 			label norareapes
-			`	Curiosity gets the better of you, and you pay 5 credits to the machine. The binoculars whir softly as they adjust, bringing the distant canyon into focus. A group of brightly dressed tourists walks along a winding trail, pointing at rock formations and stopping to take photos. One of them waves excitedly at something -- maybe an unseen guide explaining the landscape.`
+			`	Curiosity gets the better of you, and you pay a credit to the machine. The binoculars whir softly as they adjust, bringing the distant canyon into focus. A group of brightly dressed tourists walks along a winding trail, pointing at rock formations and stopping to take photos. One of them waves excitedly at something -- maybe an unseen guide explaining the landscape.`
 			`	Just another tour group exploring the canyons. You step back from the binoculars with a small chuckle.`
 			label closing
 			`	You walk back to your ship from the binoculars.`

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -868,7 +868,7 @@ mission "Exotic Animals - Glaze"
 						credits < 5
 					goto closing
 			action
-				payment -5			
+				payment -5
 			branch norareapes
 				random > 20
 			`	The binoculars hum as you focus in on the figures, expecting hikers. But what you see is something else entirely. A small group of shaggy, long-limbed creatures moves carefully through the canyon. Their fur is the same hue as the sandstone, blending almost perfectly with the terrain. They walk on two legs, but with a hunched, cautious gait, pausing often to glance around before continuing.`

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -845,3 +845,41 @@ mission "Republic 300 Year Anniversary"
 			label "sestor beaten at farpoint"
 			`	Web comments and news anchors seem to be particularly excited to comment on the recent victory of the Navy over the mysterious armada of robotic warships that invaded the Far North. Though at a great cost to the northern fleet garrisons, the invading fleets were successfully stopped at the Farpoint base, preventing the ships from causing any further harm. Veterans of the Farpoint battle seem to be hoarding the spotlight, giving emotional reports of their memory of the fight, and of the sacrifices they went through to achieve victory.`
 				goto end
+
+mission "Exotic Animals - Glaze"
+	minor
+	source Glaze
+	to offer
+		random < 10
+	on offer
+		conversation
+			`You step to the edge of the mesa from the spaceport, the wind blowing as you take in the view. The canyons stretch out before you, a maze of red and gold stone, their depths lost in shadow. Far in the distance, something moves -- small figures, barely more than specks, making their way through one of the ravines. You squint, but the details remain elusive.`
+			`	Nearby, a weathered set of credit-operated binoculars stands bolted to the ground, a faded sign above them reading: 5 credits per use.`
+			choice
+				`	(Take a closer look for 5 credits.)`
+					to display
+						credits >= 5
+				`	(Ignore the specks and return to your ship.)`
+					to display
+						credits >= 5
+					goto closing
+				`	(Pat your empty pockets. Return to your ship as you can't even afford the 5 credits.)`
+					to display
+						credits < 5
+					goto closing
+			action
+				payment -5			
+			branch norareapes
+				random > 20
+			`	The binoculars hum as you focus in on the figures, expecting hikers. But what you see is something else entirely. A small group of shaggy, long-limbed creatures moves carefully through the canyon. Their fur is the same hue as the sandstone, blending almost perfectly with the terrain. They walk on two legs, but with a hunched, cautious gait, pausing often to glance around before continuing.`
+			`	One of them stops near a boulder, kneeling to scoop up a handful of dust and let it run through its fingers, as if testing the wind. Another lingers behind the rest, turning its head slightly, as if listening for something. There are no signs of tools or fire, certainly nothing to suggest the 'canyon people' of local legend -- but there's an undeniable sense of awareness in the way they move and seem to belong to the landscape itself.`
+			`	After a long moment, they disappear behind a ridge, blending so seamlessly into the terrain that it's hard to tell if they were ever there at all. You step back from the binoculars, the last glimpse of them lingering in your mind.`
+			choice
+				`	(Return to your ship.)`
+					goto closing
+			label norareapes
+			`	Curiosity gets the better of you, and you pay 5 credits to the machine. The binoculars whir softly as they adjust, bringing the distant canyon into focus. A group of brightly dressed tourists walks along a winding trail, pointing at rock formations and stopping to take photos. One of them waves excitedly at something -- maybe an unseen guide explaining the landscape.`
+			`	Just another tour group exploring the canyons. You step back from the binoculars with a small chuckle.`
+			label closing
+			`	You walk back to your ship from the binoculars.`
+				decline

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -847,6 +847,7 @@ mission "Republic 300 Year Anniversary"
 				goto end
 
 mission "Exotic Life: Glaze"
+	repeat
 	minor
 	source Glaze
 	to offer
@@ -854,6 +855,8 @@ mission "Exotic Life: Glaze"
 		or
 			not "chosen sides"
 			has "main plot completed"
+		and
+			not "exotic life: seen glaze apes"
 	on offer
 		conversation
 			`You step to the edge of the mesa from the spaceport, the wind blowing as you take in the view. The canyons stretch out before you, a maze of red and gold stone, their depths lost in shadow. Far in the distance, something moves - small figures, barely more than specks, making their way through one of the ravines. You squint, but the details remain elusive.`
@@ -873,9 +876,11 @@ mission "Exotic Life: Glaze"
 			action
 				payment -1
 			branch norareapes
-				random > 20
+				random < 20
 			`	The binoculars hum as you focus in on the figures, expecting hikers. But what you see is something else entirely. A small group of shaggy, long-limbed creatures moves carefully through the canyon. Their fur is the same hue as the sandstone, blending almost perfectly with the terrain. They walk on two legs, but with a hunched, cautious gait, pausing often to glance around before continuing.`
 			`	One of them stops near a boulder, kneeling to scoop up a handful of dust and let it run through its fingers, as if testing the wind. Another lingers behind the rest, turning its head slightly, as if listening for something. There are no signs of tools or fire, certainly nothing to suggest the 'canyon people' of local legend -- but there's an undeniable sense of awareness in the way they move and seem to belong to the landscape itself.`
+			action
+					set "exotic life: seen glaze apes"
 			`	After a long moment, they disappear behind a ridge, blending so seamlessly into the terrain that it's hard to tell if they were ever there at all. You step back from the binoculars, the last glimpse of them lingering in your mind.`
 			choice
 				`	(Return to your ship.)`

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -862,7 +862,7 @@ mission "Exotic Life: Glaze"
 			`You step to the edge of the mesa from the spaceport, the wind blowing as you take in the view. The canyons stretch out before you, a maze of red and gold stone, their depths lost in shadow. Far in the distance, something moves - small figures, barely more than specks, making their way through one of the ravines. You squint, but the details remain elusive.`
 			`	Nearby, a weathered set of credit-operated binoculars stands bolted to the ground, a faded sign above them reading: 1 credit per use.`
 			choice
-				`	(Take a closer look for 1 credits.)`
+				`	(Take a closer look for 1 credit.)`
 					to display
 						credits >= 1
 				`	(Ignore the specks and return to your ship.)`

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -855,8 +855,7 @@ mission "Exotic Life: Glaze"
 		or
 			not "chosen sides"
 			has "main plot completed"
-		and
-			not "exotic life: seen glaze apes"
+		not "exotic life: seen glaze apes"
 	on offer
 		conversation
 			`You step to the edge of the mesa from the spaceport, the wind blowing as you take in the view. The canyons stretch out before you, a maze of red and gold stone, their depths lost in shadow. Far in the distance, something moves - small figures, barely more than specks, making their way through one of the ravines. You squint, but the details remain elusive.`
@@ -878,9 +877,9 @@ mission "Exotic Life: Glaze"
 			branch norareapes
 				random < 20
 			`	The binoculars hum as you focus in on the figures, expecting hikers. But what you see is something else entirely. A small group of shaggy, long-limbed creatures moves carefully through the canyon. Their fur is the same hue as the sandstone, blending almost perfectly with the terrain. They walk on two legs, but with a hunched, cautious gait, pausing often to glance around before continuing.`
-			`	One of them stops near a boulder, kneeling to scoop up a handful of dust and let it run through its fingers, as if testing the wind. Another lingers behind the rest, turning its head slightly, as if listening for something. There are no signs of tools or fire, certainly nothing to suggest the 'canyon people' of local legend -- but there's an undeniable sense of awareness in the way they move and seem to belong to the landscape itself.`
+			`	One of them stops near a boulder, kneeling to scoop up a handful of dust and let it run through its fingers, as if testing the wind. Another lingers behind the rest, turning its head slightly, as if listening for something. There are no signs of tools or fire, certainly nothing to suggest the "canyon people" of local legend -- but there's an undeniable sense of awareness in the way they move and seem to belong to the landscape itself.`
 			action
-					set "exotic life: seen glaze apes"
+				set "exotic life: seen glaze apes"
 			`	After a long moment, they disappear behind a ridge, blending so seamlessly into the terrain that it's hard to tell if they were ever there at all. You step back from the binoculars, the last glimpse of them lingering in your mind.`
 			choice
 				`	(Return to your ship.)`

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -864,11 +864,11 @@ mission "Exotic Life: Glaze"
 				`	(Take a closer look for 1 credit.)`
 					to display
 						credits >= 1
-				`	(Ignore the specks and return to your ship.)`
+				`	(Ignore the specks and return to my ship.)`
 					to display
 						credits >= 1
 					goto closing
-				`	(Pat your empty pockets. Return to your ship as you can't even afford the 1 credit fee.)`
+				`	(Pat my empty pockets and return to my ship as I can't even afford the 1 credit fee.)`
 					to display
 						credits < 1
 					goto closing
@@ -877,7 +877,7 @@ mission "Exotic Life: Glaze"
 			branch norareapes
 				random < 20
 			`	The binoculars hum as you focus in on the figures, expecting hikers. But what you see is something else entirely. A small group of shaggy, long-limbed creatures moves carefully through the canyon. Their fur is the same hue as the sandstone, blending almost perfectly with the terrain. They walk on two legs, but with a hunched, cautious gait, pausing often to glance around before continuing.`
-			`	One of them stops near a boulder, kneeling to scoop up a handful of dust and let it run through its fingers, as if testing the wind. Another lingers behind the rest, turning its head slightly, as if listening for something. There are no signs of tools or fire, certainly nothing to suggest the "canyon people" of local legend -- but there's an undeniable sense of awareness in the way they move and seem to belong to the landscape itself.`
+			`	One of them stops near a boulder, kneeling to scoop up a handful of dust and let it run through its fingers, as if testing the wind. Another lingers behind the rest, turning its head slightly, perhaps listening for something. There are no signs of tools or fire, certainly nothing to suggest the "canyon people" of local legend - but there's an undeniable sense of awareness in the way they move and seem to belong to the landscape itself.`
 			action
 				set "exotic life: seen glaze apes"
 			`	After a long moment, they disappear behind a ridge, blending so seamlessly into the terrain that it's hard to tell if they were ever there at all. You step back from the binoculars, the last glimpse of them lingering in your mind.`


### PR DESCRIPTION
**Content (Missions)**

This PR addresses the bug/feature described in issue #10659. ~~I originally said I'd get the ball rolling in a week but time is an illusion.~~

## Summary
opusforlife2 shared in the issue that there aren't many cases of getting to see exotic organisms native to the many livable planets in the game. I agree, and this culture conversation starts to expand that by giving the player a chance to see the `reclusive ape-like` `"canyon people"` already stated to live on Glaze (or just a bunch of tourists). 

I also plan to make at least a couple more exotic organism culture conversations in a similar vein to expand out the scope of alien life in Endless Sky.

## Testing Done
Played through the mission

## Save File
TBD
