### PR TITLE
Successor, Avgi afterburners zoom with engine scale

### DIFF
--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -388,12 +388,14 @@ effect "small remass injection"
 		"scale" 0.75
 	sound "flamethrower"
 	"sound category" "afterburner"
+	zoom
 
 effect "medium remass injection"
 	sprite "effect/avgi flare/remass"
 		"frame rate" 30
 	sound "flamethrower"
 	"sound category" "afterburner"
+	zoom
 
 effect "large remass injection"
 	sprite "effect/avgi flare/remass"
@@ -401,6 +403,7 @@ effect "large remass injection"
 		"scale" 2
 	sound "flamethrower"
 	"sound category" "afterburner"
+	zoom
 
 
 outfit "Remass Injector"

--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -386,24 +386,24 @@ effect "small remass injection"
 	sprite "effect/avgi flare/remass"
 		"frame rate" 30
 		"scale" 0.75
+	zooms
 	sound "flamethrower"
 	"sound category" "afterburner"
-	zooms
 
 effect "medium remass injection"
 	sprite "effect/avgi flare/remass"
 		"frame rate" 30
+	zooms
 	sound "flamethrower"
 	"sound category" "afterburner"
-	zooms
 
 effect "large remass injection"
 	sprite "effect/avgi flare/remass"
 		"frame rate" 30
 		"scale" 2
+	zooms
 	sound "flamethrower"
 	"sound category" "afterburner"
-	zooms
 
 
 outfit "Remass Injector"

--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -388,14 +388,14 @@ effect "small remass injection"
 		"scale" 0.75
 	sound "flamethrower"
 	"sound category" "afterburner"
-	zoom
+	zooms
 
 effect "medium remass injection"
 	sprite "effect/avgi flare/remass"
 		"frame rate" 30
 	sound "flamethrower"
 	"sound category" "afterburner"
-	zoom
+	zooms
 
 effect "large remass injection"
 	sprite "effect/avgi flare/remass"
@@ -403,7 +403,7 @@ effect "large remass injection"
 		"scale" 2
 	sound "flamethrower"
 	"sound category" "afterburner"
-	zoom
+	zooms
 
 
 outfit "Remass Injector"

--- a/data/successors/successor outfits.txt
+++ b/data/successors/successor outfits.txt
@@ -609,33 +609,33 @@ effect "tiny successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
 		"frame rate" 20
 		"scale" 0.20
+	zooms
 	sound "successor afterburner tiny"
 	"sound category" "afterburner"
 	lifetime 1
-	zooms
 
 effect "small successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
 		"frame rate" 20
 		"scale" 0.36
+	zooms
 	sound "successor afterburner small"
 	"sound category" "afterburner"
 	lifetime 1
-	zooms
 
 effect "medium successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
 		"frame rate" 20
 		"scale" 0.6
+	zooms
 	sound "successor afterburner medium"
 	"sound category" "afterburner"
 	lifetime 1
-	zooms
 
 effect "large successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
 		"frame rate" 20
+	zooms
 	sound "successor afterburner large"
 	"sound category" "afterburner"
 	lifetime 1
-	zooms

--- a/data/successors/successor outfits.txt
+++ b/data/successors/successor outfits.txt
@@ -612,6 +612,7 @@ effect "tiny successor afterburner"
 	sound "successor afterburner tiny"
 	"sound category" "afterburner"
 	lifetime 1
+	zooms
 
 effect "small successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
@@ -620,6 +621,7 @@ effect "small successor afterburner"
 	sound "successor afterburner small"
 	"sound category" "afterburner"
 	lifetime 1
+	zooms
 
 effect "medium successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
@@ -628,6 +630,7 @@ effect "medium successor afterburner"
 	sound "successor afterburner medium"
 	"sound category" "afterburner"
 	lifetime 1
+	zooms
 
 effect "large successor afterburner"
 	sprite "effect/successor flare/afterburner/afterburner"
@@ -635,3 +638,4 @@ effect "large successor afterburner"
 	sound "successor afterburner large"
 	"sound category" "afterburner"
 	lifetime 1
+	zooms


### PR DESCRIPTION
**Content**

## Summary
As of 2c2e654, afterburner effects can scale with the engine hardpoints that spawned them. For the Successor **edit: and also Avgi** afterburners, which are an integrated part or mode of their engines, scaling along with regular engines plumes is desirable. I have changed them accordingly by adding the `zooms` keyword to their afterburner effects.

## Screenshots
Before:
![1740841705](https://github.com/user-attachments/assets/6448d0e5-4932-4868-b7c5-24aae78ab161)
After:
![1740842059](https://github.com/user-attachments/assets/4af9275e-1af0-4043-9f0e-0e743558add1)

**With regular engines also firing:**
Before:
![1740841605](https://github.com/user-attachments/assets/a63f08da-4335-4497-a1a8-5192a73780e6)
After:
![1740841545](https://github.com/user-attachments/assets/7eeacf78-bac8-4509-967a-da1a51a8f7b1)


## Testing Done
Things look fine on ships with multiple engine zooms (like the Korsmanath)

## Save File
This save file can be used to test these changes:
Let me know if you really need one