### PR TITLE
Ildico Save Compatibility Patch

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2822,8 +2822,7 @@ mission "Stone of our Fathers 5"
 		dialog `You have reached <planet>, but your escort with the space reserved for Thorleif and Ragnhild has not arrived! Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		event "stone waiting most" 30
-		action
-			set "stone waiting most: triggered"
+		set "stone waiting most: triggered"
 		payment 500000
 		conversation
 			`The trip back to Norn was restful.`

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -2822,6 +2822,8 @@ mission "Stone of our Fathers 5"
 		dialog `You have reached <planet>, but your escort with the space reserved for Thorleif and Ragnhild has not arrived! Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		event "stone waiting most" 30
+		action
+			set "stone waiting most: triggered"
 		payment 500000
 		conversation
 			`The trip back to Norn was restful.`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10199,3 +10199,12 @@ mission "Stone to Hope: Thanks"
 			`	He returns to tinkering with the repulsor but continues, "There's no money or reward, but a good deed is its own reward, isn't it?`
 			`	"At least that's what I believe," he says more to himself than to you.`
 				decline
+
+# For compatibility with saves that got the completed Stones of our Fathers 5, but didn't get the new event connected to it.
+mission "Patch Stone Waiting"
+	invisible
+	landing
+	to offer
+		has "Stone of our Fathers 5: done"
+	on offer
+		event "stone waiting most" 14

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10206,5 +10206,7 @@ mission "Patch Stone Waiting"
 	landing
 	to offer
 		has "Stone of our Fathers 5: done"
+		not "stone waiting most: triggered"
 	on offer
 		event "stone waiting most" 14
+		fail

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10202,8 +10202,8 @@ mission "Stone to Hope: Thanks"
 
 # For compatibility with saves that completed Stones of our Fathers 5, but didn't get the new event connected to it.
 mission "Patch Stone Waiting"
-	invisible
 	landing
+	invisible
 	to offer
 		has "Stone of our Fathers 5: done"
 		not "stone waiting most: triggered"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10200,7 +10200,7 @@ mission "Stone to Hope: Thanks"
 			`	"At least that's what I believe," he says more to himself than to you.`
 				decline
 
-# For compatibility with saves that got the completed Stones of our Fathers 5, but didn't get the new event connected to it.
+# For compatibility with saves that completed Stones of our Fathers 5, but didn't get the new event connected to it.
 mission "Patch Stone Waiting"
 	invisible
 	landing


### PR DESCRIPTION
This adds a very small invisible mission that makes it so someone who completed Stones of our Fathers 5 prior to getting the update with the Ildico missions can now still get the missions.
