### PR TITLE
fix(bug): fix Kasii-Tuur-Saqru overlapping its mother planet

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -22989,7 +22989,7 @@ system Kella-Uoasa
 		period 5000
 		object Kasii-Tuur-Saqru
 			sprite "planet/station successor 2"
-			distance 500
+			distance 464
 			period 64
 		object
 			sprite planet/ice8

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -22989,11 +22989,11 @@ system Kella-Uoasa
 		period 5000
 		object Kasii-Tuur-Saqru
 			sprite "planet/station successor 2"
-			distance 180
+			distance 500
 			period 64
 		object
 			sprite planet/ice8
-			distance 700
+			distance 1000
 			period 1000
 	object Giiq-Sou-Kella
 		sprite planet/ocean9


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described by Witch of Many Colours on Discord

## Summary
Moved Kasii-Tuur-Saqru out a bit from the planet it orbits to prevent overlap. Also moved the moon a little to accommodate this.

## Testing Done
I haven't tested every orbit, but it seems to work just fine.

## Save File
This save file can be used to test these changes:
[Successor Station.txt](https://github.com/user-attachments/files/19072930/Successor.Station.txt)
