### PR TITLE
fix(ci): Rename editorconfig-checker's config file

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,0 @@
-{
-  "Exclude": ["\\.mp3$", "test_datafile.cpp", "\\Shader.cpp$", "Font.cpp", "Mask.cpp"]
-}

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,3 @@
+{
+	"Exclude": ["test_datafile.cpp", "\\Shader.cpp$", "Font.cpp", "Mask.cpp"]
+}


### PR DESCRIPTION
**Bug fix**

This PR addresses the issue describe in [this job](https://github.com/endless-sky/endless-sky/actions/runs/13704344545/job/38326402398?pr=10391).

## Summary
Apparently, the name of the config file changed, so this PR renames it to match the changes. I also removed the exclusion for mp3 files, as those are filtered by default. The checker also complained about the space-based indentation, so that was changed to tabs.

## Testing Done
Runs fine.