### PR TITLE
fix(load/ui): Use display names for systems and planets in the load panel

### DIFF
--- a/source/SavedGame.cpp
+++ b/source/SavedGame.cpp
@@ -19,7 +19,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DataNode.h"
 #include "Date.h"
 #include "text/Format.h"
+#include "GameData.h"
+#include "Planet.h"
 #include "image/SpriteSet.h"
+#include "System.h"
 
 using namespace std;
 

--- a/source/SavedGame.cpp
+++ b/source/SavedGame.cpp
@@ -59,7 +59,12 @@ void SavedGame::Load(const filesystem::path &path)
 				system = savedSystem->DisplayName();
 		}
 		else if(node.Token(0) == "planet" && node.Size() >= 2)
+		{
 			planet = node.Token(1);
+			const Planet *savedPlanet = GameData::Planets().Find(planet);
+			if(savedPlanet)
+				planet = savedPlanet->DisplayName();
+		}
 		else if(node.Token(0) == "playtime" && node.Size() >= 2)
 			playTime = Format::PlayTime(node.Value(1));
 		else if(node.Token(0) == "flagship index" && node.Size() >= 2)

--- a/source/SavedGame.cpp
+++ b/source/SavedGame.cpp
@@ -55,14 +55,14 @@ void SavedGame::Load(const filesystem::path &path)
 		{
 			system = node.Token(1);
 			const System *savedSystem = GameData::Systems().Find(system);
-			if(savedSystem)
+			if(savedSystem && savedSystem->IsValid())
 				system = savedSystem->DisplayName();
 		}
 		else if(node.Token(0) == "planet" && node.Size() >= 2)
 		{
 			planet = node.Token(1);
 			const Planet *savedPlanet = GameData::Planets().Find(planet);
-			if(savedPlanet)
+			if(savedPlanet && savedPlanet->IsValid())
 				planet = savedPlanet->DisplayName();
 		}
 		else if(node.Token(0) == "playtime" && node.Size() >= 2)

--- a/source/SavedGame.cpp
+++ b/source/SavedGame.cpp
@@ -52,7 +52,12 @@ void SavedGame::Load(const filesystem::path &path)
 		else if(node.Token(0) == "date" && node.Size() >= 4)
 			date = Date(node.Value(1), node.Value(2), node.Value(3)).ToString();
 		else if(node.Token(0) == "system" && node.Size() >= 2)
+		{
 			system = node.Token(1);
+			const System *savedSystem = GameData::Systems().Find(system);
+			if(savedSystem)
+				system = savedSystem->DisplayName();
+		}
 		else if(node.Token(0) == "planet" && node.Size() >= 2)
 			planet = node.Token(1);
 		else if(node.Token(0) == "playtime" && node.Size() >= 2)


### PR DESCRIPTION
**Bug fix**

Thanks to @MidnightPlugins for reporting this on Discord.

## Summary
Currently, the "load panel" (the panel where you load saves from) displays the name of the system and planet the selected save file is at. However, the names it displays are the unique names of the system and planet, not necessarily the display names. This is because it just reads the text from the save file, which uses the unique name (in order to uniquely identify the objects).
This PR updates this code to check if a system and planet with the given names are valid and, if they are, retrieves their display names.
This will not display the correct names if either the planet or the system display names are updated by changes present in the selected save file but not currently loaded.

## Testing Done
No.

## Save File
This save file can be used to test these changes:
No.
