### PR TITLE
feat: Gradient in the LineShader

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1046,7 +1046,7 @@ interface "hud"
 	bar "heat"
 		from -13.5 403
 		dimensions 0 -192
-		color "heat"
+		color "heat" "overheat"
 		size 2
 	bar "overheat"
 		from -13.5 403

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1046,7 +1046,7 @@ interface "hud"
 	bar "heat"
 		from -13.5 403
 		dimensions 0 -192
-		color "heat" "overheat"
+		color "heat"
 		size 2
 	bar "overheat"
 		from -13.5 403

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -666,13 +666,8 @@ bool Interface::BarElement::ParseLine(const DataNode &node)
 {
 	if(node.Token(0) == "color" && node.Size() >= 2)
 	{
-		if(node.Size() >= 3)
-		{
-			fromColor = GameData::Colors().Get(node.Token(1));
-			toColor = GameData::Colors().Get(node.Token(2));
-		}
-		else
-			fromColor = toColor = GameData::Colors().Get(node.Token(1));
+		fromColor = GameData::Colors().Get(node.Token(1));
+		toColor = node.Size() >= 3 ? GameData::Colors().Get(node.Token(2)) : fromColor;
 	}
 	else if(node.Token(0) == "size" && node.Size() >= 2)
 		width = node.Value(1);
@@ -732,7 +727,7 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 		double v = 0.;
 		while(v < value)
 		{
-			Color nFromColor = Color::Combine((1 - v), *fromColor, v, *toColor);
+			Color nFromColor = Color::Combine(1 - v, *fromColor, v, *toColor);
 			Point from = start + v * dimensions;
 			v += filled;
 			double lim = min(v, value);

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -734,14 +734,12 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 		while(v < value)
 		{
 			Color nFromColor = Color::Combine((1 - v), *fromColor, v, *toColor);
-			cerr << v << ", "; 
 			Point from = start + v * dimensions;
 			v += filled;
-			cerr << v << ", "; 
-			Point to = start + min(v, value) * dimensions;
-			Color nToColor = Color::Combine((1 - v), *fromColor, v, *toColor);
+			double lim = min(v, value);
+			Point to = start + lim * dimensions;
+			Color nToColor = Color::Combine(1 - lim, *fromColor, lim, *toColor);
 			v += empty;
-			cerr << v << ".\n"; 
 
 			// Rounded lines have a bit of padding, so account for that here.
 			float d = (to - from).Length() / 2.;

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -38,7 +38,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 
 using namespace std;
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -196,7 +196,8 @@ private:
 
 	private:
 		std::string name;
-		const Color *color = nullptr;
+		const Color *fromColor = nullptr;
+		const Color *toColor = nullptr;
 		float width = 2.f;
 		bool reversed = false;
 		bool isRing = false;

--- a/source/shader/LineShader.cpp
+++ b/source/shader/LineShader.cpp
@@ -193,7 +193,8 @@ void LineShader::DrawDashed(const Point &from, const Point &to, const Point &uni
 
 
 
-void LineShader::DrawGradient(const Point &from, const Point &to, float width, const Color &fromColor, const Color &toColor, bool roundCap)
+void LineShader::DrawGradient(const Point &from, const Point &to, float width,
+		const Color &fromColor, const Color &toColor, bool roundCap)
 {
 	if(!shader.Object())
 		throw runtime_error("LineShader: Draw() called before Init().");

--- a/source/shader/LineShader.cpp
+++ b/source/shader/LineShader.cpp
@@ -222,3 +222,31 @@ void LineShader::DrawGradient(const Point &from, const Point &to, float width, c
 	glBindVertexArray(0);
 	glUseProgram(0);
 }
+
+
+
+void LineShader::DrawGradientDashed(const Point &from, const Point &to, const Point &unit, const float width,
+		const Color &fromColor, const Color &toColor, const double dashLength, double spaceLength, bool roundCap)
+{
+	const double length = (to - from).Length();
+	const double patternLength = dashLength + spaceLength;
+	int segments = static_cast<int>(length / patternLength);
+	// If needed, scale pattern down so we can draw at least two of them over length.
+	if(segments < 2)
+	{
+		segments = 2;
+		spaceLength *= length / (segments * patternLength);
+	}
+	spaceLength /= 2.;
+	float capOffset = roundCap ? width : 0.;
+	for(int i = 0; i < segments; ++i)
+	{
+		float p  = static_cast<float>(i) / segments;
+		Color mixed = Color::Combine(1. - p, fromColor, p, toColor);
+		float pv  = static_cast<float>(i + 1) / segments;
+		Color mixed2 = Color::Combine(1. - pv, fromColor, pv, toColor);
+		DrawGradient(from + unit * ((i * length) / segments + spaceLength + capOffset),
+			from + unit * (((i + 1) * length) / segments - spaceLength - capOffset),
+			width, mixed, mixed2, roundCap);
+	}
+}

--- a/source/shader/LineShader.cpp
+++ b/source/shader/LineShader.cpp
@@ -166,7 +166,7 @@ void LineShader::Init()
 
 void LineShader::Draw(const Point &from, const Point &to, float width, const Color &color, bool roundCap)
 {
-	DrawGradient(from, to, width, color, color);
+	DrawGradient(from, to, width, color, color, roundCap);
 }
 
 
@@ -176,7 +176,7 @@ void LineShader::DrawDashed(const Point &from, const Point &to, const Point &uni
 {
 	const double length = (to - from).Length();
 	const double patternLength = dashLength + spaceLength;
-	int segments = static_cast<int>(length / patternLength);
+	int segments = length / patternLength;
 	// If needed, scale pattern down so we can draw at least two of them over length.
 	if(segments < 2)
 	{
@@ -231,7 +231,7 @@ void LineShader::DrawGradientDashed(const Point &from, const Point &to, const Po
 {
 	const double length = (to - from).Length();
 	const double patternLength = dashLength + spaceLength;
-	int segments = static_cast<int>(length / patternLength);
+	int segments = length / patternLength;
 	// If needed, scale pattern down so we can draw at least two of them over length.
 	if(segments < 2)
 	{

--- a/source/shader/LineShader.cpp
+++ b/source/shader/LineShader.cpp
@@ -172,7 +172,7 @@ void LineShader::Draw(const Point &from, const Point &to, float width, const Col
 
 
 void LineShader::DrawDashed(const Point &from, const Point &to, const Point &unit, const float width,
-		const Color &color, const double dashLength, double spaceLength, bool roundCap)
+	const Color &color, const double dashLength, double spaceLength, bool roundCap)
 {
 	const double length = (to - from).Length();
 	const double patternLength = dashLength + spaceLength;
@@ -186,15 +186,15 @@ void LineShader::DrawDashed(const Point &from, const Point &to, const Point &uni
 	spaceLength /= 2.;
 	float capOffset = roundCap ? width : 0.;
 	for(int i = 0; i < segments; ++i)
-		Draw(from + unit * ((i * length) / segments + spaceLength + capOffset),
-			from + unit * (((i + 1) * length) / segments - spaceLength - capOffset),
+		Draw(from + unit * (i * length / segments + spaceLength + capOffset),
+			from + unit * ((i + 1) * length / segments - spaceLength - capOffset),
 			width, color, roundCap);
 }
 
 
 
 void LineShader::DrawGradient(const Point &from, const Point &to, float width,
-		const Color &fromColor, const Color &toColor, bool roundCap)
+	const Color &fromColor, const Color &toColor, bool roundCap)
 {
 	if(!shader.Object())
 		throw runtime_error("LineShader: Draw() called before Init().");
@@ -242,12 +242,12 @@ void LineShader::DrawGradientDashed(const Point &from, const Point &to, const Po
 	float capOffset = roundCap ? width : 0.;
 	for(int i = 0; i < segments; ++i)
 	{
-		float p  = static_cast<float>(i) / segments;
+		float p = static_cast<float>(i) / segments;
 		Color mixed = Color::Combine(1. - p, fromColor, p, toColor);
-		float pv  = static_cast<float>(i + 1) / segments;
+		float pv = static_cast<float>(i + 1) / segments;
 		Color mixed2 = Color::Combine(1. - pv, fromColor, pv, toColor);
-		DrawGradient(from + unit * ((i * length) / segments + spaceLength + capOffset),
-			from + unit * (((i + 1) * length) / segments - spaceLength - capOffset),
+		DrawGradient(from + unit * (i * length / segments + spaceLength + capOffset),
+			from + unit * ((i + 1) * length / segments - spaceLength - capOffset),
 			width, mixed, mixed2, roundCap);
 	}
 }

--- a/source/shader/LineShader.h
+++ b/source/shader/LineShader.h
@@ -28,4 +28,5 @@ public:
 	static void Draw(const Point &from, const Point &to, float width, const Color &color, bool roundCap = true);
 	static void DrawDashed(const Point &from, const Point &to, const Point &unit, float width, const Color &color,
 		double dashLength, double spaceLength, bool roundCap = true);
+	static void DrawGradient(const Point &from, const Point &to, float width, const Color &fromColor, const Color &toColor, bool roundCap = true);
 };

--- a/source/shader/LineShader.h
+++ b/source/shader/LineShader.h
@@ -31,5 +31,5 @@ public:
 	static void DrawGradient(const Point &from, const Point &to, float width,
 		const Color &fromColor, const Color &toColor, bool roundCap = true);
 	static void DrawGradientDashed(const Point &from, const Point &to, const Point &unit, float width,
-	    const Color &fromColor, const Color &toColor, double dashLength, double spaceLength, bool roundCap = true);
+		const Color &fromColor, const Color &toColor, double dashLength, double spaceLength, bool roundCap = true);
 };

--- a/source/shader/LineShader.h
+++ b/source/shader/LineShader.h
@@ -29,4 +29,6 @@ public:
 	static void DrawDashed(const Point &from, const Point &to, const Point &unit, float width, const Color &color,
 		double dashLength, double spaceLength, bool roundCap = true);
 	static void DrawGradient(const Point &from, const Point &to, float width, const Color &fromColor, const Color &toColor, bool roundCap = true);
+	static void DrawGradientDashed(const Point &from, const Point &to, const Point &unit, float width, const Color &fromColor,
+		const Color &toColor, double dashLength, double spaceLength, bool roundCap = true);
 };

--- a/source/shader/LineShader.h
+++ b/source/shader/LineShader.h
@@ -28,7 +28,8 @@ public:
 	static void Draw(const Point &from, const Point &to, float width, const Color &color, bool roundCap = true);
 	static void DrawDashed(const Point &from, const Point &to, const Point &unit, float width, const Color &color,
 		double dashLength, double spaceLength, bool roundCap = true);
-	static void DrawGradient(const Point &from, const Point &to, float width, const Color &fromColor, const Color &toColor, bool roundCap = true);
-	static void DrawGradientDashed(const Point &from, const Point &to, const Point &unit, float width, const Color &fromColor,
-		const Color &toColor, double dashLength, double spaceLength, bool roundCap = true);
+	static void DrawGradient(const Point &from, const Point &to, float width,
+		const Color &fromColor, const Color &toColor, bool roundCap = true);
+	static void DrawGradientDashed(const Point &from, const Point &to, const Point &unit, float width,
+	    const Color &fromColor, const Color &toColor, double dashLength, double spaceLength, bool roundCap = true);
 };


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #my head, but could be useful for stuff like az's gunsights

## Summary
Adds a gradient method to lineshader that draws a linearly interpolated gradient between two point.

## Screenshots

![image](https://github.com/user-attachments/assets/a3e2e14a-0760-4dce-b96a-d32799c9f6e0)
spoopy orange-to-yellow gradient

(for demonstration purposes only, not part of this PR)

## Performance Impact

I'd guess pretty little, as all of the gradient work is being done on dedicated hardware by GPUs.
