### PR TITLE
feat(news): Use global and player substitutions in news messages

### DIFF
--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "text/alignment.hpp"
 #include "text/FontSet.h"
+#include "text/Format.h"
 #include "GameData.h"
 #include "Interface.h"
 #include "News.h"
@@ -63,7 +64,10 @@ void SpaceportPanel::UpdateNews()
 	newsInfo.SetSprite("portrait", portrait);
 	newsInfo.SetString("name", news->Name() + ':');
 	newsMessage.SetWrapWidth(hasPortrait ? portraitWidth : normalWidth);
-	newsMessage.Wrap(news->Message());
+	map<string, string> subs;
+	GameData::GetTextReplacements().Substitutions(subs, player.Conditions());
+	player.AddPlayerSubstitutions(subs);
+	newsMessage.Wrap(Format::Replace(news->Message(), subs));
 }
 
 


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #11139

## Summary
Global and player (\<first\>, \<last\>, \<ship\>, \<model\>, \<system\>, \<date\>, and \<day\>) substitutions will now be used in news messages.

## Testing Done
None.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/113

## Performance Impact
Minimal; this is only done when updating the news text which is only when the player clicks the spaceport button or presses the "p" key in one of hte planet panels.
