### PR TITLE
Use PlayerInfo::AddPlayerSubstitutions method more widely

### DIFF
--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -44,6 +44,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Files.h"
 #endif
 
+#include <array>
 #include <iterator>
 
 using namespace std;
@@ -73,7 +74,7 @@ ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &con
 	// These substitutions need to be applied on the fly as each paragraph of
 	// text is prepared for display. Some substitutions already in the map
 	// should not be overwritten.
-	static const set<string> subsToSave = {"<system>", "<date>", "<day>"};
+	static const array<string, 3> subsToSave = {"<system>", "<date>", "<day>"};
 	map<string, string> savedSubs;
 	for(const auto &sub : subsToSave)
 	{

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -83,6 +83,7 @@ ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &con
 			savedSubs.emplace(*it);
 	}
 	player.AddPlayerSubstitutions(subs);
+	// Restore substitutions that need to be preserved.
 	for(auto &it : savedSubs)
 		subs[it.first].swap(it.second);
 	if(ship)

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -71,18 +71,23 @@ ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &con
 #endif
 	Audio::Pause();
 	// These substitutions need to be applied on the fly as each paragraph of
-	// text is prepared for display.
-	subs["<first>"] = player.FirstName();
-	subs["<last>"] = player.LastName();
+	// text is prepared for display. Some substitutions already in the map
+	// should not be overwritten.
+	static const set<string> subsToSave = {"<system>", "<date>", "<day>"};
+	map<string, string> savedSubs;
+	for(const auto &sub : subsToSave)
+	{
+		const auto it = subs.find(sub);
+		if(it != subs.end() && !it.second.empty())
+			savedSubs.emplace(*it);
+	}
+	player.AddPlayerSubstitutions(subs);
+	for(auto &it : savedSubs)
+		subs[it.first].swap(it.second);
 	if(ship)
 	{
 		subs["<ship>"] = ship->Name();
 		subs["<model>"] = ship->DisplayModelName();
-	}
-	else if(player.Flagship())
-	{
-		subs["<ship>"] = player.Flagship()->Name();
-		subs["<model>"] = player.Flagship()->DisplayModelName();
 	}
 
 	// Start a PlayerInfo transaction to prevent saves during the conversation

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -78,7 +78,7 @@ ConversationPanel::ConversationPanel(PlayerInfo &player, const Conversation &con
 	for(const auto &sub : subsToSave)
 	{
 		const auto it = subs.find(sub);
-		if(it != subs.end() && !it.second.empty())
+		if(it != subs.end() && !it->second.empty())
 			savedSubs.emplace(*it);
 	}
 	player.AddPlayerSubstitutions(subs);

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1008,13 +1008,7 @@ string Mission::BlockedMessage(const PlayerInfo &player)
 	map<string, string> subs;
 	GameData::GetTextReplacements().Substitutions(subs, player.Conditions());
 	substitutions.Substitutions(subs, player.Conditions());
-	subs["<first>"] = player.FirstName();
-	subs["<last>"] = player.LastName();
-	if(flagship)
-	{
-		subs["<ship>"] = flagship->Name();
-		subs["<model>"] = flagship->DisplayModelName();
-	}
+	player.AddPlayerSubstitutions(subs);
 
 	const auto &playerConditions = player.Conditions();
 	subs["<conditions>"] = toAccept.Test(playerConditions) ? "meet" : "do not meet";

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -383,14 +383,7 @@ void MissionAction::Do(PlayerInfo &player, UI *ui, const Mission *caller, const 
 	{
 		map<string, string> subs;
 		GameData::GetTextReplacements().Substitutions(subs, player.Conditions());
-		subs["<first>"] = player.FirstName();
-		subs["<last>"] = player.LastName();
-		const Ship *flagship = player.Flagship();
-		if(flagship)
-		{
-			subs["<ship>"] = flagship->Name();
-			subs["<model>"] = flagship->DisplayModelName();
-		}
+		player.AddPlayerSubstitutions(subs);
 		string text = Format::Replace(dialogText, subs);
 
 		// Don't push the dialog text if this is a visit action on a nonunique


### PR DESCRIPTION
**Refactor**

## Summary
A little while ago, a new method was added to `PlayerInfo` that provides a central place to apply some substitutions that involve information about the current state of the player info:
`<first>`, `<last>`, `<ship>`, `<model>`, `<system>`, `<date>`, `<day>`.
This PR makes use of this function in some places that were manually adding a subset of these substitutions:
- Mission blocked messages.
- MissionAction dialogs.
- The conversation panel.

In the case of the conversation panel, a mission may already be using the "<system>", "<date>", and "<day>" substitutions. The values provided by the mission (if they are not empty strings) will be preserved.
Similarly, the player's "<ship>" and "<model>" substitutions will be replaced by the values for the ship if this conversation was offered upon boarding a ship (which is the existing behaviour).

## Testing Done
No.

## Wiki Update
Possibly; I'll have to look at how well thi stuff is already documented.

## Performance Impact
Minimal
