### PR TITLE
Differentiate variants in map shipyard

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -260,7 +260,7 @@ void MapOutfitterPanel::DrawItems()
 				? "1 unit in storage"
 				: Format::Number(storedInSystem) + " units in storage";
 			Draw(corner, outfit->Thumbnail(), 0, isForSale, outfit == selected,
-				outfit->DisplayName(), price, info, storage_details);
+				outfit->DisplayName(), "", price, info, storage_details);
 			list.push_back(outfit);
 		}
 	}

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -363,20 +363,26 @@ void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite, int sw
 
 
 void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, int swizzle, bool isForSale,
-		bool isSelected, const string &name, const string &price, const string &info,
-		const std::string &storage)
+		bool isSelected, const string &name, const string &variantName,
+		const string &price, const string &info, const std::string &storage)
 {
 	const Font &font = FontSet::Get(14);
 	const Color &selectionColor = *GameData::Colors().Get("item selected");
 
 	// Set the padding so the text takes the same height overall,
 	// regardless of whether it's three lines of text or four.
-	const auto pad = storage.empty() ? PAD : (PAD * 2. / 3.);
-	const auto lines = storage.empty() ? 3 : 4;
+	const auto pad = storage.empty() && variantName.empty() ? PAD : (PAD * 2. / 3.);
+	const auto lines = storage.empty() && variantName.empty() ? 3 : 4;
 	Point nameOffset(ICON_HEIGHT, .5 * (ICON_HEIGHT - (lines - 1) * pad - lines * font.Height()));
 	Point priceOffset(ICON_HEIGHT, nameOffset.Y() + font.Height() + pad);
 	Point infoOffset(ICON_HEIGHT, priceOffset.Y() + font.Height() + pad);
 	Point storageOffset(ICON_HEIGHT, infoOffset.Y() + font.Height() + pad);
+	Point variantOffset = priceOffset;
+	if(!variantName.empty())
+	{
+		priceOffset = infoOffset;
+		infoOffset = storageOffset;
+	}
 	Point blockSize(WIDTH, ICON_HEIGHT);
 
 	if(corner.Y() < Screen::Bottom() && corner.Y() + ICON_HEIGHT >= Screen::Top())
@@ -392,6 +398,8 @@ void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, int swizzle, bool 
 			? dimColor : Color::Combine(.5f, mediumColor, .5f, dimColor);
 		auto layout = Layout(static_cast<int>(WIDTH - ICON_HEIGHT - 1), Truncate::BACK);
 		font.Draw({name, layout}, corner + nameOffset, textColor);
+		if(!variantName.empty())
+			font.Draw({"\t" + variantName, layout}, corner + variantOffset, textColor);
 		font.Draw({price, layout}, corner + priceOffset, textColor);
 		font.Draw({info, layout}, corner + infoOffset, textColor);
 		if(!storage.empty())

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -69,8 +69,8 @@ protected:
 	bool DrawHeader(Point &corner, const std::string &category);
 	void DrawSprite(const Point &corner, const Sprite *sprite, int swizzle) const;
 	void Draw(Point &corner, const Sprite *sprite, int swizzle, bool isForSale, bool isSelected,
-		const std::string &name, const std::string &price, const std::string &info,
-		const std::string &storage = "");
+		const std::string &name, const std::string &variantName, const std::string &price,
+		const std::string &info, const std::string &storage);
 
 	void DoFind(const std::string &text);
 	void ScrollTo(int index);

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -250,7 +250,7 @@ void MapShipyardPanel::DrawItems()
 				? "1 ship parked"
 				: Format::Number(parkedInSystem) + " ships parked";
 			Draw(corner, sprite, ship->CustomSwizzle(), isForSale, ship == selected,
-					ship->DisplayModelName(), price, info, parking_details);
+					ship->DisplayModelName(), ship->VariantMapShopName(), price, info, parking_details);
 			list.push_back(ship);
 		}
 	}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1213,6 +1213,7 @@ const string &Ship::VariantName() const
 
 
 
+// Get the variant name to be displayed on the Shipyard tab of the Map screen.
 const string &Ship::VariantMapShopName() const
 {
 	return variantMapShopName;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -272,7 +272,7 @@ void Ship::Load(const DataNode &node)
 			displayModelName = child.Token(1);
 		else if(key == "plural" && child.Size() >= 2)
 			pluralModelName = child.Token(1);
-		else if(key == "variant map shipyard name" && child.Size() >= 2)
+		else if(key == "variant map name" && child.Size() >= 2)
 			variantMapShopName = child.Token(1);
 		else if(key == "noun" && child.Size() >= 2)
 			noun = child.Token(1);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -272,6 +272,8 @@ void Ship::Load(const DataNode &node)
 			displayModelName = child.Token(1);
 		else if(key == "plural" && child.Size() >= 2)
 			pluralModelName = child.Token(1);
+		else if(key == "variant map shipyard name" && child.Size() >= 2)
+			variantMapShopName = child.Token(1);
 		else if(key == "noun" && child.Size() >= 2)
 			noun = child.Token(1);
 		else if(key == "swizzle" && child.Size() >= 2)
@@ -1207,6 +1209,13 @@ const string &Ship::PluralModelName() const
 const string &Ship::VariantName() const
 {
 	return variantName.empty() ? trueModelName : variantName;
+}
+
+
+
+const string &Ship::VariantMapShopName() const
+{
+	return variantMapShopName;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -153,6 +153,7 @@ public:
 	const std::string &PluralModelName() const;
 	// Get the name of this ship as a variant.
 	const std::string &VariantName() const;
+	const std::string &VariantMapShopName() const;
 	// Get the generic noun (e.g. "ship") to be used when describing this ship.
 	const std::string &Noun() const;
 	// Get this ship's description.
@@ -573,6 +574,7 @@ private:
 	std::string displayModelName;
 	std::string pluralModelName;
 	std::string variantName;
+	std::string variantMapShopName;
 	std::string noun;
 	std::string description;
 	const Sprite *thumbnail = nullptr;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -153,6 +153,7 @@ public:
 	const std::string &PluralModelName() const;
 	// Get the name of this ship as a variant.
 	const std::string &VariantName() const;
+	// Get the variant name to be displayed on the Shipyard tab of the Map screen.
 	const std::string &VariantMapShopName() const;
 	// Get the generic noun (e.g. "ship") to be used when describing this ship.
 	const std::string &Noun() const;


### PR DESCRIPTION
**Feature**

## Summary
Since the addition of the "Unfettered Shipyards" variants of the Shield Beetle and Lightning Bug (variants of those ships with different outfit configurations sold at the shipyard in Unfettered Hai space), various people have been confused by the appearance of two very similar looking entries for each ship in the map shipyard panel.

This PR adds a feature to try to resolve some of this confusion: variants (well, all ships, really) can be given an extra name that will appear below the model name in the map shipyard panel.

## Screenshots
before | after
-- | --
![image](https://github.com/user-attachments/assets/0c3ae245-7de2-4304-880a-1843c88fb443) | ![image](https://github.com/user-attachments/assets/93492051-f7ca-4340-9ee6-0efa4d5a3ed6)

## Usage examples
```
ship "Whatever" "Whatever (Two)"
    "variant map shipyard name" "A different configuration"
```

## Testing Done
Gave the "Shield Beetle (Unfettered Shipyards)" a variant map shipyard name and see that it appears in the map shipyard as expected.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/118

## Performance Impact
Minimal
