### PR TITLE
Relative ramscoop and solar energy collection indicators in the HUD

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -62,6 +62,8 @@ color "heat" .70 .43 .43 .75
 color "overheat" .70 .61 .43 .75
 color "energy" .6 .6 .6 .75
 color "fuel" .70 .62 .43 .75
+color "solar energy collection" .6 .6 .6 .75
+color "solar fuel collection" .70 .62 .43 .75
 
 # Colors for the escort HUD status bars.
 color "escort shields" .43 .55 .70 0.
@@ -1041,12 +1043,12 @@ interface "hud"
 	bar "fuel collection"
 		from -58.5 425
 		dimensions 0 -192
-		color "fuel"
+		color "solar fuel collection"
 		size 1
 	bar "fuel collection"
 		from -48.5 425
 		dimensions 0 -192
-		color "fuel"
+		color "solar fuel collection"
 		size 1
 	bar "energy"
 		from -33.5 415
@@ -1056,12 +1058,12 @@ interface "hud"
 	bar "energy collection"
 		from -38.5 415
 		dimensions 0 -192
-		color "energy"
+		color "solar energy collection"
 		size 1
 	bar "energy collection"
 		from -28.5 415
 		dimensions 0 -192
-		color "energy"
+		color "solar energy collection"
 		size 1
 	bar "heat"
 		from -13.5 403

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1038,11 +1038,31 @@ interface "hud"
 		dimensions 0 -192
 		color "fuel"
 		size 2
+	bar "fuel collection"
+		from -58.5 425
+		dimensions 0 -192
+		color "fuel"
+		size 1
+	bar "fuel collection"
+		from -48.5 425
+		dimensions 0 -192
+		color "fuel"
+		size 1
 	bar "energy"
 		from -33.5 415
 		dimensions 0 -192
 		color "energy"
 		size 2
+	bar "energy collection"
+		from -38.5 415
+		dimensions 0 -192
+		color "energy"
+		size 1
+	bar "energy collection"
+		from -28.5 415
+		dimensions 0 -192
+		color "energy"
+		size 1
 	bar "heat"
 		from -13.5 403
 		dimensions 0 -192

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -747,7 +747,17 @@ void Engine::Step(bool isActive)
 			info.SetBar("fuel", flagship->Fuel(), fuelCap * .01);
 		else
 			info.SetBar("fuel", flagship->Fuel());
+		const double scale = .2 + 1.8 / (.001 * flagship->Position().Length() + 1);
+		const double ramscoop = flagship->Attributes().Get("ramscoop");
+		if(ramscoop > 0.)
+		{
+			const double maxRamscoopFuel = flagship->GetSystem()->RamscoopFuel(ramscoop, 2.);
+			const double currentRamscoopFuel = flagship->GetSystem()->RamscoopFuel(ramscoop, scale);
+			info.SetBar("fuel collection", currentRamscoopFuel / maxRamscoopFuel);
+		}
 		info.SetBar("energy", flagship->Energy());
+		if(flagship->Attributes().Get("solar collection"))
+			info.SetBar("energy collection", .5 * scale);
 		double heat = flagship->Heat();
 		info.SetBar("heat", min(1., heat));
 		// If heat is above 100%, draw a second overlaid bar to indicate the

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -747,7 +747,7 @@ void Engine::Step(bool isActive)
 			info.SetBar("fuel", flagship->Fuel(), fuelCap * .01);
 		else
 			info.SetBar("fuel", flagship->Fuel());
-		const double scale = .2 + 1.8 / (.001 * flagship->Position().Length() + 1);
+		const double scale = flagship->SolarDistanceScale();
 		const double ramscoop = flagship->Attributes().Get("ramscoop");
 		if(ramscoop > 0.)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2190,6 +2190,15 @@ const Planet *Ship::GetPlanet() const
 }
 
 
+// Get a "scale" value, ranging from 0.2 to 2.0, based on the distance this
+// ship is from the center of its system.
+// Used for ramscoop and solar energy collection calculations.
+double Ship::SolarDistanceScale() const
+{
+	return .2 + 1.8 / (.001 * position.Length() + 1);
+}
+
+
 
 bool Ship::IsCapturable() const
 {
@@ -4227,7 +4236,7 @@ void Ship::DoGeneration()
 		// Carried fighters can't collect fuel or energy this way.
 		if(currentSystem)
 		{
-			double scale = .2 + 1.8 / (.001 * position.Length() + 1);
+			double scale = SolarDistanceScale();
 			fuel += currentSystem->RamscoopFuel(attributes.Get("ramscoop"), scale);
 
 			double solarScaling = currentSystem->SolarPower() * scale;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -251,6 +251,11 @@ public:
 	// If the ship is landed, get the planet it has landed on.
 	const Planet *GetPlanet() const;
 
+	// Get a "scale" value, ranging from 0.2 to 2.0, based on the distance this
+	// ship is from the center of its system.
+	// Used for ramscoop and solar energy collection calculations.
+	double SolarDistanceScale() const;
+
 	// Check the status of this ship.
 	bool IsCapturable() const;
 	bool IsTargetable() const;


### PR DESCRIPTION
**Feature**

## Summary
This PR adds thin bars/highlights to the edges of the fuel and energy bars for the flagship in the HUD that indicate relative ramscoop and solar energy collection.
That is, the bar represents the fraction of the maximum available collection rate for the current system that is currently being collected. In general, this means that the bar will be full when you are at the exact centre of the system, and at 10% when you are a very large distance away. (In the case of Ember Waste systems, the ramscoop fuel collection can reach zero when far away, though.)

The idea being that this gives some indication of how much collection you gain or lose by moving closer to or further away from the centre of the system, for example, if there are hostile ships around and you need fuel, it can allow you to gauge how much more ramscoop collection you're gaining as you get closer, potentially making it easier to weight that against the increased risk of being closer to the hostile ships.

The bars are described in the HUD interface, and so can be fairly easily customised.

## Screenshots
![image](https://github.com/user-attachments/assets/c9b60a15-6742-40b7-818a-7c544afc9ad2)

## Testing Done
Looked at the fuel bar on the HUD.

## Save File
This save file can be used to test these changes:
[warpest core.txt](https://github.com/user-attachments/files/19153175/warpest.core.txt)

## Wiki Update
I haven't checked if this is necessary. Maybe?

## Performance Impact
Minimal
