### PR TITLE
feat(content): Display log entries to remind players of blocked missions and to check spaceport

### DIFF
--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -390,7 +390,7 @@ mission "Avgi: Humans From the Deep"
 		clear "avgi: asked about humans"
 		clear "avgi: asked about aberrant"
 	on complete
-		log "Reminders" "Avgi" `Come back to Aktina Cylinder in the Concerto system when you have a free bunk to take Darius off the station.`
+		log "Reminders" "Avgi" `Going to return to <destination> with a free bunk to take Darius off the station.`
 
 
 
@@ -499,7 +499,7 @@ mission "Avgi: Defend Ensemble 1"
 			`	He looks at you, hopeful. "We've got to do something. The Avgi are assembling a relief force around the Navigeo Yards, their big shipyard not too far from here. Come on, let's join it."`
 				accept
 	on complete
-		log "Reminders" "Avgi" `Come back to Navigeo Yards in the Symphony system when you have a free bunk to transport Darius to Weledos.`
+		log "Reminders" "Avgi" `Going to <destination> with a free bunk to transport Darius to Weledos.`
 
 
 mission "Avgi: Defend Ensemble 2"
@@ -664,7 +664,7 @@ mission "Avgi: Defend Ensemble 2"
 				`	"No, the <ship> isn't made for combat."`
 			action
 				set "avgi: rescue intro"
-				log "Reminders" "Avgi" `You have a mission to wrap up on Weledos in the Ensemble system that requires 12 bunks.`
+				log "Reminders" "Avgi" `Going to wrap up a mission on <destination> that requires 12 bunks.`
 			`	"Consideration. But, are you still willing to help us in a way that takes advantage of your ship's ability to bypass the starways, question?"`
 			choice
 				`	"Yes, of course."`
@@ -675,7 +675,7 @@ mission "Avgi: Defend Ensemble 2"
 			label warship
 			action
 				set "avgi: warship intro"
-				log "Reminders" "Avgi" `You have a mission to wrap up on Weledos in the Ensemble system.`
+				log "Reminders" "Avgi" `Going to wrap up a mission on <destination>.`
 			`	"Excellent. I am unsurprised, given its performance in the battle, but for all we know your alien vessel could be a simple freighter and yet still be formidable in our eyes. Are you willing to assist us with your warship's strength, question?"`
 			choice
 				`	"Yes, of course."`
@@ -756,7 +756,7 @@ mission "Avgi: Scout Rescue"
 				depart
 
 	on complete
-		log "Reminders" "Avgi" `Darius asked you to meet him in the spaceport bar on Peripheria in the Concerto system in order to help resolve a political dispute and meet one of his friends. You will need 3 bunks.`
+		log "Reminders" "Avgi" `Going to meet Darius in <destination spaceport> with 3 bunks in order to help resolve a political dispute and meet one of his friends.`
 		conversation
 			`You receive a warm welcome back on Peripheria Station, as the former crew of the Silver Albedo disembarks. Some of the more badly injured crew members are carried out on hammock-like stretchers, but most are able to walk or fly out of the <ship> on their own power.`
 			`	After a short celebration and many expressions of deep gratitude toward you, you find Darius and Sora waiting by the <ship> to speak with you.`
@@ -794,7 +794,7 @@ mission "Avgi: Frontline Combat"
 		log `Agreed to help Kokkino by clearing out Aberrant stragglers infesting a cluster of systems behind the front lines.`
 
 	on complete
-		log "Reminders" "Avgi" `Come back to Feo Platform in the Arche system when you have 2 bunks to transport Darius and Sora.`
+		log "Reminders" "Avgi" `Going to return to <destination> with 2 bunks to transport Darius and Sora.`
 
 	npc kill
 		government "Aberrant"
@@ -860,7 +860,7 @@ mission "Avgi: Dissonance Outreach 0.5"
 			`	"Something about the miners grumbling about price controls on nickel-iron," Darius says after a moment, "but he wants to know if you could use your jump drive to take him there for some outreach to the miners without needing to spend weeks wandering through the mess of twisted hyperlanes. It's the perfect chance to meet my friend and ask him some questions. We'll need to head to Peripheria to pick up Hriso and get this trip sorted out."`
 				accept
 	on complete
-		log "Reminders" "Avgi" `Darius wants you to meet him and Hriso in the Peripheria spaceport in the Concerto system. You will need 3 bunks.`
+		log "Reminders" "Avgi" `Going to meet Darius and Hriso in <destination spaceport> with 3 bunks.`
 		dialog
 			`As you take the <ship> in for a landing in one of the hangars, Darius says, "I'll get in contact with Hriso and have him meet us in the spaceport."`
 
@@ -901,7 +901,7 @@ mission "Avgi: Dissonance Outreach"
 	on accept
 		log `Agreed to transport Hriso to a Dissonance mining station in the Tangled Shroud, while Darius and Sora investigate a lead that could potentially help you escape the Twilight.`
 	on complete
-		log "Reminders" "Avgi" `Come back to Outpost Tekis in the Interlude system when you have 3 bunks.`
+		log "Reminders" "Avgi" `Going to return to <destination> with 3 bunks.`
 
 
 mission "Avgi: Twilight Escape 1"
@@ -993,7 +993,7 @@ mission "Avgi: Twilight Escape 1"
 			`	"<first>," says Darius in a shaky voice. "Take us to the Deep, please. I need to see my home. And my wife."`
 			`	"Drop me off on Vinci first," interjects Leon. "I need to get my life in order again, and there's someone there I need to talk to about all this. It's on the way to the Deep, anyway."`
 	on complete
-		log "Reminders" "Avgi" `Remember to pick up Darius and Sora in the Vinci spaceport in the Miaplacidus system before you take off. You will need 2 bunks.`
+		log "Reminders" "Avgi" `Going to pick up Darius and Sora in <destination spaceport> with 2 bunks before taking off.`
 		log `Successfully escaped the Twilight together with the humans stranded there.`
 		log "People" "Leon Shez" `Leon is extremely grateful to you for helping him return to Avgi space. He wants to tell a contact on Vinci about the Avgi, and asks you to stay in touch.`
 		clear "avgi: lost in twilight"
@@ -1037,7 +1037,7 @@ mission "Avgi: Twilight Escape 2"
 		log `Agreed to take Sora to her parents' farm on Memory, as she has nowhere else to go.`
 		log "People" "Darius Caldwell" `Despite escaping the Twilight, Darius still feels guilty over his crew members that lost their lives to the Aberrant.`
 	on complete
-		log "Reminders" "Avgi" `Come back to Memory in the Zosma system when you have a free bunk to transport Darius.`
+		log "Reminders" "Avgi" `Going to return to to <destination> with a free bunk to transport Darius.`
 
 
 mission "Avgi: Twilight Escape 3"

--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -217,7 +217,7 @@ mission "Avgi: First Contact"
 		dialog `The alien ship has been destroyed. If you want to continue the Avgi story, revert to the autosave or another earlier snapshot of the game.`
 
 	on visit
-		dialog `You have reached <planet>, but you left the alien ship behind! Better depart and wait for them to to properly introduce you.`
+		dialog `You have reached <planet>, but you left the alien ship behind! Better depart and wait for them to properly introduce you.`
 
 	on complete
 		"reputation: Avgi" += 10
@@ -1037,7 +1037,7 @@ mission "Avgi: Twilight Escape 2"
 		log `Agreed to take Sora to her parents' farm on Memory, as she has nowhere else to go.`
 		log "People" "Darius Caldwell" `Despite escaping the Twilight, Darius still feels guilty over his crew members that lost their lives to the Aberrant.`
 	on complete
-		log "Reminders" "Avgi" `Going to return to to <destination> with a free bunk to transport Darius.`
+		log "Reminders" "Avgi" `Going to return to <destination> with a free bunk to transport Darius.`
 
 
 mission "Avgi: Twilight Escape 3"

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -347,7 +347,7 @@ mission "Coalition Yottrite 3"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying the yottrite samples hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Yottrite" `Going to meet an Arach in the Delve of Bloptab spaceport in the Bloptab system.`
+		log "Reminders" "Coalition Yottrite" `Going to meet an Arach in <destination spaceport>.`
 		conversation
 			`Though on <origin> you weren't greeted by him, the same Arach from the other trips now contacts you as you prepare to land on <planet>.`
 			`	"Captain <last>! Forgive me for my absence in our latest deal, you must. Sort out some business here, I had to," he says.`
@@ -379,7 +379,7 @@ mission "Coalition Yottrite 4"
 				`	"Sorry, I'm not one to take passenger jobs."`
 					decline
 	on complete
-		log "Reminders" "Coalition Yottrite" `Going to meet Lugglop and his friends in the Shadowed Valley spaceport in the Fallen Leaf system. Will need 2 bunks to take on the mission.`
+		log "Reminders" "Coalition Yottrite" `Going to meet Lugglop and his friends in <destination spaceport> with 2 bunks.`
 		dialog `When you land on <planet>, Lugglop contacts you and informs you that he has already told his friends about you. He says they will be waiting in the spaceport.`
 
 
@@ -426,7 +426,7 @@ mission "Coalition Yottrite 6"
 			`	You're about to head back to your ship when he hands you 200,000 credits. "Nearly forgot to pay you for this last service, I did."`
 				accept
 	on complete
-		log "Reminders" "Coalition Yottrite" `Going to come back to Market of Gupta in the Gupta system when I have a free bunk.`
+		log "Reminders" "Coalition Yottrite" `Going to come back to <destination> when I have a free bunk.`
 
 
 
@@ -509,7 +509,7 @@ mission "Coalition Yottrite 8"
 			`	He thanks you and says he and the rest of the team will be waiting in <destination>. "Moved here about halfway through the project, we did, to make use of the station's facilities."`
 				accept
 	on complete
-		log "Reminders" "Coalition Yottrite" `Going to meet Lugglop and his compatriots in the Pelubta Station spaceport in the Pelubta system with 6 free bunks.`
+		log "Reminders" "Coalition Yottrite" `Going to meet Lugglop and his compatriots in <destination spaceport> with 6 free bunks.`
 		outfit "Yottrite" -1
 		payment 400000
 		dialog `Lugglop pays you <payment> as you deliver the yottrite, accompanied by a Heliarch agent. "Finish preparing our presentation, we now must. If to help us further you wish, in the spaceport meet us you must."`
@@ -788,7 +788,7 @@ mission "Coalition Outbreak 1"
 	on visit
 		dialog `You've reached <planet>, but the doctors and the medical supplies haven't arrived yet. Depart and wait for the ships carrying them.`
 	on complete
-		log "Reminders" "Coalition Outbreak" `Going to meet some medical workers in the Celestial Third spaceport in the 1 Axis system to help with an outbreak. Will need 80 tons of cargo space.`
+		log "Reminders" "Coalition Outbreak" `Going to meet some medical workers in <destination spaceport> with 80 tons of cargo space to help with an outbreak.`
 		payment 768540
 		"coalition jobs" += 2
 		dialog `The medical workers exit your ship just as quickly as they entered it and head off to different sections of the city, directed by some emergency workers. After the <cargo> are also taken off your ship, a worker hands you <payment> and says you could look for more ways to help with the outbreak by looking for their colleagues in the spaceport.`
@@ -827,7 +827,7 @@ mission "Coalition Outbreak 2"
 	on visit
 		dialog `You've reached <planet>, but the vaccines aren't here yet. Once you've picked them up, make sure all ships that are carrying them arrive in this system.`
 	on complete
-		log "Reminders" "Coalition Outbreak" `Going to the Ki Patek Ka spaceport in the Sol Kimek system to help deal with a viral outbreak. Will need 80 tons of cargo space.`
+		log "Reminders" "Coalition Outbreak" `Going to <destination spaceport> with 80 tons of cargo space to help deal with a viral outbreak.`
 		payment 943720
 		"coalition jobs" += 2
 		conversation
@@ -963,7 +963,7 @@ mission "Saryd Students 1"
 	on visit
 		dialog `You ask around and are directed to a large refinery on one of the more populated cities here. The rum's price is impressive indeed, 5,642 credits per ton, but what is more impressive is how you worried about the students' irresponsibility when they asked you to buy this when you yourself aren't responsible enough to have a bit over ten thousand credits to spend. Go earn some money, then return here.`
 	on complete
-		log "Reminders" "Coalition Rum" `Going to return to Weir of Glubatub in the Glubatub system with 2 tons of free cargo space in order to pick up some rum for students at Starlit University.`
+		log "Reminders" "Coalition Rum" `Going to return to <destination> with 2 tons of cargo space in order to pick up some rum for students at Starlit University.`
 		payment -11284
 
 
@@ -1031,7 +1031,7 @@ mission "Saryd Census 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying the census workers hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Census" `Going to check the Flowing Fields spaceport in the Four Pillars system by night in order to continue to help some Saryds take a census. Will need 17 bunks.`
+		log "Reminders" "Coalition Census" `Going to check <destination spaceport>, by night, with 17 bunks, in order to continue to help some Saryds take a census.`
 		"coalition jobs" ++
 		payment 342000
 		dialog `You're paid <payment> for transporting the Saryds here, and they leave your ship, ready to get to work and ask around. They say that they'll probably all be back in the spaceport by night time, so you should check there later if you want to help them further.`
@@ -1115,7 +1115,7 @@ mission "Saryd Couple 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Aunaris hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Couple" `Going to return to Shadow of Leaves in the Hunter system in a few months in order to collect payment from two Saryds, Inturi and Aunaris, who are saving up funds in order to buy a house. Will need to have 2 bunks free, just in case the house is not on the same planet.`
+		log "Reminders" "Coalition Couple" `Going to return to <destination> in a few months in order to collect payment from two Saryds, Inturi and Aunaris, who are saving up funds in order to buy a house, with 2 bunks free, just in case the house is not on the same planet.`
 		"coalition jobs" ++
 		event "saryd couple has money" 42 86
 		dialog `Aunaris thanks you for bringing her here, and apologizes for not being able to pay you right away, but promises once she and Inturi have figured out their home, they will work hard to pay you. "Stay here for a few months, I probably will, before the remaining funds I have acquired," she says before saying goodbye and taking a cable car to her new workplace.`
@@ -1953,7 +1953,7 @@ mission "Coalition: Pilgrimage 5"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Vellorae hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Pilgrimage" `Going to meet Vellorae in the Cold Horizon spaceport in the Fell Omen system to take her back home. Will need a free bunk.`
+		log "Reminders" "Coalition Pilgrimage" `Going to meet Vellorae in <destination spaceport> to take her back home. Will need a free bunk.`
 		"coalition jobs" ++
 		payment 80000
 		conversation
@@ -2276,7 +2276,7 @@ mission "Coalition: Submarines 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Apri'ie hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Submarines" `Going to meet Apri'ie in the Market of Gupta spaceport in the Gupta system to transport 60 tons of submarines. Will also need one bunk free.`
+		log "Reminders" "Coalition Submarines" `Going to meet Apri'ie in <destination spaceport> with a free bunk to transport 60 tons of submarines.`
 		"coalition jobs" ++
 		payment 90000
 		conversation
@@ -2320,7 +2320,7 @@ mission "Coalition: Submarines 2"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Apri'ie and the unmanned submarines hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Submarines" `Going to meet Apri'ie in the Inmost Blue spaceport in the 4 Winter Rising system. Will need 60 tons of cargo space and a free bunk.`
+		log "Reminders" "Coalition Submarines" `Going to meet Apri'ie in <destination spaceport> with 60 tons of cargo space and a free bunk.`
 		"coalition jobs" ++
 		payment 210000
 		conversation
@@ -2451,7 +2451,7 @@ mission "Coalition: Expeditions Past 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Sedlitaris hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Expedition" `Going to the Ring of Friendship spaceport in the Quaru system to wait for Sedlatiris and start a scouting expedition for the Coalition. Will need 6 bunks.`
+		log "Reminders" "Coalition Expedition" `Going to <destination spaceport> with 6 bunks to wait for Sedlatiris and start a scouting expedition for the Coalition.`
 		payment 100000
 		conversation
 			`Sedlitaris gives you your payment of <payment> before you open your hatch for her to leave. "Take a few hours, this might, so wait for me in the spaceport, you can. Know the layout well, I do, so find you without issue, I will."`
@@ -3043,7 +3043,7 @@ mission "Coalition: Long Lost Property 3"
 			branch money
 				"credits" > 1000000
 			action
-				log "Reminders" "Coalition Probe" `Going to return to Greenrock in the Shaula system once 1,000,000 credits have been accumulated in order to purchase information on the location of a Coalition probe.`
+				log "Reminders" "Coalition Probe" `Going to return to <destination> once 1,000,000 credits have been accumulated in order to purchase information on the location of a Coalition probe.`
 			`	They come back alone, saying, "Boss has looked you up, and found your pockets a bit empty. If you want that kind of information, come back when you're ready to pay."`
 				defer
 			label money
@@ -3124,7 +3124,7 @@ mission "Coalition: Long Lost Property 3"
 	to complete
 		has "idriss probe recovered"
 	on complete
-		log "Reminders" "Coalition Probe" `Going to meet Flopug and the other Arachi in the Ablub's Invention spaceport in the Ablub spaceport once they have finished collecting the data.`
+		log "Reminders" "Coalition Probe" `Going to meet Flopug and the other Arachi in <destination spaceport> once they have finished collecting the data.`
 		clear "idriss probe recovered"
 		payment 500000
 		conversation
@@ -3152,7 +3152,7 @@ mission "Coalition: Long Lost Property 4"
 	on enter "Alnasl"
 		dialog `One of your monitors brings up various sets of data written in the Arach language when you enter the system, and your scanners begin gathering the data House Idriss wants. A few minutes pass until a loading bar comes up. When it reaches the end, another one appears, and the process repeats a few more times. After about an hour, your monitor goes back to normal.`
 	on complete
-		log "Reminders" "Coalition Probe" `Going to head back to Ablub's Invention in the Ablub system once the new scanning equipment has been developed in a few months.`
+		log "Reminders" "Coalition Probe" `Going to head back to <destination> once the new scanning equipment has been developed in a few months.`
 		event "outskirts gauger ready" 157 342
 		payment 250000
 		conversation

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -963,7 +963,7 @@ mission "Saryd Students 1"
 	on visit
 		dialog `You ask around and are directed to a large refinery on one of the more populated cities here. The rum's price is impressive indeed, 5,642 credits per ton, but what is more impressive is how you worried about the students' irresponsibility when they asked you to buy this when you yourself aren't responsible enough to have a bit over ten thousand credits to spend. Go earn some money, then return here.`
 	on complete
-		log "Reminders" "Coalition Rum" `Was asked to return to Weir of Glubatub in the Glubatub system with 2 tons of free cargo space in order to pick up some rum for students at Starlit University.` 
+		log "Reminders" "Coalition Rum" `Was asked to return to Weir of Glubatub in the Glubatub system with 2 tons of free cargo space in order to pick up some rum for students at Starlit University.`
 		payment -11284
 
 

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -347,6 +347,7 @@ mission "Coalition Yottrite 3"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying the yottrite samples hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Yottrite" `Was asked to meet an Arach in the Delve of Bloptab spaceport in the Bloptab system.`
 		conversation
 			`Though on <origin> you weren't greeted by him, the same Arach from the other trips now contacts you as you prepare to land on <planet>.`
 			`	"Captain <last>! Forgive me for my absence in our latest deal, you must. Sort out some business here, I had to," he says.`
@@ -364,6 +365,7 @@ mission "Coalition Yottrite 4"
 	source "Delve of Bloptab"
 	destination "Shadowed Valley"
 	on offer
+		remove log "Reminders" "Coalition Yottrite"
 		conversation
 			`You wait around the spaceport for some minutes before finally spotting the Arach. He invites you to his office.`
 			`	"Responsible for overseeing deliveries of such exotic materials to the warehouses here, I also am. For the inconvenience and bureaucracy, I apologize," he says. "Forget to properly introduce myself, I often do. Lugglop, I am called."`
@@ -377,6 +379,7 @@ mission "Coalition Yottrite 4"
 				`	"Sorry, I'm not one to take passenger jobs."`
 					decline
 	on complete
+		log "Reminders" "Coalition Yottrite" `Was asked to meet Lugglop and his friends in the Shadowed Valley spaceport in the Fallen Leaf system. Will need 2 bunks to take on the mission.`
 		dialog `When you land on <planet>, Lugglop contacts you and informs you that he has already told his friends about you. He says they will be waiting in the spaceport.`
 
 
@@ -391,6 +394,7 @@ mission "Coalition Yottrite 5"
 	source "Shadowed Valley"
 	destination "Delve of Bloptab"
 	on offer
+		remove log "Reminders" "Coalition Yottrite"
 		conversation
 			`A Saryd wearing their version of a lab coat is waiting for you when you enter the spaceport.`
 			`	"Working with Lugglop, you are?" He asks, and you nod. "Nasilor, my name is. Packing up our belongings, my sister is. Bring you to our laboratory, I shall."`
@@ -421,6 +425,8 @@ mission "Coalition Yottrite 6"
 			`	He shows you to his map again, this time pointing to a nearby Arach world. "Once cracked some aspects of yottrite, the twins have, an expert in ship making, we will need," he says. "On <destination>, prepared one of their representatives, House Mallob has. Bring them here, you must."`
 			`	You're about to head back to your ship when he hands you 200,000 credits. "Nearly forgot to pay you for this last service, I did."`
 				accept
+	on complete
+		log "Reminders" "Coalition Yottrite" `Was asked to come back to Market of Gupta in the Gupta system when I have a free bunk.`
 
 
 
@@ -435,6 +441,7 @@ mission "Coalition Yottrite 7"
 	source "Market of Gupta"
 	destination "Delve of Bloptab"
 	on offer
+		remove log "Reminders" "Coalition Yottrite"
 		conversation
 			`You're immediately hailed by House Mallob when your ship is entering the atmosphere of <origin>. They guide you through the planet, bringing you to what looks like a massive, castle-like structure, which appears to be made out of a similar material to that of Arach ships, sitting at the base of a mountain.`
 			`	You land on a large docking area, where some other ships are also conducting business. Stepping off of your ship you're greeted by what is unmistakably an outfitter, and as you look around you spot some other large buildings dotting the surrounding area, with members of the Coalition going to and from them. The atmosphere feels like that of a small village turned into an outdoor shopping mall.`
@@ -502,6 +509,7 @@ mission "Coalition Yottrite 8"
 			`	He thanks you and says he and the rest of the team will be waiting in <destination>. "Moved here about halfway through the project, we did, to make use of the station's facilities."`
 				accept
 	on complete
+		log "Reminders" "Coalition Yottrite" `Was asked to meet Lugglop and his compatriots in the Pelubta Station spaceport in the Pelubta system with 6 free bunks.`
 		outfit "Yottrite" -1
 		payment 400000
 		dialog `Lugglop pays you <payment> as you deliver the yottrite, accompanied by a Heliarch agent. "Finish preparing our presentation, we now must. If to help us further you wish, in the spaceport meet us you must."`
@@ -519,6 +527,7 @@ mission "Coalition Yottrite 9"
 	source "Pelubta Station"
 	destination "Ring of Wisdom"
 	on offer
+		remove log "Reminders" "Coalition Yottrite"
 		conversation
 			`You meet Lugglop in the spaceport and follow him to meet with Nasilor, Alituri, and Pichiie, who are overseeing some workers place a few sealed metal crates inside a container and the yottrite sample you just brought here into another. They detail how they have prepared all the material they needed and now just need a transport to the <destination>.`
 			`	"If with us, you come, Captain, perhaps a better detailed description of the systems where the yottrite was found, you could provide," Nasilor says.`
@@ -779,6 +788,7 @@ mission "Coalition Outbreak 1"
 	on visit
 		dialog `You've reached <planet>, but the doctors and the medical supplies haven't arrived yet. Depart and wait for the ships carrying them.`
 	on complete
+		log "Reminders" "Coalition Outbreak" `Was asked to meet some medical workers in the Celestial Third spaceport in the 1 Axis system to help with an outbreak. Will need 80 tons of cargo space.`
 		payment 768540
 		"coalition jobs" += 2
 		dialog `The medical workers exit your ship just as quickly as they entered it and head off to different sections of the city, directed by some emergency workers. After the <cargo> are also taken off your ship, a worker hands you <payment> and says you could look for more ways to help with the outbreak by looking for their colleagues in the spaceport.`
@@ -797,6 +807,7 @@ mission "Coalition Outbreak 2"
 	stopover "Secret Sky"
 	destination "Ki Patek Ka"
 	on offer
+		remove log "Reminders" "Coalition Outbreak"
 		conversation
 			`As before, the spaceport is completely dominated by doctors and nurses. You don't find the person who told you to come here, but as you ask one of the other emergency workers, they direct you to a makeshift office set up next to a few trading panels.`
 			`	"Fairly new to us, this virus is," the Kimek manning the stand says. "But finally developed an initial batch of vaccines for it, the researchers on Secret Sky thankfully have."`
@@ -816,6 +827,7 @@ mission "Coalition Outbreak 2"
 	on visit
 		dialog `You've reached <planet>, but the vaccines aren't here yet. Once you've picked them up, make sure all ships that are carrying them arrive in this system.`
 	on complete
+		log "Reminders" "Coalition Outbreak" `Medical workers are waiting in the Ki Patek Ka spaceport in the Sol Kimek system to give more tasks to deal with a viral outbreak. These tasks require 80 tons of cargo space.`
 		payment 943720
 		"coalition jobs" += 2
 		conversation
@@ -830,6 +842,7 @@ mission "Coalition Outbreak 3"
 	description "Accompanied by the three volunteer ships, head to the designated Kimek worlds, delivering vaccines to deal with the current viral outbreak, then return to <destination> by <date>."
 	deadline
 	cargo "vaccines" 80
+	blocked "You need <capacity> in order to take on the next mission. Return here when you have the required space free."
 	to offer
 		has "Coalition Outbreak 2: done"
 	source "Ki Patek Ka"
@@ -842,6 +855,7 @@ mission "Coalition Outbreak 3"
 	stopover "Second Viridian"
 	stopover "Remote Blue"
 	on offer
+		remove log "Reminders" "Coalition Outbreak"
 		conversation
 			`This time you're expected and are brought to a large conference room where many Saryds, and the occasional Arach, are waiting. A Kimek that is part of the team organizing the containment procedures comes in and says you will once again be transporting vaccines.`
 			`	"In a few hours, fully replicated, the vaccine samples will be. Load them onto your ships, we will. Deliver them to <stopovers>, you must."`
@@ -949,6 +963,7 @@ mission "Saryd Students 1"
 	on visit
 		dialog `You ask around and are directed to a large refinery on one of the more populated cities here. The rum's price is impressive indeed, 5,642 credits per ton, but what is more impressive is how you worried about the students' irresponsibility when they asked you to buy this when you yourself aren't responsible enough to have a bit over ten thousand credits to spend. Go earn some money, then return here.`
 	on complete
+		log "Reminders" "Coalition Rum" `Was asked to return to Weir of Glubatub in the Glubatub system with 2 tons of free cargo space in order to pick up some rum for students at Starlit University.` 
 		payment -11284
 
 
@@ -965,6 +980,7 @@ mission "Saryd Students 2"
 	source "Weir of Glubatub"
 	destination "Shadow of Leaves"
 	on offer
+		remove log "Reminders" "Coalition Rum"
 		conversation
 			`You ask around and are directed to a large refinery on one of the more populated cities here. Apparently it's the original building where the Arach rum was first produced.`
 			`	You ask for two tons, avoiding giving the exact details of what it's for, as you do not wish to be held accountable for whatever some drunken Saryds may do, and pay the price for all the rum: 11,284 credits.`
@@ -1015,6 +1031,7 @@ mission "Saryd Census 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying the census workers hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Census" `Was asked to check the Flowing Fields spaceport in the Four Pillars system by night in order to continue to help some Saryds take a census. Will need 17 bunks.`
 		"coalition jobs" ++
 		payment 342000
 		dialog `You're paid <payment> for transporting the Saryds here, and they leave your ship, ready to get to work and ask around. They say that they'll probably all be back in the spaceport by night time, so you should check there later if you want to help them further.`
@@ -1098,6 +1115,7 @@ mission "Saryd Couple 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Aunaris hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Couple" `Two Saryds, Inturi and Aunaris, are saving up funds in Shadow of Leaves in the Hunter system, in order to buy a house. Will likely be ready to buy the house in a few months, at which point they will offer payment. Will need to have 2 bunks free if the house is not on the same planet.`
 		"coalition jobs" ++
 		event "saryd couple has money" 42 86
 		dialog `Aunaris thanks you for bringing her here, and apologizes for not being able to pay you right away, but promises once she and Inturi have figured out their home, they will work hard to pay you. "Stay here for a few months, I probably will, before the remaining funds I have acquired," she says before saying goodbye and taking a cable car to her new workplace.`
@@ -1117,6 +1135,7 @@ mission "Saryd Couple 2"
 	source "Shadow of Leaves"
 	destination "Far Garden"
 	on offer
+		remove log "Reminders" "Coalition Couple"
 		conversation
 			`You're met with two familiar faces in the spaceport: the Saryd couple you met some time ago, Inturi and Aunaris, who were working on acquiring the funding needed to build their own home.`
 			`	"Worked for a week in another ship, I did, until landed here we had," Inturi says, joking about his way of catching a ride on a ship without paying a transport fee.`
@@ -1934,6 +1953,7 @@ mission "Coalition: Pilgrimage 5"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Vellorae hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Pilgrimage" `Was asked to meet Vellorae in the Cold Horizon spaceport in the Fell Omen system to take her back home. Will need a free bunk.`
 		"coalition jobs" ++
 		payment 80000
 		conversation
@@ -1969,11 +1989,13 @@ mission "Coalition: Pilgrimage 6"
 	name "Pilgrimage's End"
 	description "Bring Vellorae back to her home on <destination>."
 	passengers 1
+	blocked "You need <capacity> in order to take on the next mission. Return here when you have the required space free."
 	to offer
 		has "Coalition: Pilgrimage 5: done"
 	source "Cold Horizon"
 	destination "Bright Echo"
 	on offer
+		remove log "Reminders" "Coalition Pilgrimage"
 		conversation
 			`You find Vellorae in a snack shop, finishing up a hot drink. "Apologize for the wait I must, Captain. Ready to leave, I was not."`
 			choice

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -347,7 +347,7 @@ mission "Coalition Yottrite 3"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying the yottrite samples hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Yottrite" `Was asked to meet an Arach in the Delve of Bloptab spaceport in the Bloptab system.`
+		log "Reminders" "Coalition Yottrite" `Going to meet an Arach in the Delve of Bloptab spaceport in the Bloptab system.`
 		conversation
 			`Though on <origin> you weren't greeted by him, the same Arach from the other trips now contacts you as you prepare to land on <planet>.`
 			`	"Captain <last>! Forgive me for my absence in our latest deal, you must. Sort out some business here, I had to," he says.`
@@ -379,7 +379,7 @@ mission "Coalition Yottrite 4"
 				`	"Sorry, I'm not one to take passenger jobs."`
 					decline
 	on complete
-		log "Reminders" "Coalition Yottrite" `Was asked to meet Lugglop and his friends in the Shadowed Valley spaceport in the Fallen Leaf system. Will need 2 bunks to take on the mission.`
+		log "Reminders" "Coalition Yottrite" `Going to meet Lugglop and his friends in the Shadowed Valley spaceport in the Fallen Leaf system. Will need 2 bunks to take on the mission.`
 		dialog `When you land on <planet>, Lugglop contacts you and informs you that he has already told his friends about you. He says they will be waiting in the spaceport.`
 
 
@@ -426,7 +426,7 @@ mission "Coalition Yottrite 6"
 			`	You're about to head back to your ship when he hands you 200,000 credits. "Nearly forgot to pay you for this last service, I did."`
 				accept
 	on complete
-		log "Reminders" "Coalition Yottrite" `Was asked to come back to Market of Gupta in the Gupta system when I have a free bunk.`
+		log "Reminders" "Coalition Yottrite" `Going to come back to Market of Gupta in the Gupta system when I have a free bunk.`
 
 
 
@@ -509,7 +509,7 @@ mission "Coalition Yottrite 8"
 			`	He thanks you and says he and the rest of the team will be waiting in <destination>. "Moved here about halfway through the project, we did, to make use of the station's facilities."`
 				accept
 	on complete
-		log "Reminders" "Coalition Yottrite" `Was asked to meet Lugglop and his compatriots in the Pelubta Station spaceport in the Pelubta system with 6 free bunks.`
+		log "Reminders" "Coalition Yottrite" `Going to meet Lugglop and his compatriots in the Pelubta Station spaceport in the Pelubta system with 6 free bunks.`
 		outfit "Yottrite" -1
 		payment 400000
 		dialog `Lugglop pays you <payment> as you deliver the yottrite, accompanied by a Heliarch agent. "Finish preparing our presentation, we now must. If to help us further you wish, in the spaceport meet us you must."`
@@ -788,7 +788,7 @@ mission "Coalition Outbreak 1"
 	on visit
 		dialog `You've reached <planet>, but the doctors and the medical supplies haven't arrived yet. Depart and wait for the ships carrying them.`
 	on complete
-		log "Reminders" "Coalition Outbreak" `Was asked to meet some medical workers in the Celestial Third spaceport in the 1 Axis system to help with an outbreak. Will need 80 tons of cargo space.`
+		log "Reminders" "Coalition Outbreak" `Going to meet some medical workers in the Celestial Third spaceport in the 1 Axis system to help with an outbreak. Will need 80 tons of cargo space.`
 		payment 768540
 		"coalition jobs" += 2
 		dialog `The medical workers exit your ship just as quickly as they entered it and head off to different sections of the city, directed by some emergency workers. After the <cargo> are also taken off your ship, a worker hands you <payment> and says you could look for more ways to help with the outbreak by looking for their colleagues in the spaceport.`
@@ -827,7 +827,7 @@ mission "Coalition Outbreak 2"
 	on visit
 		dialog `You've reached <planet>, but the vaccines aren't here yet. Once you've picked them up, make sure all ships that are carrying them arrive in this system.`
 	on complete
-		log "Reminders" "Coalition Outbreak" `Medical workers are waiting in the Ki Patek Ka spaceport in the Sol Kimek system to give more tasks to deal with a viral outbreak. These tasks require 80 tons of cargo space.`
+		log "Reminders" "Coalition Outbreak" `Going to the Ki Patek Ka spaceport in the Sol Kimek system to help deal with a viral outbreak. Will need 80 tons of cargo space.`
 		payment 943720
 		"coalition jobs" += 2
 		conversation
@@ -963,7 +963,7 @@ mission "Saryd Students 1"
 	on visit
 		dialog `You ask around and are directed to a large refinery on one of the more populated cities here. The rum's price is impressive indeed, 5,642 credits per ton, but what is more impressive is how you worried about the students' irresponsibility when they asked you to buy this when you yourself aren't responsible enough to have a bit over ten thousand credits to spend. Go earn some money, then return here.`
 	on complete
-		log "Reminders" "Coalition Rum" `Was asked to return to Weir of Glubatub in the Glubatub system with 2 tons of free cargo space in order to pick up some rum for students at Starlit University.`
+		log "Reminders" "Coalition Rum" `Going to return to Weir of Glubatub in the Glubatub system with 2 tons of free cargo space in order to pick up some rum for students at Starlit University.`
 		payment -11284
 
 
@@ -1031,7 +1031,7 @@ mission "Saryd Census 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying the census workers hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Census" `Was asked to check the Flowing Fields spaceport in the Four Pillars system by night in order to continue to help some Saryds take a census. Will need 17 bunks.`
+		log "Reminders" "Coalition Census" `Going to check the Flowing Fields spaceport in the Four Pillars system by night in order to continue to help some Saryds take a census. Will need 17 bunks.`
 		"coalition jobs" ++
 		payment 342000
 		dialog `You're paid <payment> for transporting the Saryds here, and they leave your ship, ready to get to work and ask around. They say that they'll probably all be back in the spaceport by night time, so you should check there later if you want to help them further.`
@@ -1115,7 +1115,7 @@ mission "Saryd Couple 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Aunaris hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Couple" `Two Saryds, Inturi and Aunaris, are saving up funds in Shadow of Leaves in the Hunter system, in order to buy a house. Will likely be ready to buy the house in a few months, at which point they will offer payment. Will need to have 2 bunks free if the house is not on the same planet.`
+		log "Reminders" "Coalition Couple" `Going to return to Shadow of Leaves in the Hunter system in a few months in order to collect payment from two Saryds, Inturi and Aunaris, who are saving up funds in order to buy a house. Will need to have 2 bunks free, just in case the house is not on the same planet.`
 		"coalition jobs" ++
 		event "saryd couple has money" 42 86
 		dialog `Aunaris thanks you for bringing her here, and apologizes for not being able to pay you right away, but promises once she and Inturi have figured out their home, they will work hard to pay you. "Stay here for a few months, I probably will, before the remaining funds I have acquired," she says before saying goodbye and taking a cable car to her new workplace.`
@@ -1953,7 +1953,7 @@ mission "Coalition: Pilgrimage 5"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Vellorae hasn't entered the system yet. Better depart and wait for it.`
 	on complete
-		log "Reminders" "Coalition Pilgrimage" `Was asked to meet Vellorae in the Cold Horizon spaceport in the Fell Omen system to take her back home. Will need a free bunk.`
+		log "Reminders" "Coalition Pilgrimage" `Going to meet Vellorae in the Cold Horizon spaceport in the Fell Omen system to take her back home. Will need a free bunk.`
 		"coalition jobs" ++
 		payment 80000
 		conversation
@@ -2276,6 +2276,7 @@ mission "Coalition: Submarines 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Apri'ie hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Submarines" `Going to meet Apri'ie in the Market of Gupta spaceport in the Gupta system to transport 60 tons of submarines. Will also need one bunk free.`
 		"coalition jobs" ++
 		payment 90000
 		conversation
@@ -2293,6 +2294,7 @@ mission "Coalition: Submarines 2"
 	source "Market of Gupta"
 	destination "Inmost Blue"
 	on offer
+		remove log "Reminders" "Coalition Submarines"
 		conversation
 			`After spending some time in the spaceport, you begin to ask around for Apri'ie and are directed to a small office of House Mallob. There, a manager briefly looks into their systems and informs you that Apri'ie hasn't left his meeting yet, and so you take a seat in the spaceport, occasionally getting up to check back at the entrance of the office he entered. After some hours, you finally see him exit, accompanied by a Saryd speaking on a communication device as they glance at a data pad.`
 			`	"Captain <last>! Glad that you are interested in assisting us further, I am. Prepared to have the submarines loaded into your cargo hold, are you?" Apri'ie asks. "Ready to conduct some final stress tests, colleagues of mine on <planet> are."`
@@ -2318,6 +2320,7 @@ mission "Coalition: Submarines 2"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Apri'ie and the unmanned submarines hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Submarines" `Going to meet Apri'ie in the Inmost Blue spaceport in the 4 Winter Rising system. Will need 60 tons of cargo space and a free bunk.`
 		"coalition jobs" ++
 		payment 210000
 		conversation
@@ -2344,6 +2347,7 @@ mission "Coalition: Submarines 3"
 	source "Inmost Blue"
 	destination "Dusk Companion"
 	on offer
+		remove log "Reminders" "Coalition Submarines"
 		conversation
 			`Apri'ie comes to the spaceport followed by one of his colleagues. "Have to perform one more test, we will, Captain. To assess the subs' repair abilities in hazardous environments, Pale Waters wants, so a quick stop at <destination>, we must make."`
 			choice
@@ -2447,6 +2451,7 @@ mission "Coalition: Expeditions Past 1"
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Sedlitaris hasn't entered the system yet. Better depart and wait for it.`
 	on complete
+		log "Reminders" "Coalition Expedition" `Going to the Ring of Friendship spaceport in the Quaru system to wait for Sedlatiris and start a scouting expedition for the Coalition. Will need 6 bunks.`
 		payment 100000
 		conversation
 			`Sedlitaris gives you your payment of <payment> before you open your hatch for her to leave. "Take a few hours, this might, so wait for me in the spaceport, you can. Know the layout well, I do, so find you without issue, I will."`
@@ -2469,6 +2474,7 @@ mission "Coalition: Expeditions Past 2"
 	source "Ring of Friendship"
 	destination "Ablub's Invention"
 	on offer
+		remove log "Reminders" "Coalition Expedition"
 		conversation
 			`When you don't see Sedlitaris in the spaceport, you look for a spot to sit and wait for her, and notice a set of seats made for the Quarg, still around to this day. You take one that you assume was meant for a Quarg child, standing lower than the others, and wait. Captains and workers that pass by give you all sorts of looks, and after a few minutes even some Heliarch agents are gawking at you, discussing among themselves. Just as you decide you should get up and sit somewhere else, you look to see Sedlitaris coming into the spaceport.`
 			`	"A short wait, wasn't it?" she comments once you're close. "Care to hear my case, the consuls didn't, just told me that to leave whenever I wish, I may. 'If I can,' they said, as provide me a jump drive, they won't, but that's where you come in."`
@@ -2814,6 +2820,7 @@ mission "Coalition: Expeditions Past 9"
 		has "Coalition: Expeditions Past 8: active"
 	source "Hopper"
 	on offer
+		log "Reminders" "Coalition Expedition" `Searching for a planet on route to the Ablub system. Trying multiple different routes, since the Coalition vessel may have taken a different route than the one recommended by the ship's computer. Was told that the journey was supposed to have taken 7 jumps.`
 		conversation
 			`You fly around <origin> as Sedlitaris searches for the pylon's exact position, in the hopes that she can bring it back as well. She tells you to land by a mountain range, and has you readjust your landing spot every so often as she tries to nail the exact location of the pylon. "Buried it to protect it from the atmosphere's acidity, they must have," she comments.`
 			`	By the time she's done, you open your ship's hatch right to where the pylon should be and help her dig it out, taking care to not be out for too long. When the device is dug out, you bring it inside your ship while Sedlitaris fills up the hole with what dirt had been dug out.`
@@ -2823,7 +2830,7 @@ mission "Coalition: Expeditions Past 9"
 				`	"Are you alright?"`
 				`	"He said they were going back immediately, but they never made it. You think that was the last pylon?"`
 				`	(Stay quiet.)`
-			`	She goes without a word for a while still. "Set a route for Ablub, could you, Captain? If follow the same route they used, we do, and if any more to find, there is, pick up the signals, I will."`
+			`	She goes without a word for a while still. "Set a route for Ablub, could you, Captain? If follow the same route they used, we do, and if any more to find, there is, pick up the signals, I will. Taken seven jumps, the journey should've."`
 			`	You agree, and look to set a route straight to Ablub.`
 				accept
 	on enter "Girtab"
@@ -2845,6 +2852,7 @@ mission "Coalition: Expeditions Past 10"
 	source "Harmony"
 	destination "Ring of Friendship"
 	on offer
+		remove log "Reminders" "Coalition Expedition"
 		conversation
 			`Once you're close to the planet's surface, Sedlitaris starts trying to access the recorded data in the pylon. "If possible, recover it later, we can." She tries for a few minutes, but all she can get is a twisted static, so she starts working on determining its location. "Clear up the transmission, getting closer to it should."`
 			`	You fly around until you're right above an ocean, with no land in sight wherever you look. "Below us, it is," she says. "Why underwater? Why throw it into an ocean, would they?" She works on transferring the data to her own pylon, as you won't manage to get to the original one, and clears up the recording as much as possible before playing it.`
@@ -3018,17 +3026,29 @@ mission "Coalition: Long Lost Property 3"
 	description "Search around pirate systems outside the South, and find the fleet that stole the probe. When you find it, bring it back to <destination>."
 	to offer
 		has "Coalition: Long Lost Property 2: active"
+		or
+			"credits" > 1000000
+			not "Coalition: Long Lost Property 3: deferred"
 	source "Greenrock"
 	destination "Ablub's Invention"
 	on offer
 		conversation
 			`When you ask one of the market organizers about a local pirate returning with an alien probe, you find out he already sold it. You are then pointed to a large, surprisingly well-kept junkyard, which is something of a miniature shipyard: a few crews work on their ships in the vicinity, adding or switching parts for those they just bought. The junkyard itself is surrounded by half a dozen concrete buildings, with defensive turrets on top. A few excavators and bulldozers move ship pieces and other components around, trying to keep everything organized.`
+				to display
+					not "Coalition: Long Lost Property 3: deferred"
+			`You return back to the junkyard. Hopefully this time things will go better.`
+				to display
+					has "Coalition: Long Lost Property 3: deferred"
 			`	You tell one of the workers you're looking for the probe, and they leave for a few minutes, heading inside the gray building by the entrance.`
 			branch money
 				"credits" > 1000000
+			action
+				log "Reminders" "Coalition Probe" `Going to return to Greenrock in the Shaula system once 1,000,000 credits have been accumulated in order to purchase information on the location of a Coalition probe.`
 			`	They come back alone, saying, "Boss has looked you up, and found your pockets a bit empty. If you want that kind of information, come back when you're ready to pay."`
 				defer
 			label money
+			action
+				remove log "Reminders" "Coalition Probe"
 			`	When they come back, they beckon you to go inside, bringing you to a simple office where a middle-aged, balding man is waiting. "So, I hear you're looking for my latest big acquisition? Mind telling me what has you so interested in it?"`
 			choice
 				`	"I was hired to get it for someone."`
@@ -3048,11 +3068,10 @@ mission "Coalition: Long Lost Property 3"
 			label fail
 			`	"Now I can't just trust you to get every last one of their ships, can I?" he replies. "If you want to make it worth for me, it's a million. If you're not interested, there's nothing I can do about it."`
 			
-			# For the mission NPCs to work properly, this needs to force an accept at this point.
-			# Add a choice to defer once some sort of "on board" child of "npc" exists and allows for all NPCs to be defined in just this mission.
-			
 			choice
 				`	"Fine, just tell me already."`
+				`	"Then I guess I'm not interested."`
+					defer
 			label bribe
 			action
 				payment -1000000
@@ -3072,6 +3091,8 @@ mission "Coalition: Long Lost Property 3"
 				accept
 	on enter "Persian"
 		dialog `Entering the system, your scanners catch a trio of heavily modified Quicksilvers. They also inform you that the probe is in the system, though it fails at giving you its exact location, as if something is causing interference. The Quicksilvers notice you and ready their guns.`
+	on defer
+		set "Coalition: Long Lost Property 3: deferred"
 	npc board
 		personality staying nemesis target
 		government "Bounty"
@@ -3082,56 +3103,34 @@ mission "Coalition: Long Lost Property 3"
 				set "idriss probe recovered"
 			`The pirates are waiting for you when you board their Quicksilver, and you exchange shots for a while. Once you've cleared the entrance, you explore the ship, and find what should be the probe - it matches what you were shown by House Idriss' workers, if with a lot of extra wiring wrapped around it. The pirates must have tinkered with it in attempts to use it as a warning system about incoming fleets. You remove the wires, free the probe from its attachments to the ship, and let it loose into the void. You then hurry back to your ship, and catch the drifting probe into your hold. Now you need only bring it back to House Idriss.`
 				launch
+	npc
+		personality staying nemesis target
+		government "Bounty"
+		system "Persian"
+		ship "Marauder Quicksilver (Safe)" "Coven"
+		on board
+			conversation
+				`You fight you way through the ship, but after you search the cargo hold and outfits in the Quicksilver, you realize the probe must be in another ship.`
+					launch
+	npc
+		personality staying nemesis target
+		government "Bounty"
+		system "Persian"
+		ship "Marauder Quicksilver (Weapons) (Safe)" "Conan"
+		on board
+			conversation
+				`After walking in the oddly empty vessel for a while, you hear an alarm sound and see pirates rushing to you from a door they blast open. You head back to your ship, avoiding what shots come your way as best as you can, and quickly close off the entrance on your side. When you look at the Quicksilver again, you see its self-destruction sequence is starting.`
+					launch
 	to complete
 		has "idriss probe recovered"
 	on complete
+		log "Reminders" "Coalition Probe" `Going to meet Flopug and the other Arachi in the Ablub's Invention spaceport in the Ablub spaceport once they have finished collecting the data.`
 		clear "idriss probe recovered"
 		payment 500000
 		conversation
 			`After you land, you head to the underground base of House Idriss, where Flopug meets with you again. "Arrange for the probe to be brought here at once, I will," she says, dispatching some workers to where your ship is. After a few minutes, she is informed that it's secured in the "lower levels," and heads there herself to take a look at what data it gathered.`
 			`	When she returns, followed by the Arach duo who brought you here the first time, she hands you <payment>. "Registers of some attempts at breaching the probe's security, there are, but compromised the data, thankfully none of them have. A most curious path, its AI took," she says. "As fine-tuned as our current systems, it is not, but developed its algorithms to better determine the current status of distant stars, it has. Still going over the data, we are, so how accurate it became, we don't yet know."`
 			`	The other Arachi tell you they'll meet you in the spaceport once they finish checking the data, as they'd like you to check a system personally in order to compare it with what the probe's information. They accompany you to the staircase leading back to the street, then head back to continue analyzing the data.`
-
-# Replace the below two missions once some sort of "on board" child of "npc" exists.
-mission "Coalition: Long Lost Property 3A"
-	invisible
-	landing
-	to offer
-		has "Coalition: Long Lost Property 2: active"
-		"credits" > 1000000
-	source "Greenrock"
-	npc board
-		personality staying nemesis target
-		government "Bounty"
-		system "Persian"
-		ship "Marauder Quicksilver (Safe)" "Coven"
-		conversation
-			`You fight you way through the ship, but after you search the cargo hold and outfits in the Quicksilver, you realize the probe must be in another ship.`
-				launch
-	to complete
-		never
-	to fail
-		has "Coalition: Long Lost Property 3: done"
-
-mission "Coalition: Long Lost Property 3B"
-	invisible
-	landing
-	to offer
-		has "Coalition: Long Lost Property 2: active"
-		"credits" > 1000000
-	source "Greenrock"
-	npc board
-		personality staying nemesis target
-		government "Bounty"
-		system "Persian"
-		ship "Marauder Quicksilver (Weapons) (Safe)" "Conan"
-		conversation
-			`After walking in the oddly empty vessel for a while, you hear an alarm sound and see pirates rushing to you from a door they blast open. You head back to your ship, avoiding what shots come your way as best as you can, and quickly close off the entrance on your side. When you look at the Quicksilver again, you see its self-destruction sequence is starting.`
-				launch
-	to complete
-		never
-	to fail
-		has "Coalition: Long Lost Property 3: done"
 
 mission "Coalition: Long Lost Property 4"
 	name "Comparing Binaries"
@@ -3141,6 +3140,7 @@ mission "Coalition: Long Lost Property 4"
 	source "Ablub's Invention"
 	waypoint "Alnasl"
 	on offer
+		remove log "Reminders" "Coalition Probe"
 		conversation
 			`The Arach duo greet you in the spaceport and ask you to bring them inside your ship to talk. They look to the sides and behind them every other moment, as if watching out for something. When you're inside your ship's command room, the taller one speaks. "Compared the probe's prediction with its last reading of the system of arrival, we have. A very good approximation to real conditions, it reached. Though incredibly outdated, its hardware is, an ingenious program, what my ancestors-"`
 			`	"Our ancestors," the short one interrupts him.`
@@ -3152,6 +3152,7 @@ mission "Coalition: Long Lost Property 4"
 	on enter "Alnasl"
 		dialog `One of your monitors brings up various sets of data written in the Arach language when you enter the system, and your scanners begin gathering the data House Idriss wants. A few minutes pass until a loading bar comes up. When it reaches the end, another one appears, and the process repeats a few more times. After about an hour, your monitor goes back to normal.`
 	on complete
+		log "Reminders" "Coalition Probe" `Going to head back to Ablub's Invention in the Ablub system once the new scanning equipment has been developed in a few months.`
 		event "outskirts gauger ready" 157 342
 		payment 250000
 		conversation
@@ -3170,6 +3171,7 @@ mission "Coalition: Outskirts Gauger Ready"
 		has "event: outskirts gauger ready"
 	source "Ablub's Invention"
 	on offer
+		remove log "Reminders" "Coalition Probe"
 		outfit "Outskirts Gauger" 1
 		conversation
 			`When you leave your ship, you're greeted by Flopug of House Idriss. "Completed the work on our newest set of scanners, we have. Since helped us with recovering the probe and its data, you have, only fair, it is, that gifted a copy of the equipment, you are."`

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -846,6 +846,86 @@ mission "Republic 300 Year Anniversary"
 			`	Web comments and news anchors seem to be particularly excited to comment on the recent victory of the Navy over the mysterious armada of robotic warships that invaded the Far North. Though at a great cost to the northern fleet garrisons, the invading fleets were successfully stopped at the Farpoint base, preventing the ships from causing any further harm. Veterans of the Farpoint battle seem to be hoarding the spotlight, giving emotional reports of their memory of the fight, and of the sacrifices they went through to achieve victory.`
 				goto end
 
+mission "Exotic Life: Delve"
+	minor
+	source Delve
+	to offer
+		random < 20
+	on offer
+		conversation
+			`The air in Delve's spaceport is crisp, carrying the mineral tang of weathered stone alongside occasional whiffs of fuel and lingering industrial cleaners. As you walk toward your ship, you notice teams of workers dressed in biohazard gear moving between the departing vessels in pairs, bulky sprayers strapped to their backs, nozzles hissing as they coat hulls in a fine mist. Each ship gets a thorough pass before takeoff, the workers checking crevices and landing gear with practiced efficiency.`
+			choice
+				`	(Ask them what they're doing.)`
+				`	(Ignore them and continue on your way.)`
+					decline
+				`	"Shipworm outbreak?"`
+					to display
+						has "exotic animals: delvan shipworm known"
+					goto known
+			`	You approach a pair of workers as they finish spraying down a Bulk Freighter and ask what they're doing. One of them, a grizzled veteran with deep lines around his eyes, barely glances at you. "Shipworms," he mutters, already moving to the next ship.`
+			`	The other, a younger worker practically bouncing in his boots, grins behind his respirator. "Yeah! Little metal-chewing pests. They're native to Delve, infest the mines, the shipyards - anywhere there's metal to sink their teeth into. If we didn't spray every ship before takeoff, they'd be all over the galaxy by now." The veteran sighs. "They already are all over the galaxy. Because people aren't careful enough."`
+			`	The rookie ignores him. "They start as tiny worms, barely bigger than your pinky, but once they find metal, they melt into it, make a cocoon that looks just like part of the ship! Bombacle, we call 'em. Then BAM! A few months later, the casing bursts open like a bomb! Bombacle!"`
+			`	The veteran shakes his head. "What he means is, they're an invasive hazard if they get off-world. That's why we spray. No shipworms, no problems."`
+			`	The rookie gives his sprayer an enthusiastic shake. "And I get to torch every last one I find. You ever see one pop under a high-heat blast? Satisfying as hell." The veteran just mutters, "You'd think the novelty would wear off."`
+			action
+				set "exotic animals: delvan shipworm known"
+			`	With another look at the freshly sprayed Bulk Freighter, you make a mental note to give your own ship a once-over before takeoff.`
+				goto ending
+			label known
+			`	One of them, a seasoned veteran with weary eyes, lets out a long-suffering sigh. "Great. At least this one actually knows what they are." In contrast, the other - a fresh-faced worker brimming with energy - practically lights up. "They're like space barnacles - until they hatch into wormy bombs! I was just telling him how fun it is to fry 'em!"`
+			`	The veteran gestures around at the cavernous spaceport. "We don't get outbreaks here. This is Delve. They're Delvan shipworms. They're native. Always have been. They infest the mines, the shipyards, anywhere with exposed metal. That's why every ship gets fumigated before takeoff - to keep 'em from spreading even more than they already have."`
+			`	The rookie eagerly jumps back in. "You ever see one break out of a cocoon in real time? Casing splits and it blasts out like a grenade - it's wild!" The veteran just rubs his face.`
+			`	With nothing more to add, you make a mental note to give your ship a once-over before takeoff as the workers continue their routine.`
+			label ending
+			`	You give the fumigation teams a final glance and make your way back to your ship. The metallic surfaces around you now hint at unseen creatures lurking.`
+				decline
+
+mission "Exotic Life: Ada"
+	minor
+	source Ada
+	to offer
+		random < 10
+	on offer
+		conversation
+			`You make your way through a dimly lit section of the spaceport to a near-empty hangar, where the usual hum of activity is dampened by an eerie stillness. The back of the hangar has a reinforced glass cargo door cracked open, perhaps by mistake. You peer inside to see large, sealed tarps stretched across the area, some draped over cargo crates, others covering entire sections. One enormous tarp appears big enough to be covering a whole ship. Each one bears the same stark warning in bold lettering: "DELVAN SHIPWORM FUMIGATION." The air has a faint chemical tang to it, and ahead, two figures move methodically between the tarps towards the door.`
+			`	They are covered head to toe in protective suits, thick gloves, and respirators obscuring their faces. One carries a handheld sprayer, releasing a fine mist into the air, while the other checks a monitor strapped to their arm. Their boots crunch softly against the floor as they pass.`
+			choice
+				`	(Ask them what's going on.)`
+				`	(Ignore them and continue on your way.)`
+					decline
+				`	"Nasty little bombacles, aren't they?"`
+					to display
+						has "exotic animals: delvan shipworm known"
+					goto known
+			`	Curiosity gets the better of you, and you ask what this is all about, gesturing at the tarps. One of them pauses, their voice muffled by the respirator. "Delvan shipworm outbreak. Nasty infestation. We're exterminating them before they spread to other ships or the city." You can see small scorch marks on the floor nearby - signs of something being burned away.`
+			choice
+				`	"What's a Delvan shipworm?"`
+				`	"Nasty bombacles, aren't they?"`
+					to display
+						has "exotic animals: delvan shipworm known"
+					goto known
+				`	"Well, good luck with that. I should get going."`
+					decline
+			`	The worker with the monitor barely hesitates before responding. "Delvan shipworms are an invasive species from Delve. They start as larvae, tiny worms-"`
+			`	"Bombacles!" the one with the sprayer interjects, voice distorted through the respirator. "They latch on ships, grow into barnacles, then they're bombs!"`
+			`	The first worker exhales, shaking their head. "They're more than that. The larvae attach to metal - usually ship hulls, but it can be mining equipment, or anything, really - and secrete an enzyme that corrodes the surface, breaking it down so they can form a cocoon around themselves. This builds up a high-pressure gas, so the outer shell hardens to compensate, blending in with the surrounding metal."`
+			`	"Yeah, until - BOOM! Three months later, it blasts open like a grenade and out come a dozen disgusting worms!"`
+			`	"You make it sound like a horror movie."`
+			`	"It is a horror movie if you're next to one when it hatches." The sprayer-wielding worker turns back to you. "Writhing wrigglers that leave a hole the size of your palm in whatever they break out of. Plenty of ships have lost pressure 'cause of them."`
+			`	The first worker sighs. "That's why we're dealing with it now. We don't let them spread, we don't get people vented into space."`
+			action
+				set "exotic animals: delvan shipworm known"
+			`	Your gaze drifts back to the tarps, imagining what might be skittering beneath them. You nod in thanks and step away, making a mental note to double-check your ship's hull before takeoff.`
+				goto ending
+			label known
+			`	The worker with the sprayer perks up. "Finally, someone who gets it!" they say, shaking their sprayer for emphasis.`
+			`	The other groans. "They are not barnacles and they are not bombs. They are a highly adaptive invasive species with a complex-"`
+			`	"Yeah, yeah, they're still bombacles," the sprayer worker cuts in. "Point is, we kill 'em before they kill ships. And cities. And people."`
+			`	The monitor worker exhales but gives you a nod. "At least you understand how important this is. Most folks just walk by without a second thought." The sprayer worker waves you along. "Anyway, let us work before one of these things chews through something vital."`
+			`	Satisfied, you leave them to their job, making a mental note to check your own hull before takeoff.`
+			label ending
+			`	With one last glance at the fumigation tarps, you head back to your ship, suddenly aware of how fragile a metal hull can be in the wrong circumstances.`
+
 mission "Exotic Life: Glaze"
 	repeat
 	minor

--- a/data/substitutions.txt
+++ b/data/substitutions.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 by Michael Zahniser
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+substitutions
+	"<destination spaceport>" "the <planet> spaceport in the <system> system"


### PR DESCRIPTION
**Feature**

This PR addresses the feature described by issues #2342, #9482, and several others.
Closes #9482 

## Summary
Whenever it is possible to receive a `blocked` message in the next mission, or are told to visit the spaceport to continue the mission chain, a reminder is set, telling you which planet to visit, what system that planet is in, where in the planet to go if necessary (e.g. the spaceport), and how much space you need in order to take on the mission, if space is needed. This reminder is removed as soon as that mission offers.

Other Changes:
* I added a global substitution called “\<destination spaceport>” in a new file, “substitutions.txt” located in the main data folder, which is used in the log entries as a shorthand for the spaceport you need to check.
* Upon arachi’s request, I updated “Coalition Expeditions Past 9” to mention that it took 7 jumps to reach the destination
* While searching the code, I found a comment mentioning that a defer option could be added to “Coalitions Expeditions Past 3” once it was possible to condense the missions into one due to the addition of “on board.” Since “on board” does in fact now exist, I have condensed the missions and added a defer option, along with slightly changing the intro text on defer, which can already happen if you don't have enough credits.

## Screenshots
TBD

## Testing Done
Made sure substitutions worked in log entries.

## Save File
Once I finish this, James missions should have log entries, so you can make a new pilot if you don’t have a free save to test with.

## Performance Impact
I hope the code base isn’t so bad that two more actions per mission will freeze or crash the game.