### PR TITLE
fix(style): fix overindentation in Cap'n Pester's definition

### DIFF
--- a/data/persons.txt
+++ b/data/persons.txt
@@ -166,7 +166,7 @@ ship "Wardragon"
 		"Cargo Scanner"
 		"Outfit Scanner"
 		"Wanderer Ramscoop"
-			
+		
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Scram Drive"


### PR DESCRIPTION
**Style**

## Summary
The content style check is throwing warnings about an overindented line in Cap'n Pester's definition. While it won't (shouldn't) break anything in-game, it could get confusing for other contributors. This PR fixes it.