### PR TITLE
Fix text area height calculations in the snapshot save dialog

### DIFF
--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -110,7 +110,7 @@ void TextArea::SetTruncate(Truncate t)
 
 int TextArea::GetTextHeight(bool trailingBreak)
 {
-	Validate();
+	Validate(trailingBreak);
 	return wrappedText.Height(trailingBreak);
 }
 
@@ -118,7 +118,7 @@ int TextArea::GetTextHeight(bool trailingBreak)
 
 int TextArea::GetLongestLineWidth()
 {
-	Validate();
+	Validate(scrollHeightIncludesTrailingBreak);
 	return wrappedText.LongestLineWidth();
 }
 
@@ -129,7 +129,7 @@ void TextArea::Draw()
 	if(!buffer)
 		buffer = std::make_unique<RenderBuffer>(size);
 
-	Validate();
+	Validate(scrollHeightIncludesTrailingBreak);
 	if(!bufferIsValid || !scroll.IsAnimationDone())
 	{
 		scroll.Step();
@@ -239,12 +239,13 @@ void TextArea::Invalidate()
 
 
 
-void TextArea::Validate()
+void TextArea::Validate(bool trailingBreak)
 {
-	if(!textIsValid)
+	if(!textIsValid || trailingBreak != scrollHeightIncludesTrailingBreak)
 	{
 		wrappedText.Wrap(text);
-		scroll.SetMaxValue(wrappedText.Height());
+		scroll.SetMaxValue(wrappedText.Height(trailingBreak));
+		scrollHeightIncludesTrailingBreak = trailingBreak;
 		textIsValid = true;
 	}
 }

--- a/source/TextArea.h
+++ b/source/TextArea.h
@@ -60,7 +60,7 @@ protected:
 	virtual bool Scroll(double dx, double dy) override;
 
 	void Invalidate();
-	void Validate();
+	void Validate(bool trailingBreak);
 
 
 private:
@@ -78,4 +78,5 @@ private:
 	bool hovering = false;
 
 	ScrollBar scrollBar;
+	bool scrollHeightIncludesTrailingBreak = false;
 };


### PR DESCRIPTION
**Bug fix**

## Summary
The snapshot save dialog is scrolling its text even though it is nowhere near long enough to need scrolling.
This has been because the `ScrollBar` thing has been getting the height of the text including a trailing paragraph break, but the enclosing `TextArea` and consequently `Dialog` get the height without the trailing paragraph break.
The `TextArea` object tells the `ScrollBar` object how much space there is, which is less than how much space `ScrollBar` thinks it needs, so it scrolls the text, unnecessarily.

This PR fixes that by making sure that when the `TextArea` calculates its own height, the `ScrollBar` either includes or excludes the trailing paragraph break the same way, probably.

~~I have at least 10% confidence that no other dialogs will be adversely affected by this change.~~

## Screenshots
before | after
-- | --
![image](https://github.com/user-attachments/assets/82ec41fd-3464-4998-a7e2-7a11ef6bc235) | ![image](https://github.com/user-attachments/assets/ceeaa0fa-6eaf-45f2-85ed-f709f47fe1f3)

## Testing Done
Looked at the snapshot save dialog.

## Performance Impact
Minimal, probably.
