### PR TITLE
fix(mechanics): Remove tribute definitions properly

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -128,7 +128,12 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes)
 			else if(key == "security")
 				security = 0.;
 			else if(key == "tribute")
+			{
 				tribute = 0;
+				defenseThreshold = 4000;
+				defenseFleets.clear();
+				ResetDefense();
+			}
 			else if(key == "wormhole")
 				wormhole = nullptr;
 


### PR DESCRIPTION
**Bug fix**

## Summary
Currently, when you try to remove the tribute definition from a planet, only the salary value gets actually cleared. It's not a problem initially, because the game doesn't let you fight the fleets if the tribute value is 0. But when you define a new tribute on the planet, the rest is reused from the old instance that was supposedly removed. With this PR, everything tribute-related gets cleared when you do `remove tribute`.

## Testing Done
Used [this test plugin](https://github.com/user-attachments/files/19198442/test-plugin-tribute.zip).

## Wiki Update
N/A

## Performance Impact
N/A