### PR TITLE
fix(content): Remnant no longer can follow you to Nenia until after you release the void sprite samples

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1969,6 +1969,8 @@ government "Remnant"
 	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "remnant uncontacted hostile"
 	"hostile disabled hail" "hostile disabled"
+	"travel restrictions"
+		system "Nenia"
 
 government "Remnant (Research)"
 	"display name" "Remnant"
@@ -1995,6 +1997,8 @@ government "Remnant (Research)"
 	"friendly disabled hail" "friendly disabled"
 	"hostile hail" "remnant uncontacted hostile"
 	"hostile disabled hail" "hostile disabled"
+	"travel restrictions"
+		system "Nenia"
 
 color "governments: Republic" .91 .42 .09
 

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -84,6 +84,10 @@ event "remnant: sign studies complete"
 
 
 event "remnant: return the samples timer"
+	government "Remnant"
+		remove "travel restrictions"
+	government "Remnant (Research)"
+		remove "travel restrictions"
 
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in PR #10489.

## Summary
The Remnant can no longer follow you to Nenia until a few days after you release the samples due to travel restrictions, since they wouldn’t want to get blown up by the Archon.

## Testing Done
TBD

## Save File
TBD