### PR TITLE
ui: Fix off-by-one index on boarding panel

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -279,7 +279,8 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 		if(count == plunder[selected].Count())
 		{
 			plunder.erase(plunder.begin() + selected);
-			selected = min<int>(selected, plunder.size());
+			if(plunder.size() && selected == static_cast<int>(plunder.size()))
+				--selected;
 		}
 		else
 			plunder[selected].Take(count);


### PR DESCRIPTION
**Bug fix**

## Summary
There was a line limiting the selected outfit index on the boarding panel when the previously selected item is removed from the list. However, it didn't do anything as the index was already at the limiting value. Instead of subtracting 1, I chose to do it in a different way to not mess up the logic in the rest of the file.
Now when you take everything from the last element of the list, the selection changes to the now-last element.

## Testing Done
yes.™
