### PR TITLE
fix(bug) Fix resource directory not being found on linux

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -101,7 +101,7 @@ void Files::Init(const char * const *argv)
 		// Special case, for Linux: the resource files are not in the same place as
 		// the executable, but are under the same prefix (/usr or /usr/local).
 		// When used as an iterator, a trailing / will create an empty item at
-		// the end, so parent paths not include it
+		// the end, so parent paths do not include it.
 		static const filesystem::path LOCAL_PATH = "/usr/local";
 		static const filesystem::path STANDARD_PATH = "/usr";
 		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -100,8 +100,10 @@ void Files::Init(const char * const *argv)
 #if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
 		// Special case, for Linux: the resource files are not in the same place as
 		// the executable, but are under the same prefix (/usr or /usr/local).
-		static const filesystem::path LOCAL_PATH = "/usr/local/";
-		static const filesystem::path STANDARD_PATH = "/usr/";
+		// When used as an iterator, a trailing / will create an empty item at
+		// the end, so parent paths not include it
+		static const filesystem::path LOCAL_PATH = "/usr/local";
+		static const filesystem::path STANDARD_PATH = "/usr";
 		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
 
 		const auto IsParent = [](const auto parent, const auto child) -> bool {


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11160 

## Summary
Removes trailing slashes from parent directories, to prevent iterator from creating an empty trailing element that fails the match.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Tested locally by just running the game. Fails to start without the change (see issue for details)

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A