### PR TITLE
feat(ui): Move the message log filter toggle to interfaces

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2076,6 +2076,25 @@ interface "info panel"
 interface "message log"
 	value "width" 570
 
+	sprite "ui/message log key"
+		center 710 -30 bottom left
+	visible if "!important only"
+	sprite "ui/unchecked"
+		center 640 -30 bottom left
+	visible if "important only"
+	sprite "ui/checked"
+		center 640 -30 bottom left
+	visible
+	active if "important only"
+	button i ""
+		center 706 -20 bottom left
+		dimensions 142 40
+	"wrapped label" "Hide less _important messages"
+		center 714 -16 bottom left
+		width 130
+		color active
+		inactive medium
+
 	visible if "empty"
 	label "(The message log is empty.)"
 		from 300 0 left

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -74,46 +74,36 @@ void MessageLogPanel::Draw()
 
 	Information info;
 	if(messages.empty())
-	{
 		info.SetCondition("empty");
-		GameData::Interfaces().Get("message log")->Draw(info, nullptr);
-		return;
-	}
-
-	const Font &font = FontSet::Get(14);
-
-	// Parameters for drawing messages:
-	WrappedText messageLine(font);
-	messageLine.SetAlignment(Alignment::LEFT);
-	messageLine.SetWrapWidth(width - 2. * PAD);
-
-	// Draw messages.
-	Point pos = Screen::BottomLeft() + Point(PAD, scroll);
-	for(const auto &it : messages)
+	else
 	{
-		if(importantOnly && (it.second == Messages::Importance::Low || it.second == Messages::Importance::High))
-			continue;
+		const Font &font = FontSet::Get(14);
 
-		messageLine.Wrap(it.first);
-		pos.Y() -= messageLine.Height();
-		if(pos.Y() >= Screen::Top() - 3 * font.Height())
-			messageLine.Draw(pos, *Messages::GetColor(it.second, true));
+		// Parameters for drawing messages:
+		WrappedText messageLine(font);
+		messageLine.SetAlignment(Alignment::LEFT);
+		messageLine.SetWrapWidth(width - 2. * PAD);
+
+		// Draw messages.
+		Point pos = Screen::BottomLeft() + Point(PAD, scroll);
+		for(const auto &it : messages)
+		{
+			if(importantOnly && (it.second == Messages::Importance::Low || it.second == Messages::Importance::High))
+				continue;
+
+			messageLine.Wrap(it.first);
+			pos.Y() -= messageLine.Height();
+			if(pos.Y() >= Screen::Top() - 3 * font.Height())
+				messageLine.Draw(pos, *Messages::GetColor(it.second, true));
+		}
+
+		maxScroll = max(0., scroll - pos.Y() + Screen::Top());
 	}
 
-	maxScroll = max(0., scroll - pos.Y() + Screen::Top());
+	if(importantOnly)
+		info.SetCondition("important only");
 
-	// Draw the filter box.
-	const Sprite *filterBack = SpriteSet::Get("ui/message log key");
-	pos = Screen::BottomLeft() + Point(width + 40., 0.);
-	SpriteShader::Draw(filterBack, pos + Point(.5 * filterBack->Width(), -.5 * filterBack->Height()));
-	const Color color[2] = {*GameData::Colors().Get("medium"), *GameData::Colors().Get("bright")};
-	const Sprite *box[2] = {SpriteSet::Get("ui/unchecked"), SpriteSet::Get("ui/checked")};
-	pos += Point(30., -30.);
-	SpriteShader::Draw(box[importantOnly], pos);
-	Point off = Point(10., -.5 * font.Height());
-	font.Draw("Hide less _important", pos + off, color[importantOnly]);
-	font.Draw("messages", pos + off + Point(0., 20.), color[importantOnly]);
-	AddZone(Rectangle(pos + Point(64., 10.), Point(140., 40.)), [this](){ importantOnly = !importantOnly; });
+	GameData::Interfaces().Get("message log")->Draw(info, this);
 }
 
 


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in https://github.com/endless-sky/endless-sky/pull/9997#discussion_r1581605773.

## Summary
The box with the button toggling the message log category filter is now defined as interface data. As we can't have icons inside text fields, the button and the label are technically separate, so that the click zone covers both the text and the check box. Not ideal, but still better than the current hardcoded version.

## Screenshots
![a1](https://github.com/user-attachments/assets/4f2a576b-50d2-418a-b744-bf83cc2497cd)
![a2](https://github.com/user-attachments/assets/06cf1eb7-7863-40a5-850d-4077477d646a)

## Testing Done
See the screenshots above.

## Performance Impact
Exists in theory as with all interfaces, but should be unnoticeable.
