### PR TITLE
fix(content): Block more human space jobs from offering without landing access or in pirate space

### DIFF
--- a/data/human/deep jobs.txt
+++ b/data/human/deep jobs.txt
@@ -1102,6 +1102,7 @@ mission "Lionheart Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Valhalla"
 	source
 		near "Epsilon Leonis" 2 10
 		attributes factory
@@ -1120,6 +1121,7 @@ mission "Lionheart Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Valhalla"
 	source
 		near "Epsilon Leonis" 2 10
 		attributes factory research
@@ -1138,6 +1140,7 @@ mission "Lionheart Shipment [2]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Valhalla"
 	source
 		near "Epsilon Leonis" 2 10
 		attributes factory mining
@@ -1156,6 +1159,7 @@ mission "Deep Sky Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Asgard"
 	source
 		near Naos 2 15
 		attributes factory
@@ -1174,6 +1178,7 @@ mission "Deep Sky Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Asgard"
 	source
 		near Naos 2 15
 		attributes factory research

--- a/data/human/far north jobs.txt
+++ b/data/human/far north jobs.txt
@@ -19,6 +19,7 @@ mission "Betelgeuse Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Prime"
 	source
 		not government Pirate
 		near Betelgeuse 2 10
@@ -42,6 +43,7 @@ mission "Betelgeuse Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Prime"
 	source
 		not government Pirate
 		near Betelgeuse 2 10
@@ -65,6 +67,7 @@ mission "Betelgeuse Shipment [2]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Prime"
 	source
 		not government Pirate
 		near Betelgeuse 2 10

--- a/data/human/near earth jobs.txt
+++ b/data/human/near earth jobs.txt
@@ -238,6 +238,7 @@ mission "Transport farmers to Mars"
 	passengers 2 2 .8
 	to offer
 		random < 50
+		has "landing access: Mars"
 	source "Earth"
 	destination "Mars"
 	on visit
@@ -255,6 +256,7 @@ mission "Transport tourists to Luna"
 	passengers 2 2 .8
 	to offer
 		random < 50
+		has "landing access: Luna"
 	source "Earth"
 	destination "Luna"
 	on visit
@@ -271,6 +273,7 @@ mission "Transport seasonal workers to Earth"
 	passengers 2 2 .8
 	to offer
 		random < 50
+		has "landing access: Earth"
 	source "Mars"
 	destination "Earth"
 	on visit

--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -607,6 +607,7 @@ mission "Gemini Shipyards Shipment [0]"
 	repeat
 	to offer
 		random < 15
+		has "landing access: Geminus"
 		or
 			not "event: war begins"
 			has "event: geminus rebuilt"
@@ -627,6 +628,7 @@ mission "Gemini Shipyards Shipment [1]"
 	job
 	repeat
 	to offer
+		has "landing access: Geminus"
 		random < 15
 		or
 			not "event: war begins"
@@ -649,6 +651,7 @@ mission "Lovelace Labs Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Ada"
 	source
 		near Aldebaran 2 10
 		attributes core factory
@@ -667,6 +670,7 @@ mission "Polymath Nanoinstruments Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Vinci"
 	source
 		near Miaplacidus 2 10
 		attributes core factory

--- a/data/human/rim jobs.txt
+++ b/data/human/rim jobs.txt
@@ -19,6 +19,7 @@ mission "Southbound Shipment [0]"
 	cargo "weapons" 5 2 .1
 	to offer
 		random < 10
+		has "landing access: Zug"
 	source
 		not government "Pirate"
 		near "Zubeneschamali" 2 10
@@ -42,6 +43,7 @@ mission "Southbound Shipment [1]"
 	cargo "Ship Alloys" 5 2 .1
 	to offer
 		random < 10
+		has "landing access: Zug"
 	source
 		not government "Pirate"
 		near "Zubeneschamali" 2 10
@@ -66,6 +68,7 @@ mission "Kraz Shipment [0]"
 	cargo "weapons parts" 5 2 .1
 	to offer
 		random < 10
+		has "landing access: Rust"
 	source
 		not government "Pirate"
 		near "Kraz" 2 10
@@ -89,6 +92,7 @@ mission "Kraz Shipment [1]"
 	cargo Electronics 5 2 .1
 	to offer
 		random < 10
+		has "landing access: Rust"
 	source
 		not government "Pirate"
 		near "Kraz" 2 10

--- a/data/human/south jobs.txt
+++ b/data/human/south jobs.txt
@@ -232,6 +232,7 @@ mission "Delta V Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Solace"
 	source
 		near Pherkad 2 15
 		attributes factory
@@ -250,6 +251,7 @@ mission "Delta V Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Solace"
 	source
 		near Pherkad 2 15
 		attributes factory
@@ -268,6 +270,7 @@ mission "Tarazed Shipyards Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Wayfarer"
 	source
 		near Tarazed 2 10
 		attributes factory
@@ -286,6 +289,7 @@ mission "Tarazed Shipyards Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Wayfarer"
 	source
 		near Tarazed 2 10
 		attributes factory mining
@@ -304,6 +308,7 @@ mission "Tarazed Shipyards Shipment [2]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Wayfarer"
 	source
 		near Tarazed 2 10
 		attributes factory mining
@@ -322,6 +327,7 @@ mission "Tarazed Systems Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Wayfarer"
 	source
 		near Tarazed 2 10
 		attributes factory mining
@@ -340,6 +346,7 @@ mission "Tarazed Systems Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Wayfarer"
 	source
 		near Tarazed 2 10
 		attributes factory

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -713,6 +713,7 @@ mission "Megaparsec Shipment [0]"
 	source
 		near Mirfak 2 10
 		attributes core factory
+		not government "Pirate"
 	destination Sunracer
 	npc
 		government Pirate
@@ -736,6 +737,7 @@ mission "Megaparsec Shipment [1]"
 	source
 		near Mirfak 2 10
 		attributes core mining factory
+		not government "Pirate"
 	destination Sunracer
 	npc
 		government Pirate
@@ -759,6 +761,7 @@ mission "Megaparsec Shipment [2]"
 	source
 		near Mirfak 2 10
 		attributes core mining factory
+		not government "Pirate"
 	destination Sunracer
 	npc
 		government Pirate

--- a/data/human/syndicate jobs.txt
+++ b/data/human/syndicate jobs.txt
@@ -565,9 +565,11 @@ mission "Syndicated Shipyards Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Foundry"
 	source
 		near Achernar 2 10
 		attributes core factory
+		not government "Pirate"
 	destination Foundry
 	npc
 		government Pirate
@@ -587,9 +589,11 @@ mission "Syndicated Shipyards Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Foundry"
 	source
 		near Achernar 2 10
 		attributes core mining
+		not government "Pirate"
 	destination Foundry
 	npc
 		government Pirate
@@ -609,9 +613,11 @@ mission "Syndicated Shipyards Shipment [2]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Foundry"
 	source
 		near Achernar 2 10
 		attributes core factory
+		not government "Pirate"
 	destination Foundry
 	npc
 		government Pirate
@@ -631,9 +637,11 @@ mission "Syndicated Shipyards Shipment [3]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Foundry"
 	source
 		near Achernar 2 10
 		attributes core factory
+		not government "Pirate"
 	destination Foundry
 	npc
 		government Pirate
@@ -653,9 +661,11 @@ mission "Syndicated Systems Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Hephaestus"
 	source
 		near Markab 2 10
 		attributes core factory
+		not government "Pirate"
 	destination Hephaestus
 	npc
 		government Pirate
@@ -675,9 +685,11 @@ mission "Syndicated Systems Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Hephaestus"
 	source
 		near Markab 2 10
 		attributes core mining factory
+		not government "Pirate"
 	destination Hephaestus
 	npc
 		government Pirate
@@ -697,6 +709,7 @@ mission "Megaparsec Shipment [0]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Sunracer"
 	source
 		near Mirfak 2 10
 		attributes core factory
@@ -719,6 +732,7 @@ mission "Megaparsec Shipment [1]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Sunracer"
 	source
 		near Mirfak 2 10
 		attributes core mining factory
@@ -741,6 +755,7 @@ mission "Megaparsec Shipment [2]"
 	repeat
 	to offer
 		random < 10
+		has "landing access: Sunracer"
 	source
 		near Mirfak 2 10
 		attributes core mining factory


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/1016522571782574180/1350168505265295493).

## Summary
It was possible to get missions to transport materials to the Syndicate from Pirate planets. This is no longer possible. Furthermore, I have gone through and made it so that you cannot get these missions, along with the intrasystem jobs in Sol, if you do not have landing access to the destination.

## Testing Done
Made sure transport jobs stopped offering in the reported system.

## Save File
This save file can be used to test these changes:
[Test Pilot~Pirate.txt](https://github.com/user-attachments/files/19252900/Test.Pilot.Pirate.txt)