### PR TITLE
feat(style): Force tab-indents in CMakeLists

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,10 +12,13 @@ trim_trailing_whitespace = false
 indent_style = tab
 
 # Code files
-[{*.{cpp,h,rc,hpp}, SConstruct, SConscript}]
+[*.{cpp,h,rc,hpp}]
 indent_style = tab
 cpp_space_pointer_reference_alignment = right
 cpp_space_after_keywords_in_control_flow_statements = false
+
+[**/CMakeLists.txt]
+indent_style = tab
 
 # Changelog file
 [changelog]


### PR DESCRIPTION
## Summary
Set the editorconfig's indent style in CMakeLists to tab.

Also removed some leftover SCons files from the list as they are no longer used.