### PR TITLE
fix(content): Stop `sketchy passenger` from offering with a station as the destination.

### DIFF
--- a/data/human/south jobs.txt
+++ b/data/human/south jobs.txt
@@ -195,6 +195,7 @@ mission "Sketchy Passenger [0]"
 	destination
 		distance 2 10
 		attributes "south"
+		not attributes "station"
 	on accept
 		dialog `You have some difficulty finding your passengers, but after almost an hour of searching you finally find them. As they follow you back to your ship, you hear them whispering to each other, but you can't make out what they're saying.`
 	on visit
@@ -216,6 +217,7 @@ mission "Sketchy Passenger [1]"
 	destination
 		distance 2 10
 		attributes "south"
+		not attributes "station"
 	on accept
 		dialog `You have some difficulty finding your passengers, but after almost an hour of searching you finally find them. As they follow you back to your ship, you hear them whispering to each other, but you can't make out what they're saying.`
 	on visit


### PR DESCRIPTION
**Bug fix**

## Summary
This job's `on complete` text doesn't really make sense if it finishes on a station.

## Screenshots
Screenshot from before this change, illustrating the job completing on a station.
![image](https://github.com/user-attachments/assets/77f48147-1db6-4f53-832c-eea3d733c63d)

## Testing Done
none