### PR TITLE
fix(bug): add a description to `Timothy Radrickson 3c: Escort the Convoy`

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7894,6 +7894,7 @@ mission "Timothy Radrickson 3b: Pirate Base"
 mission "Timothy Radrickson 3c: Escort the Convoy"
 	landing
 	name "Escort the Convoy"
+	description "Escort the Hroar's Haulers Convoy from <origin> to <destination>."
 	source "Greenrock"
 	destination "Wayfarer"
 	to offer


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1350569543017300078)

## Summary
Added a missing description to the mission `Timothy Radrickson 3c: Escort the Convoy`.