### PR TITLE
Feat(update) 2025-03-16-c The rest of the data changes and one code change to continue the testing

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -30,6 +30,7 @@
 		"gard"
 		"Mata"
 		"Diamond Grey"
+			`	"Willkommen im ehrwuerdigen Bach Collegium Konzertsaal! Wir sind Lichtjahre von Mozarts Heimat entfernt, aber auch im Zentrum von Kleinwean! Geniessen Sie das Konzert!"`
 		"Grey Wolf"
 				`	"The Grey Goose."`
 			`	He smiles sadly. "Skaldgar always had a nose for good folks. Anyways, he told me he had a nephew named Helm who worked at the Norn spaceport. Find 'im and he can get'cha and this stone where it needs to go." The young man than looks you in the eye and gives a slow respectful nod, "For Ol' Skaldgar, may he be findin' ore in hel."`

--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -292,15 +292,15 @@ outfit "Magnetoplasma Drive"
 	"mass" 12
 	"outfit space" -12
 	"engine capacity" -12
-	"thrust" 9
-	"thrusting energy" 0.6
-	"thrusting heat" 0.3
-	"reverse thrust" 9
-	"reverse thrusting energy" 0.6
-	"reverse thrusting heat" 0.3
-	"turn" 270
-	"turning energy" 0.6
-	"turning heat" 0.3
+	"thrust" 7.5
+	"thrusting energy" 1.2
+	"thrusting heat" 0.6
+	"reverse thrust" 7.5
+	"reverse thrusting energy" 1.2
+	"reverse thrusting heat" 0.6
+	"turn" 240
+	"turning energy" 1.2
+	"turning heat" 0.6
 	"drag reduction" 0.3
 	"flare sprite" "effect/wanderer flare/tiny"
 		"frame rate" 5

--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -970,3 +970,34 @@ mission "Exotic Life: Glaze"
 			label closing
 			`	You walk back to your ship from the binoculars.`
 				decline
+
+mission "Little Vienna in New Austria"
+	minor
+	source "New Austria"
+	to offer
+		random < 10
+	on offer
+		conversation
+			`As you walk from the spaceport's landing pads towards the center of the village, your attention is caught by a worn-down sign pointing you to the "Kleinwean Bezirk."`
+			choice
+				`	(Follow the sign.)`
+				`	(Ignore the sign and keep walking.)`
+					decline
+			`	Curious, you decide to investigate, turning into a narrow street that feels like an echo of Old Vienna. A handful of historic-looking buildings line the cobblestone path, their facades adorned with dramatic stonework and flowery tilework. A small concert hall, labeled "Bach Collegium Konzertsaal", hums with the faint sound of string instruments tuning. Nearby, the aroma of rich, chocolatey coffee drifts from a small coffeehouse.`
+			`	Outside the coffeehouse, a man at a marble table sips his coffee while reading a local newspaper. You can see the front page with the headline: "Mitreibender Mozart mit dem Bach Collegium Konzertsaal", featuring a photograph of a smiling conductor at the center of a small orchestra. On the reader's plate rests a bright pink sponge cake, its color fitting right in with the rich tones of the street.`
+			`	As you linger, a well-dressed older woman approaches. Her voice, imbued with a musical rhythm, greets you with a hearty "Gruess Gott!`
+			`	"Not many offworld visit Kleinwean, which is a shame, as you can see it's quite the New Austrian 'gem'," she remarks with a wink. "I was on my way to the concert - my husband is sick - and I would hate for his ticket to go to waste. Would you do me the honor of taking it?"`
+			choice
+				`	(Accept the ticket.)`
+				`	(Politely decline.)`
+					goto declined
+			`	You graciously accept the invitation and follow her to the intimate concert hall. Despite its modest size, the hall houses a full orchestra. Once you're comfortably seated, the conductor steps forward, clears his throat, and in a measured tone declares:`
+			`	"Willkommen im ehrwuerdigen Bach Collegium Konzertsaal! Wir sind Lichtjahre von Mozarts Heimat entfernt, aber auch im Zentrum von Kleinwean! Geniessen Sie das Konzert!"`
+			`	The words hang in the air as you notice the conductor's smile, strikingly familiar from the newspaper photograph. With his invitation to lose yourself in the performance still echoing, the orchestra begins a stirring rendition of Mozart. The notes dance through the air with crystalline clarity, and you even recognize one or two of the melodies, each serving as a bridge to the Old Vienna of Earth.`
+			`	Even after the performance, you feel the sound of music resonate in your bones as you glance back one more time at New Austria's hidden cultural enclave.`
+				goto backtoship
+			label declined
+			`	You thank her kindly but explain that you're not in the mood for a concert. She nods understandingly, her eyes softening with disappointed yet gracious acceptance. You finish your exploration of the "Kleinwean Bezirk", absorbing the ambiance of the cobblestone street as the scents of coffee mingle with the sound of music.`
+			label backtoship
+			`	With the atmosphere steeped in nostalgia for a distant city on a distant world long past, you return to your ship.`
+

--- a/data/kahet/aberrant ships.txt
+++ b/data/kahet/aberrant ships.txt
@@ -43,6 +43,8 @@ ship "Aberrant Latte"
 		"hull repair rate" 0.6
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -112,6 +114,8 @@ ship "Aberrant Chomper"
 		"hull repair rate" 0.6
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -188,6 +192,8 @@ ship "Aberrant Pileup"
 		"hull repair rate" 0.6
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -258,6 +264,8 @@ ship "Aberrant Hugger"
 		"hull repair rate" 0.6
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -330,6 +338,8 @@ ship "Aberrant Longfellow"
 		"hull repair rate" 0.6
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -408,6 +418,8 @@ ship "Aberrant Dancer"
 		"hull repair rate" 0.6
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 500
 			"shield damage" 11400
@@ -484,6 +496,8 @@ ship "Aberrant Junior"
 		"hull repair rate" 1.2
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -557,6 +571,8 @@ ship "Aberrant Icebreaker"
 		"hull repair rate" 1.2
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -631,6 +647,8 @@ ship "Aberrant Pike"
 		"hull repair rate" 1.2
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -704,6 +722,8 @@ ship "Aberrant Mole"
 		"hull repair rate" 1.2
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -779,6 +799,8 @@ ship "Aberrant Whiskers"
 		"hull repair rate" 1.2
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 300
 			"shield damage" 6400
@@ -847,6 +869,8 @@ ship "Aberrant Trip"
 		"hull repair rate" 0.2
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 600
 			"shield damage" 12400
@@ -927,6 +951,8 @@ ship "Aberrant Triplet"
 		"hull repair rate" 1.4
 		"quantum keystone" 1
 		"ka'sei" 1
+		"overheat damage threshold" 0.7
+		"overheat damage rate" 0.7
 		weapon
 			"blast radius" 600
 			"shield damage" 12400

--- a/data/kahet/kahet ships.txt
+++ b/data/kahet/kahet ships.txt
@@ -555,6 +555,8 @@ ship "Fetri'sei"
 		"shield heat" 3.4
 		"hull repair rate" 0.3
 		"ka'sei" 1
+		"overheat damage threshold" 0.2
+		"overheat damage rate" 1
 		weapon
 			"blast radius" 120
 			"shield damage" 540

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1245,7 +1245,7 @@ void AI::SetMousePosition(Point position)
 
 
 // Get the in-system strength of each government's allies and enemies.
-int64_t AI::AllyStrength(const Government *government)
+int64_t AI::AllyStrength(const Government *government) const
 {
 	auto it = allyStrength.find(government);
 	return (it == allyStrength.end() ? 0 : it->second);
@@ -1253,7 +1253,7 @@ int64_t AI::AllyStrength(const Government *government)
 
 
 
-int64_t AI::EnemyStrength(const Government *government)
+int64_t AI::EnemyStrength(const Government *government) const
 {
 	auto it = enemyStrength.find(government);
 	return (it == enemyStrength.end() ? 0 : it->second);
@@ -2054,6 +2054,16 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 
 
 
+void AI::MoveWithParent(Ship &ship, Command &command, const Ship &parent)
+{
+	if(ship.GetFormationPattern())
+		MoveInFormation(ship, command);
+	else
+		KeepStation(ship, command, parent);
+}
+
+
+
 // TODO: Function should be const, but formation flying needed write access to the FormationPositioner.
 void AI::MoveEscort(Ship &ship, Command &command)
 {
@@ -2063,8 +2073,9 @@ void AI::MoveEscort(Ship &ship, Command &command)
 	bool needsFuel = ship.NeedsFuel();
 	bool isStaying = ship.GetPersonality().IsStaying() || !hasFuelCapacity;
 	bool parentIsHere = (currentSystem == parent.GetSystem());
-	// Check if the parent has a target planet that is in the parent's system.
-	const Planet *parentPlanet = (parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr);
+	// Check if the parent already landed, or has a target planet that is in the parent's system.
+	const Planet *parentPlanet = (parent.GetPlanet() ? parent.GetPlanet() :
+		(parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr));
 	bool planetIsHere = (parentPlanet && parentPlanet->IsInSystem(parent.GetSystem()));
 	bool systemHasFuel = hasFuelCapacity && currentSystem->HasFuelFor(ship);
 
@@ -2165,9 +2176,13 @@ void AI::MoveEscort(Ship &ship, Command &command)
 		{
 			ship.SetTargetSystem(nullptr);
 			ship.SetTargetStellar(parent.GetTargetStellar());
-			MoveToPlanet(ship, command);
 			if(parent.IsLanding())
+			{
+				MoveToPlanet(ship, command);
 				command |= Command::LAND;
+			}
+			else
+				MoveWithParent(ship, command, parent);
 		}
 		else if(parentPlanet->IsWormhole())
 		{
@@ -2191,19 +2206,15 @@ void AI::MoveEscort(Ship &ship, Command &command)
 				MoveTo(ship, command, Point(), Point(), 40., 0.1);
 			else
 				// This ship has no route to the parent's destination system, so protect it until it jumps away.
-				KeepStation(ship, command, parent);
+				MoveWithParent(ship, command, parent);
 		}
-		else if(ship.GetFormationPattern())
-			MoveInFormation(ship, command);
 		else
-			KeepStation(ship, command, parent);
+			MoveWithParent(ship, command, parent);
 	}
 	else if(parent.Commands().Has(Command::BOARD) && parent.GetTargetShip().get() == &ship)
 		Stop(ship, command, .2);
-	else if(ship.GetFormationPattern())
-		MoveInFormation(ship, command);
 	else
-		KeepStation(ship, command, parent);
+		MoveWithParent(ship, command, parent);
 }
 
 
@@ -2408,20 +2419,20 @@ double AI::TurnToward(const Ship &ship, const Point &vector, const double precis
 
 
 
-bool AI::MoveToPlanet(Ship &ship, Command &command)
+bool AI::MoveToPlanet(Ship &ship, Command &command, double cruiseSpeed)
 {
 	if(!ship.GetTargetStellar())
 		return false;
 
 	const Point &target = ship.GetTargetStellar()->Position();
-	return MoveTo(ship, command, target, Point(), ship.GetTargetStellar()->Radius(), 1.);
+	return MoveTo(ship, command, target, Point(), ship.GetTargetStellar()->Radius(), 1., cruiseSpeed);
 }
 
 
 
 // Instead of moving to a point with a fixed location, move to a moving point (Ship = position + velocity)
 bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
-	const Point &targetVelocity, double radius, double slow)
+	const Point &targetVelocity, double radius, double slow, double cruiseSpeed)
 {
 	const Point &position = ship.Position();
 	const Point &velocity = ship.Velocity();
@@ -2438,9 +2449,24 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
 
-	bool isFacing = (dp.Unit().Dot(angle.Unit()) > .95);
+	// Calculate target vector required to get where we want to be.
+	Point tv = dp;
+	bool hasCruiseSpeed = (cruiseSpeed > 0.);
+	if(hasCruiseSpeed)
+	{
+		// The ship prefers a velocity at cruise-speed towards the target, so we need
+		// to compare this preferred velocity to the current velocity and apply the
+		// delta to get to the preferred velocity.
+		tv = (dp.Unit() * cruiseSpeed) - velocity;
+		// If we are moving close to our preferred velocity, then face towards the target.
+		if(tv.LengthSquared() < .01)
+			tv = dp;
+	}
+
+	bool isFacing = (tv.Unit().Dot(angle.Unit()) > .95);
 	if(!isClose || (!isFacing && !shouldReverse))
-		command.SetTurn(TurnToward(ship, dp));
+		command.SetTurn(TurnToward(ship, tv));
+
 	// Drag is not applied when not thrusting, so stop thrusting when close to max speed
 	// to save energy. Work with a slightly lower maximum velocity to avoid border cases.
 	// In order for a ship to use their afterburner, they must also have the forward
@@ -2449,7 +2475,13 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 	double maxVelocity = ship.MaxVelocity(ShouldUseAfterburner(ship)) * .99;
 	if(isFacing && (velocity.LengthSquared() <= maxVelocity * maxVelocity
 			|| dp.Unit().Dot(velocity.Unit()) < .95))
-		command |= Command::FORWARD;
+	{
+		// We set full forward power when we don't have a cruise-speed, when we are below
+		// cruise-speed or when we need to do course corrections.
+		bool movingTowardsTarget = (velocity.Unit().Dot(dp.Unit()) > .95);
+		if(!hasCruiseSpeed || !movingTowardsTarget || velocity.Length() < cruiseSpeed)
+			command |= Command::FORWARD;
+	}
 	else if(shouldReverse)
 	{
 		command.SetTurn(TurnToward(ship, velocity));

--- a/source/AI.h
+++ b/source/AI.h
@@ -79,8 +79,8 @@ template <class Type>
 	void SetMousePosition(Point position);
 
 	// Get the in-system strength of each government's allies and enemies.
-	int64_t AllyStrength(const Government *government);
-	int64_t EnemyStrength(const Government *government);
+	int64_t AllyStrength(const Government *government) const;
+	int64_t EnemyStrength(const Government *government) const;
 
 	// Find nearest landing location.
 	static const StellarObject *FindLandingLocation(const Ship &ship, const bool refuel = true);
@@ -102,6 +102,7 @@ private:
 	bool FollowOrders(Ship &ship, Command &command);
 	void MoveInFormation(Ship &ship, Command &command);
 	void MoveIndependent(Ship &ship, Command &command) const;
+	void MoveWithParent(Ship &ship, Command &command, const Ship &parent);
 	void MoveEscort(Ship &ship, Command &command);
 	static void Refuel(Ship &ship, Command &command);
 	static bool CanRefuel(const Ship &ship, const StellarObject *target);
@@ -117,9 +118,9 @@ private:
 	// "precision" is an optional argument corresponding to a value of the dot product of the current and target facing
 	// vectors above which no turning should be attempting, to reduce constant, minute corrections.
 	static double TurnToward(const Ship &ship, const Point &vector, const double precision = 0.9999);
-	static bool MoveToPlanet(Ship &ship, Command &command);
+	static bool MoveToPlanet(Ship &ship, Command &command, double cruiseSpeed = 0.);
 	static bool MoveTo(Ship &ship, Command &command, const Point &targetPosition,
-		const Point &targetVelocity, double radius, double slow);
+		const Point &targetVelocity, double radius, double slow, double cruiseSpeed = 0.);
 	static bool Stop(Ship &ship, Command &command, double maxSpeed = 0., const Point direction = Point());
 	static void PrepareForHyperspace(Ship &ship, Command &command);
 	static void CircleAround(Ship &ship, Command &command, const Body &target);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4971,12 +4971,17 @@ void Ship::AddEscort(Ship &ship)
 void Ship::RemoveEscort(const Ship &ship)
 {
 	auto it = escorts.begin();
-	for( ; it != escorts.end(); ++it)
-		if(it->lock().get() == &ship)
+	while(it != escorts.end())
+	{
+		auto escort = it->lock();
+		if(escort.get() == &ship)
 		{
-			escorts.erase(it);
+			it = escorts.erase(it);
 			return;
 		}
+		else
+			++it;
+	}
 }
 
 


### PR DESCRIPTION
This PR is being made on the assumption that, until proven otherwise, the most likely point of failure is one of the two code PRs that was included in the general update with the failing integration tests.

So, this update has all the data changes up to the present day, along with a single code change, namely the one that makes it so that escorts stick close to their flagship. This should trigger all the integration tests, and if it clears things properly, then that reinforces the idea that the problem is the two commits in the failing update.