### PR TITLE
Refactor: Increase const correctness of reference parameters and member functions

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -495,7 +495,7 @@ void AI::IssueMoveTarget(const Point &target, const System *moveToSystem)
 
 
 // Commands issued via the keyboard (mostly, to the flagship).
-void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
+void AI::UpdateKeys(PlayerInfo &player, const Command &activeCommands)
 {
 	escortsUseAmmo = Preferences::Has("Escorts expend ammo");
 	escortsAreFrugal = Preferences::Has("Escorts use ammo frugally");
@@ -2419,7 +2419,7 @@ double AI::TurnToward(const Ship &ship, const Point &vector, const double precis
 
 
 
-bool AI::MoveToPlanet(Ship &ship, Command &command, double cruiseSpeed)
+bool AI::MoveToPlanet(const Ship &ship, Command &command, double cruiseSpeed)
 {
 	if(!ship.GetTargetStellar())
 		return false;
@@ -2431,7 +2431,7 @@ bool AI::MoveToPlanet(Ship &ship, Command &command, double cruiseSpeed)
 
 
 // Instead of moving to a point with a fixed location, move to a moving point (Ship = position + velocity)
-bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
+bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 	const Point &targetVelocity, double radius, double slow, double cruiseSpeed)
 {
 	const Point &position = ship.Position();
@@ -2493,7 +2493,7 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 
 
 
-bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point direction)
+bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &direction)
 {
 	const Point &velocity = ship.Velocity();
 	const Angle &angle = ship.Facing();
@@ -2559,7 +2559,7 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 
 
 
-void AI::PrepareForHyperspace(Ship &ship, Command &command)
+void AI::PrepareForHyperspace(const Ship &ship, Command &command)
 {
 	bool hasHyperdrive = ship.JumpNavigation().HasHyperdrive();
 	double scramThreshold = ship.Attributes().Get("scram drive");
@@ -2620,7 +2620,7 @@ void AI::PrepareForHyperspace(Ship &ship, Command &command)
 
 
 
-void AI::CircleAround(Ship &ship, Command &command, const Body &target)
+void AI::CircleAround(const Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
 	command.SetTurn(TurnToward(ship, direction));
@@ -2638,7 +2638,7 @@ void AI::CircleAround(Ship &ship, Command &command, const Body &target)
 
 
 
-void AI::Swarm(Ship &ship, Command &command, const Body &target)
+void AI::Swarm(const Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
 	double maxSpeed = ship.MaxVelocity();
@@ -2651,7 +2651,7 @@ void AI::Swarm(Ship &ship, Command &command, const Body &target)
 
 
 
-void AI::KeepStation(Ship &ship, Command &command, const Body &target)
+void AI::KeepStation(const Ship &ship, Command &command, const Body &target)
 {
 	// Constants:
 	static const double MAX_TIME = 600.;
@@ -2748,7 +2748,7 @@ void AI::KeepStation(Ship &ship, Command &command, const Body &target)
 
 
 
-void AI::Attack(Ship &ship, Command &command, const Ship &target)
+void AI::Attack(const Ship &ship, Command &command, const Ship &target)
 {
 	// Deploy any fighters you are carrying.
 	if(!ship.IsYours() && ship.HasBays())
@@ -2831,14 +2831,14 @@ void AI::Attack(Ship &ship, Command &command, const Ship &target)
 
 
 
-void AI::AimToAttack(Ship &ship, Command &command, const Body &target)
+void AI::AimToAttack(const Ship &ship, Command &command, const Body &target)
 {
 	command.SetTurn(TurnToward(ship, TargetAim(ship, target)));
 }
 
 
 
-void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
+void AI::MoveToAttack(const Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
 
@@ -2871,7 +2871,7 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 
 
 
-void AI::PickUp(Ship &ship, Command &command, const Body &target)
+void AI::PickUp(const Ship &ship, Command &command, const Body &target)
 {
 	// Figure out the target's velocity relative to the ship.
 	Point p = target.Position() - ship.Position();
@@ -2903,7 +2903,7 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 
 // Determine if using an afterburner does not use up reserve fuel, cause undue
 // energy strain, or undue thermal loads if almost overheated.
-bool AI::ShouldUseAfterburner(Ship &ship)
+bool AI::ShouldUseAfterburner(const Ship &ship)
 {
 	if(!ship.Attributes().Get("afterburner thrust"))
 		return false;
@@ -3272,7 +3272,7 @@ bool AI::DoHarvesting(Ship &ship, Command &command) const
 
 
 // Check if this ship should cloak. Returns true if this ship decided to run away while cloaking.
-bool AI::DoCloak(Ship &ship, Command &command)
+bool AI::DoCloak(const Ship &ship, Command &command) const
 {
 	if(ship.GetPersonality().IsDecloaked())
 		return false;
@@ -3418,7 +3418,7 @@ void AI::DoPatrol(Ship &ship, Command &command) const
 
 
 
-void AI::DoScatter(Ship &ship, Command &command)
+void AI::DoScatter(const Ship &ship, Command &command) const
 {
 	if(!command.Has(Command::FORWARD) && !command.Has(Command::BACK))
 		return;
@@ -3453,7 +3453,7 @@ void AI::DoScatter(Ship &ship, Command &command)
 
 
 
-bool AI::DoSecretive(Ship &ship, Command &command)
+bool AI::DoSecretive(Ship &ship, Command &command) const
 {
 	shared_ptr<Ship> scanningShip;
 	// Figure out if any ship is currently scanning us. If that is the case, move away from it.

--- a/source/AI.h
+++ b/source/AI.h
@@ -63,7 +63,7 @@ template <class Type>
 	void IssueMoveTarget(const Point &target, const System *moveToSystem);
 
 	// Commands issued via the keyboard (mostly, to the flagship).
-	void UpdateKeys(PlayerInfo &player, Command &clickCommands);
+	void UpdateKeys(PlayerInfo &player, const Command &clickCommands);
 
 	// Allow the AI to track any events it is interested in.
 	void UpdateEvents(const std::list<ShipEvent> &events);
@@ -118,31 +118,31 @@ private:
 	// "precision" is an optional argument corresponding to a value of the dot product of the current and target facing
 	// vectors above which no turning should be attempting, to reduce constant, minute corrections.
 	static double TurnToward(const Ship &ship, const Point &vector, const double precision = 0.9999);
-	static bool MoveToPlanet(Ship &ship, Command &command, double cruiseSpeed = 0.);
-	static bool MoveTo(Ship &ship, Command &command, const Point &targetPosition,
+	static bool MoveToPlanet(const Ship &ship, Command &command, double cruiseSpeed = 0.);
+	static bool MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 		const Point &targetVelocity, double radius, double slow, double cruiseSpeed = 0.);
-	static bool Stop(Ship &ship, Command &command, double maxSpeed = 0., const Point direction = Point());
-	static void PrepareForHyperspace(Ship &ship, Command &command);
-	static void CircleAround(Ship &ship, Command &command, const Body &target);
-	static void Swarm(Ship &ship, Command &command, const Body &target);
-	static void KeepStation(Ship &ship, Command &command, const Body &target);
-	static void Attack(Ship &ship, Command &command, const Ship &target);
-	static void AimToAttack(Ship &ship, Command &command, const Body &target);
-	static void MoveToAttack(Ship &ship, Command &command, const Body &target);
-	static void PickUp(Ship &ship, Command &command, const Body &target);
+	static bool Stop(const Ship &ship, Command &command, double maxSpeed = 0., const Point &direction = Point());
+	static void PrepareForHyperspace(const Ship &ship, Command &command);
+	static void CircleAround(const Ship &ship, Command &command, const Body &target);
+	static void Swarm(const Ship &ship, Command &command, const Body &target);
+	static void KeepStation(const Ship &ship, Command &command, const Body &target);
+	static void Attack(const Ship &ship, Command &command, const Ship &target);
+	static void AimToAttack(const Ship &ship, Command &command, const Body &target);
+	static void MoveToAttack(const Ship &ship, Command &command, const Body &target);
+	static void PickUp(const Ship &ship, Command &command, const Body &target);
 	// Special decisions a ship might make.
-	static bool ShouldUseAfterburner(Ship &ship);
+	static bool ShouldUseAfterburner(const Ship &ship);
 	// Special personality behaviors.
 	void DoAppeasing(const std::shared_ptr<Ship> &ship, double *threshold) const;
 	void DoSwarming(Ship &ship, Command &command, std::shared_ptr<Ship> &target);
 	void DoSurveillance(Ship &ship, Command &command, std::shared_ptr<Ship> &target) const;
 	void DoMining(Ship &ship, Command &command);
 	bool DoHarvesting(Ship &ship, Command &command) const;
-	bool DoCloak(Ship &ship, Command &command);
+	bool DoCloak(const Ship &ship, Command &command) const;
 	void DoPatrol(Ship &ship, Command &command) const;
 	// Prevent ships from stacking on each other when many are moving in sync.
-	void DoScatter(Ship &ship, Command &command);
-	bool DoSecretive(Ship &ship, Command &command);
+	void DoScatter(const Ship &ship, Command &command) const;
+	bool DoSecretive(Ship &ship, Command &command) const;
 
 	static Point StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &shouldReverse);
 	// Get a vector giving the direction this ship should aim in in order to do

--- a/source/CategoryList.h
+++ b/source/CategoryList.h
@@ -40,7 +40,7 @@ public:
 		Category(const std::string &name, int precedence) : name(name), precedence(precedence) {}
 		const std::string &Name() const { return name; }
 		const bool operator<(const Category &other) const { return SortHelper(*this, other); }
-		const bool operator()(Category &a, Category &b) const { return SortHelper(a, b); }
+		const bool operator()(const Category &a, const Category &b) const { return SortHelper(a, b); }
 
 	private:
 		static const bool SortHelper(const Category &a, const Category &b);

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -381,7 +381,7 @@ int64_t ConditionSet::Evaluate(const ConditionsStore &conditionsStore) const
 	BinFun accumulatorOp = Op(expressionOperator);
 	if(accumulatorOp != nullptr && !children.empty())
 		return accumulate(next(children.begin()), children.end(), children[0].Evaluate(conditionsStore),
-			[&accumulatorOp, &conditionsStore](int64_t accumulated, ConditionSet b) -> int64_t {
+			[&accumulatorOp, &conditionsStore](int64_t accumulated, const ConditionSet &b) -> int64_t {
 				return accumulatorOp(accumulated, b.Evaluate(conditionsStore));
 		});
 

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -371,7 +371,7 @@ const ConditionsStore::ConditionEntry *ConditionsStore::GetEntry(const string &n
 
 
 // Helper function to check if we can safely add a provider with the given name.
-bool ConditionsStore::VerifyProviderLocation(const string &name, DerivedProvider *provider) const
+bool ConditionsStore::VerifyProviderLocation(const string &name, const DerivedProvider *provider) const
 {
 	auto it = storage.upper_bound(name);
 	if(it == storage.begin())

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -137,7 +137,7 @@ private:
 	// creation if required).
 	ConditionEntry *GetEntry(const std::string &name);
 	const ConditionEntry *GetEntry(const std::string &name) const;
-	bool VerifyProviderLocation(const std::string &name, DerivedProvider *provider) const;
+	bool VerifyProviderLocation(const std::string &name, const DerivedProvider *provider) const;
 
 
 

--- a/source/DataWriter.cpp
+++ b/source/DataWriter.cpp
@@ -64,7 +64,7 @@ void DataWriter::SaveToPath(const filesystem::path &filepath)
 
 
 // Get the contents as a string.
-string DataWriter::SaveToString()
+string DataWriter::SaveToString() const
 {
 	return out.str();
 }

--- a/source/DataWriter.h
+++ b/source/DataWriter.h
@@ -48,7 +48,7 @@ public:
 	// Save the contents to a file.
 	void SaveToPath(const std::filesystem::path &path);
 	// Get the contents as a string.
-	std::string SaveToString();
+	std::string SaveToString() const;
 
 	// The Write() function can take any number of arguments. Each argument is
 	// converted to a token. Arguments may be strings or numeric values.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -405,7 +405,7 @@ void Engine::Place()
 // Add NPC ships to the known ships. These may have been freshly instantiated
 // from an accepted assisting/boarding mission, or from existing missions when
 // the player departs a planet.
-void Engine::Place(const list<NPC> &npcs, shared_ptr<Ship> flagship)
+void Engine::Place(const list<NPC> &npcs, const shared_ptr<Ship> &flagship)
 {
 	for(const NPC &npc : npcs)
 	{

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -68,7 +68,7 @@ public:
 	// Place all the player's ships, and "enter" the system the player is in.
 	void Place();
 	// Place NPCs spawned by a mission that offers when the player is not landed.
-	void Place(const std::list<NPC> &npcs, std::shared_ptr<Ship> flagship = nullptr);
+	void Place(const std::list<NPC> &npcs, const std::shared_ptr<Ship> &flagship = nullptr);
 
 	// Wait for the previous calculations (if any) to be done.
 	void Wait();

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -38,7 +38,7 @@ using namespace std;
 namespace {
 	// Generate an offset magnitude that will sample from an annulus (planets)
 	// or a circle (systems without inhabited planets).
-	double OffsetFrom(pair<Point, double> &center)
+	double OffsetFrom(const pair<Point, double> &center)
 	{
 		// If the center has a radius, then position ships further away.
 		double minimumOffset = center.second ? 1. : 0.;
@@ -537,7 +537,7 @@ vector<shared_ptr<Ship>> Fleet::Instantiate(const vector<const Ship *> &ships) c
 
 
 
-bool Fleet::PlaceFighter(shared_ptr<Ship> fighter, vector<shared_ptr<Ship>> &placed) const
+bool Fleet::PlaceFighter(const shared_ptr<Ship> &fighter, vector<shared_ptr<Ship>> &placed) const
 {
 	if(!fighter->CanBeCarried())
 		return false;

--- a/source/Fleet.h
+++ b/source/Fleet.h
@@ -79,7 +79,7 @@ public:
 private:
 	static std::pair<Point, double> ChooseCenter(const System &system);
 	std::vector<std::shared_ptr<Ship>> Instantiate(const std::vector<const Ship *> &ships) const;
-	bool PlaceFighter(std::shared_ptr<Ship> fighter, std::vector<std::shared_ptr<Ship>> &placed) const;
+	bool PlaceFighter(const std::shared_ptr<Ship> &fighter, std::vector<std::shared_ptr<Ship>> &placed) const;
 
 
 private:

--- a/source/FormationPattern.cpp
+++ b/source/FormationPattern.cpp
@@ -32,7 +32,7 @@ FormationPattern::PositionIterator::PositionIterator(const FormationPattern &pat
 
 
 
-const Point &FormationPattern::PositionIterator::operator*()
+const Point &FormationPattern::PositionIterator::operator*() const
 {
 	return currentPoint;
 }

--- a/source/FormationPattern.h
+++ b/source/FormationPattern.h
@@ -48,7 +48,7 @@ public:
 
 		// A subset of the default input_iterator operations. Limiting to
 		// only a subset, since not all operations are used in-game.
-		const Point &operator*();
+		const Point &operator*() const;
 		PositionIterator &operator++();
 
 	private:

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -1011,7 +1011,7 @@ void MissionPanel::Accept(bool force)
 		bool stillLooking = true;
 
 		// Updates availableIt if matching system found, returns true if planet also matches.
-		auto SelectNext = [this, planet, system, &stillLooking](list<Mission>::const_iterator &it) -> bool
+		auto SelectNext = [this, planet, system, &stillLooking](const list<Mission>::const_iterator &it) -> bool
 		{
 			if(it->Destination() && it->Destination()->IsInSystem(system))
 			{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -432,7 +432,7 @@ void PlayerInfo::Load(const filesystem::path &path)
 	// cargo and passengers.
 	UpdateCargoCapacities();
 
-	auto DistributeMissionCargo = [](map<string, map<string, int>> &toDistribute, const list<Mission> &missions,
+	auto DistributeMissionCargo = [](const map<string, map<string, int>> &toDistribute, const list<Mission> &missions,
 			vector<shared_ptr<Ship>> &ships, CargoHold &cargo, bool passengers) -> void
 	{
 		for(const auto &it : toDistribute)

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -50,7 +50,7 @@ namespace {
 	const int LINES_PER_PAGE = 26;
 
 	// Draw a list of (string, value) pairs.
-	void DrawList(vector<pair<int64_t, string>> &list, Table &table, const string &title,
+	void DrawList(vector<pair<int64_t, string>> &list, const Table &table, const string &title,
 		int64_t titleValue, int maxCount = 0, bool drawValues = true)
 	{
 		if(list.empty())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1939,7 +1939,7 @@ int Ship::Scan(const PlayerInfo &player)
 	doScan(outfitScan, outfitSpeed, outfitDistanceSquared, outfits, ShipEvent::SCAN_OUTFITS);
 
 	// Play the scanning sound if the actor or the target is the player's ship.
-	auto playScanSounds = [](const map<const Sound *, int> &sounds, Point &position)
+	auto playScanSounds = [](const map<const Sound *, int> &sounds, const Point &position)
 	{
 		if(sounds.empty())
 			Audio::Play(Audio::Get("scan"), position, SoundCategory::SCAN);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -1065,7 +1065,7 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 
 
 
-void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
+void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing) const
 {
 	const string &key = node.Token(0);
 	bool hasValue = (node.Size() >= 2);

--- a/source/System.h
+++ b/source/System.h
@@ -183,7 +183,7 @@ public:
 
 private:
 	void LoadObject(const DataNode &node, Set<Planet> &planets, int parent = -1);
-	void LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing = false);
+	void LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing = false) const;
 	// Once the star map is fully loaded or an event has changed systems
 	// or links, figure out which stars are "neighbors" of this one, i.e.
 	// close enough to see or to reach via jump drive.

--- a/source/audio/Sound.cpp
+++ b/source/audio/Sound.cpp
@@ -30,8 +30,8 @@ namespace {
 	// is an unsupported format (anything but little-endian 16-bit PCM at 44100 HZ),
 	// this will return 0.
 	uint32_t ReadHeader(File &in, uint32_t &frequency);
-	uint32_t Read4(File &in);
-	uint16_t Read2(File &in);
+	uint32_t Read4(const File &in);
+	uint16_t Read2(const File &in);
 }
 
 
@@ -158,7 +158,7 @@ namespace {
 
 
 
-	uint32_t Read4(File &in)
+	uint32_t Read4(const File &in)
 	{
 		unsigned char data[4];
 		if(fread(data, 1, 4, in) != 4)
@@ -171,7 +171,7 @@ namespace {
 
 
 
-	uint16_t Read2(File &in)
+	uint16_t Read2(const File &in)
 	{
 		unsigned char data[2];
 		if(fread(data, 1, 2, in) != 2)

--- a/source/comparators/BySeriesAndIndex.h
+++ b/source/comparators/BySeriesAndIndex.h
@@ -53,7 +53,7 @@ public:
 template<>
 class BySeriesAndIndex<Outfit> {
 public:
-	bool operator()(const std::string &nameA, const std::string &nameB)
+	bool operator()(const std::string &nameA, const std::string &nameB) const
 	{
 		const Outfit *outfitA = GameData::Outfits().Get(nameA);
 		const Outfit *outfitB = GameData::Outfits().Get(nameB);

--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -209,7 +209,7 @@ void ImageSet::Load() noexcept(false)
 	FillSwizzleMasks(paths[3], paths[0].size());
 
 
-	auto LoadSprites = [&](vector<filesystem::path> &toLoad, ImageBuffer &buffer, const string &specifier) {
+	auto LoadSprites = [&](const vector<filesystem::path> &toLoad, ImageBuffer &buffer, const string &specifier) {
 		for(size_t i = 0; i < frames && i < toLoad.size(); ++i)
 			if(!buffer.Read(toLoad[i], i))
 			{


### PR DESCRIPTION
## Summary
* Declare reference parameters as const reference where applicable.
* Declare member functions as const where they don't manipulate state of the class. Some more member functions could be declared const, but they manipulate reference or pointer member of their class. So I left them as mutable as constness would only be "memory const" not "logical const". Examples are the "click" functions of Gui Panels.

I am currently trying to familiarize myself with the ES codebase and usually do a bit of surface level refactorings / core cleanups when doing so.

This is a pure refactoring, there are no changes in functionality.


## Testing Done
Existing unit-tests are green

## Performance Impact
None expected, 
