### PR TITLE
feat(balance) Removing Yottrite from Incipias Space

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -10456,7 +10456,6 @@ system Clepsydra
 	asteroids "medium metal" 3 1.261
 	asteroids "large metal" 1 1.287
 	minables aluminum 3 1.513
-	minables yottrite 4 7
 	object
 		sprite star/a-eater
 		period 10
@@ -30962,7 +30961,6 @@ system "Pedita Pri"
 	asteroids "medium metal" 4 2.55
 	asteroids "large metal" 6 2.67
 	minables iron 15 3.025
-	minables yottrite 2 7
 	object
 		sprite star/o5
 		distance 1.485
@@ -31003,7 +31001,6 @@ system "Pedita Sec"
 	link Clepsydra
 	link "Pedita Pri"
 	asteroids "large metal" 1 4.638
-	minables yottrite 4 7
 	object
 		sprite star/g0
 		period 10
@@ -38422,7 +38419,6 @@ system Supra
 	asteroids "medium metal" 174 2.352
 	asteroids "large metal" 8 1.296
 	minables lead 32 3.752
-	minables yottrite 1 3
 	object
 		sprite star/o3
 		distance 18.018


### PR DESCRIPTION


## Details
> An extraordinarily rare crystalline formation, forged over tens of thousands of years in the molecular clouds around supernova remnants. Although less advanced species can potentially harvest it, very few civilizations other than the Quarg have developed the technology needed to incorporate Yottrite in an alloy.

This description would indicate only systems with large nebulae should have Yottrite formation. Therefore, I propose some changes below to bring every system which would bring the systems inline.

- Middle Incipias Cluster :  Main Sequence / Giant Stars in these systems do not have sizable nebula, therefore should have Yottrite removed.
- Ildaria : As a Nova, has the potential addition for the addition of Yottrite

