### PR TITLE
[Balance] Buff the Sheragi EM Batteries

### DIFF
--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -26,7 +26,8 @@ outfit "Small EM Battery"
 	"shield generation" 0.14
 	"shield energy" 0.14
 	"shield heat" 0.14
-	"energy capacity" 3600
+	"heat generation" 0.8
+	"energy capacity" 12600
 	description "This small superconductive inductor stores just enough power to keep a fighter running, and the electromagnetic field it generates helps to maintain the shield matrix."
 
 outfit "Large EM Battery"
@@ -42,7 +43,8 @@ outfit "Large EM Battery"
 	"shield generation" 0.8
 	"shield energy" 0.8
 	"shield heat" 0.8
-	"energy capacity" 40000
+	"heat generation" 6.5
+	"energy capacity" 165000
 	description "This is a massive superconductive coil, capable of storing large amounts of energy in an electromagnetic field and discharging all of it in a fraction of a second. The magnetic field also provides a small boost to the shield regeneration of the ship, which is otherwise very underdeveloped."
 
 outfit "Small Hybrid Cooling"

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -27,7 +27,7 @@ outfit "Small EM Battery"
 	"shield energy" 0.14
 	"shield heat" 0.14
 	"heat generation" 0.8
-	"energy capacity" 12600
+	"energy capacity" 8300
 	description "This small superconductive inductor stores just enough power to keep a fighter running, and the electromagnetic field it generates helps to maintain the shield matrix."
 
 outfit "Large EM Battery"
@@ -44,7 +44,7 @@ outfit "Large EM Battery"
 	"shield energy" 0.8
 	"shield heat" 0.8
 	"heat generation" 6.5
-	"energy capacity" 165000
+	"energy capacity" 100000
 	description "This is a massive superconductive coil, capable of storing large amounts of energy in an electromagnetic field and discharging all of it in a fraction of a second. The magnetic field also provides a small boost to the shield regeneration of the ship, which is otherwise very underdeveloped."
 
 outfit "Small Hybrid Cooling"


### PR DESCRIPTION
**Balance**

This PR addresses the incessant complaining described in my fever dreams

## Summary
The Sheragi batteries were skipped over during the big battery buff in #6783, only receiving a 2x buff when most other battery outfits received buffs between 4-10x. This was because they are technically dual use outfits, being shield generators as well as batteries. However, literally no one is going to go for a 150 ton shield generator that has 0.8 shield generation.

More importantly, the Sheragi batteries are described as Superconducting Magnetic Energy Storages, (SMES) which are incredibly cool, and depending on the critical field limits of the superconductors in question, are up near the upper limit of energy storage density. Since these are unique outfits, with the player only able to ever obtain 1 of the Large EM Batteries and 6 of the Small ones, I don't feel too bad about giving these a significant buff (not like they'll be all that useful anyway when the Coalition batteries exist). I also gave them a small amount of heat generation because something something cryocoolers (you want to cryocool your superconductors even if they have a room temperature critical temperature because critical field goes up with lower temperatures).

## Usage examples
You could use the Sheragi batteries on a space ship.

## Testing Done
I didn't.

## Performance Impact
Big performance improvement for Sheragi batteries
