### PR TITLE
fix(bug) Fix Korath settler job appearing before Wanderer Colony

### DIFF
--- a/data/korath/korath jobs.txt
+++ b/data/korath/korath jobs.txt
@@ -209,7 +209,7 @@ mission "Kor Efreti: Settlers"
 	passengers 10 5 .15
 	cargo "supplies" 5 3 .16
 	to offer
-		has "wanderers sestor done"
+		has "event: wanderers: sabira eseskrai colony"
 		random < 90
 	source
 		government "Kor Efret"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue None
Didn't report, sorry. Fix is quick and simple, however.

## Summary
It was possible to be offered "Korath settlers to Sabira Eseskrai" jobs, before the Wanderer colony there was established. This PR is attempting to fix this by changing the `to offer` condition to the founding of the colony instead of allowing them to be offered as soon as the Kor Sestor story line is finished.

## Screenshots
Before:
![Screenshot_20250316-234159](https://github.com/user-attachments/assets/eefa3164-6c93-4972-93b9-96c613add6bd)


## Usage examples
N/A

## Testing Done
None whatsoever

## Save File
None provided

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A