### PR TITLE
fix(content): Have `Timmy Radrickson 1` describe how you entered the system before detecting Timmy 

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7527,10 +7527,10 @@ mission "Timothy Radrickson 1: Stowaway"
 		conversation
 			`Upon completing your jump, one of your internal sensors begins to beep. You flick off the siren and check the diagnostic report: apparently there is a non-negligible heat source detected in the food storage of your ship.`
 				to display
-					not "entered system by: take off"
+					not "entered system by: takeoff"
 			`Upon taking off, one of your internal sensors begins to beep. You flick off the siren and check the diagnostic report: apparently there is a non-negligible heat source detected in the food storage of your ship.`
 				to display
-					has "entered system by: take off"
+					has "entered system by: takeoff"
 			`	As problems go, it is not a particularly alarming one: there are plenty of reasons there may be a heat spike in storage, and most of them would not require the captain of the ship to investigate.`
 			`	It is unusual, however.`
 			choice

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7526,6 +7526,11 @@ mission "Timothy Radrickson 1: Stowaway"
 	on enter
 		conversation
 			`Upon completing your jump, one of your internal sensors begins to beep. You flick off the siren and check the diagnostic report: apparently there is a non-negligible heat source detected in the food storage of your ship.`
+				to display
+					not "entered system by: take off"
+			`Upon taking off, one of your internal sensors begins to beep. You flick off the siren and check the diagnostic report: apparently there is a non-negligible heat source detected in the food storage of your ship.`
+				to display
+					has "entered system by: take off"
 			`	As problems go, it is not a particularly alarming one: there are plenty of reasons there may be a heat spike in storage, and most of them would not require the captain of the ship to investigate.`
 			`	It is unusual, however.`
 			choice


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the bug described in issue #11190. (closes #11190)

## Summary
In `Timmy Radrickson 1`, one day after you take off, you detect Timmy due to his infrared radiation, however, the mission text assumes that you always jump after taking off, which is not necesarily the case. This PR updates the text so that, if you take off, the text mentions you taking off instead of completing your jump.

## Testing Done
Warp core did the testing for me