### PR TITLE
Timothy Radrickson 5: Oblivion Meeting: simplify and fix

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -8920,7 +8920,7 @@ mission "Timothy Radrickson 5: Oblivion Meeting"
 				`	"I'm sorry, Timothy."`
 				`	"Is there any way I can help?"`
 				`	"Shouldn't have broken the law."`
-			`	"I could use your help. Just to buy some things. Might help." His red eyes glance side to side before he says, conspiratorially, "Meet me tonight in the spaceport. Outside the Stephenson warehouse. I'll tell you what I need."`
+			`	"I could use your help. Just to buy some things. Might help." His red eyes glance side to side before he says, conspiratorially, "Meet me tonight in the spaceport. Outside the Stephenson warehouse. Stephenson. I'll tell you what I need."`
 			`	With that, he returns to moving the mineral trolley, leaving you to yourself.`
 				accept
 	on enter

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -8906,7 +8906,6 @@ mission "Timothy Radrickson 5: Oblivion Meeting"
 		random < 90
 		has "Timothy Radrickson 4: Imprisoned: active"
 	source "Oblivion"
-	deadline 1
 	invisible
 	on offer
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
@@ -8921,12 +8920,11 @@ mission "Timothy Radrickson 5: Oblivion Meeting"
 				`	"I'm sorry, Timothy."`
 				`	"Is there any way I can help?"`
 				`	"Shouldn't have broken the law."`
-
-			`	"I could use your help. Just to buy some things. Might help." His red eyes glance side to side before he says, conspiratorially, "Meet me tonight in the spaceport. Outside the Stephenson warehouse. Stephenson. I'll tell you what I need."`
+			`	"I could use your help. Just to buy some things. Might help." His red eyes glance side to side before he says, conspiratorially, "Meet me tonight in the spaceport. Outside the Stephenson warehouse. I'll tell you what I need."`
 			`	With that, he returns to moving the mineral trolley, leaving you to yourself.`
 				accept
-	to complete
-		never
+	on enter
+		fail
 
 
 mission "Timothy Radrickson 5a: Timshank Redemption"
@@ -8941,7 +8939,8 @@ mission "Timothy Radrickson 5a: Timshank Redemption"
 		"timothy radrickson suit" >= 1
 		"timothy radrickson id" >= 1
 	to offer
-		has "Timothy Radrickson 5: Oblivion Meeting: active"
+		has "Timothy Radrickson 5: Oblivion Meeting: offered"
+		not "Timothy Radrickson 5: Oblivion Meeting: failed"
 	on offer
 		conversation
 			`Even after donning a particulate mask, Oblivion's toxic atmosphere is so thick it seems as if you could swallow it; it doesn't help that the air somehow feels even denser at night. The warehouse marked "Stephenson Heavy Industries" turns out to be at the very edge of the spaceport's boundary, and all you see when you get there is a lone box truck parked in the loading bay.`


### PR DESCRIPTION
**Bug fix**
**Typo fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1350872989763375249)

## Summary
Simplified the mission `Timothy Radrickson 5: Oblivion Meeting` so that `Timothy Radrickson 5a: Timshank Redemption` properly offers.
Also fixed a typo in the dialog. Before merge, I'd like @SpearDane to confirm it was actually a typo and not an intentional repeated word.

## Save File
This save file can be used to test these changes:
[Dag Roth~Timothy.txt](https://github.com/user-attachments/files/19387077/Dag.Roth.Timothy.txt)
