### PR TITLE
fix(sound): Read 32 and 16 bit sound fragments fully

### DIFF
--- a/source/audio/Sound.cpp
+++ b/source/audio/Sound.cpp
@@ -172,7 +172,8 @@ namespace {
 	uint16_t Read2(const shared_ptr<iostream> in)
 	{
 		unsigned char data[2];
-		if(in->readsome(reinterpret_cast<char *>(data), 2) != 2)
+		in->read(reinterpret_cast<char *>(data), 2);
+		if(in->gcount() != 2)
 			return 0;
 		uint16_t result = 0;
 		for(int i = 0; i < 2; ++i)

--- a/source/audio/Sound.cpp
+++ b/source/audio/Sound.cpp
@@ -158,7 +158,8 @@ namespace {
 	uint32_t Read4(const shared_ptr<iostream> in)
 	{
 		unsigned char data[4];
-		if(in->readsome(reinterpret_cast<char *>(data), 4) != 4)
+		in->read(reinterpret_cast<char *>(data), 4);
+		if(in->gcount() != 4)
 			return 0;
 		uint32_t result = 0;
 		for(int i = 0; i < 4; ++i)


### PR DESCRIPTION
**Bug fix**

## Summary
Sounds are not currently loaded by executables built by clang (self-compiled on Windows or our MacOS CD).
This is because of a difference in behaviour of `std::fstream` objects upon construction between gcc and clang implementations of the C++ standard.
This difference results in there being no available bytes when `std::istream::readsome` is called to traverse the audio file header in the clang implementation, while there are many available bytes in the gcc implementation.
`std::istream::readsome` will only read from already available bytes, and so it reads nothing in the clang implementation. Not reading files is not conducive to loading them, and so, they are not loaded.

This PR removes the calls to `std::istream::readsome` and replaces them with calls to `std::istream::read` which does not care about whether or not bytes are already available. This means that it can always read the bytes regardless of if they were made available during or following construction.

## Testing Done
Game launches and makes the hangar sound or whatever upon finishing loading, and there are no errors about not being able to load sounds. Without this PR, no sound is played and there are a lot of errors about not being able to laod sounds.

## Performance Impact
It actually loads the data now, so it might take a little longer.
