### PR TITLE
Test parse every platform in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
         testPreset: ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
     - name: Run Benchmarks
       run: ctest --preset ${{ matrix.opengl == 'GL' && 'linux-ci-benchmark' || 'linux-gles-ci-benchmark' }}
+    - name: Run Test Parse
+      run: build/ci/endless-sky.exe --parse-assets
 
 
   build_steam:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset ${{ matrix.opengl == 'GL' && 'linux-ci-benchmark' || 'linux-gles-ci-benchmark' }}
     - name: Run Test Parse
-      run: build/ci/endless-sky.exe --parse-assets
+      run: ./build/ci/endless-sky --parse-assets
 
 
   build_steam:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless Sky.exe' --parse-assets"
+      run: "'build/ci/Endless Sky' --parse-assets"
 
 
   build_macos-arm:
@@ -269,7 +269,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-arm-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless Sky.exe' --parse-assets"
+      run: "'build/ci/Endless Sky' --parse-assets"
 
 
   build_documentation_doxygen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless SKy.exe' --parse-assets"
+      run: "'build/ci/Endless Sky.exe' --parse-assets"
 
 
   build_macos-arm:
@@ -269,7 +269,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-arm-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless SKy.exe' --parse-assets"
+      run: "'build/ci/Endless Sky.exe' --parse-assets"
 
 
   build_documentation_doxygen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset clang-cl-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless Sky.exe' --parse-assets"
+      run: '"build/ci/Endless Sky.exe" --parse-assets'
 
 
   build_macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,8 @@ jobs:
         testPreset: 'macos-arm-ci'
     - name: Run Benchmarks
       run: ctest --preset macos-arm-ci-benchmark
+    - name: Run Test Parse
+      run: "'build/ci/Endless SKy.exe' --parse-assets"
 
 
   build_documentation_doxygen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-ci-benchmark
     - name: Run Test Parse
-      run: |
-        ls
-        cd build
-        ls
-        cd ci
-        ls
-        cd ../..
-        "'./build/ci/Endless Sky' --parse-assets"
+      run: "'build/ci/endless-sky' --parse-assets"
 
 
   build_macos-arm:
@@ -277,14 +270,7 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-arm-ci-benchmark
     - name: Run Test Parse
-      run: |
-        ls
-        cd build
-        ls
-        cd ci
-        ls
-        cd ../..
-        "'./build/ci/Endless Sky' --parse-assets"
+      run: "'build/ci/endless-sky' --parse-assets"
 
 
   build_documentation_doxygen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,8 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset clang-cl-ci-benchmark
     - name: Run Test Parse
-      run: '"build/ci/Endless Sky.exe" --parse-assets'
+      run: "'build/ci/Endless Sky.exe' --parse-assets"
+      shell: bash
 
 
   build_macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,8 @@ jobs:
         testPreset: 'clang-cl-ci'
     - name: Run Benchmarks
       run: ctest --preset clang-cl-ci-benchmark
+    - name: Run Test Parse
+      run: "'build/ci/Endless Sky.exe' --parse-assets"
 
 
   build_macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,14 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless Sky' --parse-assets"
+      run: |
+        ls
+        cd build
+        ls
+        cd ci
+        ls
+        cd ../..
+        "'./build/ci/Endless Sky' --parse-assets"
 
 
   build_macos-arm:
@@ -270,7 +277,14 @@ jobs:
     - name: Run Benchmarks
       run: ctest --preset macos-arm-ci-benchmark
     - name: Run Test Parse
-      run: "'build/ci/Endless Sky' --parse-assets"
+      run: |
+        ls
+        cd build
+        ls
+        cd ci
+        ls
+        cd ../..
+        "'./build/ci/Endless Sky' --parse-assets"
 
 
   build_documentation_doxygen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,8 @@ jobs:
         testPreset: 'macos-ci'
     - name: Run Benchmarks
       run: ctest --preset macos-ci-benchmark
+    - name: Run Test Parse
+      run: "'build/ci/Endless SKy.exe' --parse-assets"
 
 
   build_macos-arm:

--- a/steam/docker-compose.yml
+++ b/steam/docker-compose.yml
@@ -28,3 +28,4 @@ services:
         ninja
         ./endless-sky --version
         ctest --label-exclude "integration-debug"
+        ./endless-sky --parse-assets


### PR DESCRIPTION
**CI/CD/Testing**

## Summary
This PR adds an extra step to the Linux, Steam, Windows Clang, Mac OS, and Mac OS ARM CI jobs that runs the "test parse" facility of Endless Sky, to ensure that all assets (game data, images, and sounds) load correctly (maybe).
The standard Windows build is already test parsed in the dedicated "test parse" CI job, so I have not changed the build job.
This is because, apparently, compiler specific behaviours can affect how this stuff is loaded (see #11199). The goal of the new steps is to highlight such issues.
I've left the existing test parse job alone because we still want to test that content only changes are parsed correctly, and such changes will not run the other CI jobs.

## Testing Done
Let the CI run. It fails on executables built with clang (Windows Clang, Mac OS, and Mac OS ARM) citing the inability to load any sound files, but has no issues when the executable was built with gcc.

## Performance Impact
CI will take a little longer, but the time to run the new steps vs the time to build the application and run integration tests is very small.
