### PR TITLE
feat(enhancement): Load plugins from zip files

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libfuse2
+          sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libminizip-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libfuse2
       - name: Setup cached directories
         uses: actions/cache@v4
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -78,6 +78,8 @@ jobs:
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
         shell: bash
+      - name: Find minizip
+        run: pkg-config --libs minizip
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
@@ -117,6 +119,8 @@ jobs:
         uses: Mozilla-Actions/sccache-action@v0.0.5
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
+      - name: Find minizip
+        run: pkg-config --libs minizip
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -119,8 +119,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@v0.0.5
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
-      - name: Find minizip
-        run: pkg-config --libs minizip
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -78,8 +78,6 @@ jobs:
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
         shell: bash
-      - name: Find minizip
-        run: pkg-config --libs minizip
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libfuse2
+          sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libminizip-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libfuse2
       - name: Setup sccache
         uses: Mozilla-Actions/sccache-action@v0.0.5
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install development dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libosmesa6 mesa-utils libglvnd-dev x11-utils catch2 libltdl-dev
+        sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libminizip-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libosmesa6 mesa-utils libglvnd-dev x11-utils catch2 libltdl-dev
     - name: Disable VM sound card
       run: |
         sudo sh -c 'echo "pcm.!default { type plug slave.pcm \"null\" }"  >> /etc/asound.conf'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 find_package(ZLIB REQUIRED)
 find_package(PkgConfig REQUIRED PkgConfig PkgConf)
 pkg_check_modules(MINIZIP REQUIRED minizip)
-message(${MINIZIP_LIBRARIES})
 
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,11 @@ find_path(LIBMAD_INCLUDE_DIR mad.h)
 find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
 
+# Find the zip-reading component of zlib.
+find_package(ZLIB REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(MINIZIP REQUIRED minizip)
+
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)
 	# On Windows copy the MinGW runtime DLLs to the output folder as well.
@@ -131,7 +136,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL minizip
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES}
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES} ${ZLIB_LIBRARIES}
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,12 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 find_package(ZLIB REQUIRED)
 find_package(PkgConfig REQUIRED PkgConfig PkgConf)
 
+# Minizip has a different target name in vcpkg.
 if(ES_USE_VCPKG)
-    find_package(unofficial-minizip CONFIG REQUIRED)
-    set(MINIZIP_LIBRARIES "unofficial::minizip::minizip")
+	find_package(unofficial-minizip CONFIG REQUIRED)
+	set(MINIZIP_LIBRARIES "unofficial::minizip::minizip")
 else()
-    pkg_check_modules(MINIZIP REQUIRED minizip)
+	pkg_check_modules(MINIZIP REQUIRED minizip)
 endif()
 
 # Find the MinGW runtime DLLs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL minizip
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES}
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ project("Endless Sky" VERSION 0.10.13
 find_package(SDL2 CONFIG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(JPEG REQUIRED)
-find_package(ZLIB REQUIRED)
 if(NOT APPLE)
 	find_package(GLEW REQUIRED)
 endif()
@@ -88,6 +87,11 @@ endif()
 find_path(LIBMAD_INCLUDE_DIR mad.h)
 find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
+
+# Find the zip-reading component of zlib.
+find_package(ZLIB REQUIRED)
+find_package(PkgConfig REQUIRED PkgConfig PkgConf)
+pkg_check_modules(MINIZIP REQUIRED minizip)
 
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)
@@ -132,7 +136,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ZLIB::ZLIB
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL minizip
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ project("Endless Sky" VERSION 0.10.13
 find_package(SDL2 CONFIG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(JPEG REQUIRED)
+find_package(ZLIB REQUIRED)
 if(NOT APPLE)
 	find_package(GLEW REQUIRED)
 endif()
@@ -87,11 +88,6 @@ endif()
 find_path(LIBMAD_INCLUDE_DIR mad.h)
 find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
-
-# Find the zip-reading component of zlib.
-find_package(ZLIB REQUIRED)
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(MINIZIP REQUIRED minizip)
 
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)
@@ -136,7 +132,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL minizip
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ZLIB::ZLIB
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,13 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 # Find the zip-reading component of zlib.
 find_package(ZLIB REQUIRED)
 find_package(PkgConfig REQUIRED PkgConfig PkgConf)
-pkg_check_modules(MINIZIP REQUIRED minizip)
+
+if(ES_USE_VCPKG)
+    find_package(unofficial-minizip CONFIG REQUIRED)
+    set(MINIZIP_LIBRARIES "unofficial::minizip::minizip")
+else()
+    pkg_check_modules(MINIZIP REQUIRED minizip)
+endif()
 
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)
@@ -136,7 +142,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL minizip
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES}
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 # Find the zip-reading component of zlib.
 find_package(ZLIB REQUIRED)
 find_package(PkgConfig REQUIRED PkgConfig PkgConf)
-pkg_check_modules(MINIZIP REQUIRED minizip)
+pkg_check_modules(MINIZIP REQUIRED minizip-ng)
 
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES} ${ZLIB_LIBRARIES}
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES}
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 # Find the zip-reading component of zlib.
 find_package(ZLIB REQUIRED)
 find_package(PkgConfig REQUIRED PkgConfig PkgConf)
-pkg_check_modules(MINIZIP REQUIRED minizip-ng)
+pkg_check_modules(MINIZIP REQUIRED minizip)
+message(${MINIZIP_LIBRARIES})
 
 # Find the MinGW runtime DLLs.
 if(MINGW AND WIN32)
@@ -136,7 +137,7 @@ if(MINGW)
 endif()
 
 # Link with the general libraries.
-target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES}
+target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL minizip
 	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.

--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -51,7 +51,7 @@ Endless Sky requires precompiled libraries to compile and play: [Download link](
 Install [Homebrew](https://brew.sh). Once it is installed, use it to install the tools and libraries you will need:
 
 ```bash
-$ brew install cmake ninja mad libpng jpeg-turbo sdl2
+$ brew install cmake ninja mad libpng jpeg-turbo sdl2 minizip
 ```
 
 **Note**: If you are on Apple Silicon (and want to compile for ARM), make sure that you are using ARM Homebrew!

--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -70,7 +70,7 @@ In addition to the below dependencies, you will also need CMake 3.16 or newer, h
 <summary>DEB-based distros</summary>
 
 ```
-g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libopenal-dev libmad0-dev uuid-dev
+g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libminizip-dev libopenal-dev libmad0-dev uuid-dev
 ```
 Additionally, if you want to build unit tests:
 ```
@@ -85,7 +85,7 @@ While sufficient versions of other dependencies are available, Ubuntu 22.04 does
 <summary>RPM-based distros</summary>
 
 ```
-gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel openal-soft-devel libmad-devel libuuid-devel
+gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel minizip-devel openal-soft-devel libmad-devel libuuid-devel
 ```
 Additionally, if you want to build unit tests:
 ```

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -318,6 +318,8 @@ target_sources(EndlessSkyLib PRIVATE
 	Wormhole.cpp
 	Wormhole.h
 	WormholeStrategy.h
+	ZipFile.cpp
+	ZipFile.h
 	opengl.cpp
 	opengl.h
 	pi.h

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -82,7 +82,11 @@ namespace {
 			zipPath = zipPath.parent_path();
 		}
 		if(zipPath.extension() == ".zip" && is_regular_file(zipPath))
+		{
+			/// Limit the number of open zip files to one per thread to avoid having too many files open.
+			OPEN_ZIP_FILES.clear();
 			return OPEN_ZIP_FILES.emplace(zipPath, make_shared<ZipFile>(zipPath)).first->second;
+		}
 
 		return {};
 	}

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -398,11 +398,14 @@ shared_ptr<iostream> Files::Open(const filesystem::path &path, bool write)
 {
 	if(!exists(path))
 	{
-		// Writing to a zip is not supported.
-		shared_ptr<ZipFile> zip = GetZipFile(path);
-		if(zip)
-			return shared_ptr<iostream>(new stringstream(zip->ReadFile(path), ios::in | ios::binary));
-		return {};
+		if(!write)
+		{
+			// Writing to a zip is not supported.
+			shared_ptr<ZipFile> zip = GetZipFile(path);
+			if(zip)
+				return shared_ptr<iostream>(new stringstream(zip->ReadFile(path), ios::in | ios::binary));
+			return {};
+		}
 	}
 
 	if(write)

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -16,20 +16,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Files.h"
 
 #include "Logger.h"
+#include "ZipFile.h"
 
 #include <SDL2/SDL.h>
-
-#if defined _WIN32
-#define STRICT
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#else
-#include <dirent.h>
-#endif
 
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <map>
 #include <mutex>
 #include <stdexcept>
 
@@ -65,6 +59,31 @@ namespace {
 #warning SDL 2.0.14 or higher is needed for opening folders!
 		Logger::LogError("Warning: No handler found to open \"" + path + "\" in a new window.");
 #endif
+	}
+
+	/// The open zip files per thread. Since ZLIB doesn't support multithreaded access on the same zip handle,
+	/// each file is opened multiple times on demand.
+	thread_local map<filesystem::path, shared_ptr<ZipFile>> OPEN_ZIP_FILES;
+
+	shared_ptr<ZipFile> GetZipFile(const filesystem::path& filePath)
+	{
+		/// Check if this zip is already open on this thread.
+		for(auto &[zip_path, file] : OPEN_ZIP_FILES)
+			if(Files::IsParent(zip_path, filePath))
+				return file;
+
+		/// If not, open the zip file.
+		filesystem::path zipPath = filePath;
+		while(!exists(zipPath))
+		{
+			if(!zipPath.has_parent_path() || zipPath.parent_path() == zipPath)
+				return {};
+			zipPath = zipPath.parent_path();
+		}
+		if(zipPath.extension() == ".zip" && is_regular_file(zipPath))
+			return OPEN_ZIP_FILES.emplace(zipPath, make_shared<ZipFile>(zipPath)).first->second;
+
+		return {};
 	}
 }
 
@@ -106,12 +125,6 @@ void Files::Init(const char * const *argv)
 		static const filesystem::path STANDARD_PATH = "/usr";
 		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
 
-		const auto IsParent = [](const auto parent, const auto child) -> bool {
-			if(distance(child.begin(), child.end()) < distance(parent.begin(), parent.end()))
-				return false;
-			return equal(parent.begin(), parent.end(), child.begin());
-		};
-
 		if(IsParent(LOCAL_PATH, resources))
 			resources = LOCAL_PATH / RESOURCE_PATH;
 		else if(IsParent(STANDARD_PATH, resources))
@@ -127,10 +140,10 @@ void Files::Init(const char * const *argv)
 			throw runtime_error("Unable to find the resource directories!");
 		resources = resources.parent_path();
 	}
-	dataPath = resources / "data/";
-	imagePath = resources / "images/";
-	soundPath = resources / "sounds/";
-	globalPluginPath = resources / "plugins/";
+	dataPath = resources / "data";
+	imagePath = resources / "images";
+	soundPath = resources / "sounds";
+	globalPluginPath = resources / "plugins";
 
 	if(config.empty())
 	{
@@ -147,12 +160,12 @@ void Files::Init(const char * const *argv)
 
 	config = filesystem::canonical(config);
 
-	savePath = config / "saves/";
+	savePath = config / "saves";
 	CreateFolder(savePath);
 
 	// Create the "plugins" directory if it does not yet exist, so that it is
 	// clear to the user where plugins should go.
-	userPluginPath = config / "plugins/";
+	userPluginPath = config / "plugins";
 	CreateFolder(userPluginPath);
 
 	// Check that all the directories exist.
@@ -234,7 +247,17 @@ vector<filesystem::path> Files::List(const filesystem::path &directory)
 	vector<filesystem::path> list;
 
 	if(!Exists(directory) || !is_directory(directory))
+	{
+		// Check if the requested file is in a known zip.
+		shared_ptr<ZipFile> zip = GetZipFile(directory);
+		if(zip)
+		{
+			list = zip->ListFiles(directory, false, false);
+			sort(list.begin(), list.end());
+		}
 		return list;
+	}
+
 
 	for(const auto &entry : filesystem::directory_iterator(directory))
 		if(entry.is_regular_file())
@@ -253,7 +276,16 @@ vector<filesystem::path> Files::ListDirectories(const filesystem::path &director
 	vector<filesystem::path> list;
 
 	if(!Exists(directory) || !is_directory(directory))
+	{
+		// Check if the requested file is in a known zip.
+		shared_ptr<ZipFile> zip = GetZipFile(directory);
+		if(zip)
+		{
+			list = zip->ListFiles(directory, false, true);
+			sort(list.begin(), list.end());
+		}
 		return list;
+	}
 
 	for(const auto &entry : filesystem::directory_iterator(directory))
 		if(entry.is_directory())
@@ -269,7 +301,16 @@ vector<filesystem::path> Files::RecursiveList(const filesystem::path &directory)
 {
 	vector<filesystem::path> list;
 	if(!Exists(directory) || !is_directory(directory))
+	{
+		// Check if the requested file is in a known zip.
+		shared_ptr<ZipFile> zip = GetZipFile(directory);
+		if(zip)
+		{
+			list = zip->ListFiles(directory, true, false);
+			sort(list.begin(), list.end());
+		}
 		return list;
+	}
 
 	for(const auto &entry : filesystem::recursive_directory_iterator(directory))
 		if(entry.is_regular_file())
@@ -283,7 +324,13 @@ vector<filesystem::path> Files::RecursiveList(const filesystem::path &directory)
 
 bool Files::Exists(const filesystem::path &filePath)
 {
-	return exists(filePath);
+	if(exists(filePath))
+		return true;
+
+	shared_ptr<ZipFile> zip = GetZipFile(filePath);
+	if(zip)
+		return zip->Exists(filePath);
+	return false;
 }
 
 
@@ -337,8 +384,26 @@ string Files::Name(const filesystem::path &path)
 
 
 
+bool Files::IsParent(const filesystem::path &parent, const filesystem::path &child)
+{
+	if(distance(child.begin(), child.end()) < distance(parent.begin(), parent.end()))
+		return false;
+	return equal(parent.begin(), parent.end(), child.begin());
+}
+
+
+
 shared_ptr<iostream> Files::Open(const filesystem::path &path, bool write)
 {
+	if(!exists(path))
+	{
+		// Writing to a zip is not supported.
+		shared_ptr<ZipFile> zip = GetZipFile(path);
+		if(zip)
+			return shared_ptr<iostream>(new stringstream(zip->ReadFile(path), ios::in | ios::binary));
+		return {};
+	}
+
 	if(write)
 		return shared_ptr<iostream>{new fstream{path, ios::out | ios::binary}};
 	return shared_ptr<iostream>{new fstream{path, ios::in | ios::binary}};

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -66,11 +66,11 @@ namespace {
 	/// each file is opened multiple times on demand.
 	thread_local map<filesystem::path, shared_ptr<ZipFile>> OPEN_ZIP_FILES;
 
-	shared_ptr<ZipFile> GetZipFile(const filesystem::path& filePath)
+	shared_ptr<ZipFile> GetZipFile(const filesystem::path &filePath)
 	{
 		/// Check if this zip is already open on this thread.
-		for(auto &[zip_path, file] : OPEN_ZIP_FILES)
-			if(Files::IsParent(zip_path, filePath))
+		for(auto &[zipPath, file] : OPEN_ZIP_FILES)
+			if(Files::IsParent(zipPath, filePath))
 				return file;
 
 		/// If not, open the zip file.
@@ -396,16 +396,13 @@ bool Files::IsParent(const filesystem::path &parent, const filesystem::path &chi
 
 shared_ptr<iostream> Files::Open(const filesystem::path &path, bool write)
 {
-	if(!exists(path))
+	if(!exists(path) && !write)
 	{
-		if(!write)
-		{
-			// Writing to a zip is not supported.
-			shared_ptr<ZipFile> zip = GetZipFile(path);
-			if(zip)
-				return shared_ptr<iostream>(new stringstream(zip->ReadFile(path), ios::in | ios::binary));
-			return {};
-		}
+		// Writing to a zip is not supported.
+		shared_ptr<ZipFile> zip = GetZipFile(path);
+		if(zip)
+			return shared_ptr<iostream>(new stringstream(zip->ReadFile(path), ios::in | ios::binary));
+		return {};
 	}
 
 	if(write)

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -25,8 +25,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <iostream>
 #include <map>
 #include <mutex>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 using namespace std;
 

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -26,6 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <map>
 #include <mutex>
 #include <stdexcept>
+#include <sstream>
 
 using namespace std;
 

--- a/source/Files.h
+++ b/source/Files.h
@@ -60,6 +60,9 @@ public:
 	// Get the filename from a path.
 	static std::string Name(const std::filesystem::path &path);
 
+	/// Check whether one path is a parent of another.
+	static bool IsParent(const std::filesystem::path &parent, const std::filesystem::path &child);
+
 	// File IO.
 	static std::shared_ptr<std::iostream> Open(const std::filesystem::path &path, bool write = false);
 	static std::string Read(const std::filesystem::path &path);

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -932,6 +932,7 @@ void GameData::LoadSources(TaskQueue &queue)
 	for(const auto &path : globalPlugins)
 		if(Plugins::IsPlugin(path))
 			LoadPlugin(queue, path);
+	// Load unzipped plugins first to give them precedence, then load the zipped plugins.
 	globalPlugins = Files::List(Files::GlobalPlugins());
 	for(const auto &path : globalPlugins)
 		if(path.extension() == ".zip" && Plugins::IsPlugin(path))

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -932,10 +932,18 @@ void GameData::LoadSources(TaskQueue &queue)
 	for(const auto &path : globalPlugins)
 		if(Plugins::IsPlugin(path))
 			LoadPlugin(queue, path);
+	globalPlugins = Files::List(Files::GlobalPlugins());
+	for(const auto &path : globalPlugins)
+		if(path.extension() == ".zip" && Plugins::IsPlugin(path))
+			LoadPlugin(queue, path);
 
 	vector<filesystem::path> localPlugins = Files::ListDirectories(Files::UserPlugins());
 	for(const auto &path : localPlugins)
 		if(Plugins::IsPlugin(path))
+			LoadPlugin(queue, path);
+	localPlugins = Files::List(Files::UserPlugins());
+	for(const auto &path : localPlugins)
+		if(path.extension() == ".zip" && Plugins::IsPlugin(path))
 			LoadPlugin(queue, path);
 }
 
@@ -948,7 +956,7 @@ map<string, shared_ptr<ImageSet>> GameData::FindImages()
 	{
 		// All names will only include the portion of the path that comes after
 		// this directory prefix.
-		filesystem::path directoryPath = source / "images/";
+		filesystem::path directoryPath = source / "images";
 
 		vector<filesystem::path> imageFiles = Files::RecursiveList(directoryPath);
 		for(auto &path : imageFiles)

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -50,7 +50,7 @@ shared_future<void> UniverseObjects::Load(TaskQueue &queue, const vector<filesys
 				// Iterate through the paths starting with the last directory given. That
 				// is, things in folders near the start of the path have the ability to
 				// override things in folders later in the path.
-				auto list = Files::RecursiveList(source / "data/");
+				auto list = Files::RecursiveList(source / "data");
 				files.reserve(files.size() + list.size());
 				files.insert(files.end(),
 						make_move_iterator(list.begin()),

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -23,7 +23,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 
-ZipFile::ZipFile(const filesystem::path &zipPath) : basePath(zipPath), topLevelDirectory(), lock()
+
+ZipFile::ZipFile(const filesystem::path &zipPath)
+	: basePath(zipPath)
 {
 	lock_guard<recursive_mutex> guard(lock);
 	zipFile = unzOpen(basePath.string().c_str());

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -1,0 +1,141 @@
+/* ZipFile.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ZipFile.h"
+
+#include "Files.h"
+
+#include <numeric>
+
+using namespace std;
+
+
+
+ZipFile::ZipFile(const filesystem::path &zipPath) : basePath(zipPath), hasNestedDirectory(false), lock()
+{
+	lock_guard<recursive_mutex> guard(lock);
+	zipFile = unzOpen(basePath.string().c_str());
+	if(!zipFile)
+		throw runtime_error("Failed to open ZIP file" + zipPath.generic_string());
+
+	// Check whether this zip has a top-level directory with a matching name (such as high-dpi.zip/high-dpi)
+	hasNestedDirectory = Exists(basePath / basePath.filename().replace_extension());
+}
+
+
+
+ZipFile::~ZipFile()
+{
+	if(zipFile)
+	{
+		lock_guard<recursive_mutex> guard(lock);
+		unzClose(zipFile);
+	}
+}
+
+
+
+vector<filesystem::path> ZipFile::ListFiles(const filesystem::path &directory, bool recursive, bool directories) const
+{
+	filesystem::path relative = GetPathInZip(directory);
+	vector<filesystem::path> fileList;
+
+	lock_guard<recursive_mutex> guard(lock);
+	if(unzGoToFirstFile(zipFile) != UNZ_OK)
+		throw runtime_error("Failed to go to first file in ZIP");
+	do
+	{
+		char filename[256];
+		unz_file_info fileInfo;
+		unzGetCurrentFileInfo(zipFile, &fileInfo, filename, sizeof(filename), NULL, 0, NULL, 0);
+
+		filesystem::path zipEntry = filename;
+		bool isDirectory = string(filename).back() == '/';
+		bool isValidSubtree = Files::IsParent(relative, zipEntry);
+		bool isRecursive = distance(zipEntry.begin(), zipEntry.end()) == distance(relative.begin(), relative.end()) + 1;
+
+		if(isValidSubtree && isDirectory == directories && (!isRecursive || recursive))
+			fileList.push_back(GetGlobalPath(zipEntry));
+	} while(unzGoToNextFile(zipFile) == UNZ_OK);
+
+	return fileList;
+}
+
+
+
+bool ZipFile::Exists(const filesystem::path &filePath) const
+{
+	filesystem::path relative = GetPathInZip(filePath);
+	string name = relative.generic_string();
+
+	lock_guard<recursive_mutex> guard(lock);
+	return unzLocateFile(zipFile, name.c_str(), 0) == UNZ_OK ||
+			unzLocateFile(zipFile, (name + "/").c_str(), 0) == UNZ_OK;
+}
+
+
+
+string ZipFile::ReadFile(const filesystem::path &filePath) const
+{
+	filesystem::path relative = GetPathInZip(filePath);
+
+	lock_guard<recursive_mutex> guard(lock);
+	if(unzLocateFile(zipFile, relative.generic_string().c_str(), 0) != UNZ_OK)
+		return {};
+
+	if(unzOpenCurrentFile(zipFile) != UNZ_OK)
+		return {};
+
+	unz_file_info64 info;
+
+	info.uncompressed_size = 0;
+	unzGetCurrentFileInfo64(zipFile, &info, nullptr, 0, nullptr, 0, nullptr, 0);
+
+	char buffer[8192];
+	string contents;
+	int bytesRead = 0;
+	while((bytesRead = unzReadCurrentFile(zipFile, buffer, sizeof(buffer))) > 0)
+		contents.append(buffer, bytesRead);
+
+	unzCloseCurrentFile(zipFile);
+
+	if(bytesRead < 0)
+		return {};
+
+	return contents;
+}
+
+
+
+filesystem::path ZipFile::GetPathInZip(const filesystem::path &path) const
+{
+	filesystem::path relative = path.lexically_relative(basePath);
+	if(hasNestedDirectory)
+		relative = basePath.filename().replace_extension() / relative;
+	return relative;
+}
+
+
+
+filesystem::path ZipFile::GetGlobalPath(const filesystem::path &path) const
+{
+	if(path.empty())
+		return path;
+
+	// If this zip has a top-level directory, remove it from the path.
+	if(hasNestedDirectory)
+		return basePath / accumulate(std::next(path.begin()), path.end(), filesystem::path{}, std::divides{});
+	return basePath / path;
+}

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -28,7 +28,7 @@ ZipFile::ZipFile(const filesystem::path &zipPath)
 	: basePath(zipPath)
 {
 	lock_guard<recursive_mutex> guard(lock);
-	zipFile = unzOpen(basePath.string().c_str());
+	zipFile = unzOpen(basePath.native().c_str());
 	if(!zipFile)
 		throw runtime_error("Failed to open ZIP file" + zipPath.generic_string());
 

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Files.h"
 
+#include <functional>
 #include <numeric>
 
 using namespace std;

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -55,8 +55,7 @@ vector<filesystem::path> ZipFile::ListFiles(const filesystem::path &directory, b
 	lock_guard<recursive_mutex> guard(lock);
 	if(unzGoToFirstFile(zipFile) != UNZ_OK)
 		throw runtime_error("Failed to go to first file in ZIP");
-	do
-	{
+	do {
 		char filename[256];
 		unz_file_info fileInfo;
 		unzGetCurrentFileInfo(zipFile, &fileInfo, filename, sizeof(filename), NULL, 0, NULL, 0);

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -28,7 +28,7 @@ ZipFile::ZipFile(const filesystem::path &zipPath)
 	: basePath(zipPath)
 {
 	lock_guard<recursive_mutex> guard(lock);
-	zipFile = unzOpen(basePath.native().c_str());
+	zipFile = unzOpen(basePath.string().c_str());
 	if(!zipFile)
 		throw runtime_error("Failed to open ZIP file" + zipPath.generic_string());
 

--- a/source/ZipFile.cpp
+++ b/source/ZipFile.cpp
@@ -27,7 +27,6 @@ using namespace std;
 ZipFile::ZipFile(const filesystem::path &zipPath)
 	: basePath(zipPath)
 {
-	lock_guard<recursive_mutex> guard(lock);
 	zipFile = unzOpen(basePath.string().c_str());
 	if(!zipFile)
 		throw runtime_error("Failed to open ZIP file" + zipPath.generic_string());
@@ -51,7 +50,6 @@ ZipFile::~ZipFile()
 {
 	if(zipFile)
 	{
-		lock_guard<recursive_mutex> guard(lock);
 		unzClose(zipFile);
 	}
 }
@@ -63,7 +61,6 @@ vector<filesystem::path> ZipFile::ListFiles(const filesystem::path &directory, b
 	filesystem::path relative = GetPathInZip(directory);
 	vector<filesystem::path> fileList;
 
-	lock_guard<recursive_mutex> guard(lock);
 	if(unzGoToFirstFile(zipFile) != UNZ_OK)
 		throw runtime_error("Failed to go to first file in ZIP");
 	do {
@@ -90,7 +87,6 @@ bool ZipFile::Exists(const filesystem::path &filePath) const
 	filesystem::path relative = GetPathInZip(filePath);
 	string name = relative.generic_string();
 
-	lock_guard<recursive_mutex> guard(lock);
 	return unzLocateFile(zipFile, name.c_str(), 0) == UNZ_OK ||
 			unzLocateFile(zipFile, (name + "/").c_str(), 0) == UNZ_OK;
 }
@@ -101,7 +97,6 @@ string ZipFile::ReadFile(const filesystem::path &filePath) const
 {
 	filesystem::path relative = GetPathInZip(filePath);
 
-	lock_guard<recursive_mutex> guard(lock);
 	if(unzLocateFile(zipFile, relative.generic_string().c_str(), 0) != UNZ_OK)
 		return {};
 

--- a/source/ZipFile.h
+++ b/source/ZipFile.h
@@ -1,0 +1,65 @@
+/* ZipFile.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <minizip/unzip.h>
+
+#include <filesystem>
+#include <mutex>
+#include <vector>
+
+/// Wrapper around a zip file that provides basic file listing and reading functions.
+/// This class supports zips both with and without a top-level directory, as long as
+/// the directory's name matches the zip's name. The necessary path translations are
+/// performed within this class, and aren't visible to the user.
+class ZipFile {
+public:
+	explicit ZipFile(const std::filesystem::path &zipPath);
+	ZipFile(const ZipFile& other) = delete;
+	~ZipFile();
+
+	/// Lists files in a directory inside of a zip file.
+	/// @param directory The complete file path, including the zip's path.
+	/// @param recursive List all files in the subtree, rather than just the top level.
+	/// @param directories Whether to list only directories instead of only regular files.
+	std::vector<std::filesystem::path> ListFiles(const std::filesystem::path &directory, bool recursive,
+		bool directories) const;
+
+	/// Checks whether the given file or directory exists in the zip.
+	/// @param filePath The complete file path, including the zip's path.
+	bool Exists(const std::filesystem::path &filePath) const;
+
+	/// Reads a frp, from the zip.
+	/// @param filePath The complete file path, including the zip's path.
+	std::string ReadFile(const std::filesystem::path &filePath) const;
+
+
+private:
+	/// Translates a global filesystem path to a relative path within the zip file.
+	/// @param path The complete file path, including the zip's path.
+	std::filesystem::path GetPathInZip(const std::filesystem::path &path) const;
+	/// Translates an in-zip relative path to a global filesystem path.
+	/// @param path The in-zip path, without the zip's own path.
+	std::filesystem::path GetGlobalPath(const std::filesystem::path &path) const;
+
+
+private:
+	unzFile zipFile = nullptr;
+	std::filesystem::path basePath;
+	bool hasNestedDirectory;
+
+	mutable std::recursive_mutex lock;
+};

--- a/source/ZipFile.h
+++ b/source/ZipFile.h
@@ -28,7 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class ZipFile {
 public:
 	explicit ZipFile(const std::filesystem::path &zipPath);
-	ZipFile(const ZipFile& other) = delete;
+	ZipFile(const ZipFile &other) = delete;
 	~ZipFile();
 
 	/// Lists files in a directory inside of a zip file.

--- a/source/ZipFile.h
+++ b/source/ZipFile.h
@@ -21,6 +21,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <mutex>
 #include <vector>
 
+
+
 /// Wrapper around a zip file that provides basic file listing and reading functions.
 /// This class supports zips both with and without a top-level directory, as long as
 /// the directory's name matches the zip's name. The necessary path translations are

--- a/source/ZipFile.h
+++ b/source/ZipFile.h
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 /// This class supports zips both with and without a top-level directory, as long as
 /// the directory's name matches the zip's name. The necessary path translations are
 /// performed within this class, and aren't visible to the user.
+/// ZipFiles are not thread safe. A zip file may only be used on one thread at a time.
 class ZipFile {
 public:
 	explicit ZipFile(const std::filesystem::path &zipPath);
@@ -65,6 +66,4 @@ private:
 	std::filesystem::path basePath;
 	/// The name of the top-level directory inside the zip, or an empty string if it doesn't have such a directory
 	std::filesystem::path topLevelDirectory;
-
-	mutable std::recursive_mutex lock;
 };

--- a/source/ZipFile.h
+++ b/source/ZipFile.h
@@ -57,9 +57,12 @@ private:
 
 
 private:
+	/// The zip handle
 	unzFile zipFile = nullptr;
+	/// The path of the zip file in the filesystem
 	std::filesystem::path basePath;
-	bool hasNestedDirectory;
+	/// The name of the top-level directory inside the zip, or an empty string if it doesn't have such a directory
+	std::filesystem::path topLevelDirectory;
 
 	mutable std::recursive_mutex lock;
 };

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -178,7 +178,7 @@ void Audio::LoadSounds(const vector<filesystem::path> &sources)
 {
 	for(const auto &source : sources)
 	{
-		filesystem::path root = source / "sounds/";
+		filesystem::path root = source / "sounds";
 		vector<filesystem::path> files = Files::RecursiveList(root);
 		for(const auto &path : files)
 		{

--- a/source/audio/Music.cpp
+++ b/source/audio/Music.cpp
@@ -44,7 +44,7 @@ void Music::Init(const vector<filesystem::path> &sources)
 	for(const auto &source : sources)
 	{
 		// Find all the sound files that this resource source provides.
-		filesystem::path root = source / "sounds/";
+		filesystem::path root = source / "sounds";
 		vector<filesystem::path> files = Files::RecursiveList(root);
 
 		for(const auto &path : files)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
-				"minizip",
+				"zlib",
 				"openal-soft",
 				{
 					"name": "openal-soft",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,6 +20,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
+				"minizip",
 				"openal-soft",
 				{
 					"name": "openal-soft",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
-				"minizip",
+				"minizip-ng",
 				"openal-soft",
 				{
 					"name": "openal-soft",
@@ -38,7 +38,7 @@
 			"dependencies": [
 				"libmad",
 				"catch2",
-				"minizip"
+				"minizip-ng"
 			]
 		},
 		"test-libs": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
-				"minizip-ng",
+				"minizip",
 				"openal-soft",
 				{
 					"name": "openal-soft",
@@ -38,7 +38,7 @@
 			"dependencies": [
 				"libmad",
 				"catch2",
-				"minizip-ng"
+				"minizip"
 			]
 		},
 		"test-libs": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
-				"zlib",
+				"minizip",
 				"openal-soft",
 				{
 					"name": "openal-soft",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
-				"zlib",
+				"minizip",
 				"openal-soft",
 				{
 					"name": "openal-soft",
@@ -29,7 +29,8 @@
 					],
 					"platform": "linux"
 				},
-				"sdl2"
+				"sdl2",
+				"pkgconf"
 			]
 		},
 		"steam-libs": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,7 +37,8 @@
 			"description": "System libraries not provided in the Steam Sniper Runtime.",
 			"dependencies": [
 				"libmad",
-				"catch2"
+				"catch2",
+				"minizip"
 			]
 		},
 		"test-libs": {


### PR DESCRIPTION
**Feature**

This PR enables loading plugins directly from zip files, without having to unzip them.

## Summary
Related: #10431, #9068

Adds support for loading plugins from zip files using zlib. This implementation is abstracted away from the users via `Files`, `std::iostream` and `std::filesystem::path`, so no changes were necessary in any other part of the codebase (unlike in #10431). (I did remove trailing slashes from directory names everywhere, though, as that's been known to be problematic with path comparisons.)

Individual zip files are handled via `ZipFile`, which provides a `Files`-like interface. This class is used only by `Files`, I just didn't want to dump all the code there.

The relevant `Files` functions were patched to check zip files and open them as needed. Since zlib doesn't support concurrent processing on the same zip handle, each thread opens the needed zip files for itself. This results in comparable performance to unzipped plugins.

## Screenshots
![image](https://github.com/user-attachments/assets/83c7ed15-81af-4845-9806-3cee5d8924ae)
![image](https://github.com/user-attachments/assets/5b08d3e7-3e05-4dd8-8a03-208c872014c2)

## Usage examples
Easier plugin usage, easier in-game plugin downloading.

## Testing Done
l loaded various large and small plugins, and tested whether everything was loaded correctly. I also tested that the enable/disable functionality worked with zipped plugins.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/117

## Performance Impact
`Files` queries to non-existent files will be slightly slower.