### PR TITLE
feat(content): Adjust the contents of the `Large Core Pirates` fleet

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2328,9 +2328,9 @@ fleet "Large Core Pirates"
 		"Splinter (Proton)"
 		"Quicksilver"
 	variant 4
-		"Manta (Proton)"
-	variant 2
-		"Manta"
+		"Manta (Proton)" 2
+	variant 3
+		"Manta" 2
 	variant 2
 		"Splinter" 2
 	variant 1
@@ -2339,14 +2339,8 @@ fleet "Large Core Pirates"
 		"Splinter (Proton)" 2
 	variant 1
 		"Splinter (Tractor Beam)"
-	variant 2
-		"Falcon"
 	variant 1
-		"Falcon (Heavy)"
-	variant 1
-		"Falcon (Laser)"
-	variant 1
-		"Falcon (Tractor Beam)"
+		"Leviathan"
 	variant 2
 		"Firebird"
 	variant 2
@@ -2359,15 +2353,15 @@ fleet "Large Core Pirates"
 		"Vanguard (Particle)"
 	variant 1
 		"Vanguard (Missile)"
-	variant 1
+	variant 2
 		"Vanguard"
 	variant 1
 		"Protector (Laser)"
-	variant 1
+	variant 2
 		"Protector (Proton)"
 	variant 1
 		"Protector (Tractor Beam)"
-	variant 1
+	variant 2
 		"Protector"
 
 fleet "Small Northern Pirates"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Summary
Removed the four falcon variants (total weight 5), added a variant which is just a Leviathan (weight 1), and added a total of 3 weight to variants with the Protector or the Vanguard.

Falcons shouldn't be appearing at all in random pirate spawns in the core - the Falcon is a relatively new ship that's only manufactured in Tarazed, it shouldn't be showing up anywhere near this frequently in the hands of Core pirates. The Leviathan, on the other hand, is old enough that there might reasonably be some around further from where they're built, and in any case the Far North is more accessible for Core pirates than the South.
Conversely, ships made in the Core should appear more commonly in the Core, and the increased spawn frequency for Protectors and Vanguards balances out the total frequency of heavy warships.

Also adjusted two variants that were just one manta, because even for pirates that doesn't really constitute a large fleet, and slightly increased the probability of one of them spawning to balance the probabilities.