### PR TITLE
(balance) Nerf Heliarch Ion Weapons

### DIFF
--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -380,8 +380,8 @@ outfit "ion hail"
 		"hit force" 1
 		"shield damage" 12
 		"hull damage" 5
-		"ion damage" .32
-		"scrambling damage" .32
+		"ion damage" .3
+		"scrambling damage" .3
 
 
 outfit "Ion Rain Gun"
@@ -412,8 +412,8 @@ outfit "Ion Rain Gun"
 		"firing heat" 4
 		"shield damage" 12
 		"hull damage" 5
-		"ion damage" .32
-		"scrambling damage" .32
+		"ion damage" .2
+		"scrambling damage" .2
 	description "Heliarch ships primarily serve as a police force. This weapon is designed to neutralize a target's offensive capabilities until more Heliarch ships can join the fray."
 
 effect "ion rain impact"


### PR DESCRIPTION
**Balance**

This PR reverts the buff to the Ion Rain Gun's ion damage done in #4868, and also nerfs the Ion Hail Turret's ion damage. Both weapons' scrambling damage values were also updated.

## Summary

With the advent of the Quarg Revamp, it's been noticed that the Quarg ships are affected quite a bit by the Heliarch ion/scrambling weaponry. This isn't really the purpose of these weapons - as it stands, they're the only weapon in the Heliarch arsenal *not* specifically developed to fight the Quarg, and instead are more of the police-force and general peacekeeping weaponry.

This PR brings the ion DPS of the Ion Rain Gun from 480 back to its original 300, and also lowers the Ion Hail Turret's from 512 to 480 (if I did my math right). Scrambling damage values also followed these changes in values.

Here is a table with ion/scrambling per outfit space:

| Outfit | Size | Previous Damage | New Damage | Previous Efficiency | New Efficiency |
|--------|------|--------------------|----------------|----------------------|-----------------|
| Ion Cannon | 47 | 600 | Still 600 | 12.765 | Still 12.765 |
| Ion Rain Gun | 17 | 480 | 300 | 28.235 | 17.647 |
| Ion Hail Turret | 26 | 512 | 480 | 19.692 | 18.461 |

While the Heliarchs being higher up than the Hai in Tier, and also being very focused on their military and weaponry, would justify a better efficiency in principle, the current efficiencies, especially of the Ion Rain Gun, are just way above and beyond what that gap would justify. The new values make their efficiencies more reasonable, and should help make it so that when fighting the Quarg, the Heliarchs' actually have to rely on the weapons intentionally developed for that purpose, rather than these "peacetime" weapons.
