### PR TITLE
fix(bug): Li-7 star changes

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -24956,13 +24956,13 @@ system Li-7
 	hazard "Predecessors Spatial Rift Weak" 30000
 	object
 		sprite planet/browndwarf-l-rogue
-		distance 271.899
-		period 179.337
+		distance 272
+		period 180
 		offset 180
 	object
 		sprite planet/browndwarf-y-rogue
-		distance 272.733
-		period 180.163
+		distance 272
+		period 180
 	object
 		sprite planet/gas7-hot
 		distance 1531


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1353112333580505129)

## Summary
Fixed the overlapping of two stars.

## Screenshots
Before:
![before](https://cdn.discordapp.com/attachments/536900466655887360/1353112333362266112/404410_57.jpg?ex=67e0778f&is=67df260f&hm=56bbdc206c9dcd30c2a9ea1d46647342b2b55bd30563955e471c7c1ffac564c2&)

## Testing Done
It takes many years of in-game time to get the star to the right point, so I haven't tested it.