### PR TITLE
fix(bug): Camera disassociates while paused

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1562,14 +1562,19 @@ void Engine::CalculateStep()
 	Point newCenterVelocity;
 	if(flagship)
 	{
-		bool isHyperspacing = flagship->IsHyperspacing();
-		if(isHyperspacing)
-			hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
-		const auto [newCameraCenter, newCameraVelocity] = NewCenter(center, centerVelocity,
-			flagship->Center(), flagship->Velocity(), hyperspacePercentage,
-			isHyperspacing);
-		newCenter = newCameraCenter;
-		newCenterVelocity = newCameraVelocity;
+		if(!timePaused)
+		{
+			bool isHyperspacing = flagship->IsHyperspacing();
+			if(isHyperspacing)
+				hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
+			const auto [newCameraCenter, newCameraVelocity] = NewCenter(center, centerVelocity,
+				flagship->Center(), flagship->Velocity(), hyperspacePercentage,
+				isHyperspacing);
+			newCenter = newCameraCenter;
+			newCenterVelocity = newCameraVelocity;
+		}
+		else
+			newCenterVelocity = flagship->Velocity();
 	}
 	draw[currentCalcBuffer].SetCenter(newCenter, newCenterVelocity);
 	batchDraw[currentCalcBuffer].SetCenter(newCenter);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #on discord by me

## Summary
Fixes the camera being one step ahead while paused.

## Screenshots

https://github.com/user-attachments/assets/f04342f1-a3cf-4bac-b738-d2a7eb80c857
