### PR TITLE
feat(balance): default Model 512 engine update

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -2307,8 +2307,9 @@ ship "Model 512"
 		"Small Heat Shunt" 2
 		"Reasoning Node" 3
 		
+		"Thruster (Lunar Class)"
 		"Thruster (Planetary Class)"
-		"Steering (Stellar Class)"
+		"Steering (Planetary Class)"
 		Hyperdrive
 
 	engine -145 97


### PR DESCRIPTION
**Balance**

## Summary
Currently, the Model 512 suffers in prolonged battles with the Kor Sestor due to a low top speed. Since it spends most of its time fighting, it doesn't make sense for it to spin like a top and move in a straight line slowly, especially because it's mostly armed with turrets and its guns don't need to be pointing the correct way.
I downgraded the steering level by one, and added another Lunar thruster to increase the top speed. This halves the turn rate, but increases the acceleration level by an extra half. I think it makes more sense; the ship definitely performs a lot better in fights.

## Testing Done
Flew around with the new and old versions.

## Save File
This save file can be used to test these changes (requires Omnis):
[t t.txt](https://github.com/user-attachments/files/19434096/t.t.txt)
