### PR TITLE
Fix follow-up question display logic in Successors: First Contact 3

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -365,7 +365,7 @@ mission "Successors: First Contact 3"
 			choice
 				`	"We'd better get started, then."`
 					goto embark
-				`	"What do you mean that jump drives are 'familiar?'"`
+				`	"What did you mean that jump drives are 'familiar?'"`
 					to display
 						has "Successors: knowledge"
 						not "Successors: jump drives"

--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -365,6 +365,16 @@ mission "Successors: First Contact 3"
 			choice
 				`	"We'd better get started, then."`
 					goto embark
+				`	"What do you mean that jump drives are 'familiar?'"`
+					to display
+						has "Successors: knowledge"
+						not "Successors: jump drives"
+					goto "jump drives"
+				`	"Do the scions have their own jump drives?"`
+					to display
+						has "Successors: jump drives"
+						not "Successors: warning"
+					goto warning
 				`	"What more can you tell me about these Kijra-pets?"`
 					to display
 						not "Successors: kijra-pet"
@@ -390,58 +400,26 @@ mission "Successors: First Contact 3"
 			action
 				set "Successors: knowledge"
 			`	"'Tis a mix of things," Sieasej says. "The... paths in space which connect those stars are ever-changing, year by year. A hazard of the space. Some years ago, t'was a pathway leading to it through which craft of all the Houses could find passage and explore. Now, it's been closed for many years and our vessels may not enter. The scions know thou must possess a jump drive in order for thou t'ave reach'd us here, for this technology's a familiar one to us. And so they know thou cans't retrieve that thing which they desire."`
-			choice
-				`	"We'd better get started then."`
-					goto embark
-				`	"What do you mean that jump drives are 'familiar?'"`
-					to display
-						not "Successors: jump drives"
-					goto "jump drives"
-				`	"What more can you tell me about the Kijra-pets?"`
-					to display
-						not "Successors: kijra-pet"
-					goto kijra-pet
-				`	"Are you certain you're okay going with me?"`
-					to display
-						not "Successors: you okay"
-					goto "you okay"
-				`	"Is there anything I should watch out for?"`
-					to display
-						not "Successors: watch out"
-					goto "watch out"
+				goto questions
+			label "jump drives"
+			action
+				set "Successors: jump drives"
+			`	"Remember, Captain, our Predecessors did ply the stars for ten thousand years before we last set eyes on thine own race, who then had only just discovered industry. Drives like the one within thy ship have been known to us for long into thy past."`
+				goto questions
+			label warning
+			action
+				set "Successors: warning"
+			`	"That is not for me to know, nor, I think, for thee."`
+				goto questions
 			label "you okay"
+			action
 				set "Successors: you okay"
 			`	Splotches of orange color emerge at the tips of Sieasej's arms. "I confess this is a little strange, and know the prospect of this... journey instills within me some thoughts of trepidation. But to visit these worlds is reward itself, and to do so in thy company, the very aliens who I have studied, makes it a reward that's doubly grand. Thou must realize that thou'rt a historian's dream. Thou'rt a creature from a distant story-page made flesh and blood in the modern age."`
 				goto questions
 			label "watch out"
+			action
 				set "Successors: watch out"
 			`	"The House hast warned me of the dangers which that space entails. Thy vessel must've endured enough to make it here intact, so I must trust that it shall be enduring once again."`
-				goto questions
-			label "jump drives"
-				set "Successors: jump drives"
-			`	"Remember, Captain, our Predecessors did ply the stars for ten thousand years before we last set eyes on thine own race, who then had only just discovered industry. Drives like the one within thy ship have been known to us for long into thy past."`
-			choice
-				`	"We'd better get going."`
-					goto embark
-				`	"Do the scions have their own jump drives?"`
-					to display
-						not "Successors: warning"
-					goto warning
-				`	"What more can you tell me about the Kijra-pets?"`
-					to display
-						not "Successors: kijra-pet"
-					goto kijra-pet
-				`	"Are you certain you're okay going with me?"`
-					to display
-						not "Successors: you okay"
-					goto "you okay"
-				`	"Is there anything I should watch out for?"`
-					to display
-						not "Successors: watch out"
-					goto "watch out"
-			label warning
-				set "Successors: warning"
-			`	"That is not for me to know, nor, I think, for thee."`
 				goto questions
 			label embark
 			action


### PR DESCRIPTION
**Bug fix**

## Summary
In Successors: First Contact 3, the spaceport (on offer) conversation options had a few display logic issues:
- Some options could be selected multiple times, when this was not intended by the author.
- Some follow-up questions could not be asked if a different question was asked in between. I confirmed with @Daeridanii1 on [discord](https://discord.com/channels/251118043411775489/266345072554016768/1354650059786027089) that this was not desired.
These issues have been fixed in this PR.

## Testing Done
Steps to reproduce this issue:
1. Load the attached save.
2. Take off and land on the same planet. (This step is required, as the mission is cached in the save file after landing.)
2. Select the following conversation options. Picking other options should also work, as long as you accept their mission. (Otherwise, First Contact 3 is never offered.)
  - (Go with them.)
  - (Say nothing.)
  - (Say nothing.)
  - "I accept."
  (Dismiss the conversation)
3. Go to the spaceport.
4. A conversation should appear. The following issues present themselves, pre-patch:
- Selecting "How does Sioeora even know that the Kijra-pets are on this moon?", then picking any option other than "What do you mean that jump drives are 'familiar?'" locks you out of asking the aforementioned question.
  - Selecting that follow-up question, then picking any option other than "Do the scions have their own jump drives?" locks you out of asking the second follow-up question.
- It is possible to repeatedly ask "Are you certain you're okay going with me?" and "Is there anything I should watch out for?", even though this was not intended to be possible.

With the patch active, the issues above no longer occur.


## Save File
This save file can be used to test these changes: [First Last 2~3013-12-20 repro.txt](https://github.com/user-attachments/files/19478894/First.Last.2.3013-12-20.repro.txt)
