### PR TITLE
fix(content): Fix remaining shipment jobs from offering on pirate planets

### DIFF
--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -655,6 +655,7 @@ mission "Lovelace Labs Shipment [0]"
 	source
 		near Aldebaran 2 10
 		attributes core factory
+		not government "Pirate"
 	destination Ada
 	on visit
 		dialog phrase "generic cargo on visit"

--- a/data/human/south jobs.txt
+++ b/data/human/south jobs.txt
@@ -238,6 +238,7 @@ mission "Delta V Shipment [0]"
 	source
 		near Pherkad 2 15
 		attributes factory
+		not government "Pirate"
 	destination Solace
 	on visit
 		dialog phrase "generic cargo on visit"
@@ -257,6 +258,7 @@ mission "Delta V Shipment [1]"
 	source
 		near Pherkad 2 15
 		attributes factory
+		not government "Pirate"
 	destination Solace
 	on visit
 		dialog phrase "generic cargo on visit"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1354795576289398814).

## Summary
There were still a few shipment jobs that could offer on pirate worlds, that were not fixed in https://github.com/endless-sky/endless-sky/commit/34383dd960f42de2537a06c2bb0ba3f35a8a73c0. This PR makes sure that all shipment jobs cannot offer on pirate worlds.

## Screenshots
Before
![image](https://github.com/user-attachments/assets/3ef2d139-56bf-49d7-856e-0a8d7e9f3935)
After
![image](https://github.com/user-attachments/assets/2af19b00-aef5-47cf-a737-7a7169a983d7)

## Testing Done
Made sure each of the jobs in https://github.com/endless-sky/endless-sky/commit/34383dd960f42de2537a06c2bb0ba3f35a8a73c0 either specified that they were not offered on pirate systems, or their location filter did not match any inhabited pirate systems, by using the `--matches` flag.

## Save File
This save file can be used to test these changes: [Test Pilot~R.txt](https://github.com/user-attachments/files/19491058/Test.Pilot.R.txt)
