### PR TITLE
fix(bug): Avgi: Defend Ensemble 1 fix

### DIFF
--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -490,7 +490,7 @@ mission "Avgi: Defend Ensemble 1"
 				goto end
 
 			label blame
-				`	"I wish it was that simple. I made more mistakes after that, ones with a price measured in lives. Eleven dead after our ship was disabled, all because I ordered us to get too close to the scary-looking alien ships in the hope we could communicate with them. Sure, you could say I couldn't have known the Aberrant would try to kill us, but I ignored the advice of my crew, just because I was desperate to get home. Sora, Leon, they both told me we should run, but I didn't listen to them."`
+			`	"I wish it was that simple. I made more mistakes after that, ones with a price measured in lives. Eleven dead after our ship was disabled, all because I ordered us to get too close to the scary-looking alien ships in the hope we could communicate with them. Sure, you could say I couldn't have known the Aberrant would try to kill us, but I ignored the advice of my crew, just because I was desperate to get home. Sora, Leon, they both told me we should run, but I didn't listen to them."`
 
 			label end
 			`	You sit together in silence for a few more minutes, when Darius seems to receive a message on his communicator. "I get patched in to the emergency alert system," he explains as he reads it. Suddenly, he pales. "A scout is reporting a massive invasion headed towards the Ensemble system. Dozens of Aberrations, flying straight through the Shroud." He looks up at you. "They don't normally try to go too deep in the Shroud. Something about it spooks them, I think, but Ensemble is shallow enough that they've attacked it before. Nothing of this scale though, and... damn, Sora's on Weledos, the moon in the Ensemble system."`


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on Discord

## Summary
Deleted an extraneous tab character to make a label work properly. ~~I was sure Azure had fixed this, but apparently not~~
edit: oops, I apparently PRed this from master

## Save File
This save file can be used to test these changes:
[Dag Roth.txt](https://github.com/user-attachments/files/19525910/Dag.Roth.txt)
