### PR TITLE
fix(ci/cd): Fix libjpeg version on Mac

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -96,44 +96,44 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-cd_macos_x64:
-  name: MacOS
-  runs-on: macos-13
-  env:
-    OUTPUT: EndlessSky-macOS-continuous.zip
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  steps:
-    - uses: actions/checkout@v4
-      with:
-        show-progress: false
-    - name: Setup cached directories
-      uses: actions/cache@v4
-      with:
-        path: /Users/runner/Library/Caches/Mozilla.sccache
-        key: ${{ runner.os }}-${{ runner.arch }}-cd-sccache-${{ github.ref }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-cd-sccache-refs/heads/master
-    - name: Setup sccache
-      uses: Mozilla-Actions/sccache-action@v0.0.5
-    - name: Install pkg-config
-      run: type -P pkg-config || brew install pkg-config
-    - uses: lukka/get-cmake@latest
-    - uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
-    - uses: lukka/run-cmake@v10
-      with:
-        configurePreset: 'macos-release'
-        buildPreset: 'macos-ci-release'
-    - name: Package Application
-      run: |
-        cmake --install build/release
-        7z a ${{ env.OUTPUT }} "./install/release/*"
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.OUTPUT }}
-        path: ${{ env.OUTPUT }}
+  cd_macos_x64:
+    name: MacOS
+    runs-on: macos-13
+    env:
+      OUTPUT: EndlessSky-macOS-continuous.zip
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Setup cached directories
+        uses: actions/cache@v4
+        with:
+          path: /Users/runner/Library/Caches/Mozilla.sccache
+          key: ${{ runner.os }}-${{ runner.arch }}-cd-sccache-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cd-sccache-refs/heads/master
+      - name: Setup sccache
+        uses: Mozilla-Actions/sccache-action@v0.0.5
+      - name: Install pkg-config
+        run: type -P pkg-config || brew install pkg-config
+      - uses: lukka/get-cmake@latest
+      - uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
+      - uses: lukka/run-cmake@v10
+        with:
+          configurePreset: 'macos-release'
+          buildPreset: 'macos-ci-release'
+      - name: Package Application
+        run: |
+          cmake --install build/release
+          7z a ${{ env.OUTPUT }} "./install/release/*"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.OUTPUT }}
+          path: ${{ env.OUTPUT }}
 
   cd_upload_artifacts_to_release:
     name: Upload

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -96,44 +96,44 @@ jobs:
           name: ${{ env.OUTPUT }}
           path: ${{ env.OUTPUT }}
 
-#  cd_macos_x64:
-#    name: MacOS
-#    runs-on: macos-13
-#    env:
-#      OUTPUT: EndlessSky-macOS-continuous.zip
-#      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          show-progress: false
-#      - name: Setup cached directories
-#        uses: actions/cache@v4
-#        with:
-#          path: /Users/runner/Library/Caches/Mozilla.sccache
-#          key: ${{ runner.os }}-${{ runner.arch }}-cd-sccache-${{ github.ref }}
-#          restore-keys: |
-#            ${{ runner.os }}-${{ runner.arch }}-cd-sccache-refs/heads/master
-#      - name: Setup sccache
-#        uses: Mozilla-Actions/sccache-action@v0.0.5
-#      - name: Install pkg-config
-#        run: type -P pkg-config || brew install pkg-config
-#      - uses: lukka/get-cmake@latest
-#      - uses: lukka/run-vcpkg@v11
-#        with:
-#          vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
-#      - uses: lukka/run-cmake@v10
-#        with:
-#          configurePreset: 'macos-release'
-#          buildPreset: 'macos-ci-release'
-#      - name: Package Application
-#        run: |
-#          cmake --install build/release
-#          7z a ${{ env.OUTPUT }} "./install/release/*"
-#      - name: Upload artifact
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: ${{ env.OUTPUT }}
-#          path: ${{ env.OUTPUT }}
+cd_macos_x64:
+  name: MacOS
+  runs-on: macos-13
+  env:
+    OUTPUT: EndlessSky-macOS-continuous.zip
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        show-progress: false
+    - name: Setup cached directories
+      uses: actions/cache@v4
+      with:
+        path: /Users/runner/Library/Caches/Mozilla.sccache
+        key: ${{ runner.os }}-${{ runner.arch }}-cd-sccache-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cd-sccache-refs/heads/master
+    - name: Setup sccache
+      uses: Mozilla-Actions/sccache-action@v0.0.5
+    - name: Install pkg-config
+      run: type -P pkg-config || brew install pkg-config
+    - uses: lukka/get-cmake@latest
+    - uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
+    - uses: lukka/run-cmake@v10
+      with:
+        configurePreset: 'macos-release'
+        buildPreset: 'macos-ci-release'
+    - name: Package Application
+      run: |
+        cmake --install build/release
+        7z a ${{ env.OUTPUT }} "./install/release/*"
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.OUTPUT }}
+        path: ${{ env.OUTPUT }}
 
   cd_upload_artifacts_to_release:
     name: Upload

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,6 +15,13 @@
 				},
 				"libpng",
 				"libjpeg-turbo",
+				{
+					"name": "libjpeg-turbo",
+					"features": [
+						"jpeg8"
+					],
+					"platform": "osx"
+				},
 				"libmad",
 				{
 					"name": "libuuid",


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug/feature described in issue #11248

## Summary
The failing CI is complaining about the difference between the expected and installed versions of libjpeg-turbo. This PR enables the v8 compatibility mode that should allow the library to function with our binary.

## Testing Done
Let's see if the CI works