### PR TITLE
feat(ci): Also run CI on overlay changes

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -43,6 +43,7 @@ cmake_files:
   - utils/vcpkg_bootstrap.cmake
   - utils/check_cmake.sh
   - CMakePresets.json
+  - 'overlays/**'
   - vcpkg.json
   - vcpkg-configuration.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
     - 'steam/**'
     - 'CMakeLists.txt'
     - 'CMakePresets.json'
+    - 'overlays/**'
     - Doxyfile
     - keys.txt
   pull_request:
@@ -29,6 +30,7 @@ on:
     - 'steam/**'
     - 'CMakeLists.txt'
     - 'CMakePresets.json'
+    - 'overlays/**'
     - Doxyfile
     - keys.txt
 


### PR DESCRIPTION
**Feature**

This PR enables CI-build-runs for PRs with overlay-only changes, noticed by warp_core and me while investigating #11242

## Summary
Test-PRs like https://github.com/petervdmeer/endless-sky/pull/13 were not triggering CI-builds.

## Testing Done
Added a commit on the test-PR in the summary and noticed that the CI-buids do run. Then copied the change into this PR.

## Wiki Update
N/A

## Performance Impact
No noticeable impact expected.
