### PR TITLE
fix(ui): Add a missing message to the help command

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -329,6 +329,20 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		{
 			if(isOutfitter)
 				DoHelp("outfitter with multiple ships", true);
+
+			set<string> modelNames;
+			for(const auto &it : player.Ships())
+			{
+				if(!CanShowInSidebar(*it, player.GetPlanet()))
+					continue;
+				if(modelNames.contains(it->DisplayModelName()))
+				{
+					DoHelp("shop with multiple ships", true);
+					break;
+				}
+				modelNames.insert(it->DisplayModelName());
+			}
+
 			DoHelp("multiple ships", true);
 		}
 		if(isOutfitter)


### PR DESCRIPTION
**Bug fix**

## Summary
Forgot to add the new message introduced in #11048 to the manual show help command functionality. The code in this PR is the same as in the place where it's displayed automatically, except for the flag required for manual messages.

## Testing Done
yes.™

## Wiki Update
N/A

## Performance Impact
haha std::set go brrr