### PR TITLE
feat(content): Remove reference to kittens from korath hails

### DIFF
--- a/data/korath/korath hails.txt
+++ b/data/korath/korath hails.txt
@@ -665,7 +665,6 @@ phrase "exile humanika: cultural items"
 # among the Korath that make them ask for this.
 phrase "exile humanika: strange items"
 	word
-		"kit'ens"                            # Kittens (mispronounced)
 		"Hoy a'orn cookees"                  # Hai acorn cookies (mispronounced)
 		"toilat pepper"                      # Toilet paper (mispronounced)
 		"geko"                               # Gecko (mispronounced)


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the feature described on [Swizzle 6](https://discord.com/channels/844344915454722089/849060713485041704/1355953019333775372).

## Summary
Raven deosn’t want the korath to eat kittens.

## Testing Done
Unlikely