### PR TITLE
feat: Flagship property (bays, shields, hull, mass) autoconditions

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3453,6 +3453,11 @@ void PlayerInfo::RegisterDerivedConditions()
 	auto &&flagshipMassProvider = conditions.GetProviderNamed("flagship mass");
 	flagshipMassProvider.SetGetFunction([this](const string &name) { return flagship ? flagship->Mass() : 0; });
 
+	auto &&flagshipShieldsProvider = conditions.GetProviderNamed("flagship shields");
+	flagshipShieldsProvider.SetGetFunction([this](const string &name) {
+		return flagship ? (flagship->Shields() * flagship->MaxShields()) : 0;
+	});
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3471,12 +3471,12 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	auto &&flagshipHullProvider = conditions.GetProviderNamed("flagship hull");
 	flagshipHullProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return flagship ? (flagship->Hull() * flagship->MaxHull()) : 0;
+		return flagship ? flagship->HullLevel() : 0;
 	});
 
 	auto &&flagshipFuelProvider = conditions.GetProviderNamed("flagship fuel");
 	flagshipFuelProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return flagship ? (flagship->Fuel() * flagship->Attributes().Get("fuel capacity")) : 0;
+		return flagship ? flagship->FuelLevel() : 0;
 	});
 
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3419,6 +3419,16 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipBaysCategoryProvider.SetGetFunction(flagshipBaysCategoryFun);
 
+	auto &&flagshipBaysCategoryFreeProvider = conditions.GetProviderPrefixed("flagship bays free: ");
+	auto flagshipBaysCategoryFreeFun = [this](const string &name) -> int64_t
+	{
+		if(!flagship)
+			return 0;
+
+		return flagship->BaysFree(name.substr(strlen("flagship bays free: ")));
+	};
+	flagshipBaysCategoryFreeProvider.SetGetFunction(flagshipBaysCategoryFreeFun);
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3409,15 +3409,15 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipAttributeProvider.SetGetFunction(flagshipAttributeFun);
 
-	auto &&flagshipBaysProvider = conditions.GetProviderPrefixed("flagship bays: ");
-	auto flagshipBaysFun = [this](const string &name) -> int64_t
+	auto &&flagshipBaysCategoryProvider = conditions.GetProviderPrefixed("flagship bays: ");
+	auto flagshipBaysCategoryFun = [this](const string &name) -> int64_t
 	{
 		if(!flagship)
 			return 0;
 
 		return flagship->BaysTotal(name.substr(strlen("flagship bays: ")));
 	};
-	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);
+	flagshipBaysCategoryProvider.SetGetFunction(flagshipBaysCategoryFun);
 
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3462,20 +3462,20 @@ void PlayerInfo::RegisterDerivedConditions()
 	flagshipBaysFreeProvider.SetGetFunction(flagshipBaysFreeFun);
 
 	auto &&flagshipMassProvider = conditions.GetProviderNamed("flagship mass");
-	flagshipMassProvider.SetGetFunction([this](const string &name) { return flagship ? flagship->Mass() : 0; });
+	flagshipMassProvider.SetGetFunction([this](const string &name) -> int64_t { return flagship ? flagship->Mass() : 0; });
 
 	auto &&flagshipShieldsProvider = conditions.GetProviderNamed("flagship shields");
-	flagshipShieldsProvider.SetGetFunction([this](const string &name) {
+	flagshipShieldsProvider.SetGetFunction([this](const string &name) -> int64_t {
 		return flagship ? (flagship->Shields() * flagship->MaxShields()) : 0;
 	});
 
 	auto &&flagshipHullProvider = conditions.GetProviderNamed("flagship hull");
-	flagshipHullProvider.SetGetFunction([this](const string &name) {
+	flagshipHullProvider.SetGetFunction([this](const string &name) -> int64_t {
 		return flagship ? (flagship->Hull() * flagship->MaxHull()) : 0;
 	});
 
 	auto &&flagshipFuelProvider = conditions.GetProviderNamed("flagship fuel");
-	flagshipFuelProvider.SetGetFunction([this](const string &name) {
+	flagshipFuelProvider.SetGetFunction([this](const string &name) -> int64_t {
 		return flagship ? (flagship->Fuel() * flagship->Attributes().Get("fuel capacity")) : 0;
 	});
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3427,6 +3427,10 @@ void PlayerInfo::RegisterDerivedConditions()
 		if(!flagship)
 			return 0;
 
+		if(GetPlanet())
+			Logger::LogError("Warning: Use of \"flagship bays free: <category>\""
+				" condition while landed is unstable behavior.");
+
 		return flagship->BaysFree(name.substr(strlen("flagship bays free: ")));
 	};
 	flagshipBaysCategoryFreeProvider.SetGetFunction(flagshipBaysCategoryFreeFun);
@@ -3448,6 +3452,9 @@ void PlayerInfo::RegisterDerivedConditions()
 	{
 		if(!flagship)
 			return 0;
+
+			if(GetPlanet())
+				Logger::LogError("Warning: Use of \"flagship bays free\" condition while landed is unstable behavior.");
 
 		const vector<Ship::Bay> &bays = flagship->Bays();
 		return count_if(bays.begin(), bays.end(), [](const Ship::Bay &bay) { return !bay.ship; });

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3463,6 +3463,11 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagship ? (flagship->Hull() * flagship->MaxHull()) : 0;
 	});
 
+	auto &&flagshipFuelProvider = conditions.GetProviderNamed("flagship fuel");
+	flagshipFuelProvider.SetGetFunction([this](const string &name) {
+		return flagship ? (flagship->Fuel() * flagship->Attributes().Get("fuel capacity")) : 0;
+	});
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3453,8 +3453,8 @@ void PlayerInfo::RegisterDerivedConditions()
 		if(!flagship)
 			return 0;
 
-			if(GetPlanet())
-				Logger::LogError("Warning: Use of \"flagship bays free\" condition while landed is unstable behavior.");
+		if(GetPlanet())
+			Logger::LogError("Warning: Use of \"flagship bays free\" condition while landed is unstable behavior.");
 
 		const vector<Ship::Bay> &bays = flagship->Bays();
 		return count_if(bays.begin(), bays.end(), [](const Ship::Bay &bay) { return !bay.ship; });

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3439,6 +3439,17 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);
 
+	auto &&flagshipBaysFreeProvider = conditions.GetProviderNamed("flagship bays free");
+	auto flagshipBaysFreeFun = [this](const string &name) -> int64_t
+	{
+		if(!flagship)
+			return 0;
+
+		const vector<Ship::Bay> &bays = flagship->Bays();
+		return count_if(bays.begin(), bays.end(), [](const Ship::Bay &bay) { return static_cast<bool>(bay.ship); });
+	};
+	flagshipBaysFreeProvider.SetGetFunction(flagshipBaysFreeFun);
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3446,7 +3446,7 @@ void PlayerInfo::RegisterDerivedConditions()
 			return 0;
 
 		const vector<Ship::Bay> &bays = flagship->Bays();
-		return count_if(bays.begin(), bays.end(), [](const Ship::Bay &bay) { return static_cast<bool>(bay.ship); });
+		return count_if(bays.begin(), bays.end(), [](const Ship::Bay &bay) { return !bay.ship; });
 	};
 	flagshipBaysFreeProvider.SetGetFunction(flagshipBaysFreeFun);
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3450,6 +3450,9 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipBaysFreeProvider.SetGetFunction(flagshipBaysFreeFun);
 
+	auto &&flagshipMassProvider = conditions.GetProviderNamed("flagship mass");
+	flagshipMassProvider.SetGetFunction([this](const string &name) { return flagship ? flagship->Mass() : 0; });
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3466,7 +3466,7 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	auto &&flagshipShieldsProvider = conditions.GetProviderNamed("flagship shields");
 	flagshipShieldsProvider.SetGetFunction([this](const string &name) -> int64_t {
-		return flagship ? (flagship->Shields() * flagship->MaxShields()) : 0;
+		return flagship ? flagship->ShieldLevel() : 0;
 	});
 
 	auto &&flagshipHullProvider = conditions.GetProviderNamed("flagship hull");

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3429,6 +3429,16 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipBaysCategoryFreeProvider.SetGetFunction(flagshipBaysCategoryFreeFun);
 
+	auto &&flagshipBaysProvider = conditions.GetProviderNamed("flagship bays");
+	auto flagshipBaysFun = [this](const string &name) -> int64_t
+	{
+		if(!flagship)
+			return 0;
+
+		return flagship->Bays().size();
+	};
+	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3458,6 +3458,11 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagship ? (flagship->Shields() * flagship->MaxShields()) : 0;
 	});
 
+	auto &&flagshipHullProvider = conditions.GetProviderNamed("flagship hull");
+	flagshipHullProvider.SetGetFunction([this](const string &name) {
+		return flagship ? (flagship->Hull() * flagship->MaxHull()) : 0;
+	});
+
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3419,6 +3419,8 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipBaysCategoryProvider.SetGetFunction(flagshipBaysCategoryFun);
 
+	// The behaviour of this condition while landed is not stable and may change in the future.
+	// It should only be used while in-flight.
 	auto &&flagshipBaysCategoryFreeProvider = conditions.GetProviderPrefixed("flagship bays free: ");
 	auto flagshipBaysCategoryFreeFun = [this](const string &name) -> int64_t
 	{
@@ -3439,6 +3441,8 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipBaysProvider.SetGetFunction(flagshipBaysFun);
 
+	// The behaviour of this condition while landed is not stable and may change in the future.
+	// It should only be used while in-flight.
 	auto &&flagshipBaysFreeProvider = conditions.GetProviderNamed("flagship bays free");
 	auto flagshipBaysFreeFun = [this](const string &name) -> int64_t
 	{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2799,10 +2799,26 @@ double Ship::MaxHull() const
 
 
 
-// Get the actual shield level of the ship.
+// Get the absolute shield level of the ship.
 double Ship::ShieldLevel() const
 {
 	return shields;
+}
+
+
+
+// Get the absolute hull level of the ship.
+double Ship::HullLevel() const
+{
+	return hull;
+}
+
+
+
+// Get the absolute fuel level of the ship.
+double Ship::FuelLevel() const
+{
+	return fuel;
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -363,8 +363,10 @@ public:
 	// Get the maximum shield and hull values of the ship, accounting for multipliers.
 	double MaxShields() const;
 	double MaxHull() const;
-	// Get the actual shield level of the ship.
+	// Get the absolute shield, hull, and fuel levels of the ship.
 	double ShieldLevel() const;
+	double HullLevel() const;
+	double FuelLevel() const;
 	// Get how disrupted this ship's shields are.
 	double DisruptionLevel() const;
 	// Get the (absolute) amount of hull that needs to be damaged until the

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -171,6 +171,8 @@ test "Flagship Attribute Autoconditions"
 			"flagship attribute: outfit space" == 17000
 			"flagship attribute: weapon capacity" == 58000
 		call "Depart"
+		apply
+			"test: flagship attributes: mass: divided" = "flagship attributes: mass" / 1000
 		assert
 			"flagship shields" == 16400
 			"flagship hull" == 10600

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -175,7 +175,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship shields" == 16400
 			"flagship hull" == 10600
 			"flagship fuel" == 1100
-			"flagship mass" - 15 == "flagship attributes: mass" / 1000
+			"flagship mass" * 1000 == "flagship attributes: mass" + 15000
 		navigate
 			travel Arculus
 		input

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -67,6 +67,7 @@ test-data "Flagship Attribute Autoconditions Save"
 				"Jump Drive"
 				"NDR-114 Android" 5
 				"Point Defense Turret"
+				"Quantum Key Stone"
 				"Salvage Scanner"
 				"Smelter-Class Steering"
 				"Smelter-Class Thruster"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -114,6 +114,9 @@ test-data "Flagship Attribute Autoconditions Save"
 			"final explode" "final explosion medium" 1
 			system Pantica
 			planet Aventine
+		cargo
+			outfits
+				"Heavy Laser" 1
 		account
 			credits 131000
 			score 400
@@ -169,3 +172,19 @@ test "Flagship Attribute Autoconditions"
 			"flagship attribute: heat generation" == 32300
 			"flagship attribute: outfit space" == 16000
 			"flagship attribute: weapon capacity" == 58000
+		call "Depart"
+		assert
+			"flagship shields" == 16400
+			"flagship hull" == 10400
+			"flagship fuel" == 1100
+			"flagship mass" - 15 == "flagship attributes: mass" * 1000
+		navigate
+			travel Pantica
+		input
+			command Jump
+		label "not pantica"
+		branch "not pantica"
+			not "flagship system: Pantica"
+		assert
+			"flagship fuel" == 900
+

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -162,26 +162,24 @@ test "Flagship Attribute Autoconditions"
 			"flagship base attribute: turret mounts" == 2000
 			"flagship base attribute: weapon capacity" == 220000
 			"flagship base attribute: heat generation" == 0
-			"flagship attribute: cost" == 56294000
-			"flagship attribute: mass" == 882000
+			"flagship attribute: cost" == 56534000
+			"flagship attribute: mass" == 882100
 			"flagship attribute: drag" == 4300
 			"flagship attribute: engine capacity" == 9000
 			"flagship attribute: gun ports" == 0
 			"flagship attribute: heat generation" == 32300
-			"flagship attribute: outfit space" == 17000
+			"flagship attribute: outfit space" == 16000
 			"flagship attribute: weapon capacity" == 58000
 		call "Depart"
-		apply
-			"test: flagship attributes: mass: divided" = "flagship attributes: mass" / 1000
 		assert
 			"flagship shields" == 16400
 			"flagship hull" == 10600
 			"flagship fuel" == 1100
-			"flagship mass" * 1000 == "flagship attributes: mass" + 15000
+			"flagship mass" - 15 == "flagship attributes: mass" / 1000
 		navigate
 			travel Arculus
 		input
-			command jump
+			command Jump
 		label "not arculus"
 		branch "not arculus"
 			not "flagship system: Arculus"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -179,12 +179,12 @@ test "Flagship Attribute Autoconditions"
 			"flagship fuel" == 1100
 			"flagship mass" - 15 == "flagship attributes: mass" * 1000
 		navigate
-			travel Pantica
+			travel Arculus
 		input
 			command Jump
-		label "not pantica"
-		branch "not pantica"
-			not "flagship system: Pantica"
+		label "not arculus"
+		branch "not arculus"
+			not "flagship system: Arculus"
 		assert
 			"flagship fuel" == 900
 

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -175,7 +175,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship shields" == 16400
 			"flagship hull" == 10600
 			"flagship fuel" == 1100
-			"flagship mass" - 15 == "flagship attributes: mass" / 1000
+			"flagship mass" - 15 == "flagship attribute: mass" / 1000
 		navigate
 			travel Arculus
 		input

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -174,7 +174,7 @@ test "Flagship Attribute Autoconditions"
 		call "Depart"
 		assert
 			"flagship shields" == 16400
-			"flagship hull" == 10400
+			"flagship hull" == 10600
 			"flagship fuel" == 1100
 			"flagship mass" - 15 == "flagship attributes: mass" * 1000
 		navigate

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -163,7 +163,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship base attribute: weapon capacity" == 220000
 			"flagship base attribute: heat generation" == 0
 			"flagship attribute: cost" == 56534000
-			"flagship attribute: mass" == 882100
+			"flagship attribute: mass" == 882000
 			"flagship attribute: drag" == 4300
 			"flagship attribute: engine capacity" == 9000
 			"flagship attribute: gun ports" == 0

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -168,7 +168,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship attribute: engine capacity" == 9000
 			"flagship attribute: gun ports" == 0
 			"flagship attribute: heat generation" == 32300
-			"flagship attribute: outfit space" == 16000
+			"flagship attribute: outfit space" == 17000
 			"flagship attribute: weapon capacity" == 58000
 		call "Depart"
 		assert

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -67,7 +67,6 @@ test-data "Flagship Attribute Autoconditions Save"
 				"Jump Drive"
 				"NDR-114 Android" 5
 				"Point Defense Turret"
-				"Quantum Key Stone"
 				"Salvage Scanner"
 				"Smelter-Class Steering"
 				"Smelter-Class Thruster"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -180,7 +180,7 @@ test "Flagship Attribute Autoconditions"
 		navigate
 			travel Arculus
 		input
-			command Jump
+			command jump
 		label "not arculus"
 		branch "not arculus"
 			not "flagship system: Arculus"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -162,7 +162,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship base attribute: turret mounts" == 2000
 			"flagship base attribute: weapon capacity" == 220000
 			"flagship base attribute: heat generation" == 0
-			"flagship attribute: cost" == 56534000
+			"flagship attribute: cost" == 56294000
 			"flagship attribute: mass" == 882000
 			"flagship attribute: drag" == 4300
 			"flagship attribute: engine capacity" == 9000

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -179,7 +179,7 @@ test "Flagship Attribute Autoconditions"
 		navigate
 			travel Arculus
 		input
-			command Jump
+			command jump
 		label "not arculus"
 		branch "not arculus"
 			not "flagship system: Arculus"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -49,7 +49,6 @@ test-data "Flagship Attribute Autoconditions Save"
 				"outfit scan power" 18
 				"outfit scan efficiency" 22
 				"outfit space" 552
-				ramscoop 2.5
 				"remnant node" 5
 				"required crew" 9
 				"shield energy" 3
@@ -153,7 +152,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship base attribute: outfit scan power" == 18000
 			"flagship base attribute: outfit scan efficiency" == 22000
 			"flagship base attribute: outfit space" == 552000
-			"flagship base attribute: ramscoop" == 2500
+			"flagship base attribute: ramscoop" == 0
 			"flagship base attribute: remnant node" == 5000
 			"flagship base attribute: required crew" == 9000
 			"flagship base attribute: shield energy" == 3000

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -176,7 +176,7 @@ test "Flagship Attribute Autoconditions"
 			"flagship shields" == 16400
 			"flagship hull" == 10600
 			"flagship fuel" == 1100
-			"flagship mass" - 15 == "flagship attributes: mass" * 1000
+			"flagship mass" - 15 == "flagship attributes: mass" / 1000
 		navigate
 			travel Arculus
 		input


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #7795

## Summary
Adds autoconditions for the flagship properties that were left over from the linked feature request:
- "flagship bays free: <category>" - Like the existing "flagship bays: <category>" autocondition, but one only returns the number of bays of that category that are free.
- "flagship bays" - Like the existing "flagship bays: <category>" but returns the total number of bays across all categories.
- "flagship bays free" - Returns the total number of bays that are free across all categories.
- "flagship shields" - The current absolute shield level.
- "flagship hull" - The current absolute hull level.
- "flagship mass" - The current mass of the flagship; the masses of any carried ships, any cargo, and this ship and its outfits.
- "flagship fuel" - The current absolute amount of fuel.

Unlike the "attribute" conditions, none of these are multiplied by a thousand, despite shields, hull, mass, and fuel supporting non-integer values; that level of precision doesn't seem necessary here.

## Usage examples
Like any other condition.

## Testing Done
Check some of the new conditions in an integration test.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/122

## Performance Impact
Immeasurable.
