### PR TITLE
feat(mechanics): Added 3 optional settings in gamerules.txt, 

### DIFF
--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -88,3 +88,18 @@ gamerules
 	# DEFAULT: 1000 (1000 days)
 	# ALLOWABLE VALUES: any integer >= 0.
 	"depreciation max age" 1000
+	
+	# Here you can set a global minium departure distance instead of changing all systems indivually.
+	# DEFAULT: 0 (no minimum)
+	# ALLOWABLE VALUES: any integer >= 0.
+	"system departure min" 0
+	
+	# Here you can set a global minium arrival distance instead of changing all systems indivually.
+	# DEFAULT: 0 (no minimum)
+	# ALLOWABLE VALUES: any integer >= 0.
+	"system arrival min" 0
+	
+	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.
+	# DEFAULT: 1.0 (no changes)
+	# ALLOWABLE VALUES: any float >= 0.
+	"fleet multiplier" 1.0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -89,7 +89,9 @@ gamerules
 	# ALLOWABLE VALUES: any integer >= 0.
 	"depreciation max age" 1000
 	
-	# The minimum departure distance for all systems.
+	# The minimum departure distance for all systems. A ship can only jump out of a system if
+	# it is further from the system center than the departure distance. If a system has a
+	# defined departure distance greater than this value, that value will be used instead.
 	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any value >= 0.
 	"system departure min" 0.0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -102,5 +102,5 @@ gamerules
 	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.
 	# A value of 2.0 means double the normal npc fleet spawns, a value of 0.5 means half as many npc fleets spawn
 	# DEFAULT: 1.0 (no changes)
-	# ALLOWABLE VALUES: any float > 0.001
+	# ALLOWABLE VALUES: any value > 0.001
 	"fleet multiplier" 1.0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -89,12 +89,12 @@ gamerules
 	# ALLOWABLE VALUES: any integer >= 0.
 	"depreciation max age" 1000
 	
-	# Here you can set a global minium departure distance instead of changing all systems indivually.
+	# Here you can set a global minimum departure distance instead of changing all systems individually.
 	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any integer >= 0.
 	"system departure min" 0
 	
-	# Here you can set a global minium arrival distance instead of changing all systems indivually.
+	# Here you can set a global minimum arrival distance instead of changing all systems individually.
 	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any integer >= 0.
 	"system arrival min" 0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -96,7 +96,10 @@ gamerules
 	# ALLOWABLE VALUES: any value >= 0.
 	"system departure min" 0.0
 	
-	# The minimum arrival distance for all systems.
+	# The minimum arrival distance for all systems. Ships entering a system will exit hyperspace
+	# this distance away from their landing target, or the system center if no landing target
+	# is selected. If a system has a defined arrival distance greater than this value,
+	# that value will be used instead.
 	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any value >= 0.
 	"system arrival min" 0.0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -96,7 +96,7 @@ gamerules
 	
 	# The minimum arrival distance for all systems.
 	# DEFAULT: 0 (no minimum)
-	# ALLOWABLE VALUES: any float >= 0.
+	# ALLOWABLE VALUES: any value >= 0.
 	"system arrival min" 0.0
 	
 	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -94,7 +94,7 @@ gamerules
 	# defined departure distance greater than this value, that value will be used instead.
 	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any value >= 0.
-	"system departure min" 0.0
+	"system departure min" 0.
 	
 	# The minimum arrival distance for all systems. Ships entering a system will exit hyperspace
 	# this distance away from their landing target, or the system center if no landing target

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -102,7 +102,7 @@ gamerules
 	# that value will be used instead.
 	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any value >= 0.
-	"system arrival min" 0.0
+	"system arrival min" 0.
 	
 	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.
 	# A value of 2.0 means double the normal npc fleet spawns, a value of 0.5 means half as many npc fleets spawn

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -104,8 +104,8 @@ gamerules
 	# ALLOWABLE VALUES: any value >= 0.
 	"system arrival min" 0.
 	
-	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.
-	# A value of 2.0 means double the normal npc fleet spawns, a value of 0.5 means half as many npc fleets spawn
+	# The global fleet spawn rate multiplier. A value of 2.0 means twice as many random fleets spawn
+	# in all systems, while a value of 0.5 means half as many fleets spawn.
 	# DEFAULT: 1.0 (no changes)
 	# ALLOWABLE VALUES: any value > 0.001
 	"fleet multiplier" 1.0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -91,7 +91,7 @@ gamerules
 	
 	# The minimum departure distance for all systems.
 	# DEFAULT: 0 (no minimum)
-	# ALLOWABLE VALUES: any float >= 0.
+	# ALLOWABLE VALUES: any value >= 0.
 	"system departure min" 0.0
 	
 	# The minimum arrival distance for all systems.

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -89,17 +89,15 @@ gamerules
 	# ALLOWABLE VALUES: any integer >= 0.
 	"depreciation max age" 1000
 	
-	# The default departure distance for all systems. If a system has no defined departure distance
-	# or a departure distance less than this value, this value will be used instead.
-	# DEFAULT: 0 (no default)
+	# The minimum departure distance for all systems.
+	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any float >= 0.
-	"default system departure" 0
+	"system departure min" 0.0
 	
-	# The default arrival distance for all systems. If a system has no defined arrival distance
-	# or an arrival distance less than this value, this value will be used instead.
-	# DEFAULT: 0 (no default)
+	# The minimum arrival distance for all systems.
+	# DEFAULT: 0 (no minimum)
 	# ALLOWABLE VALUES: any float >= 0.
-	"default system arrival" 0
+	"system arrival min" 0.0
 	
 	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.
 	# A value of 2.0 means double the normal npc fleet spawns, a value of 0.5 means half as many npc fleets spawn

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -107,5 +107,5 @@ gamerules
 	# The global fleet spawn rate multiplier. A value of 2.0 means twice as many random fleets spawn
 	# in all systems, while a value of 0.5 means half as many fleets spawn.
 	# DEFAULT: 1.0 (no changes)
-	# ALLOWABLE VALUES: any value > 0.001
+	# ALLOWABLE VALUES: any value >= 0.
 	"fleet multiplier" 1.0

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -108,4 +108,4 @@ gamerules
 	# in all systems, while a value of 0.5 means half as many fleets spawn.
 	# DEFAULT: 1.0 (no changes)
 	# ALLOWABLE VALUES: any value >= 0.
-	"fleet multiplier" 1.0
+	"fleet multiplier" 1.

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -89,17 +89,20 @@ gamerules
 	# ALLOWABLE VALUES: any integer >= 0.
 	"depreciation max age" 1000
 	
-	# Here you can set a global minimum departure distance instead of changing all systems individually.
-	# DEFAULT: 0 (no minimum)
-	# ALLOWABLE VALUES: any integer >= 0.
-	"system departure min" 0
+	# The default departure distance for all systems. If a system has no defined departure distance
+	# or a departure distance less than this value, this value will be used instead.
+	# DEFAULT: 0 (no default)
+	# ALLOWABLE VALUES: any float >= 0.
+	"default system departure" 0
 	
-	# Here you can set a global minimum arrival distance instead of changing all systems individually.
-	# DEFAULT: 0 (no minimum)
-	# ALLOWABLE VALUES: any integer >= 0.
-	"system arrival min" 0
+	# The default arrival distance for all systems. If a system has no defined arrival distance
+	# or an arrival distance less than this value, this value will be used instead.
+	# DEFAULT: 0 (no default)
+	# ALLOWABLE VALUES: any float >= 0.
+	"default system arrival" 0
 	
 	# Here you can set a global spawn rate multiplier to change the fleet rates of all systems.
+	# A value of 2.0 means double the normal npc fleet spawns, a value of 0.5 means half as many npc fleets spawn
 	# DEFAULT: 1.0 (no changes)
-	# ALLOWABLE VALUES: any float >= 0.
+	# ALLOWABLE VALUES: any float > 0.001
 	"fleet multiplier" 1.0

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1491,7 +1491,7 @@ void Engine::EnterSystem()
 	{
 		for(const auto &fleet : system->Fleets())
 			if(fleetMultiplier ? fleet.Get()->GetGovernment() && Random::Int(fleet.Period() / fleetMultiplier) < 60
-			&& fleet.CanTrigger(conditions) : false)
+				&& fleet.CanTrigger(conditions) : false)
 				fleet.Get()->Place(*system, newShips);
 
 		auto CreateWeather = [this, conditions](const RandomEvent<Hazard> &hazard, Point origin)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1490,7 +1490,8 @@ void Engine::EnterSystem()
 	for(int i = 0; i < 5; ++i)
 	{
 		for(const auto &fleet : system->Fleets())
-			if(fleet.Get()->GetGovernment() && (fleetMultiplier ? Random::Int(fleet.Period() / fleetMultiplier) < 60 : false) && fleet.CanTrigger(conditions))
+			if(fleetMultiplier ? fleet.Get()->GetGovernment() && Random::Int(fleet.Period() / fleetMultiplier) < 60
+			&& fleet.CanTrigger(conditions) : false)
 				fleet.Get()->Place(*system, newShips);
 
 		auto CreateWeather = [this, conditions](const RandomEvent<Hazard> &hazard, Point origin)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1987,7 +1987,7 @@ void Engine::SpawnFleets()
 	// or coming from planets in the current one.
 	ConditionsStore &conditions = player.Conditions();
 	for(const auto &fleet : player.GetSystem()->Fleets())
-		if(!Random::Int(fleet.Period()) && fleet.CanTrigger(conditions))
+		if(!Random::Int(fleet.Period() * GameData::GetGamerules().FleetMultiplier()) && fleet.CanTrigger(conditions))
 		{
 			const Government *gov = fleet.Get()->GetGovernment();
 			if(!gov)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1987,7 +1987,7 @@ void Engine::SpawnFleets()
 	// or coming from planets in the current one.
 	ConditionsStore &conditions = player.Conditions();
 	for(const auto &fleet : player.GetSystem()->Fleets())
-		if(!Random::Int(fleet.Period() * GameData::GetGamerules().FleetMultiplier()) && fleet.CanTrigger(conditions))
+		if(!Random::Int(fleet.Period() / GameData::GetGamerules().FleetMultiplier()) && fleet.CanTrigger(conditions))
 		{
 			const Government *gov = fleet.Get()->GetGovernment();
 			if(!gov)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1486,10 +1486,11 @@ void Engine::EnterSystem()
 	// undefined fleets by not trying to create anything with no
 	// government set.
 	ConditionsStore &conditions = player.Conditions();
+	double fleetMultiplier = GameData::GetGamerules().FleetMultiplier();
 	for(int i = 0; i < 5; ++i)
 	{
 		for(const auto &fleet : system->Fleets())
-			if(fleet.Get()->GetGovernment() && Random::Int(fleet.Period()) < 60 && fleet.CanTrigger(conditions))
+			if(fleet.Get()->GetGovernment() && (fleetMultiplier ? Random::Int(fleet.Period() / fleetMultiplier) < 60 : false) && fleet.CanTrigger(conditions))
 				fleet.Get()->Place(*system, newShips);
 
 		auto CreateWeather = [this, conditions](const RandomEvent<Hazard> &hazard, Point origin)
@@ -1988,7 +1989,7 @@ void Engine::SpawnFleets()
 	ConditionsStore &conditions = player.Conditions();
 	double fleetMultiplier = GameData::GetGamerules().FleetMultiplier();
 	for(const auto &fleet : player.GetSystem()->Fleets())
-		if(fleetMultiplier ? !Random::Int(fleet.Period() / fleetMultiplier) && fleet.CanTrigger(conditions) : true)
+		if(fleetMultiplier ? !Random::Int(fleet.Period() / fleetMultiplier) && fleet.CanTrigger(conditions) : false)
 		{
 			const Government *gov = fleet.Get()->GetGovernment();
 			if(!gov)

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1986,8 +1986,9 @@ void Engine::SpawnFleets()
 	// Non-mission NPCs spawn at random intervals in neighboring systems,
 	// or coming from planets in the current one.
 	ConditionsStore &conditions = player.Conditions();
+	double fleetMultiplier = GameData::GetGamerules().FleetMultiplier();
 	for(const auto &fleet : player.GetSystem()->Fleets())
-		if(!Random::Int(fleet.Period() / GameData::GetGamerules().FleetMultiplier()) && fleet.CanTrigger(conditions))
+		if(fleetMultiplier ? !Random::Int(fleet.Period() / fleetMultiplier) && fleet.CanTrigger(conditions) : true)
 		{
 			const Government *gov = fleet.Get()->GetGovernment();
 			if(!gov)

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -71,7 +71,7 @@ void Gamerules::Load(const DataNode &node)
 		else if(key == "system arrival min")
 			systemArrivalMin = max<double>(0.0, child.Value(1));
 		else if(key == "fleet multiplier")
-			fleetMultiplier = max<double>(0.001, child.Value(1)); //0.001 to avoid division with a very small number
+			fleetMultiplier = max<double>(0.001, child.Value(1)); // 0.001 to avoid division with a very small number
 		else
 			child.PrintTrace("Skipping unrecognized gamerule:");
 	}

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -66,10 +66,10 @@ void Gamerules::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized value for gamerule:");
 		}
-		else if(key == "default system departure")
-			defaultSystemDeparture = max<double>(0.0, child.Value(1));
-		else if(key == "default system arrival")
-			defaultSystemArrival = max<double>(0.0, child.Value(1));
+		else if(key == "system departure min")
+			systemDepartureMin = max<double>(0.0, child.Value(1));
+		else if(key == "system arrival min")
+			systemArrivalMin = max<double>(0.0, child.Value(1));
 		else if(key == "fleet multiplier")
 			fleetMultiplier = max<double>(0.001, child.Value(1)); //0.001 to avoid division with a very small number
 		else
@@ -149,16 +149,16 @@ Gamerules::FighterDodgePolicy Gamerules::FightersHitWhenDisabled() const
 
 
 
-double Gamerules::DefaultSystemDeparture() const
+double Gamerules::SystemDepartureMin() const
 {
-	return defaultSystemDeparture;
+	return systemDepartureMin;
 }
 
 
 
-double Gamerules::DefaultSystemArrival() const
+double Gamerules::SystemArrivalMin() const
 {
-	return defaultSystemArrival;
+	return systemArrivalMin;
 }
 
 

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -66,6 +66,12 @@ void Gamerules::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized value for gamerule:");
 		}
+		else if(key == "system departure min")
+			systemDepartureMin = max<double>(0.0, child.Value(1));
+		else if(key == "system arrival min")
+			systemArrivalMin = max<double>(0.0, child.Value(1));
+		else if(key == "fleet multiplier")
+			fleetMultiplier = max<double>(0.0, child.Value(1));
 		else
 			child.PrintTrace("Skipping unrecognized gamerule:");
 	}
@@ -139,4 +145,25 @@ int Gamerules::DepreciationMaxAge() const
 Gamerules::FighterDodgePolicy Gamerules::FightersHitWhenDisabled() const
 {
 	return fighterHitPolicy;
+}
+
+
+
+double Gamerules::SystemDepartureMin() const
+{
+	return systemDepartureMin;
+}
+
+
+
+double Gamerules::SystemArrivalMin() const
+{
+	return systemArrivalMin;
+}
+
+
+
+double Gamerules::FleetMultiplier() const
+{
+	return fleetMultiplier;
 }

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -66,12 +66,12 @@ void Gamerules::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized value for gamerule:");
 		}
-		else if(key == "system departure min")
-			systemDepartureMin = max<double>(0.0, child.Value(1));
-		else if(key == "system arrival min")
-			systemArrivalMin = max<double>(0.0, child.Value(1));
+		else if(key == "default system departure")
+			defaultSystemDeparture = max<double>(0.0, child.Value(1));
+		else if(key == "default system arrival")
+			defaultSystemArrival = max<double>(0.0, child.Value(1));
 		else if(key == "fleet multiplier")
-			fleetMultiplier = max<double>(0.0, child.Value(1));
+			fleetMultiplier = max<double>(0.001, child.Value(1)); //0.001 to avoid division with a very small number
 		else
 			child.PrintTrace("Skipping unrecognized gamerule:");
 	}
@@ -149,16 +149,16 @@ Gamerules::FighterDodgePolicy Gamerules::FightersHitWhenDisabled() const
 
 
 
-double Gamerules::SystemDepartureMin() const
+double Gamerules::DefaultSystemDeparture() const
 {
-	return systemDepartureMin;
+	return defaultSystemDeparture;
 }
 
 
 
-double Gamerules::SystemArrivalMin() const
+double Gamerules::DefaultSystemArrival() const
 {
-	return systemArrivalMin;
+	return defaultSystemArrival;
 }
 
 

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -67,11 +67,11 @@ void Gamerules::Load(const DataNode &node)
 				child.PrintTrace("Skipping unrecognized value for gamerule:");
 		}
 		else if(key == "system departure min")
-			systemDepartureMin = max<double>(0.0, child.Value(1));
+			systemDepartureMin = max<double>(0., child.Value(1));
 		else if(key == "system arrival min")
-			systemArrivalMin = max<double>(0.0, child.Value(1));
+			systemArrivalMin = max<double>(0., child.Value(1));
 		else if(key == "fleet multiplier")
-			fleetMultiplier = max<double>(0.001, child.Value(1)); // 0.001 to avoid division with a very small number
+			fleetMultiplier = max<double>(0., child.Value(1));
 		else
 			child.PrintTrace("Skipping unrecognized gamerule:");
 	}

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -46,8 +46,8 @@ public:
 	int DepreciationGracePeriod() const;
 	int DepreciationMaxAge() const;
 	FighterDodgePolicy FightersHitWhenDisabled() const;
-	double SystemDepartureMin() const;
-	double SystemArrivalMin() const;
+	double DefaultSystemDeparture() const;
+	double DefaultSystemArrival() const;
 	double FleetMultiplier() const;
 
 
@@ -62,7 +62,7 @@ private:
 	int depreciationGracePeriod = 7;
 	int depreciationMaxAge = 1000;
 	FighterDodgePolicy fighterHitPolicy = FighterDodgePolicy::ALL;
-	double systemDepartureMin = 0;
-	double systemArrivalMin = 0;
+	double defaultSystemDeparture = 0.0;
+	double defaultSystemArrival = 0.0;
 	double fleetMultiplier = 1.0;
 };

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -62,7 +62,7 @@ private:
 	int depreciationGracePeriod = 7;
 	int depreciationMaxAge = 1000;
 	FighterDodgePolicy fighterHitPolicy = FighterDodgePolicy::ALL;
-	double systemDepartureMin = 0.0;
-	double systemArrivalMin = 0.0;
-	double fleetMultiplier = 1.0;
+	double systemDepartureMin = 0.;
+	double systemArrivalMin = 0.;
+	double fleetMultiplier = 1.;
 };

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -46,6 +46,9 @@ public:
 	int DepreciationGracePeriod() const;
 	int DepreciationMaxAge() const;
 	FighterDodgePolicy FightersHitWhenDisabled() const;
+	double SystemDepartureMin() const;
+	double SystemArrivalMin() const;
+	double FleetMultiplier() const;
 
 
 private:
@@ -59,4 +62,7 @@ private:
 	int depreciationGracePeriod = 7;
 	int depreciationMaxAge = 1000;
 	FighterDodgePolicy fighterHitPolicy = FighterDodgePolicy::ALL;
+	double systemDepartureMin = 0;
+	double systemArrivalMin = 0;
+	double fleetMultiplier = 1.0;
 };

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -46,8 +46,8 @@ public:
 	int DepreciationGracePeriod() const;
 	int DepreciationMaxAge() const;
 	FighterDodgePolicy FightersHitWhenDisabled() const;
-	double DefaultSystemDeparture() const;
-	double DefaultSystemArrival() const;
+	double SystemDepartureMin() const;
+	double SystemArrivalMin() const;
 	double FleetMultiplier() const;
 
 
@@ -62,7 +62,7 @@ private:
 	int depreciationGracePeriod = 7;
 	int depreciationMaxAge = 1000;
 	FighterDodgePolicy fighterHitPolicy = FighterDodgePolicy::ALL;
-	double defaultSystemDeparture = 0.0;
-	double defaultSystemArrival = 0.0;
+	double systemDepartureMin = 0.0;
+	double systemArrivalMin = 0.0;
 	double fleetMultiplier = 1.0;
 };

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -721,7 +721,7 @@ double System::RamscoopFuel(double shipRamscoop, double scale) const
 // Additional travel distance to target for ships entering through hyperspace.
 double System::ExtraHyperArrivalDistance() const
 {
-	return max(extraHyperArrivalDistance, GameData::GetGamerules().SystemArrivalMin());
+	return (extraHyperArrivalDistance > 0) ? extraHyperArrivalDistance : GameData::GetGamerules().DefaultSystemArrival();
 }
 
 
@@ -729,21 +729,21 @@ double System::ExtraHyperArrivalDistance() const
 // Additional travel distance to target for ships entering using a jumpdrive.
 double System::ExtraJumpArrivalDistance() const
 {
-	return max(extraJumpArrivalDistance, GameData::GetGamerules().SystemArrivalMin());
+	return (extraJumpArrivalDistance > 0) ? extraJumpArrivalDistance : GameData::GetGamerules().DefaultSystemArrival();
 }
 
 
 
 double System::JumpDepartureDistance() const
 {
-	return max(jumpDepartureDistance, GameData::GetGamerules().SystemDepartureMin());
+	return (jumpDepartureDistance > 0) ?  jumpDepartureDistance : GameData::GetGamerules().DefaultSystemDeparture();
 }
 
 
 
 double System::HyperDepartureDistance() const
 {
-	return max(hyperDepartureDistance, GameData::GetGamerules().SystemDepartureMin());
+	return (hyperDepartureDistance > 0) ? hyperDepartureDistance : GameData::GetGamerules().DefaultSystemDeparture();
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -721,7 +721,7 @@ double System::RamscoopFuel(double shipRamscoop, double scale) const
 // Additional travel distance to target for ships entering through hyperspace.
 double System::ExtraHyperArrivalDistance() const
 {
-	return extraHyperArrivalDistance;
+	return max(extraHyperArrivalDistance, GameData::GetGamerules().SystemArrivalMin());
 }
 
 
@@ -729,21 +729,21 @@ double System::ExtraHyperArrivalDistance() const
 // Additional travel distance to target for ships entering using a jumpdrive.
 double System::ExtraJumpArrivalDistance() const
 {
-	return extraJumpArrivalDistance;
+	return max(extraJumpArrivalDistance, GameData::GetGamerules().SystemArrivalMin());
 }
 
 
 
 double System::JumpDepartureDistance() const
 {
-	return jumpDepartureDistance;
+	return max(jumpDepartureDistance, GameData::GetGamerules().SystemDepartureMin());
 }
 
 
 
 double System::HyperDepartureDistance() const
 {
-	return hyperDepartureDistance;
+	return max(hyperDepartureDistance, GameData::GetGamerules().SystemDepartureMin());
 }
 
 

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -721,7 +721,7 @@ double System::RamscoopFuel(double shipRamscoop, double scale) const
 // Additional travel distance to target for ships entering through hyperspace.
 double System::ExtraHyperArrivalDistance() const
 {
-	return (extraHyperArrivalDistance > 0) ? extraHyperArrivalDistance : GameData::GetGamerules().DefaultSystemArrival();
+	return max(extraHyperArrivalDistance, GameData::GetGamerules().SystemArrivalMin());
 }
 
 
@@ -729,21 +729,21 @@ double System::ExtraHyperArrivalDistance() const
 // Additional travel distance to target for ships entering using a jumpdrive.
 double System::ExtraJumpArrivalDistance() const
 {
-	return (extraJumpArrivalDistance > 0) ? extraJumpArrivalDistance : GameData::GetGamerules().DefaultSystemArrival();
+	return max(extraJumpArrivalDistance, GameData::GetGamerules().SystemArrivalMin());
 }
 
 
 
 double System::JumpDepartureDistance() const
 {
-	return (jumpDepartureDistance > 0) ?  jumpDepartureDistance : GameData::GetGamerules().DefaultSystemDeparture();
+	return max(jumpDepartureDistance, GameData::GetGamerules().SystemDepartureMin());
 }
 
 
 
 double System::HyperDepartureDistance() const
 {
-	return (hyperDepartureDistance > 0) ? hyperDepartureDistance : GameData::GetGamerules().DefaultSystemDeparture();
+	return max(hyperDepartureDistance, GameData::GetGamerules().SystemDepartureMin());
 }
 
 


### PR DESCRIPTION
Added in gamerules.txt "system arrival min", "system departure min", "fleets multiplier" 
Default Values keep the game content unchanged. 

You can achieve a slower Gamefeeling closer to Escape Velocity by setting default system departure and default system arrival to 4500 and fleet multiplier to 0.5  without having to edit hundreds of systems individually via a plugin impossible to maintain.

**Feature**

This PR addresses  discussions about the game feeling too fast to some players described in [issue](https://steamcommunity.com/app/404410/discussions/0/591761634944357020/).

## Summary
You can achieve a slower Gamefeeling closer to Escape Velocity by setting system departure min and system arrival min to 4500 and fleet multiplier to 0.5  without having to edit hundreds of systems individually via a plugin impossible to maintain.

## Testing Done
I build the changes and flew around a bit in human space by setting system departure min and system arrival min to 4500 and fleet multiplier to 0.5, observing the lowered spawn rates and the jump arrivals and distances. The npcs and my ship were jumping according to the new min distances and the amount of npc fleets spawned were noticeably lowered.

## Save File
Not Needed, any File will work.

## Wiki Update
(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)
ToDo?

## Performance Impact
{{If this PR changed code, describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed.}}
The performance impact should be very minor introduced by the extra min execution and multiplikation, but how big it is in realtive terms, that i can not answer.