### PR TITLE
Fix misdeployment of Republican fleets in Syndicate Systems after Pug flee

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -2488,8 +2488,8 @@ event "pug flee"
 	system "Fomalhaut"
 		fleet "Small Core Merchants" 1000
 		fleet "Large Core Merchants" 1200
-		fleet "Small Republic" 1600
-		fleet "Large Republic" 3000
+		fleet "Small Syndicate" 1600
+		fleet "Large Syndicate" 3000
 	system "Delta Capricorni"
 		fleet "Small Core Merchants" 700
 		fleet "Large Core Merchants" 800
@@ -2503,13 +2503,13 @@ event "pug flee"
 	system "Diphda"
 		fleet "Small Core Merchants" 2000
 		fleet "Large Core Merchants" 600
-		fleet "Small Republic" 1600
-		fleet "Large Republic" 3000
+		fleet "Small Syndicate" 1600
+		fleet "Large Syndicate" 3000
 	system "Caph"
 		fleet "Small Core Merchants" 500
 		fleet "Large Core Merchants" 600
-		fleet "Small Republic" 1600
-		fleet "Large Republic" 3000
+		fleet "Small Syndicate" 1600
+		fleet "Large Syndicate" 3000
 	system "Nocte"
 		fleet "Small Northern Merchants" 1500
 		fleet "Large Northern Merchants" 5000


### PR DESCRIPTION
## Free Syndicate Space ##

The event `pug flee` gives the *Syndicate* systems Caph, Diphda and Fomalhaut *Republican* fleets to spawn instead of restoring the Syndicate fleets, while the Syndicate systems Alderamin and Delta Capricorni correctly get their Syndicate fleets back.

Unless there's some lore behind this -- Republic continues to occupy some Syndicate systems as a buffer zone -- the pre-pug state should be restored like in the other pug-affected systems.

Mentioned by me on the Discord channels [endless-sky](https://discord.com/channels/251118043411775489/308902312741568512/1322745109611020379) and [bug-reporting](https://discord.com/channels/251118043411775489/536900466655887360/1322754161816633507) in December but might have got forgotten because of holidays.

#### Test ####

Yep, Syndicate ships cruising along instead of Republican Navy.