### PR TITLE
Rebalance Javelin Turret's Turn Rate

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1178,7 +1178,7 @@ outfit "Javelin Turret"
 		icon "icon/javelin turret"
 		"hit effect" "tiny explosion"
 		"inaccuracy" 4
-		"turret turn" 3.6
+		"turret turn" 2.6
 		"velocity" 10
 		"lifetime" 60
 		"reload" 7.5


### PR DESCRIPTION
## Jav Turr Nerf ##

Small follow-up on [PR #11194](https://github.com/endless-sky/endless-sky/pull/11194) where everyone seemed to agree, that the Javelin Turret's turn rate can be nerfed down from 3.6 to 2.6.

That's all this PR does.

#### Test ####

It turns slower, feeling less OP.

#### Performance ####

The overall game balance increased by 1.7%.