### PR TITLE
fix(bug): "stranded" help tooltip no longer shows when not actually stranded

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -516,7 +516,8 @@ bool MainPanel::ShowHelp(bool force)
 			return true;
 	}
 	bool canRefuel = player.GetSystem()->HasFuelFor(*flagship);
-	if(!flagship->IsHyperspacing() && !flagship->JumpsRemaining() && !canRefuel)
+	if(!flagship->IsHyperspacing() && !flagship->JumpsRemaining() &&
+		flagship->JumpNavigation().HasAnyDrive() && !canRefuel)
 	{
 		if(force)
 			forced.push_back("stranded");

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -516,8 +516,8 @@ bool MainPanel::ShowHelp(bool force)
 			return true;
 	}
 	bool canRefuel = player.GetSystem()->HasFuelFor(*flagship);
-	if(!flagship->IsHyperspacing() && !flagship->JumpsRemaining() &&
-		flagship->JumpNavigation().HasAnyDrive() && !canRefuel)
+	bool hasEnoughFuel = flagship->JumpNavigation().JumpFuel(*player.GetSystem()->Links().cbegin());
+	if(!flagship->IsHyperspacing() && !hasEnoughFuel && !canRefuel)
 	{
 		if(force)
 			forced.push_back("stranded");

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -516,8 +516,7 @@ bool MainPanel::ShowHelp(bool force)
 			return true;
 	}
 	bool canRefuel = player.GetSystem()->HasFuelFor(*flagship);
-	bool hasEnoughFuel = flagship->JumpNavigation().JumpFuel(*player.GetSystem()->Links().cbegin());
-	if(!flagship->IsHyperspacing() && !hasEnoughFuel && !canRefuel)
+	if(!flagship->IsHyperspacing() && !flagship->JumpsRemaining() && !canRefuel)
 	{
 		if(force)
 			forced.push_back("stranded");

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2848,15 +2848,19 @@ int Ship::JumpsRemaining(bool followParent) const
 	// Make sure this ship has some sort of hyperdrive, and if so return how
 	// many jumps it can make.
 	double jumpFuel = 0.;
-	if(!targetSystem && followParent)
+	if(!targetSystem)
 	{
-		// If this ship has no destination, the parent's substitutes for it,
-		// but only if the location is reachable.
-		auto p = GetParent();
-		if(p)
-			jumpFuel = navigation.JumpFuel(p->GetTargetSystem());
+		if(followParent)
+		{
+			// If this ship has no destination, the parent's substitutes for it,
+			// but only if the location is reachable.
+			auto p = GetParent();
+			jumpFuel = p ? navigation.JumpFuel(p->GetTargetSystem()) : navigation.JumpFuelNearest();
+		}
+		else
+			jumpFuel = navigation.JumpFuelNearest();
 	}
-	if(!jumpFuel)
+	else
 		jumpFuel = navigation.JumpFuel(targetSystem);
 	return jumpFuel ? fuel / jumpFuel : 0.;
 }

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -199,6 +199,13 @@ bool ShipJumpNavigation::HasJumpDrive() const
 
 
 
+bool ShipJumpNavigation::HasAnyDrive() const
+{
+	return hasHyperdrive || hasScramDrive || hasHyperdrive;
+}
+
+
+
 // Parse the given outfit to determine if it has the capability to jump, and update any
 // jump information accordingly.
 void ShipJumpNavigation::ParseOutfit(const Outfit &outfit)

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -92,8 +92,9 @@ double ShipJumpNavigation::JumpFuel(const System *destination) const
 double ShipJumpNavigation::JumpFuelNearest() const
 {
 	// A currently-carried ship or ship without drives requires no fuel to jump,
-	// because it cannot jump.
-	if(!currentSystem || !HasAnyDrive())
+	// because it cannot jump. If the system has a wormhole, then the nearest system
+	// is accessible via wormhole and thus requires no fuel to jump.
+	if(!currentSystem || !HasAnyDrive() || currentSystem->HasWormhole())
 		return 0.;
 
 	double jumpDriveCost = JumpDriveFuel();
@@ -101,11 +102,9 @@ double ShipJumpNavigation::JumpFuelNearest() const
 
 	// Check whether the ship can jump, that jumping is more expensive than hyperdriving,
 	// and whether the system has links.
-	if((!jumpDriveCost || jumpDriveCost >= hyperdriveCost) && !currentSystem->Links().empty())
+	if(hyperdriveCost && (!jumpDriveCost || jumpDriveCost >= hyperdriveCost) && !currentSystem->Links().empty())
 		return hyperdriveCost;
-	else if(!currentSystem->VisibleNeighbors().empty())
-		return jumpDriveCost;
-	return 0.;
+	return jumpDriveCost;
 }
 
 

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -71,17 +71,25 @@ void ShipJumpNavigation::SetSystem(const System *system)
 
 
 // Get the amount of fuel that would be expended to jump to the destination. If the destination is
-// nullptr then return the maximum amount of fuel that this ship could expend in one jump.
+// nullptr then return the minimum amount of fuel that this ship could expend in one jump from the
+// current system.
 double ShipJumpNavigation::JumpFuel(const System *destination) const
 {
-	// A currently-carried ship requires no fuel to jump, because it cannot jump.
-	if(!currentSystem)
+	// A currently-carried ship or ship without drives requires no fuel to jump,
+	// because it cannot jump.
+	if(currentSystem != nullptr && !(hasJumpDrive || hasHyperdrive || hasScramDrive))
 		return 0.;
 
-	// If no destination is given, return the maximum fuel per jump.
-	if(!destination)
-		return max(JumpDriveFuel(), HyperdriveFuel());
-
+	// If no destination is given, return the minimum jump-fuel to the nearest system.
+	// If no system is accessible via hyperdrive, return assuming jump drive usage.
+	if(destination == nullptr)
+	{
+		if(!currentSystem->Links().empty() && (hasHyperdrive || hasScramDrive))
+		{
+			return HyperdriveFuel();
+		}
+		return JumpDriveFuel();
+	}
 	return GetCheapestJumpType(currentSystem, destination).second;
 }
 

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -71,8 +71,7 @@ void ShipJumpNavigation::SetSystem(const System *system)
 
 
 // Get the amount of fuel that would be expended to jump to the destination. If the destination is
-// nullptr then return the minimum amount of fuel that this ship could expend in one jump from the
-// current system.
+// nullptr then return the maximum amount of fuel that this ship could expend in one jump.
 double ShipJumpNavigation::JumpFuel(const System *destination) const
 {
 	// A currently-carried ship or ship without drives requires no fuel to jump,
@@ -80,16 +79,10 @@ double ShipJumpNavigation::JumpFuel(const System *destination) const
 	if(!currentSystem || !HasAnyDrive())
 		return 0.;
 
-	// If no destination is given, return the minimum jump-fuel to the nearest system.
-	// If no system is accessible via hyperdrive, return assuming jump drive usage.
-	if(destination == nullptr)
-	{
-		if(!currentSystem->Links().empty() && (hasHyperdrive || hasScramDrive))
-		{
-			return HyperdriveFuel();
-		}
-		return JumpDriveFuel();
-	}
+	// If no destination is given, return the maximum fuel per jump.
+	if(!destination)
+		return max(JumpDriveFuel(), HyperdriveFuel());
+
 	return GetCheapestJumpType(currentSystem, destination).second;
 }
 
@@ -195,13 +188,6 @@ bool ShipJumpNavigation::HasScramDrive() const
 bool ShipJumpNavigation::HasJumpDrive() const
 {
 	return hasJumpDrive;
-}
-
-
-
-bool ShipJumpNavigation::HasAnyDrive() const
-{
-	return hasHyperdrive || hasScramDrive || hasHyperdrive;
 }
 
 

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -88,6 +88,28 @@ double ShipJumpNavigation::JumpFuel(const System *destination) const
 
 
 
+// Get the amount of fuel that would be expended to jump to the "nearest" (in fuel) system.
+double ShipJumpNavigation::JumpFuelNearest() const
+{
+	// A currently-carried ship or ship without drives requires no fuel to jump,
+	// because it cannot jump.
+	if(!currentSystem || !HasAnyDrive())
+		return 0.;
+
+	double jumpDriveCost = JumpDriveFuel();
+	double hyperdriveCost = HyperdriveFuel();
+
+	// Check whether the ship can jump, that jumping is more expensive than hyperdriving,
+	// and whether the system has links.
+	if((!jumpDriveCost || jumpDriveCost >= hyperdriveCost) && !currentSystem->Links().empty())
+		return hyperdriveCost;
+	else if(!currentSystem->VisibleNeighbors().empty())
+		return jumpDriveCost;
+	return 0.;
+}
+
+
+
 // Get the maximum distance that this ship can jump.
 double ShipJumpNavigation::JumpRange() const
 {

--- a/source/ShipJumpNavigation.cpp
+++ b/source/ShipJumpNavigation.cpp
@@ -77,7 +77,7 @@ double ShipJumpNavigation::JumpFuel(const System *destination) const
 {
 	// A currently-carried ship or ship without drives requires no fuel to jump,
 	// because it cannot jump.
-	if(currentSystem != nullptr && !(hasJumpDrive || hasHyperdrive || hasScramDrive))
+	if(!currentSystem || !HasAnyDrive())
 		return 0.;
 
 	// If no destination is given, return the minimum jump-fuel to the nearest system.
@@ -195,6 +195,13 @@ bool ShipJumpNavigation::HasScramDrive() const
 bool ShipJumpNavigation::HasJumpDrive() const
 {
 	return hasJumpDrive;
+}
+
+
+
+bool ShipJumpNavigation::HasAnyDrive() const
+{
+	return hasHyperdrive || hasScramDrive || hasHyperdrive;
 }
 
 

--- a/source/ShipJumpNavigation.h
+++ b/source/ShipJumpNavigation.h
@@ -42,6 +42,8 @@ public:
 	// Get the amount of fuel that would be expended to jump to the destination. If the destination is
 	// nullptr then return the maximum amount of fuel that this ship could expend in one jump.
 	double JumpFuel(const System *destination = nullptr) const;
+	// Get the amount of fuel that would be expended to jump to the "nearest" (in fuel) system.
+	double JumpFuelNearest() const;
 	// Get the maximum distance that this ship can jump.
 	double JumpRange() const;
 	// Get the cost of making a jump of the given type (if possible). Returns 0 if the jump can't be made.

--- a/source/ShipJumpNavigation.h
+++ b/source/ShipJumpNavigation.h
@@ -60,6 +60,7 @@ public:
 	bool HasHyperdrive() const;
 	bool HasScramDrive() const;
 	bool HasJumpDrive() const;
+	bool HasAnyDrive() const;
 
 
 private:

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -921,6 +921,18 @@ bool System::HasOutfitter() const
 
 
 
+// Check whether this system contains a wormhole.
+bool System::HasWormhole() const
+{
+	for(const StellarObject &object : objects)
+		if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsWormhole())
+			return true;
+
+	return false;
+}
+
+
+
 // Get the specification of how many asteroids of each type there are.
 const vector<System::Asteroid> &System::Asteroids() const
 {

--- a/source/System.h
+++ b/source/System.h
@@ -153,6 +153,8 @@ public:
 	bool HasShipyard() const;
 	// Check whether you can buy or sell ship outfits in this system.
 	bool HasOutfitter() const;
+	// Check whether this system contains a wormhole.
+	bool HasWormhole() const;
 
 	// Get the specification of how many asteroids of each type there are.
 	const std::vector<Asteroid> &Asteroids() const;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11270 

## Summary
Changes the way `JumpFuel` handles `destination == nullptr` to getting jump-fuel based on whether the system your flagship is in has hyperspace connection, and adds a check on whether the flagship has any form of drive in MainPanel's ShowHelp. This solves the issue of "Stranded" message showing when you're not really stranded.

## Screenshots

Before:
![Before 1](https://github.com/user-attachments/assets/59e50d06-aa31-4624-836d-b22be24a2315)

After:
![After 1](https://github.com/user-attachments/assets/818f9767-3604-4453-b652-fb826b0293a8)

(Without Hyperdrive)
![After 2 Without Hyperdrive](https://github.com/user-attachments/assets/9239c0fd-86b1-481d-937e-8f94bf5f5d8f)

Reference Map:
![Reference Map](https://github.com/user-attachments/assets/3674b6ca-d6b0-488a-9cb5-19811fb17aac)

## Testing Done

1. Load up in Cebalrai
2. Use a 1100 fuel ship equipped with a Jump Drive and a Hyperdrive
3. Go to Belenos, or the neighboring systems (empty or hostile) until fuel is less than 200 (2 bars), but higher than 100
4. If no help tooltip shows up, press F1 to force it
5. Check whether "Stranded" is there or not
6. Bribe Mordente-Bridi, then land there
7. Unequip any sort of drive you have in the outfitter
8. Depart, and confirm
9. Repeat step 4-5

## Performance Impact

The impact on performance should be negligible, however on extreme edge cases (like an insane amount of ships to do JumpFuel checks on), this might reduce performance slightly.