### PR TITLE
fix(bug): remove extra character

### DIFF
--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -263,7 +263,7 @@ outfit "Ultracapacitor Cell"
 	"outfit space" -3
 	"energy capacity" 1500
 	"ion protection" -0.01
-	"description" "The internal structure of this deceptively light capacitor cell resembles a fractal of molecule-thin graphene sheets interlocked together, flexing as charge builds up. While not the most efficient in their use of volumetric outfit space, this capacitor cell is extraordinarily energy dense for its mass, a legacy design choice from the days of sublight interstellar travel when every gram counted."c
+	"description" "The internal structure of this deceptively light capacitor cell resembles a fractal of molecule-thin graphene sheets interlocked together, flexing as charge builds up. While not the most efficient in their use of volumetric outfit space, this capacitor cell is extraordinarily energy dense for its mass, a legacy design choice from the days of sublight interstellar travel when every gram counted."
 	description "	Unfortunately, the internal structure of the capacitor is quite delicate, and is prone to potential discharge when exposed to external currents and ionization. Thankfully, resilient grounding and safety interlocks can prevent this discharge from becoming catastrophic."
 	
 	


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described by 7even in https://github.com/7even/endless-ships/issues/26#issuecomment-2781673443

## Summary
Removed an extraneous "c" character at the end of an Avgi outfit description.

## Testing Done
If this causes problems, call me a toad.