### PR TITLE
fix(bug) Timothy

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -8727,7 +8727,7 @@ mission "Timothy Radrickson 3c: Escort the Convoy"
 			`	Her hand vigorously shakes yours. "Gotta say you handled yourself well out there. Always good to see a capt'n worth more than the dust on their boots." She gives you an approving nod.`
 
 			label nextup
-			`	"I got word from Rand they are more than a little pleased with your heroics. They'd like you to head on over to the spaceport when you can. Probably have some credits or a photo op or something fancy and tedious waiting for you."`
+			`	"I got word from Rand they are more than a little pleased with your heroics. They'd like you to head on over to the spaceport on Rand when you can. Probably have some credits or a photo op or something fancy and tedious waiting for you."`
 			`	She shrugs, and winks, "Anyways, I got plenty of work that needs doing. Take care of yourself, Capt'n."`
 			`	With that she heads back to her freighter fleet.`
 
@@ -8774,7 +8774,7 @@ mission "Timothy Radrickson 3d: Return to Rand"
 			`	He gives you a sheepish smile and says, "This is a celebration in your honor, Hero of Rand."`
 			choice
 				`	"Hero of Rand?"`
-				`	"What do mean?"`
+				`	"What do you mean?"`
 				`	"So you lied to me."`
 			`	He shrugs. "I just thought it would be more fun this way. Who doesn't like surprises?"`
 			`	"Without you the entire planet would have defaulted. Our creditors were circling like vultures eager to assume ownership of all our production capabilities, and turn the population into indentured servants. The whole world would have been their debtor's prison."`
@@ -8908,6 +8908,7 @@ mission "Timothy Radrickson 5: Oblivion Meeting"
 	source "Oblivion"
 	invisible
 	on offer
+		event "rad tim dies" 2
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
 		log `Oblivion had not been kind to Timothy. The last time he had been seen alive he was dying the slow, toxic death that world is famed for. Asked me to help him.`
 		set "timothy radrickson 4 log entry correct"
@@ -8922,10 +8923,9 @@ mission "Timothy Radrickson 5: Oblivion Meeting"
 				`	"Shouldn't have broken the law."`
 			`	"I could use your help. Just to buy some things. Might help." His red eyes glance side to side before he says, conspiratorially, "Meet me tonight in the spaceport. Outside the Stephenson warehouse. Stephenson. I'll tell you what I need."`
 			`	With that, he returns to moving the mineral trolley, leaving you to yourself.`
-				accept
-	on enter
-		fail
+				decline
 
+event "rad tim dies"
 
 mission "Timothy Radrickson 5a: Timshank Redemption"
 	name "Meet Tim's contact on <planet>"
@@ -8940,7 +8940,7 @@ mission "Timothy Radrickson 5a: Timshank Redemption"
 		"timothy radrickson id" >= 1
 	to offer
 		has "Timothy Radrickson 5: Oblivion Meeting: offered"
-		not "Timothy Radrickson 5: Oblivion Meeting: failed"
+		not "event: rad tim dies"
 	on offer
 		conversation
 			`Even after donning a particulate mask, Oblivion's toxic atmosphere is so thick it seems as if you could swallow it; it doesn't help that the air somehow feels even denser at night. The warehouse marked "Stephenson Heavy Industries" turns out to be at the very edge of the spaceport's boundary, and all you see when you get there is a lone box truck parked in the loading bay.`


### PR DESCRIPTION
**Bug fix
Typo fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1358197812038205530)
***Summary***


Made changes to the mission Timothy Radrickson 5: Oblivion Meeting so that Timothy Radrickson 5a: Timshank Redemption properly offers. This fix didn't seem to work: https://github.com/endless-sky/endless-sky/pull/11198
Also fixed a typo in the dialog. 
