### PR TITLE
fix(ci/cd): Correct required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16...3.29)
+cmake_minimum_required(VERSION 3.19...4.0)
 
 include(CMakeDependentOption)
 if(UNIX AND NOT APPLE AND NOT ES_STEAM)


### PR DESCRIPTION
**Bug fix**

## Summary
Having 3.16 as the minimal required CMake version doesn't make sense, as [presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) were added in 3.19.

Also since our official workflows now use CMake 4.0, we should probably set the policy version to that.

## Testing Done
CI/CD will do the testing for me.