### PR TITLE
Remove spoiler suggesting hyperspace links are fragile

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -958,7 +958,7 @@ mission "FW Syndicate Capture 1C"
 mission "FW Pug 1"
 	landing
 	name "What happened to Rand?"
-	description "Try to determine why communications with Rand in the Zeta Aquilae system were cut off. Look for clues in neighboring systems."
+	description "Try to determine why communications with Rand in the Zeta Aquilae system were cut off."
 	autosave
 	source "New Tibet"
 	waypoint "Cebalrai"

--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -958,7 +958,7 @@ mission "FW Syndicate Capture 1C"
 mission "FW Pug 1"
 	landing
 	name "What happened to Rand?"
-	description "Try to determine why communications with Rand in the Zeta Aquilae system were cut off. If you cannot reach Rand, at least look for anything odd in the neighboring systems."
+	description "Try to determine why communications with Rand in the Zeta Aquilae system were cut off. Look for clues in neighboring systems."
 	autosave
 	source "New Tibet"
 	waypoint "Cebalrai"


### PR DESCRIPTION
**Content (Missions)**
**Bug fix** 

This PR addresses the spoiler in the FW Syndicate Capture 1C mission that tells the player Rand may have been disconnected before they can find out for themselves.

### Summary
A new player would have no idea that hyperspace connections being removed is possible in this game and should discover this naturally when they enter the waypoint systems in this mission. I have removed the text that suggests this possibility whilst keeping a hint to look in neighboring systems.