### PR TITLE
feat(mechanics): Variable outfit costs

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -529,7 +529,7 @@ BoardingPanel::Plunder::Plunder(const string &commodity, int count, int unitValu
 // Constructor (outfit installed in the victim ship or transported as cargo).
 BoardingPanel::Plunder::Plunder(const Outfit *outfit, int count)
 	: name(outfit->DisplayName()), outfit(outfit), count(count),
-	unitValue(outfit->Cost() * (outfit->Get("installable") < 0. ? 1 : Depreciation::Full()))
+	unitValue(outfit->Value() * (outfit->Get("installable") < 0. ? 1 : Depreciation::Full()))
 {
 	UpdateStrings();
 }

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -574,7 +574,7 @@ int64_t CargoHold::Value(const System *system) const
 	// For outfits, assume they're fully depreciated, since that will always be
 	// the case unless the player bought into cargo for some reason.
 	for(const auto &it : outfits)
-		value += it.first->Cost() * it.second * Depreciation::Full();
+		value += it.first->Value() * it.second * Depreciation::Full();
 	return value;
 }
 

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -391,6 +391,14 @@ int64_t ConditionSet::Evaluate(const ConditionsStore &conditionsStore) const
 
 
 
+int64_t ConditionSet::EvaluateWithoutConditions() const
+{
+	ConditionsStore emptyStore;
+	return Evaluate(emptyStore);
+}
+
+
+
 // Get the names of the conditions that are relevant for this ConditionSet.
 set<string> ConditionSet::RelevantConditions() const
 {

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -100,6 +100,10 @@ public:
 	// Evaluate this expression into a numerical value. (The value can also be used as boolean.)
 	int64_t Evaluate(const ConditionsStore &conditionsStore) const;
 
+	// Evaluate this expression into a numerical value, without actually using a conditionStore for conditions.
+	// All conditions will be treated as if they were empty.
+	int64_t EvaluateWithoutConditions() const;
+
 	/// Parse the remainder of a node into this expression.
 	bool ParseNode(const DataNode &node, int &tokenNr);
 

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -284,15 +284,15 @@ int64_t Depreciation::Value(const Ship *ship, int day, int count) const
 int64_t Depreciation::Value(const Outfit *outfit, int day, int count) const
 {
 	if(outfit->Get("installable") < 0.)
-		return count * outfit->Cost();
+		return count * outfit->Value();
 
 	// Check whether a record exists for this outfit. If not, its value is full
 	// if this is  planet's stock, or fully depreciated if this is the player.
 	auto recordIt = outfits.find(outfit);
 	if(recordIt == outfits.end() || recordIt->second.empty())
-		return DefaultDepreciation() * count * outfit->Cost();
+		return DefaultDepreciation() * count * outfit->Value();
 
-	return Depreciate(recordIt->second, day, count) * outfit->Cost();
+	return Depreciate(recordIt->second, day, count) * outfit->Value();
 }
 
 

--- a/source/FleetCargo.cpp
+++ b/source/FleetCargo.cpp
@@ -71,7 +71,7 @@ namespace {
 				{
 					double mass = outfit->Mass();
 					// Avoid free outfits, massless outfits, and those too large to fit.
-					if(mass > 0. && mass < maxSize && outfit->Cost() > 0)
+					if(mass > 0. && mass < maxSize && outfit->Value() > 0)
 					{
 						// Also avoid outfits that add space (such as Outfits / Cargo Expansions)
 						// or modify bunks.

--- a/source/Flotsam.cpp
+++ b/source/Flotsam.cpp
@@ -50,7 +50,7 @@ Flotsam::Flotsam(const Outfit *outfit, int count, const Government *sourceGovern
 	: outfit(outfit), count(count), sourceGovernment(sourceGovernment)
 {
 	// The more the outfit costs, the faster this flotsam should disappear.
-	int lifetimeBase = 3000000000 / (outfit->Cost() * count + 1000000);
+	int lifetimeBase = 3000000000 / (outfit->Value() * count + 1000000);
 	lifetime = Random::Int(lifetimeBase) + lifetimeBase + 600;
 }
 

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -201,7 +201,9 @@ void MapOutfitterPanel::DrawItems()
 
 		for(const Outfit *outfit : it->second)
 		{
-			// TODO; want to show the price on the selected planet?
+			// Showing the value instead of the sale price on the selected planet; the sale price depends on conditions,
+			// and we cannot predict all conditions up-front. Might want to add a tooltip here that states that the
+			// actual sale price could be different from what is listed here.
 			string price = Format::CreditString(outfit->Value());
 
 			string info;

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -201,7 +201,8 @@ void MapOutfitterPanel::DrawItems()
 
 		for(const Outfit *outfit : it->second)
 		{
-			string price = Format::CreditString(outfit->Cost());
+			// TODO; want to show the price on the selected planet?
+			string price = Format::CreditString(outfit->Value());
 
 			string info;
 			if(outfit->Get("minable") > 0.)

--- a/source/Minable.cpp
+++ b/source/Minable.cpp
@@ -114,7 +114,7 @@ void Minable::Load(const DataNode &node)
 void Minable::FinishLoading()
 {
 	for(const auto &it : payload)
-		value += it.outfit->Cost() * it.maxDrops * it.dropRate;
+		value += it.outfit->Value() * it.maxDrops * it.dropRate;
 }
 
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "audio/Audio.h"
 #include "Body.h"
 #include "DataNode.h"
+#include "DataWriter.h"
 #include "Effect.h"
 #include "GameData.h"
 #include "image/SpriteSet.h"
@@ -286,7 +287,10 @@ void Outfit::Load(const DataNode &node)
 			description += '\n';
 		}
 		else if(child.Token(0) == "cost" && child.Size() >= 2)
-			cost = child.Value(1);
+		{
+			int tokenNr = 1;
+			cost.ParseNode(child, tokenNr);
+		}
 		else if(child.Token(0) == "mass" && child.Size() >= 2)
 			mass = child.Value(1);
 		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))
@@ -466,6 +470,28 @@ const string &Outfit::Description() const
 
 
 
+int64_t Outfit::Cost(const ConditionsStore &conditionsStore) const
+{
+	return cost.Evaluate(conditionsStore);
+}
+
+
+
+int64_t Outfit::Value() const
+{
+	return cost.EvaluateWithoutConditions();
+}
+
+
+
+void Outfit::WriteCost(DataWriter &out) const
+{
+	cost.SaveSubset(out);
+	out.Write();
+}
+
+
+
 // Get the licenses needed to purchase this outfit.
 const vector<string> &Outfit::Licenses() const
 {
@@ -542,7 +568,8 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 // instances of the given outfit to this outfit.
 void Outfit::Add(const Outfit &other, int count)
 {
-	cost += other.cost * count;
+	// TODO: Needs fixing (By using values?).
+	//cost += other.cost * count;
 	mass += other.mass * count;
 	for(const auto &at : other.attributes)
 	{

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -568,8 +568,8 @@ int Outfit::CanAdd(const Outfit &other, int count) const
 // instances of the given outfit to this outfit.
 void Outfit::Add(const Outfit &other, int count)
 {
-	// TODO: Needs fixing (By using values?).
-	//cost += other.cost * count;
+	// Track combinations by value, not by variable local costs.
+	cost = ConditionSet(Value() + other.Value() * count);
 	mass += other.mass * count;
 	for(const auto &at : other.attributes)
 	{

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -17,8 +17,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Weapon.h"
 
-#include "Dictionary.h"
 #include "ConditionSet.h"
+#include "Dictionary.h"
 
 #include <map>
 #include <string>

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Weapon.h"
 
 #include "Dictionary.h"
+#include "ConditionSet.h"
 
 #include <map>
 #include <string>
@@ -25,6 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 class Body;
+class ConditionsStore;
 class DataNode;
 class Effect;
 class Sound;
@@ -62,7 +64,11 @@ public:
 	const std::string &Series() const;
 	const int Index() const;
 	const std::string &Description() const;
-	int64_t Cost() const;
+	/// What does it cost to buy this outfit?
+	int64_t Cost(const ConditionsStore &conditionsStore) const;
+	void WriteCost(DataWriter &out) const;
+	/// What is the value of this outfit? (Can be less than what it costs to buy it, typically not more.)
+	int64_t Value() const;
 	double Mass() const;
 	// Get the licenses needed to buy or operate this ship.
 	const std::vector<std::string> &Licenses() const;
@@ -127,7 +133,7 @@ private:
 	int index;
 	std::string description;
 	const Sprite *thumbnail = nullptr;
-	int64_t cost = 0;
+	ConditionSet cost; // Defaults to zero.
 	double mass = 0.;
 	// Licenses needed to purchase this item.
 	std::vector<std::string> licenses;
@@ -158,5 +164,4 @@ private:
 
 
 // These get called a lot, so inline them for speed.
-inline int64_t Outfit::Cost() const { return cost; }
 inline double Outfit::Mass() const { return mass; }

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -291,7 +291,7 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 	requirementsHeight = 20;
 
 	int day = player.GetDate().DaysSinceEpoch();
-	int64_t cost = outfit.Cost();
+	int64_t cost = outfit.Cost(player.Conditions());
 	int64_t buyValue = player.StockDepreciation().Value(&outfit, day);
 	int64_t sellValue = player.FleetDepreciation().Value(&outfit, day);
 
@@ -301,7 +301,7 @@ void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInf
 			continue;
 
 		const auto &licenseOutfit = GameData::Outfits().Find(license + " License");
-		if(descriptionCollapsed || (licenseOutfit && licenseOutfit->Cost()))
+		if(descriptionCollapsed || (licenseOutfit && licenseOutfit->Cost(player.Conditions())))
 		{
 			requirementLabels.push_back("license:");
 			requirementValues.push_back(license);

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -529,7 +529,7 @@ void OutfitterPanel::Buy(bool onlyOwned)
 	{
 		bool mapMinables = selectedOutfit->Get("map minables");
 		player.Map(mapSize, mapMinables);
-		player.Accounts().AddCredits(-selectedOutfit->Cost());
+		player.Accounts().AddCredits(-selectedOutfit->Cost(player.Conditions()));
 		return;
 	}
 
@@ -537,7 +537,7 @@ void OutfitterPanel::Buy(bool onlyOwned)
 	if(IsLicense(selectedOutfit->TrueName()))
 	{
 		player.AddLicense(LicenseRoot(selectedOutfit->TrueName()));
-		player.Accounts().AddCredits(-selectedOutfit->Cost());
+		player.Accounts().AddCredits(-selectedOutfit->Cost(player.Conditions()));
 		return;
 	}
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3388,8 +3388,8 @@ void PlayerInfo::RegisterDerivedConditions()
 			return 0;
 
 		const Outfit &attributes = base ? flagship->BaseAttributes() : flagship->Attributes();
-		if(attribute == "cost")
-			return attributes.Cost();
+		if(attribute == "cost" || attribute == "value")
+			return attributes.Value();
 		if(attribute == "mass")
 			return round(attributes.Mass() * 1000.);
 		return round(attributes.Get(attribute) * 1000.);

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -368,7 +368,7 @@ namespace {
 				const Outfit &outfit = it.second;
 				cout << DataWriter::Quote(it.first)<< ',';
 				cout << DataWriter::Quote(outfit.Category()) << ',';
-				cout << outfit.Cost() << ',';
+				cout << outfit.Value() << ',';
 				cout << -outfit.Get("weapon capacity") << ',';
 
 				cout << outfit.Range() << ',';
@@ -455,7 +455,7 @@ namespace {
 
 				const Outfit &outfit = it.second;
 				cout << DataWriter::Quote(it.first) << ',';
-				cout << outfit.Cost() << ',';
+				cout << outfit.Value() << ',';
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
 				cout << outfit.Get("engine capacity") << ',';
@@ -491,7 +491,7 @@ namespace {
 
 				const Outfit &outfit = it.second;
 				cout << DataWriter::Quote(it.first) << ',';
-				cout << outfit.Cost() << ',';
+				cout << outfit.Value() << ',';
 				cout << outfit.Mass() << ',';
 				cout << outfit.Get("outfit space") << ',';
 				cout << outfit.Get("energy generation") << ',';
@@ -522,7 +522,7 @@ namespace {
 				const Outfit &outfit = it.second;
 				cout << DataWriter::Quote(outfit.TrueName()) << ',';
 				cout << DataWriter::Quote(outfit.Category()) << ',';
-				cout << outfit.Cost() << ',';
+				cout << outfit.Value() << ',';
 				cout << outfit.Mass();
 				for(const auto &attribute : attributes)
 					cout << ',' << outfit.Attributes().Get(attribute);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -956,7 +956,10 @@ void Ship::Save(DataWriter &out) const
 		out.BeginChild();
 		{
 			out.Write("category", baseAttributes.Category());
-			out.Write("cost", baseAttributes.Cost());
+
+			out.WriteToken("cost");
+			baseAttributes.WriteCost(out);
+
 			out.Write("mass", baseAttributes.Mass());
 			for(const auto &it : baseAttributes.FlareSprites())
 				for(int i = 0; i < it.second; ++i)
@@ -1251,7 +1254,7 @@ const Sprite *Ship::Thumbnail() const
 // Get this ship's cost.
 int64_t Ship::Cost() const
 {
-	return attributes.Cost();
+	return attributes.Value();
 }
 
 
@@ -1259,7 +1262,7 @@ int64_t Ship::Cost() const
 // Get the cost of this ship's chassis, with no outfits installed.
 int64_t Ship::ChassisCost() const
 {
-	return baseAttributes.Cost();
+	return baseAttributes.Value();
 }
 
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -167,7 +167,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 				continue;
 
 			const auto &licenseOutfit = GameData::Outfits().Find(license + " License");
-			if(descriptionCollapsed || (licenseOutfit && licenseOutfit->Cost()))
+			if(descriptionCollapsed || (licenseOutfit && licenseOutfit->Value()))
 			{
 				attributeLabels.push_back("license:");
 				attributeValues.push_back(license);

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -762,7 +762,7 @@ void ShipInfoPanel::Dump()
 	}
 	else if(plunderAmount > 0)
 	{
-		loss += plunderAmount * selectedPlunder->Cost();
+		loss += plunderAmount * selectedPlunder->Value();
 		(*shipIt)->Jettison(selectedPlunder, plunderAmount);
 	}
 	else if(commodities)
@@ -779,7 +779,7 @@ void ShipInfoPanel::Dump()
 	{
 		for(const auto &it : cargo.Outfits())
 		{
-			loss += it.first->Cost() * max(0, it.second);
+			loss += it.first->Value() * max(0, it.second);
 			(*shipIt)->Jettison(it.first, it.second);
 		}
 	}
@@ -800,7 +800,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 	count = min(count, (*shipIt)->Cargo().Get(selectedPlunder));
 	if(count > 0)
 	{
-		loss += count * selectedPlunder->Cost();
+		loss += count * selectedPlunder->Value();
 		(*shipIt)->Jettison(selectedPlunder, count);
 		info.Update(**shipIt, player);
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -709,9 +709,9 @@ int64_t ShopPanel::LicenseCost(const Outfit *outfit, bool onlyOwned) const
 		if(!player.HasLicense(name))
 		{
 			const Outfit *license = GameData::Outfits().Find(name + " License");
-			if(!license || !license->Cost() || !available.Has(license))
+			if(!license || !license->Cost(player.Conditions()) || !available.Has(license))
 				return -1;
-			cost += license->Cost();
+			cost += license->Cost(player.Conditions());
 		}
 	return cost;
 }


### PR DESCRIPTION
**Feature**

This PR partially addresses the feature described in issue #7861. (It addresses Outfit costs.)

## Summary
This PR adds code that allows outfit prices to change based on conditions.
**Note: Work in progress. This is not fully working yet.** (Looks like some of the depreciation code still needs to be updated to get the correct prices in the outfitters.)

## Screenshots
I will add some screenshots when this is working.

## Usage examples
Use inline conditions in the `cost` section of an outfit. Here is the example I'm testing with (Sidewinders that get more expensive later in the month):

```
outfit "Sidewinder Missile"
 	category "Ammunition"
 	series "Ammunition"
 	index 01030
	cost 900 + day
 	thumbnail "outfit/sidewinder"
 	"mass" .2
 	"sidewinder capacity" -1
```

## Testing Done
Status so far:
- The game compiles
- The game starts without crashing
- The outfit price gets updated, but the price the player pays is still based on the Value, not on the Costs.

This needs some more fixing (doesn't work yet, probably because Depreciation still needs an update), and then quite a bit more testing.

## Save File
N/A; just modify a data-file similar to the example above.

## Artwork Checklist
N/A

## Wiki Update
Not yet. (Need to get the code working first.)

Note: There is a parallel discussion if we should put the price directly on the Outfit, or in the Outfitter (where you can have multiple Outfitters specifying different price overrides). If we go the Outfitter route, then we should not make the cost of the outfit itself a variable condition.

## Performance Impact
Loading an int64_t is probably faster than calculating the int64_t through a ConditionSet.