### PR TITLE
fix(bug) Timothy Fix

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -9010,7 +9010,7 @@ mission "Timothy Radrickson 3d: Return to Rand"
 			`	He gives you a sheepish smile and says, "This is a celebration in your honor, Hero of Rand."`
 			choice
 				`	"Hero of Rand?"`
-				`	"What do mean?"`
+				`	"What do you mean?"`
 				`	"So you lied to me."`
 			`	He shrugs. "I just thought it would be more fun this way. Who doesn't like surprises?"`
 			`	"Without you the entire planet would have defaulted. Our creditors were circling like vultures eager to assume ownership of all our production capabilities, and turn the population into indentured servants. The whole world would have been their debtor's prison."`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -9133,20 +9133,11 @@ mission "Timothy Radrickson 4: Imprisoned"
 			`	Tom gives that sort of news anchor laugh that's neither committal nor haughty. "In that case, forget what I said about 20 years. Anything more than 5 years on Oblivion is a life sentence."`
 			`	Both news anchors laugh, and then segue into a story about highly intelligent ferrets that have learned to sing in German.`
 				accept
-	to complete
-		never
-
-mission "Timothy Radrickson 5: Oblivion Meeting"
-	landing
-	to offer
-		random < 90
-		has "Timothy Radrickson 4: Imprisoned: active"
-	source "Oblivion"
-	invisible
-	on offer
+	on complete
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
 		log `Oblivion had not been kind to Timothy. The last time he had been seen alive he was dying the slow, toxic death that world is famed for. Asked me to help him.`
 		set "timothy radrickson 4 log entry correct"
+		event "rad tim dead" 1
 		conversation
 			`Your ship descends through the beautiful, toxic horizon and lands in the dirty, dismal spaceport outside of the provincial capital, Tukayyid. The clumped together warehouses they liberally call a spaceport are used as a central clearing house by all on-world industries, and workers from every industry filter in and out of this never-ending boom town. In the shadows, and on the fringes, the sick and infirm linger, looking for a handout; the price of progress on such a hostile world.`
 			`	Among the crowd one face draws your attention. A worker, unsupervised, is moving around a trolley of minerals by your ship as you have it refueled. His complexion is sallow, and his skin seems to droop off his bones. His blood red eyes, noticing your attention, languidly rise to look at you. Despite the damage, you realize you recognize him.`
@@ -9158,10 +9149,8 @@ mission "Timothy Radrickson 5: Oblivion Meeting"
 				`	"Shouldn't have broken the law."`
 			`	"I could use your help. Just to buy some things. Might help." His red eyes glance side to side before he says, conspiratorially, "Meet me tonight in the spaceport. Outside the Stephenson warehouse. Stephenson. I'll tell you what I need."`
 			`	With that, he returns to moving the mineral trolley, leaving you to yourself.`
-				accept
-	on enter
-		fail
 
+event "rad tim dead"
 
 mission "Timothy Radrickson 5a: Timshank Redemption"
 	name "Meet Tim's contact on <planet>"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10367,7 +10367,7 @@ mission "Timothy Radrickson: Log Fix 3"
 	invisible
 	to offer
 		has "Timothy Radrickson 3d: Return to Rand: done"
-		not "Timothy Radrickson 5: Oblivion Meeting: offered"
+		not "Timothy Radrickson 4: Imprisoned: done"
 		not "timothy radrickson 3 log entry correct"
 		not "Timothy Radrickson: Log Fix 2: offered"
 	on offer
@@ -10381,7 +10381,7 @@ mission "Timothy Radrickson: Log Fix 4"
 	landing
 	invisible
 	to offer
-		has "Timothy Radrickson 5: Oblivion Meeting: offered"
+		has "Timothy Radrickson 4: Imprisoned: done"
 		not "Timothy Radrickson 5a: Timshank Redemption: offered"
 		not "timothy radrickson 4 log entry correct"
 		not "Timothy Radrickson: Log Fix 3: offered"

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -8963,7 +8963,7 @@ mission "Timothy Radrickson 3c: Escort the Convoy"
 			`	Her hand vigorously shakes yours. "Gotta say you handled yourself well out there. Always good to see a capt'n worth more than the dust on their boots." She gives you an approving nod.`
 
 			label nextup
-			`	"I got word from Rand they are more than a little pleased with your heroics. They'd like you to head on over to the spaceport when you can. Probably have some credits or a photo op or something fancy and tedious waiting for you."`
+			`	"I got word from Rand they are more than a little pleased with your heroics. They'd like you to head on over to the spaceport on Rand when you can. Probably have some credits or a photo op or something fancy and tedious waiting for you."`
 			`	She shrugs, and winks, "Anyways, I got plenty of work that needs doing. Take care of yourself, Capt'n."`
 			`	With that she heads back to her freighter fleet.`
 

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -9164,8 +9164,8 @@ mission "Timothy Radrickson 5a: Timshank Redemption"
 		"timothy radrickson suit" >= 1
 		"timothy radrickson id" >= 1
 	to offer
-		has "Timothy Radrickson 5: Oblivion Meeting: offered"
-		not "Timothy Radrickson 5: Oblivion Meeting: failed"
+		has "Timothy Radrickson 4: Imprisoned: done"
+		not "event: rad tim dead"
 	on offer
 		conversation
 			`Even after donning a particulate mask, Oblivion's toxic atmosphere is so thick it seems as if you could swallow it; it doesn't help that the air somehow feels even denser at night. The warehouse marked "Stephenson Heavy Industries" turns out to be at the very edge of the spaceport's boundary, and all you see when you get there is a lone box truck parked in the loading bay.`


### PR DESCRIPTION
(The lines in parentheses (like this one) are instructions for filling out this template. These lines can be deleted.)
(The lines in double curly brackets ({{}}) should be replaced as it describes.)
(You can open a PR to add to or improve this template, if you find it lacking!)

(Choose one heading, or add your own.)
**Content  Missions**

**Bug fix**
**Typo fix**



This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1358197812038205530)

## Summary
Made changes to the mission Timothy Radrickson 5: Oblivion Meeting so that Timothy Radrickson 5a: Timshank Redemption properly offers. This fix didn't seem to work: https://github.com/endless-sky/endless-sky/pull/11198
Also fixed a typo in the dialog. 

I tested it using the pilot file given to me by the person who had the issue.

I also tried to switch out the log fix stuff, but I have no idea what any of that is doing and frankly it looks insane to me and I feel bad that it exists and that someone had to make it exist.

[Major Tom~3046-12-13-oblivion.txt](https://github.com/user-attachments/files/19661261/Major.Tom.3046-12-13-oblivion.txt)


