### PR TITLE
feat(content): Culture Convos for Exotic Life: Bloodsea Blooms & Albatross Bans

### DIFF
--- a/data/human/culture conversations.txt
+++ b/data/human/culture conversations.txt
@@ -1071,6 +1071,180 @@ mission "Exotic Life: Geyser"
 			`	"Bah!" With a dismissive wave, they storm off, cursing tourists under their breath.`
 				decline
 
+phrase "old man waiting"
+	word
+		"Brooding in the dim light,"
+		"Sitting with a weary stare,"
+		"Resting his weathered gaze,"
+		"Hunched over silent memories,"
+		"Lost in quiet rumination,"
+	word
+		" "
+	word
+		"his fingers tap the scarred wood,"
+		"his eyes drift over the shadowed floor,"
+		"his breath mingles with the smoky air,"
+		"his silence is smothered by the conversations of bar patrons,"
+	word
+		" "
+	word
+		"awaiting your next question with a secretive look."
+		"with mystery etched into every line of his face."
+		"poised at the edge of revelation and reticence."
+		"anticipating the spark of your next question."
+
+phrase "old man tirade start"
+	word
+		"The old man's eyes flash with sudden fury as he begins his rant,"
+		"His face twists with disdain as he lets loose a storm of angry words,"
+		"With a heavy shake of his head, he bursts forth in a torrent of complaints,"
+		"His lips curl into a bitter snarl as he spills a flood of exasperation,"
+
+phrase "old man rest of tirade"
+	word
+		"I can't stand those ${pirate adjectives that work as titles} things,"
+		"I'm sick and tired of those ${pirate adjectives that work as titles} lot,"
+		"Every time, it's the same with these ${pirate adjectives that work as titles} nuisances,"
+		"I'm fed up with those ${pirate adjectives that work as titles} pests,"
+	word
+		" "
+	word
+		"constantly stirring up ${bad outcomes}," 3
+		"always wrecking my plans,"
+		"always ruining my plants,"
+		"forever making a mess of things,"
+		"incessantly causing ${bad outcomes}," 3
+	word
+		" "
+	word
+		"and it makes my blood boil every time!"
+		"and I swear, one day they'll pay dearly for it!"
+		"and I'm done putting up with their antics!"
+		"and trust me, I've had enough of their ${bad outcomes}!" 3
+		"and it's enough to drive any sane person... insane!"
+
+mission "Exotic Life: Bloodsea"
+	minor
+	source Bloodsea
+	to offer
+		random < 10
+	on offer
+		conversation
+			`You step into one of the raucous open-air marketplaces of Bloodsea, where armed vendors and hulking guards barter over stolen cargo amid piles of weathered cates. As you weave through the maze of noise and color, you catch sight of a man huddled behind one of the crates - he's coughing violently, blood staining his lips, the crate, and the ground beside him. Before you can react, a lean, scarred woman fixes her steely gaze on you, her face hidden beneath a pair of stained bandanas - one concealing her mouth and nose, the other wrapped around her head.`
+			`	"That man's got the Bloodsea Bloom," she says flatly, as if mentioning the weather.`
+			choice
+				`	"What's that?"`
+				`	(Try to sulk away quickly and sprint back to your ship.)`
+					goto declined
+			`	She scoffs and leans in, her voice dropping to a rough whisper. "The red tide. Every summer, the bloody sea blooms, fills the air with nasty, toxic bits that chew up your lungs if you catch a whiff. No local goes near the beach when the bloom's a blooming."`
+			`	Then, she suddenly screams, "Only offworlders and blind fools with a death wish swim in that poison!"`
+			`	A wry grin floods her face, and she adds in a conversational tone, almost as an afterthought while waving a scarred hand, "Now, I'll flay you alive and turn you into chum if you don't buy some fish bait. Eight racks." She slams a rancid barrel beside her.`
+			choice
+				`	(Buy a barrel of rotten fish bait for 8,000 credits.)`
+					action
+						payment -8000
+					to display
+						credits > 8000
+				`	(Run for it.)`
+					goto declined
+			`	You grit your teeth against the stench and fight back the urge to gag as you fumble over the credits to the gnarled pirate. With an irritated snort, she shoves the putrid barrel towards you, and you quickly roll the it away. Once she's out of sight, you ditch the barrel and dart back to the <ship>, leaving behind a grim and grimy reminder of this lawless port.`
+				decline
+			label declined
+			`	You race through the maze of weathered crates and guarded stalls. As you push past the chaotic crowd, her bellowing laughter - a harsh, unbridled roar of contempt - echoes in your ears as you flee back to the safety of your <model>.`		
+				decline
+
+mission "Exotic Life: Albatross"
+	minor
+	source Albatross
+	to offer
+		random < 10
+	on offer
+		conversation
+			`You trudge through the biting wind to a weathered spaceport bar, its exterior marked by the signs proclaiming "No Gods, No Masters," and "No Cybernetic Implants. No Badgers, Weasels, Or Polecats." Inside, the air is heavy with shadow and smoke - worn wood panels, dim, flickering lights, and cluttered signs declaring even more peculiar prohibitions. Slouched in the corner by the heavy door, an old man sits silently, his half-lidded eyes watching the drunken banter and clinking glasses. You could approach him, and perhaps press for answers about the bar's odd proclamations.`
+			label nextquestion 
+			`	${old man waiting}`
+			choice
+				`	"Why no Cybernetic implants?"`
+					goto implants
+					to display
+						not "heardimplants"
+				`	"What's the deal with Badgers?"`
+					goto badgers
+					to display
+						not "heardbadgers"
+				`	"Turnips?"`
+					to display
+						has "heardbadgers"
+						not "heardturnips"
+					goto turnips
+				`	(Squint at one of the cluttered signs.) "It says 'No ${plural nouns}'?"`
+					goto madlib
+					to display
+						or
+							has "heardimplants"
+							has "heardturnips"
+							has "heardweasels"
+						not "heardmadlib"
+				`	"What's wrong with Weasels?"`
+					goto weasels
+					to display
+						not "heardweasels"
+				`	"What about Polecats?"`
+					goto polecats
+					to display
+						has "heardweasels"
+						not "heardpolecats"
+				`	"Albatross?"`
+					goto albatross
+					to display
+						has "heardpolecats"
+				`	(Thank him for the time and leave.)`
+					goto ending
+			label implants
+			action
+				set "heardimplants"
+			`	The old man grunts, leaning forward so that his voice drops to a rough whisper. "Cybernetic impants ain't allowed 'round here - always cheat at cards. Can't trust a rigged hand when fate's supposed to be fair!"`
+				goto nextquestion
+			label badgers
+			action
+				set "heardbadgers"
+			`	He pauses, then mutters simply, "Turnips."`
+				goto nextquestion
+			label turnips
+			action
+				set "heardturnips"
+			`	He explodes into a brief tirade. "Badgers! They'll dig up every last turnip I grow, ruining my patch faster than a cyborg cleans house. Nothing but trouble!"`
+				goto nextquestion
+			label madlib
+			action
+				set "heardmadlib"
+			`	His lips curl into a bitter snarl as he spills a flood of exasperation, "They cause a ${pirate adjectives that work as titles}, ${pirate adjectives that work as titles}, ${pirate adjectives that work as titles} ${bad outcomes}!"`
+			`	It's unclear how he expects you to respond.`
+				goto nextquestion
+			label weasels
+			action
+				set "heardweasels"
+			`	He snorts dismissively. "Weasels, now, they're just tiny polecats scampering about like mischief incarnate - ain't worth their salt, and worse, troublemakers by nature!"`
+				goto nextquestion
+			label polecats
+			action
+				set "heardpolecats"
+			`	His face darkens, and his voice grows weighty and ominous. "Polecats, they attract... the Albatross." For a suspended moment, the chatter ceases; the clamor of glasses and low murmurs fall silent as every patron registers the weight of that word. Then, as if on cue, the noise resumes, and life goes on as usual.`
+				goto nextquestion
+			label albatross
+			`	Emboldened by the hushed reaction, you press on, "Albatross?" That single word slices through the renewed din, and in a heartbeat, the atmosphere shatters. Several patrons rise from their stools, their expressions hardening into threatening scowls. The old man, eyes distant and vacant, seems lost in thought while becomes clear that you have crossed a forbidden line.`
+			`	Rough hands grip your shoulders, and before you can protest, you're dragged toward the door. Outside, in the biting wind, the echo of their shouted threats follows you. Perhaps some stones are best left unturned.`
+			label ending
+			action
+				clear "heardimplants"
+				clear "heardbadgers"
+				clear "heardturnips"
+				clear "heardmadlib"
+				clear "heardweasels"
+				clear "heardpolecats"
+
+
+
 mission "Little Vienna in New Austria"
 	minor
 	source "New Austria"


### PR DESCRIPTION
**Content (Culture Conversation)**

This PR addresses the bug/feature described in issue https://github.com/endless-sky/endless-sky/issues/10659 by opusforlife2.

## Summary
This is part of an ongoing effort to populate human space with more unique culture conversations related to non-human life. This set shifts the focus over to pirate worlds, with the chance to experience:
1. A pirate infected with the Bloodsea Bloom, a [harmful algal bloom](https://en.wikipedia.org/wiki/Harmful_algal_bloom) native to Bloodsea. 
2. Questioning an old man about the various bans at the "No Cybernetic Implants. No Badgers, Weasels, Or Polecats" spaceport bar.

## Screenshots
Opening Albatross questions.
![image](https://github.com/user-attachments/assets/096b408a-a586-4df5-8059-2ffcc2f48bd8)

Followup questions for most questions, including a randomly generated ban.
![image](https://github.com/user-attachments/assets/e0fba636-262c-450f-a817-0dfc23fe68fa)

The old man goes on a potentially incoherent tirade if you ask about the randomly generated prohibition.
![image](https://github.com/user-attachments/assets/991f24d7-59af-4562-be03-d558d8a9ace8)

## Testing Done
Tested branches

## Save File
Any save that can land on Bloodsea or Albatross