### PR TITLE
Fix "Remnant: Cognizance 32" description

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1401,7 +1401,7 @@ mission "Remnant: Cognizance 31"
 
 mission "Remnant: Cognizance 32"
 	name "Pick Up Refined Fuel"
-	description "Chilia has asked you to pick up <tons> of refined fuel from <planet> by <date>."
+	description "Chilia has asked you to pick up 58 tons of refined fuel from <planet> by <date>."
 	source "Viminal"
 	destination "Clink"
 	blocked "Chilia and Taely look excited about something, but when you inquire, they shake their heads and say you need to have earned their capital license before they can tell you more."


### PR DESCRIPTION
**Typo fix**

Thanks to the numerous people who have reported this on Discord.

## Summary
This mission uses the substitution "\<tons\>" in its description, but the mission has no cargo. The description is referring to the cargo that will be collected in the subsequent mission. Since this mission has no cargo, "\<tons\>" is replaced with "0 tons" which is not very useful.
This PR replaces the use of the substitution with "58 tons", which is the amount of cargo involved in the next mission.

## Testing Done
I will not.
