### PR TITLE
fix(ui): Allow unbinding commands set to the same key as the menu command

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -269,7 +269,7 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 	}
 	else if((key == 'x' || key == SDLK_DELETE) && (page == 'c'))
 	{
-		if(zones[latest].Value().KeyName() != Command::MENU.KeyName())
+		if(!zones[latest].Value().Has(Command::MENU))
 			Command::SetKey(zones[latest].Value(), 0);
 	}
 	else


### PR DESCRIPTION
**Bug fix**

## Summary
The game doesn't allow unbinding the menu command to prevent the player from getting stuck. The problem is that it doesn't check for the command itself, but for the key that is bound to it, which means you can't unbind commands other than the menu if they have the same key assigned.

## Testing Done
yes.