### PR TITLE
Create auto conditions for reading the attributes from your fleet's ships

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3382,12 +3382,12 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	flagshipDisabledProvider.SetGetFunction(flagshipDisabledFun);
 
-	auto flagshipAttributeHelper = [](const Ship *flagship, const string &attribute, bool base) -> int64_t
+	auto shipAttributeHelper = [](const Ship *ship, const string &attribute, bool base) -> int64_t
 	{
-		if(!flagship)
+		if(!ship)
 			return 0;
 
-		const Outfit &attributes = base ? flagship->BaseAttributes() : flagship->Attributes();
+		const Outfit &attributes = base ? ship->BaseAttributes() : ship->Attributes();
 		if(attribute == "cost")
 			return attributes.Cost();
 		if(attribute == "mass")
@@ -3396,16 +3396,16 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 
 	auto &&flagshipBaseAttributeProvider = conditions.GetProviderPrefixed("flagship base attribute: ");
-	auto flagshipBaseAttributeFun = [this, flagshipAttributeHelper](const string &name) -> int64_t
+	auto flagshipBaseAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
 	{
-		return flagshipAttributeHelper(this->Flagship(), name.substr(strlen("flagship base attribute: ")), true);
+		return shipAttributeHelper(this->Flagship(), name.substr(strlen("flagship base attribute: ")), true);
 	};
 	flagshipBaseAttributeProvider.SetGetFunction(flagshipBaseAttributeFun);
 
 	auto &&flagshipAttributeProvider = conditions.GetProviderPrefixed("flagship attribute: ");
-	auto flagshipAttributeFun = [this, flagshipAttributeHelper](const string &name) -> int64_t
+	auto flagshipAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
 	{
-		return flagshipAttributeHelper(this->Flagship(), name.substr(strlen("flagship attribute: ")), false);
+		return shipAttributeHelper(this->Flagship(), name.substr(strlen("flagship attribute: ")), false);
 	};
 	flagshipAttributeProvider.SetGetFunction(flagshipAttributeFun);
 
@@ -3478,6 +3478,76 @@ void PlayerInfo::RegisterDerivedConditions()
 	flagshipFuelProvider.SetGetFunction([this](const string &name) -> int64_t {
 		return flagship ? flagship->FuelLevel() : 0;
 	});
+
+	auto &&fleetLocalBaseAttributeProvider = conditions.GetProviderNamed("ship base attribute: ");
+	auto fleetLocalBaseAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
+	{
+		string attribute = name.substr(strlen("ship base attribute: "));
+		int64_t retVal = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+		{
+			// Destroyed and parked ships aren't checked.
+			// If not on a planet, the ship's system must match.
+			// If on a planet, the ship's planet must match.
+			if(ship->IsDestroyed() || ship->IsParked()
+					|| (planet && ship->GetPlanet() != planet)
+					|| (!planet && ship->GetActualSystem() != system))
+				continue;
+			retVal += shipAttributeHelper(ship.get(), attribute, true);
+		}
+		return retVal;
+	};
+	fleetLocalBaseAttributeProvider.SetGetFunction(fleetLocalBaseAttributeFun);
+
+	auto &&fleetAllBaseAttributeProvider = conditions.GetProviderNamed("ship base attribute (all): ");
+	auto fleetAllBaseAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
+	{
+		string attribute = name.substr(strlen("ship base attribute (all): "));
+		int64_t retVal = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+		{
+			if(ship->IsDestroyed())
+				continue;
+			retVal += shipAttributeHelper(ship.get(), attribute, true);
+		}
+		return retVal;
+	};
+	fleetAllBaseAttributeProvider.SetGetFunction(fleetAllBaseAttributeFun);
+
+	auto &&fleetLocalAttributeProvider = conditions.GetProviderNamed("ship attribute: ");
+	auto fleetLocalAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
+	{
+		string attribute = name.substr(strlen("ship attribute: "));
+		int64_t retVal = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+		{
+			// Destroyed and parked ships aren't checked.
+			// If not on a planet, the ship's system must match.
+			// If on a planet, the ship's planet must match.
+			if(ship->IsDestroyed() || ship->IsParked()
+					|| (planet && ship->GetPlanet() != planet)
+					|| (!planet && ship->GetActualSystem() != system))
+				continue;
+			retVal += shipAttributeHelper(ship.get(), attribute, false);
+		}
+		return retVal;
+	};
+	fleetLocalAttributeProvider.SetGetFunction(fleetLocalAttributeFun);
+
+	auto &&fleetAllAttributeProvider = conditions.GetProviderNamed("ship attribute (all): ");
+	auto fleetAllAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
+	{
+		string attribute = name.substr(strlen("ship attribute (all): "));
+		int64_t retVal = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+		{
+			if(ship->IsDestroyed())
+				continue;
+			retVal += shipAttributeHelper(ship.get(), attribute, false);
+		}
+		return retVal;
+	};
+	fleetAllAttributeProvider.SetGetFunction(fleetAllAttributeFun);
 
 	auto &&playerNameProvider = conditions.GetProviderPrefixed("name: ");
 	auto playerNameFun = [this](const string &name) -> bool

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3479,7 +3479,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagship ? flagship->FuelLevel() : 0;
 	});
 
-	auto &&fleetLocalBaseAttributeProvider = conditions.GetProviderNamed("ship base attribute: ");
+	auto &&fleetLocalBaseAttributeProvider = conditions.GetProviderPrefixed("ship base attribute: ");
 	auto fleetLocalBaseAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
 	{
 		string attribute = name.substr(strlen("ship base attribute: "));
@@ -3499,7 +3499,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	fleetLocalBaseAttributeProvider.SetGetFunction(fleetLocalBaseAttributeFun);
 
-	auto &&fleetAllBaseAttributeProvider = conditions.GetProviderNamed("ship base attribute (all): ");
+	auto &&fleetAllBaseAttributeProvider = conditions.GetProviderPrefixed("ship base attribute (all): ");
 	auto fleetAllBaseAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
 	{
 		string attribute = name.substr(strlen("ship base attribute (all): "));
@@ -3514,7 +3514,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	fleetAllBaseAttributeProvider.SetGetFunction(fleetAllBaseAttributeFun);
 
-	auto &&fleetLocalAttributeProvider = conditions.GetProviderNamed("ship attribute: ");
+	auto &&fleetLocalAttributeProvider = conditions.GetProviderPrefixed("ship attribute: ");
 	auto fleetLocalAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
 	{
 		string attribute = name.substr(strlen("ship attribute: "));
@@ -3534,7 +3534,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	};
 	fleetLocalAttributeProvider.SetGetFunction(fleetLocalAttributeFun);
 
-	auto &&fleetAllAttributeProvider = conditions.GetProviderNamed("ship attribute (all): ");
+	auto &&fleetAllAttributeProvider = conditions.GetProviderPrefixed("ship attribute (all): ");
 	auto fleetAllAttributeFun = [this, shipAttributeHelper](const string &name) -> int64_t
 	{
 		string attribute = name.substr(strlen("ship attribute (all): "));


### PR DESCRIPTION
**Feature**

This PR adds the auto conditions described here: https://github.com/endless-sky/endless-sky/pull/10787#issuecomment-2764375703

## Summary
Adds the following auto conditions:
* `"ship attribute: <attribute name>"`: Has the same behavior as `"flagship attribute: <attribute name>"` (returns the value of the given attribute multiplied by 1000, except for cost), except it returns the sum total of the attribute across all the ships in your fleet that are local to you (i.e. in the same system when not landed, or on the same planet when landed, excluding parked ships).
* `"ship base attribute: <attribute name>"`: Same as above, but only looks at the base attributes of the ships.
* `"ship attribute (all): <attribute name>"`: Same as `"ship attribute"`, except it looks at every ship in your fleet regardless of location.
* `"ship base attribute (all): <attribute name>"`: Same as `"ship base attribute"`, except it looks at every ship in your fleet regardless of location.

## Testing Done

Used the following mission to print out the condition values when I visit the spaceport.
```
mission "Test"
	repeat
	on offer
		conversation
			`"outfit: Beam Laser" = &[outfit: Beam Laser]`
			`"outfit (all): Beam Laser" = &[outfit (all): Beam Laser]`
			`"ship attribute: cost" = &[ship attribute: cost]`
			`"ship attribute (all): cost" = &[ship attribute (all): cost]`
			`"ship base attribute: cost" = &[ship base attribute: cost]`
			`"ship base attribute (all): cost" = &[ship base attribute (all): cost]`
			`"flagship attribute: cost" = &[flagship attribute: cost]`
			`"flagship base attribute: cost" = &[flagship base attribute: cost]`
				decline
```
![image](https://github.com/user-attachments/assets/97e64d23-8225-4647-841b-43c97ce00457)
![image](https://github.com/user-attachments/assets/2fffe92e-918c-4934-97ac-bafbb7567ba9)

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/129
