### PR TITLE
Update PR template to add an acknowledgement that the author has read the Contributing article

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@
 
 This PR addresses the bug/feature described in issue #{{insert number}}
 
+## Acknowledgement
+
+- [ ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.
+
 ## Summary
 {{Describe and explain your changes. Include links to related issues.}}
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Endless Sky
 
-As a free and open source game, Endless Sky is the product of many people's work. Those who wish to contribute new content are encouraged to review the [wiki](https://github.com/endless-sky/endless-sky/wiki), and to post in the [community-run Discord](https://discord.gg/ZeuASSx) beforehand. There are also [discussion rooms](https://steamcommunity.com/app/404410/discussions/) for those who prefer to use Steam, or GitHub's [discussion zone](https://github.com/endless-sky/endless-sky/discussions). Our forums (especially the GitHub and Discord) have projects that could use your help developing artwork, storylines, and other writing. We also have a loosely defined [roadmap](https://github.com/endless-sky/endless-sky/wiki/DevelopmentRoadmap) that outlines what our current goals for game development are. 
+As a free and open source game, Endless Sky is the product of many people's work. Those who wish to contribute new content are encouraged to review the [wiki](https://github.com/endless-sky/endless-sky/wiki), and to post in the [community-run Discord](https://discord.gg/ZeuASSx) beforehand. There are also [discussion rooms](https://steamcommunity.com/app/404410/discussions/) for those who prefer to use Steam, or GitHub's [discussion zone](https://github.com/endless-sky/endless-sky/discussions). Our forums (especially the GitHub and Discord) have projects that could use your help developing artwork, storylines, and other writing. We also have a loosely defined [roadmap](https://github.com/endless-sky/endless-sky/wiki/DevelopmentRoadmap) that outlines what our current goals for game development are.
 
 We are always excited to welcome new contributors! Below are some guidelines and resources to help get involved.
 
@@ -22,6 +22,12 @@ If requesting a new feature, first ask yourself: will this make the game more fu
 If you believe your issue has been resolved, you can close the issue yourself. If your issue gets closed because a PR was merged, and you are not satisfied, please do not comment on the old issue. Open a new issue and explain the gap that you feel still needs to be addressed.
 
 ## Pull requests
+
+### Acknowledgement
+
+**By contributing to the game, you acknowledge that your work may be added to, modified, or removed as a result of future contributions by others. While we prefer to work with the original authors of contributions where possible when it comes to changing their contributions, particularly with respect to story content, you do not have strict ownership over your work after it has been contributed to the game.**
+
+If you are not comfortable with losing complete creative freedom over your work, please consider publishing it as a plugin instead. Plugins can be advertised on our [Discord server](https://discord.gg/ZeuASSx) or the [official plugins repository](https://github.com/endless-sky/endless-sky-plugins). For more information on when to consider publishing your content as a plugin or opening a pull request to add it to the game, please read the [Creation Guide - Plugin or Pull Request?](https://github.com/endless-sky/endless-sky/wiki/Creation-Guide---Plug-in-or-Pull-Request) article.
 
 ### Posting pull requests
 


### PR DESCRIPTION
**Documentation**

## Summary

This PR updates the Contributing.md file to include an "Acknowledgement" section explicitly stating that content that is contributed to the game isn't under the ownership of its contributor, and that contributors must be comfortable with the possibility that their work may be modified in the future by others should they choose to open a pull request to add it to the game, although it is also made clear that publishing one's work as a plugin is both possible and welcomed as well.

This has been an implicit expectation of content creation for years (really for the game's entire history), but this PR seeks to make that expectation explicit as to prevent issues around unshared expectations between new contributors and the existing content creator base.

This PR also updates the PR template to include a similar "Acknowledgement" section with a check box that the PR poster must check, stating that they have read and understood the contributing file. Although the contributing file is already linked by Github underneath "Create pull request" button, adding this acknowledgment to the template makes it certain that contributors will know of its existence.

See? It's right here:
![image](https://github.com/user-attachments/assets/874697c3-f070-4df3-a358-c8f83aeb8b70)