### PR TITLE
Local Map reveals minables

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -528,6 +528,7 @@ outfit "Local Map"
 	cost 1000
 	thumbnail "outfit/map"
 	"map" 12
+	"map minable" 1
 	description "This data chip contains complete information on the twelve star systems closest to this one: planets, ports, governments, trade prices, available services, etc. You can get all the same information just by exploring those systems yourself, but having a map can save you from making wrong turns if you are trying to travel through new territory to reach a certain system quickly."
 
 


### PR DESCRIPTION
**Content (Mapping Update)**

Fixes #10024

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added the `"map minable" 1` attribute, introduced in #10573, to the Local Map. This will help beginning miners get started.
