### PR TITLE
fix(ui): Display turret turn multipliers with consistent formatting

### DIFF
--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -192,6 +192,7 @@ namespace {
 		{"cloaked shield permeability", 3},
 		{"acceleration multiplier", 3},
 		{"turn multiplier", 3},
+		{"turret turn multiplier", 3},
 
 		{"burn protection", 4},
 		{"corrosion protection", 4},


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature reported in https://github.com/endless-sky/endless-sky/pull/10993#issuecomment-2800365631.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The turret turn multiplier should be displayed in the same style as other multipliers.

## Screenshots
Before:
![mul1](https://github.com/user-attachments/assets/999a59f5-98d8-489b-a7cb-e15c1754e94a)
After:
![mul2](https://github.com/user-attachments/assets/29539366-3f2e-4df4-90a4-3790a4dceca4)

## Testing Done
see the screenshots above.
