### PR TITLE
(content) Add Korath raiders to southern edge bunrodea space 

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -14790,6 +14790,8 @@ system "Eneva Katta"
 	asteroids "small metal" 17 1.819
 	asteroids "medium metal" 128 2.278
 	asteroids "large metal" 10 0.935
+	minables copper 12 12
+	minables tungsten 8 12	
 	trade Clothing 290
 	trade Electronics 740
 	trade Equipment 530
@@ -14801,6 +14803,9 @@ system "Eneva Katta"
 	trade Metal 390
 	trade Plastic 390
 	fleet "Bunrodea Defense" 5000
+	fleet "Korath Miners" 7000
+	fleet "Korath Raid" 11000
+	fleet "Korath Large Raid" 17000
 	object
 		sprite star/g-giant
 		period 10
@@ -18044,6 +18049,8 @@ system "Genta Bo"
 	asteroids "small metal" 6 10.836
 	asteroids "medium metal" 11 7.728
 	asteroids "large metal" 12 9.912
+	minables aluminum 11 10
+	minables titanium 9 9
 	trade Clothing 290
 	trade Electronics 740
 	trade Equipment 530
@@ -18055,6 +18062,9 @@ system "Genta Bo"
 	trade Metal 390
 	trade Plastic 390
 	fleet "Bunrodea Defense" 3500
+	fleet "Korath Miners" 11000
+	fleet "Korath Raid" 9000
+	fleet "Korath Large Raid" 17000	
 	object
 		sprite star/o-supergiant
 		distance 14.1508
@@ -36283,6 +36293,7 @@ system "Shini Bori"
 	fleet "Bunrodea Defense" 2000
 	fleet "Bunrodea Royalty" 3000
 	fleet "Bunrodea Royal Guard" 2000
+	fleet "Korath Large Raid" 11000
 	object
 		sprite star/f0
 		period 10
@@ -39341,6 +39352,7 @@ system "Thshybo Le"
 	fleet "Bunrodea Defense" 2000
 	fleet "Bunrodea Royalty" 5000
 	fleet "Bunrodea Royal Guard" 2000
+	fleet "Korath Large Raid" 11000
 	object
 		sprite star/a5
 		period 10

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -14791,7 +14791,7 @@ system "Eneva Katta"
 	asteroids "medium metal" 128 2.278
 	asteroids "large metal" 10 0.935
 	minables copper 12 12
-	minables tungsten 8 12	
+	minables tungsten 8 12
 	trade Clothing 290
 	trade Electronics 740
 	trade Equipment 530
@@ -18064,7 +18064,7 @@ system "Genta Bo"
 	fleet "Bunrodea Defense" 3500
 	fleet "Korath Miners" 11000
 	fleet "Korath Raid" 9000
-	fleet "Korath Large Raid" 17000	
+	fleet "Korath Large Raid" 17000
 	object
 		sprite star/o-supergiant
 		distance 14.1508


### PR DESCRIPTION
**Content
Add Korath raiders to southern edge bunrodea space 
The PR is small so i just copy paste the hole content here (the acutal PR doesnt use add) and then elaborate afterwards:

system "Eneva Katta"
	add minables copper 12 12
	add minables tungsten 8 12
	add fleet "Korath Miners" 7000
	add fleet "Korath Raid" 11000
	add fleet "Korath Large Raid" 17000

system "Genta Bo"
	add minables aluminum 11 10
	add minables titanium 9 9
	add fleet "Korath Miners" 11000
	add fleet "Korath Raid" 9000
	add fleet "Korath Large Raid" 17000

system "Thshybo Le"
	add fleet "Korath Large Raid" 11000

system "Shini Bori"
	add fleet "Korath Large Raid" 11000

![image](https://github.com/user-attachments/assets/fd64e2b9-a3c2-4495-8d04-0d5b73d5da6d)
As you can see, the southern tip was changed, korath raid it now passing trough sagitarus A*.
Notably, no Bunrodea system had minables so far. THis PR only adds some into those edge system so that it makes sense for korath miners to show up.
The nothern edge is not getting raided becuase the archons are blocking the way trough the core in fasitopfar and the other systmes on that route.

This PR addresses the feeling of bunrodea space being very empty, nothing happens there yet, this is a first step to fill the content void.