### PR TITLE
feat: Warn the player if they are rebinding the menu key or the key is not bound properly

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -299,7 +299,17 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 
 	for(unsigned index = 0; index < zones.size(); ++index)
 		if(zones[index].Contains(point))
-			editing = selected = index;
+		{
+			if(zones[index].Value().Has(Command::MENU))
+				GetUI()->Push(new Dialog([this, index]()
+				    {
+				    	this->editing = this->selected = index;
+					}, "Rebinding this key will change the keypress you need to access this menu. "
+					"You really shouldn't rebind this unless needed.",
+					Truncate::NONE, true, true));
+			else
+				editing = selected = index;
+		}
 
 	for(const auto &zone : prefZones)
 		if(zone.Contains(point))
@@ -1220,6 +1230,12 @@ void PreferencesPanel::DrawTooltips()
 
 void PreferencesPanel::Exit()
 {
+	if(Command::MENU.HasConflict() || !Command::MENU.HasBinding())
+	{
+		GetUI()->Push(new Dialog("Menu keybind is not bound or has conflicts."));
+		return;
+	}
+
 	Command::SaveSettings(Files::Config() / "keys.txt");
 
 	GetUI()->Pop(this);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -302,9 +302,10 @@ bool PreferencesPanel::Click(int x, int y, int clicks)
 		{
 			if(zones[index].Value().Has(Command::MENU))
 				GetUI()->Push(new Dialog([this, index]()
-				    {
-				    	this->editing = this->selected = index;
-					}, "Rebinding this key will change the keypress you need to access this menu. "
+					{
+						this->editing = this->selected = index;
+					},
+					"Rebinding this key will change the keypress you need to access this menu. "
 					"You really shouldn't rebind this unless needed.",
 					Truncate::NONE, true, true));
 			else


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #on discord somewhere?

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This changes the PreferencesPanel to check for the menu keybind's validity on exit, and gives a warning if the user wants to change the keybind.

## Screenshots
![image](https://github.com/user-attachments/assets/8f4d065c-4899-4373-9789-297ed80b1d0b)
![image](https://github.com/user-attachments/assets/aa9daa0f-916f-4a72-a982-26d9be5e0819)
