### PR TITLE
Allow the use of conditions to control the behavior of planets and spaceports

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1973,7 +1973,7 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 		// not land anywhere without a port.
 		vector<const StellarObject *> planets;
 		for(const StellarObject &object : origin->Objects())
-			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->HasServices()
+			if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->HasServices(ship.IsYours())
 					&& object.GetPlanet()->CanLand(ship))
 			{
 				planets.push_back(&object);
@@ -4488,7 +4488,8 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 						double distance = ship.Position().Distance(object->Position());
 						const Planet *planet = object->GetPlanet();
 						types.insert(planet->Noun());
-						if((!planet->CanLand() || !planet->GetPort().CanRecharge(Port::RechargeType::Fuel))
+						if((!planet->CanLand()
+								|| !planet->GetPort().CanRecharge(Port::RechargeType::Fuel, ship.IsYours()))
 								&& !planet->IsWormhole())
 							distance += 10000.;
 

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -72,14 +72,14 @@ public:
 	ConditionSet &operator=(const ConditionSet &other);
 
 	// Construct and Load() at the same time.
-	explicit ConditionSet(const DataNode &node);
+	explicit ConditionSet(const DataNode &node, const ConditionsStore *playerConditions = nullptr);
 
 	// Construct a terminal with a literal value.
 	explicit ConditionSet(int64_t newLiteral);
 
 	// Load a set of conditions from the children of this node. Prints a
 	// warning if the conditions cannot be parsed from the node.
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, const ConditionsStore *playerConditions = nullptr);
 	// Save a set of conditions.
 	void Save(DataWriter &out) const;
 	void SaveChild(int childNr, DataWriter &out) const;
@@ -96,6 +96,7 @@ public:
 
 	// Check if the given condition values satisfy this set of expressions.
 	bool Test(const ConditionsStore &conditions) const;
+	bool Test() const;
 
 	// Evaluate this expression into a numerical value. (The value can also be used as boolean.)
 	int64_t Evaluate(const ConditionsStore &conditionsStore) const;
@@ -159,6 +160,11 @@ private:
 
 
 private:
+	// A pointer to the player's ConditionsStore. When populated, allows this ConditionSet to
+	// call Test() from any location in the codebase without the caller needing to have access
+	// to the PlayerInfo or ConditionsStore.
+	const ConditionsStore *playerConditions = nullptr;
+
 	/// Sets of condition tests can contain nested sets of tests. Each set is
 	/// combined using the expression operator that determines how the nested
 	/// sets are to be combined.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -190,7 +190,8 @@ namespace {
 
 
 
-shared_future<void> GameData::BeginLoad(TaskQueue &queue, bool onlyLoadData, bool debugMode, bool preventUpload)
+shared_future<void> GameData::BeginLoad(TaskQueue &queue, const PlayerInfo &player,
+		bool onlyLoadData, bool debugMode, bool preventUpload)
 {
 	preventSpriteUpload = preventUpload;
 
@@ -239,7 +240,7 @@ shared_future<void> GameData::BeginLoad(TaskQueue &queue, bool onlyLoadData, boo
 		});
 	}
 
-	return objects.Load(queue, sources, debugMode);
+	return objects.Load(queue, player, sources, debugMode);
 }
 
 
@@ -540,9 +541,9 @@ void GameData::AddPurchase(const System &system, const string &commodity, int to
 
 
 // Apply the given change to the universe.
-void GameData::Change(const DataNode &node)
+void GameData::Change(const DataNode &node, const ConditionsStore *playerConditions)
 {
-	objects.Change(node);
+	objects.Change(node, playerConditions);
 }
 
 

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -54,6 +54,7 @@ class Panel;
 class Person;
 class Phrase;
 class Planet;
+class PlayerInfo;
 class Politics;
 class Ship;
 class Sprite;
@@ -77,7 +78,8 @@ class Wormhole;
 // universe.
 class GameData {
 public:
-	static std::shared_future<void> BeginLoad(TaskQueue &queue, bool onlyLoadData, bool debugMode, bool preventUpload);
+	static std::shared_future<void> BeginLoad(TaskQueue &queue, const PlayerInfo &player,
+		bool onlyLoadData, bool debugMode, bool preventUpload);
 	static void FinishLoading();
 	// Check for objects that are referred to but never defined.
 	static void CheckReferences();
@@ -105,7 +107,7 @@ public:
 	static void StepEconomy();
 	static void AddPurchase(const System &system, const std::string &commodity, int tons);
 	// Apply the given change to the universe.
-	static void Change(const DataNode &node);
+	static void Change(const DataNode &node, const ConditionsStore *playerConditions);
 	// Update the neighbor lists and other information for all the systems.
 	// This must be done any time that a change creates or moves a system.
 	static void UpdateSystems();

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -165,7 +165,7 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 		else
 		{
 			SetBribe(planet->GetBribeFraction());
-			if(bribe)
+			if(bribe && planet->GetPort().CanBribe())
 				SetMessage("If you want to land here, it'll cost you "
 					+ Format::CreditString(bribe) + ".");
 			else if(gov->IsEnemy())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -164,8 +164,9 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 			SetMessage("You are cleared to land, " + player.Flagship()->Name() + ".");
 		else
 		{
-			SetBribe(planet->GetBribeFraction());
-			if(bribe && planet->GetPort().CanBribe())
+			if(planet->CanBribe())
+				SetBribe(planet->GetBribeFraction());
+			if(bribe)
 				SetMessage("If you want to land here, it'll cost you "
 					+ Format::CreditString(bribe) + ".");
 			else if(gov->IsEnemy())

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1123,10 +1123,11 @@ void MapPanel::UpdateCache()
 					if(object.HasSprite() && object.HasValidPlanet())
 					{
 						const Planet *planet = object.GetPlanet();
-						hasSpaceport |= !planet->IsWormhole() && planet->HasServices();
+						bool hasServices = planet->HasServices();
+						hasSpaceport |= !planet->IsWormhole() && hasServices;
 						if(planet->IsWormhole() || !planet->IsAccessible(player.Flagship()))
 							continue;
-						canLand |= planet->CanLand() && planet->HasServices();
+						canLand |= planet->CanLand() && hasServices;
 						isInhabited |= planet->IsInhabited();
 						hasDominated &= (!planet->IsInhabited()
 							|| GameData::GetPolitics().HasDominated(planet));

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -144,6 +144,7 @@ public:
 	// Below are convenience functions which access the game state in Politics,
 	// but do so with a less convoluted syntax:
 	bool HasFuelFor(const Ship &ship) const;
+	bool CanBribe() const;
 	bool CanLand(const Ship &ship) const;
 	bool CanLand() const;
 	Friendliness GetFriendliness() const;
@@ -167,6 +168,11 @@ private:
 	std::string music;
 
 	std::set<std::string> attributes;
+
+	ConditionSet toKnow;
+	ConditionSet toLand;
+	ConditionSet toUnlockShipyard;
+	ConditionSet toUnlockOutfitter;
 
 	std::set<const Sale<Ship> *> shipSales;
 	std::set<const Sale<Outfit> *> outfitSales;

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+class ConditionsStore;
 class DataNode;
 class Fleet;
 class Government;
@@ -53,7 +54,7 @@ public:
 
 public:
 	// Load a planet's description from a file.
-	void Load(const DataNode &node, Set<Wormhole> &wormholes);
+	void Load(const DataNode &node, Set<Wormhole> &wormholes, const ConditionsStore *playerConditions);
 	// Legacy wormhole do not have an associated Wormhole object so
 	// we must auto generate one if we detect such legacy wormhole.
 	void FinishLoading(Set<Wormhole> &wormholes);
@@ -87,7 +88,7 @@ public:
 	const Port &GetPort() const;
 	// Check whether there are port services (such as trading, jobs, banking, and hiring)
 	// available on this planet.
-	bool HasServices() const;
+	bool HasServices(bool isPlayer = true) const;
 
 	// Check if this planet is inhabited (i.e. it has a spaceport, and does not
 	// have the "uninhabited" attribute).

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -571,7 +571,7 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 		changedSystems |= (change.Token(0) == "system");
 		changedSystems |= (change.Token(0) == "link");
 		changedSystems |= (change.Token(0) == "unlink");
-		GameData::Change(change);
+		GameData::Change(change, &conditions);
 	}
 	if(changedSystems)
 	{

--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -183,14 +183,21 @@ bool Politics::CanLand(const Planet *planet) const
 		return false;
 	if(!planet->IsInhabited())
 		return true;
-	if(dominatedPlanets.contains(planet))
-		return true;
-	if(bribedPlanets.contains(planet))
+	if(HasClearance(planet))
 		return true;
 	if(provoked.contains(planet->GetGovernment()))
 		return false;
 
 	return Reputation(planet->GetGovernment()) >= planet->RequiredReputation();
+}
+
+
+
+// Check if the player has been granted clearance to land on this planet, either
+// through bribes, domination, or mission clearance.
+bool Politics::HasClearance(const Planet *planet) const
+{
+	return dominatedPlanets.contains(planet) || bribedPlanets.contains(planet);
 }
 
 

--- a/source/Politics.h
+++ b/source/Politics.h
@@ -49,6 +49,9 @@ public:
 	bool CanLand(const Ship &ship, const Planet *planet) const;
 	// Check if the player can land on the given planet.
 	bool CanLand(const Planet *planet) const;
+	// Check if the player has been granted clearance to land on this planet, either
+	// through bribes or domination.
+	bool HasClearance(const Planet *planet) const;
 	bool CanUseServices(const Planet *planet) const;
 	// Bribe a planet to let the player's ships land there.
 	void BribePlanet(const Planet *planet, bool fullAccess);

--- a/source/Port.cpp
+++ b/source/Port.cpp
@@ -115,7 +115,9 @@ void Port::Load(const DataNode &node, const ConditionsStore *playerConditions)
 		else if(key == "to" && child.Size() >= 2)
 		{
 			const string &conditional = child.Token(1);
-			if(conditional == "bribe")
+			if(conditional == "require bribe")
+				toRequireBribe.Load(child, playerConditions);
+			else if(conditional == "bribe")
 				toBribe.Load(child, playerConditions);
 			else if(conditional == "access")
 				toAccess.Load(child, playerConditions);
@@ -236,6 +238,13 @@ const string &Port::Name() const
 const Paragraphs &Port::Description() const
 {
 	return description;
+}
+
+
+
+bool Port::RequiresBribe() const
+{
+	return !toRequireBribe.IsEmpty() && toRequireBribe.Test();
 }
 
 

--- a/source/Port.h
+++ b/source/Port.h
@@ -76,6 +76,8 @@ public:
 	const std::string &Name() const;
 	const Paragraphs &Description() const;
 
+	// Whether the player is required to bribe before landing due to their conditions.
+	bool RequiresBribe() const;
 	// Whether the player is able to bribe this port.
 	bool CanBribe() const;
 	// Whether the player is able to access this port after landing.
@@ -112,6 +114,7 @@ private:
 	int services = ServicesType::None;
 
 	// Conditions that determine how the player is allowed to interact with this port.
+	ConditionSet toRequireBribe;
 	ConditionSet toBribe;
 	ConditionSet toAccess;
 	std::map<int, ConditionSet> toRecharge;

--- a/source/Port.h
+++ b/source/Port.h
@@ -19,10 +19,13 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "ConditionSet.h"
 #include "Paragraphs.h"
 
+#include <map>
 #include <string>
 
+class ConditionsStore;
 class DataNode;
 
 
@@ -60,7 +63,7 @@ public:
 
 public:
 	// Load a port's description from a node.
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, const ConditionsStore *playerConditions);
 	void LoadDefaultSpaceport();
 	void LoadUninhabitedSpaceport();
 
@@ -70,19 +73,23 @@ public:
 	// Whether this port was loaded from the Load function.
 	bool CustomLoaded() const;
 
-	// Whether this port has any services available.
-	bool HasServices() const;
-
-	// Get all the possible sources that can get recharged at this port.
-	int GetRecharges() const;
-
 	const std::string &Name() const;
 	const Paragraphs &Description() const;
 
+	// Whether the player is able to bribe this port.
+	bool CanBribe() const;
+	// Whether the player is able to access this port after landing.
+	bool CanAccess() const;
+
+	// Get all the possible sources that can get recharged at this port.
+	int GetRecharges(bool isPlayer = true) const;
 	// Check whether the given recharging is possible.
-	bool CanRecharge(int type) const;
+	bool CanRecharge(int type, bool isPlayer = true) const;
+
+	// Whether this port has any services available.
+	bool HasServices(bool isPlayer = true) const;
 	// Check whether the given service is available.
-	bool HasService(int type) const;
+	bool HasService(int type, bool isPlayer = true) const;
 
 	bool HasNews() const;
 
@@ -103,6 +110,12 @@ private:
 
 	// What services are available on this port.
 	int services = ServicesType::None;
+
+	// Conditions that determine how the player is allowed to interact with this port.
+	ConditionSet toBribe;
+	ConditionSet toAccess;
+	std::map<int, ConditionSet> toRecharge;
+	std::map<int, ConditionSet> toService;
 
 	// Whether this port has news.
 	bool hasNews = false;

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -663,12 +663,12 @@ namespace {
 		{
 			if(node.Token(0) == "changes" || (node.Token(0) == "event" && node.Size() == 1))
 				for(const DataNode &child : node)
-					GameData::Change(child);
+					GameData::Change(child, nullptr);
 			else if(node.Token(0) == "event")
 			{
 				const auto *event = GameData::Events().Get(node.Token(1));
 				for(const auto &change : event->Changes())
-					GameData::Change(change);
+					GameData::Change(change, nullptr);
 			}
 			else if(node.Token(0) == "location")
 			{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4524,7 +4524,7 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 			{
 				for(const StellarObject &object : currentSystem->Objects())
 					if(object.HasSprite() && object.HasValidPlanet()
-							&& object.GetPlanet()->HasServices())
+							&& object.GetPlanet()->HasServices(isYours))
 					{
 						target = object.Position();
 						break;
@@ -4659,7 +4659,8 @@ bool Ship::DoLandingLogic()
 	}
 	// Only refuel if this planet has a spaceport.
 	else if(fuel >= attributes.Get("fuel capacity")
-			|| !landingPlanet || !landingPlanet->GetPort().CanRecharge(Port::RechargeType::Fuel))
+			|| !landingPlanet
+			|| !landingPlanet->GetPort().CanRecharge(Port::RechargeType::Fuel, isYours))
 	{
 		zoom = min(1.f, zoom + landingSpeed);
 		SetTargetStellar(nullptr);

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -147,7 +147,7 @@ void UniverseObjects::Change(const DataNode &node, const ConditionsStore *player
 	else if(node.Token(0) == "outfitter" && node.Size() >= 2)
 		outfitSales.Get(node.Token(1))->Load(node, outfits);
 	else if(node.Token(0) == "planet" && node.Size() >= 2)
-		planets.Get(node.Token(1))->Load(node, wormholes);
+		planets.Get(node.Token(1))->Load(node, wormholes, playerConditions);
 	else if(node.Token(0) == "shipyard" && node.Size() >= 2)
 		shipSales.Get(node.Token(1))->Load(node, ships);
 	else if(node.Token(0) == "system" && node.Size() >= 2)
@@ -381,7 +381,7 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 		else if(key == "phrase" && node.Size() >= 2)
 			phrases.Get(node.Token(1))->Load(node);
 		else if(key == "planet" && node.Size() >= 2)
-			planets.Get(node.Token(1))->Load(node, wormholes);
+			planets.Get(node.Token(1))->Load(node, wormholes, playerConditions);
 		else if(key == "ship" && node.Size() >= 2)
 		{
 			// Allow multiple named variants of the same ship model.

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -58,7 +58,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 
+class ConditionsStore;
 class Panel;
+class PlayerInfo;
 class Sprite;
 class TaskQueue;
 
@@ -72,15 +74,15 @@ class UniverseObjects {
 	friend class TestData;
 public:
 	// Load game objects from the given directories of definitions.
-	std::shared_future<void> Load(TaskQueue &queue, const std::vector<std::filesystem::path> &sources,
-		bool debugMode = false);
+	std::shared_future<void> Load(TaskQueue &queue, const PlayerInfo &player,
+		const std::vector<std::filesystem::path> &sources, bool debugMode = false);
 	// Determine the fraction of data files read from disk.
 	double GetProgress() const;
 	// Resolve every game object dependency.
 	void FinishLoading();
 
 	// Apply the given change to the universe.
-	void Change(const DataNode &node);
+	void Change(const DataNode &node, const ConditionsStore *playerConditions);
 	// Update the neighbor lists and other information for all the systems.
 	// (This must be done any time a GameEvent creates or moves a system.)
 	void UpdateSystems();
@@ -94,7 +96,7 @@ public:
 
 
 private:
-	void LoadFile(const std::filesystem::path &path, bool debugMode = false);
+	void LoadFile(const std::filesystem::path &path, const PlayerInfo &player, bool debugMode = false);
 
 
 private:

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 	const bool isTesting = !testToRunName.empty();
 	try {
 		PlayerInfo player;
-		
+
 		// Load plugin preferences before game data if any.
 		Plugins::LoadSettings();
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -135,6 +135,8 @@ int main(int argc, char *argv[])
 	// Whether we are running an integration test.
 	const bool isTesting = !testToRunName.empty();
 	try {
+		PlayerInfo player;
+		
 		// Load plugin preferences before game data if any.
 		Plugins::LoadSettings();
 
@@ -142,7 +144,7 @@ int main(int argc, char *argv[])
 
 		// Begin loading the game data.
 		bool isConsoleOnly = loadOnly || printTests || printData;
-		auto dataFuture = GameData::BeginLoad(queue, isConsoleOnly, debugMode,
+		auto dataFuture = GameData::BeginLoad(queue, player, isConsoleOnly, debugMode,
 			isConsoleOnly || checkAssets || (isTesting && !debugMode));
 
 		// If we are not using the UI, or performing some automated task, we should load
@@ -167,7 +169,6 @@ int main(int argc, char *argv[])
 			return 0;
 		}
 
-		PlayerInfo player;
 		if(loadOnly || checkAssets)
 		{
 			if(checkAssets)


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #9599.
Closes #9599.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds a bunch of new condition sets to the `planet` and `port` objects that control behavior around landing on planets and the services you see when landed there.

Added to `planet`:
* `to know`: Controls whether the planet will appear as a non-landable object.
* `to land`: Controls whether you can land on the planet, even if you know that it's a landable object. If this is false and you hail the planet, you won't be able to bribe it under any circumstances.
* `to unlock outfitter`: Controls whether the outfitter will be hidden while landed on the planet.
* `to unlock shipyard`: Controls whether the shipyard will be hidden while landed on the planet.

Added to `port`:
* `to "require bribe"`: Controls whether you'll be required to bribe your way onto the planet, even if you haven't otherwise provoked the planet's government.
* `to bribe`: Control whether your bribes will be accepted if you ever need to bribe your way onto the planet for any reason (e.g. you provoked the government, your reputation is too low, or the `to "require bribe"` is true.
* `to access`: Controls your access to the spaceport button, all the port's services, and all its recharging abilities. (Access to the outfitter and shipyard is currently controlled separately by the planet node.)
* `to recharge <recharge type>...`: For each recharging type, control whether or not it will be provided. Multiple types can be listed in a line after the `to recharge` node, similar to listing multiple planet attributes.
* `to service <service type>...`: For each service type, control whether or not it will be provided. Multiple types can be listed in a line after the `to service` node, similar to listing multiple planet attributes.

IMPORTANT NOTE! Since these nodes use conditions, they're only enforced upon the player. That means that these are not a full replacement for the `"requires: <ship attribute>"` attribute, as that will apply to both players and NPCs.

## Architectural Change

In pursuit of adding these new condition sets, I've made a change to ConditionSets. It's been noted before (see #8529) that passing the PlayerInfo around can be very cumbersome. Since ConditionSets need the player's ConditionsStore in order to be evaluated, I started to pass the PlayerInfo down to the necessary Port and Planet calls that were being added or updated, but it quickly started to become a headache as it usually does.

In a bid to address this architectural burden, I'd made it so that ConditionSets can now optionally hold a pointer to the player's ConditionsStore. This pointer gets populated when the ConditionSet is created in a Load method. This then allows a ConditionSet to evaluate to a result no matter where it's located in the code base without needing to drag the PlayerInfo down to where the ConditionSet is located.

As of right now, this architecture update is only used by the newly added ConditionSets. I have tested that reloading your save file still allows these ConditionSets to function, as the same ConditionsStore object is cleared and reused between loading save files.

## Usage examples & Testing Done
Tested by updating Earth with the following definition.
```
planet Earth
	attributes education factory "near earth" research tourism urban
	landscape land/city20
	description `The ancestral home world of humanity, Earth has a population twice that of any other inhabited planet. Sprawling cities cover large portions of its surface, many of them overcrowded and dangerous. Some people work to scrape together enough money to leave, while at the same time others, born on distant worlds, make a pilgrimage of sorts to see this planet that once cradled the entirety of the human species.`
	description `	Earth is also the capital of the Republic. Representative government becomes complicated when one planet has a greater population than a hundred planets elsewhere. As a result, settlements of less than a million are grouped together into planetary districts that elect a single representative between them - a source of much frustration in the frontier worlds.`
	# You must have one of these ships to know that the planet is even landable.
	to know
		or
			has "flagship model: Carrier"
			has "flagship model: Sparrow"
			has "flagship model: Wasp"
			has "flagship model: Shuttle"
			has "flagship model: Star Barge"
	# Even if you know it's landable, you must have one of these ships in order to land on it.
	to land
		or
			has "flagship model: Carrier"
			has "flagship model: Sparrow"
			has "flagship model: Wasp"
			has "flagship model: Shuttle"
	# You must have this ship in order to see the outfitter after landing on the planet.
	to unlock outfitter
		has "flagship model: Carrier"
	port
		recharges all
		services all
		# If you don't have this ship, you're required to bribe your way onto landing.
		# (Normal means of requiring a bribe, such as poor reputation or provoking a government,
		# still apply even if you meet these conditions.)
		to "require bribe"
			not "flagship model: Carrier"
		# If you don't have one of these ships, you can't bribe your way onto the planet under any
		# circumstances.
		to bribe
			or
				has "flagship model: Carrier"
				has "flagship model: Sparrow"
				has "flagship model: Wasp"
				has "flagship model: Shuttle"
		# If you don't have one of these ships, you can't access the spaceport button or any of the
		# port's services.
		to access
			or
				has "flagship model: Carrier"
				has "flagship model: Sparrow"
		# If you don't have this ship, all services are locked to you.
		to service all
			has "flagship model: Sparrow"
		description `Earth's spaceport is a series of massive buildings; the gaps between them form narrow concrete canyons a hundred stories deep. From a distance it has the appearance of a bustling termite mound.`
		description `	Inside the towers is a warren of dim hallways and dingy shops. Hitchhikers sleep in the corners of unused docking bays under old army blankets, a few uniformed cleaners try to keep the litter and dust in check, and rich tourists from other stars cling tightly to their expensive cameras.`
```
Used the save linked below and observed the following:
* When piloting a Hogshead, Earth doesn't show up as a landable object, as `to know` is false.
* When piloting a Star Barge, Earth does appear as a landable object since `to know` is true, but `to land` being false means I'm prevented from landing. I'm unable to bribe the planet as if the bribe scale was set to 0.
* When piloting a Shuttle, I'm able to land on the planet because `to land` is true, but because `to "require bribe"` is true, I must bribe my way onto the planet, and since `to bribe` is true, I can pay the bribe.
* When piloting a Carrier, I'm allowed to land on Earth without bribing my way on since `to land` is true and `to "require bribe"` is false. If I provoke the Republic, I'm required to bribe my way onto the planet.
* When landed on the planet and my flagship is a Carrier, I can see the spaceport button since `to access` is true and I can see the outfitter since `to unlock outfitter` is true, but I can't see the bank, jobs, trading, etc. since `to service all` is false.
* When landed on the planet and my flagship is a Sparrow, I can see all the usual spaceport services since `to access` is true, but I can't see the outfitter since `to unlock outfitter` is false.
* When landed on the planet and my flagship is a Warp, I can't see anything aside from the depart button since `to unlock outfitter` and `to access` are both false.

## Save File
This save file can be used to test these changes: WIP
You'll also need to update Earth to match the definition above.

## Wiki Update
WIP

## Performance Impact
I will note that the `to access`, `to recharge`, and `to service` condition sets are checked every frame that you're on the planet panel. (This also means that in the above example, swapping my flagship instantly updates the UI.)