### PR TITLE
feat(conditions): Make ConditionEntry standalone and simplify condition providers

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -56,6 +56,8 @@ target_sources(EndlessSkyLib PRIVATE
 	Command.h
 	ConditionAssignments.cpp
 	ConditionAssignments.h
+	ConditionEntry.cpp
+	ConditionEntry.h
 	ConditionSet.cpp
 	ConditionSet.h
 	ConditionsStore.cpp

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -20,7 +20,8 @@ using namespace std;
 
 
 
-ConditionEntry::ConditionEntry(const string &name): name(name), value(0), provider(nullptr)
+ConditionEntry::ConditionEntry(const string &name)
+	: name(name), value(0), provider(nullptr)
 {
 }
 
@@ -65,7 +66,8 @@ const string ConditionEntry::NameWithoutPrefix() const
 
 
 
-ConditionEntry::DerivedProvider::DerivedProvider(ConditionEntry *mainEntry): mainEntry(mainEntry)
+ConditionEntry::DerivedProvider::DerivedProvider(ConditionEntry *mainEntry)
+	: mainEntry(mainEntry)
 {
 }
 

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -28,10 +28,20 @@ ConditionEntry::ConditionEntry(const string &name): name(name), value(0), provid
 
 ConditionEntry::~ConditionEntry()
 {
+	Clear();
+}
+
+
+
+void ConditionEntry::Clear()
+{
 	// Remove the provider, if this is the main condition that created it.
 	if(provider && ((provider->mainEntry == nullptr) || provider->mainEntry == this))
 		delete provider;
 	provider = nullptr;
+
+	// Reset the value to the default.
+	value = 0;
 }
 
 

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -20,7 +20,7 @@ using namespace std;
 
 
 
-ConditionEntry::ConditionEntry(const string &name): name(name), value(0)
+ConditionEntry::ConditionEntry(const string &name): name(name), value(0), provider(nullptr)
 {
 }
 

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -1,0 +1,163 @@
+/* ConditionNotifier.cpp
+Copyright (c) 2024-2025 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ConditionEntry.h"
+
+
+using namespace std;
+
+
+
+ConditionEntry::ConditionEntry(const string &name): name(name), value(0)
+{
+}
+
+
+
+ConditionEntry::~ConditionEntry()
+{
+	// Remove the provider, if this is the main condition that created it.
+	if(provider && ((provider->mainEntry == nullptr) || provider->mainEntry == this))
+		delete provider;
+	provider = nullptr;
+}
+
+
+
+const string &ConditionEntry::Name() const
+{
+	return name;
+}
+
+
+
+const string ConditionEntry::NameWithoutPrefix() const
+{
+	// If we have a provider, and that provider has a main-entry, then we have prefix.
+	if(provider && provider->mainEntry)
+		return name.substr(provider->mainEntry->name.length());
+
+	// If we have no prefix, then return the name without prefix.
+	return name;
+}
+
+
+
+ConditionEntry::DerivedProvider::DerivedProvider(ConditionEntry *mainEntry): mainEntry(mainEntry)
+{
+}
+
+
+
+ConditionEntry::operator int64_t() const
+{
+	if(!provider)
+		return value;
+
+	return provider->getFunction(name);
+}
+
+
+
+ConditionEntry &ConditionEntry::operator=(int64_t val)
+{
+	if(!provider)
+	{
+		value = val;
+		NotifyUpdate(val);
+	}
+	else if(provider->setFunction)
+	{
+		provider->setFunction(*this, val);
+		NotifyUpdate(val);
+	}
+	return *this;
+}
+
+
+
+ConditionEntry &ConditionEntry::operator++()
+{
+	// Reuse assignment and int64_t conversion operators.
+	return (*this) = (*this) + 1;
+}
+
+
+
+ConditionEntry &ConditionEntry::operator--()
+{
+	// Reuse assignment and int64_t conversion operators.
+	return (*this) = (*this) - 1;
+}
+
+
+
+ConditionEntry &ConditionEntry::operator+=(int64_t val)
+{
+	// Reuse assignment and int64_t conversion operators.
+	return (*this) = (*this) + val;
+}
+
+
+
+ConditionEntry &ConditionEntry::operator-=(int64_t val)
+{
+	// Reuse assignment and int64_t conversion operators.
+	return (*this) = (*this) - val;
+}
+
+
+
+void ConditionEntry::ProvidePrefixed(function<int64_t(const string &)> getFunction)
+{
+	if(!provider)
+		provider = new DerivedProvider(this);
+	provider->getFunction = std::move(getFunction);
+}
+
+
+
+void ConditionEntry::ProvidePrefixed(function<int64_t(const string &)> getFunction,
+	function<bool(ConditionEntry &, int64_t)> setFunction)
+{
+	ProvidePrefixed(getFunction);
+	provider->setFunction = std::move(setFunction);
+}
+
+
+
+void ConditionEntry::ProvideNamed(function<int64_t(const string &)> getFunction)
+{
+	if(!provider)
+		provider = new DerivedProvider(nullptr);
+	provider->getFunction = std::move(getFunction);
+}
+
+
+
+void ConditionEntry::ProvideNamed(function<int64_t(const string &)> getFunction,
+	function<bool(ConditionEntry &, int64_t)> setFunction)
+{
+	ProvideNamed(getFunction);
+	provider->setFunction = std::move(setFunction);
+}
+
+
+
+void ConditionEntry::NotifyUpdate(uint64_t value)
+{
+	// Subscribing is not implemented yet.
+	return;
+}

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -78,7 +78,7 @@ ConditionEntry::operator int64_t() const
 	if(!provider)
 		return value;
 
-	return provider->getFunction(name);
+	return provider->getFunction(*this);
 }
 
 

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -1,4 +1,4 @@
-/* ConditionNotifier.cpp
+/* ConditionEntry.cpp
 Copyright (c) 2024-2025 by Peter van der Meer
 
 Endless Sky is free software: you can redistribute it and/or modify it under the

--- a/source/ConditionEntry.cpp
+++ b/source/ConditionEntry.cpp
@@ -132,7 +132,7 @@ ConditionEntry &ConditionEntry::operator-=(int64_t val)
 
 
 
-void ConditionEntry::ProvidePrefixed(function<int64_t(const string &)> getFunction)
+void ConditionEntry::ProvidePrefixed(function<int64_t(const ConditionEntry &)> getFunction)
 {
 	if(!provider)
 		provider = new DerivedProvider(this);
@@ -141,8 +141,8 @@ void ConditionEntry::ProvidePrefixed(function<int64_t(const string &)> getFuncti
 
 
 
-void ConditionEntry::ProvidePrefixed(function<int64_t(const string &)> getFunction,
-	function<bool(ConditionEntry &, int64_t)> setFunction)
+void ConditionEntry::ProvidePrefixed(function<int64_t(const ConditionEntry &)> getFunction,
+	function<void(ConditionEntry &, int64_t)> setFunction)
 {
 	ProvidePrefixed(getFunction);
 	provider->setFunction = std::move(setFunction);
@@ -150,7 +150,7 @@ void ConditionEntry::ProvidePrefixed(function<int64_t(const string &)> getFuncti
 
 
 
-void ConditionEntry::ProvideNamed(function<int64_t(const string &)> getFunction)
+void ConditionEntry::ProvideNamed(function<int64_t(const ConditionEntry &)> getFunction)
 {
 	if(!provider)
 		provider = new DerivedProvider(nullptr);
@@ -159,8 +159,8 @@ void ConditionEntry::ProvideNamed(function<int64_t(const string &)> getFunction)
 
 
 
-void ConditionEntry::ProvideNamed(function<int64_t(const string &)> getFunction,
-	function<bool(ConditionEntry &, int64_t)> setFunction)
+void ConditionEntry::ProvideNamed(function<int64_t(const ConditionEntry &)> getFunction,
+	function<void(ConditionEntry &, int64_t)> setFunction)
 {
 	ProvideNamed(getFunction);
 	provider->setFunction = std::move(setFunction);

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -1,0 +1,105 @@
+/* ConditionEntry.h
+Copyright (c) 2024-2025 by Peter van der Meer
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONDITION_ENTRY_H_
+#define CONDITION_ENTRY_H_
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+class ConditionsStore;
+
+/**
+ * Class that provides access to one single condition. It can:
+ * - act as an int64_t proxy, to emulate int64 values
+ * - provide direct access (polling type access)
+ * - support continuous monitoring access (interrupt driven access) for condition listeners that want to stay updated on
+ *   a condition for a longer time.
+ *
+ * This class handles the tracking of listeners for a condition and notifies those listeners on changes in the monitored
+ * condition, it depends on the actual class containing the condition to notify this class.
+ */
+class ConditionEntry {
+	friend ConditionsStore;
+
+public:
+	ConditionEntry(const std::string &name);
+	~ConditionEntry();
+
+	const std::string &Name() const;
+	const std::string NameWithoutPrefix() const;
+
+	// int64_t proxy helper functions. Those functions allow access to the conditions
+	// using `operator[]` on ConditionsStores or on ConditionsProviders.
+	operator int64_t() const;
+	ConditionEntry &operator=(int64_t val);
+	ConditionEntry &operator++();
+	ConditionEntry &operator--();
+	ConditionEntry &operator+=(int64_t val);
+	ConditionEntry &operator-=(int64_t val);
+
+
+	/// Configure entry for prefixed derived providing, with only a get function.
+	void ProvidePrefixed(std::function<int64_t(const std::string &)> getFunction);
+	/// Configure entry for prefixed derived providing, with a get and a set function.
+	void ProvidePrefixed(std::function<int64_t(const std::string &)> getFunction,
+		std::function<bool(ConditionEntry &, int64_t)> setFunction);
+
+	/// Configure entry for named derived providing, with only a get function.
+	void ProvideNamed(std::function<int64_t(const std::string &)> getFunction);
+	/// Configure entry for named derived providing, with a get and a set function.
+	void ProvideNamed(std::function<int64_t(const std::string &)> getFunction,
+		std::function<bool(ConditionEntry &, int64_t)> setFunction);
+
+
+	/// Notify all subscribed listeners that the value of the condition changed.
+	void NotifyUpdate(uint64_t value);
+
+
+private:
+	// Helper class for DerivedProviders, the (lambda) functions that provide access to the derived conditions are
+	// registered in this class.
+	class DerivedProvider {
+		friend ConditionEntry;
+
+	public:
+		/// Sets up a derived provider
+		///
+		/// @param mainEntry is nullptr for named providers, and the prefixed entry for prefix providers.
+		DerivedProvider(ConditionEntry *mainEntry);
+
+
+	public:
+		/// Get function to get the value of the ConditionEntry. GetFunctions are required for any derived provider.
+		std::function<int64_t(const std::string &)> getFunction;
+
+		/// Lambda function to set the value for a condition entry.
+		std::function<void(ConditionEntry &, int64_t)> setFunction;
+
+		/// Toplevel entry for prefixed providers, nullptr for named (non-prefixed) providers.
+		ConditionEntry *mainEntry;
+	};
+
+
+private:
+	std::string name; ///< Name of this entry, set during construction of the entry object.
+	int64_t value = 0; ///< Value of this condition, in case of direct access.
+	DerivedProvider *provider = nullptr; ///< Provider, if this is a named or prefixed derived condition.
+
+};
+
+#endif

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -26,8 +26,7 @@ class ConditionsStore;
 /// Class that provides access to one single condition. It can:
 /// - act as an int64_t proxy, to emulate int64 values
 /// - provide direct access (polling type access)
-/// - support continuous monitoring access (interrupt driven access) for condition listeners that want to stay updated on
-///   a condition for a longer time.
+/// - support continuous monitoring access for listeners that want to get an interrupt when the condition changes.
 class ConditionEntry {
 	friend ConditionsStore;
 
@@ -38,7 +37,7 @@ public:
 	// Prevent copying of ConditionEntries. We cannot safely copy the references to the provider, since we depend on the
 	// conditionsStore to set prefix providers.
 	ConditionEntry(ConditionEntry &) = delete;
-	ConditionEntry& operator=(const ConditionEntry&) = delete;
+	ConditionEntry& operator=(const ConditionEntry &) = delete;
 
 	void Clear();
 

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class ConditionsStore;
 
+
+
 /// Class that provides access to one single condition. It can:
 /// - act as an int64_t proxy, to emulate int64 values
 /// - provide direct access (polling type access)

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -23,16 +23,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class ConditionsStore;
 
-/**
- * Class that provides access to one single condition. It can:
- * - act as an int64_t proxy, to emulate int64 values
- * - provide direct access (polling type access)
- * - support continuous monitoring access (interrupt driven access) for condition listeners that want to stay updated on
- *   a condition for a longer time.
- *
- * This class handles the tracking of listeners for a condition and notifies those listeners on changes in the monitored
- * condition, it depends on the actual class containing the condition to notify this class.
- */
+/// Class that provides access to one single condition. It can:
+/// - act as an int64_t proxy, to emulate int64 values
+/// - provide direct access (polling type access)
+/// - support continuous monitoring access (interrupt driven access) for condition listeners that want to stay updated on
+///   a condition for a longer time.
 class ConditionEntry {
 	friend ConditionsStore;
 

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -13,8 +13,7 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONDITION_ENTRY_H_
-#define CONDITION_ENTRY_H_
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -104,5 +103,3 @@ private:
 	DerivedProvider *provider = nullptr; ///< Provider, if this is a named or prefixed derived condition.
 
 };
-
-#endif

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -56,16 +56,16 @@ public:
 
 
 	/// Configure entry for prefixed derived providing, with only a get function.
-	void ProvidePrefixed(std::function<int64_t(const std::string &)> getFunction);
+	void ProvidePrefixed(std::function<int64_t(const ConditionEntry &)> getFunction);
 	/// Configure entry for prefixed derived providing, with a get and a set function.
-	void ProvidePrefixed(std::function<int64_t(const std::string &)> getFunction,
-		std::function<bool(ConditionEntry &, int64_t)> setFunction);
+	void ProvidePrefixed(std::function<int64_t(const ConditionEntry &)> getFunction,
+		std::function<void(ConditionEntry &, int64_t)> setFunction);
 
 	/// Configure entry for named derived providing, with only a get function.
-	void ProvideNamed(std::function<int64_t(const std::string &)> getFunction);
+	void ProvideNamed(std::function<int64_t(const ConditionEntry &)> getFunction);
 	/// Configure entry for named derived providing, with a get and a set function.
-	void ProvideNamed(std::function<int64_t(const std::string &)> getFunction,
-		std::function<bool(ConditionEntry &, int64_t)> setFunction);
+	void ProvideNamed(std::function<int64_t(const ConditionEntry &)> getFunction,
+		std::function<void(ConditionEntry &, int64_t)> setFunction);
 
 
 	/// Notify all subscribed listeners that the value of the condition changed.
@@ -87,7 +87,7 @@ private:
 
 	public:
 		/// Get function to get the value of the ConditionEntry. GetFunctions are required for any derived provider.
-		std::function<int64_t(const std::string &)> getFunction;
+		std::function<int64_t(const ConditionEntry &)> getFunction;
 
 		/// Lambda function to set the value for a condition entry.
 		std::function<void(ConditionEntry &, int64_t)> setFunction;

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -37,7 +37,7 @@ public:
 	// Prevent copying of ConditionEntries. We cannot safely copy the references to the provider, since we depend on the
 	// conditionsStore to set prefix providers.
 	ConditionEntry(ConditionEntry &) = delete;
-	ConditionEntry& operator=(const ConditionEntry &) = delete;
+	ConditionEntry &operator=(const ConditionEntry &) = delete;
 
 	void Clear();
 

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -35,6 +35,13 @@ public:
 	ConditionEntry(const std::string &name);
 	~ConditionEntry();
 
+	// Prevent copying of ConditionEntries. We cannot safely copy the references to the provider, since we depend on the
+	// conditionsStore to set prefix providers.
+	ConditionEntry(ConditionEntry &) = delete;
+	ConditionEntry& operator=(const ConditionEntry&) = delete;
+
+	void Clear();
+
 	const std::string &Name() const;
 	const std::string NameWithoutPrefix() const;
 

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -100,14 +100,22 @@ void ConditionsStore::Save(DataWriter &out) const
 // derived from other data-structures (derived conditions).
 int64_t ConditionsStore::Get(const string &name) const
 {
+	// Look for a relevant entry, either the exact entry, or a prefixed provider.
 	const ConditionEntry *ce = GetEntry(name);
+
+	// If no entry is found, then we simply don't have any relevant data.
 	if(!ce)
 		return 0;
 
-	if(!ce->provider)
-		return ce->value;
+	// If the name matches exactly, then access directly with explicit conversion to int64_t.
+	if(ce->name == name)
+		return ce->operator int64_t();
 
-	return ce->provider->getFunction(name);
+	// If the name doesn't match exactly, then we are dealing with a prefixed provider that doesn't have an exactly
+	// matching entry. Get is const, so isn't supposed to add such an entry; use a temporary object for access.
+	ConditionEntry ceAccessor(name);
+	ceAccessor.provider = ce->provider;
+	return ceAccessor.operator int64_t();
 }
 
 

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -113,7 +113,6 @@ int64_t ConditionsStore::Get(const string &name) const
 
 
 
-// Add a value to a condition. Returns true on success, false on failure.
 void ConditionsStore::Add(const string &name, int64_t value)
 {
 	(*this)[name] += value;
@@ -121,8 +120,6 @@ void ConditionsStore::Add(const string &name, int64_t value)
 
 
 
-// Set a value for a condition, either for the local value, or by performing
-// a set on the provider.
 void ConditionsStore::Set(const string &name, int64_t value)
 {
 	(*this)[name] = value;
@@ -154,7 +151,6 @@ ConditionEntry &ConditionsStore::operator[](const string &name)
 
 
 
-// Helper to completely remove all data and linked condition-providers from the store.
 void ConditionsStore::Clear()
 {
 	// Reverse clear, to make sure that prefix providers are not cleared before it's users are cleared.

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -52,7 +52,6 @@ ConditionsStore::ConditionsStore(const map<string, int64_t> &initialConditions)
 
 
 
-/// A destructor is required to remove ConditionEntries in the correct order.
 ConditionsStore::~ConditionsStore()
 {
 	// Clear removes the ConditionEntries in the correct order.
@@ -164,7 +163,6 @@ void ConditionsStore::Clear()
 
 
 
-// Helper for testing; check how many primary conditions are registered.
 int64_t ConditionsStore::PrimariesSize() const
 {
 	int64_t result = 0;

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -1,5 +1,5 @@
 /* ConditionsStore.cpp
-Copyright (c) 2020-2022 by Peter van der Meer
+Copyright (c) 2020-2025 by Peter van der Meer
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "ConditionsStore.h"
 
+#include "ConditionEntry.h"
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "Logger.h"
@@ -22,109 +23,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 
 using namespace std;
-
-
-
-// Default constructor
-ConditionsStore::DerivedProvider::DerivedProvider(const string &name, bool isPrefixProvider)
-	: name(name), isPrefixProvider(isPrefixProvider)
-{
-}
-
-
-
-void ConditionsStore::DerivedProvider::SetGetFunction(function<int64_t(const string &)> newGetFun)
-{
-	getFunction = std::move(newGetFun);
-}
-
-
-
-void ConditionsStore::DerivedProvider::SetSetFunction(function<bool(const string &, int64_t)> newSetFun)
-{
-	setFunction = std::move(newSetFun);
-}
-
-
-
-ConditionsStore::ConditionEntry::operator int64_t() const
-{
-	if(!provider)
-		return value;
-
-	const string &key = fullKey.empty() ? provider->name : fullKey;
-	return provider->getFunction(key);
-}
-
-
-
-ConditionsStore::ConditionEntry &ConditionsStore::ConditionEntry::operator=(int64_t val)
-{
-	if(!provider)
-		value = val;
-	else
-	{
-		const string &key = fullKey.empty() ? provider->name : fullKey;
-		provider->setFunction(key, val);
-	}
-	return *this;
-}
-
-
-
-ConditionsStore::ConditionEntry &ConditionsStore::ConditionEntry::operator++()
-{
-	if(!provider)
-		++value;
-	else
-	{
-		const string &key = fullKey.empty() ? provider->name : fullKey;
-		provider->setFunction(key, provider->getFunction(key) + 1);
-	}
-	return *this;
-}
-
-
-
-ConditionsStore::ConditionEntry &ConditionsStore::ConditionEntry::operator--()
-{
-	if(!provider)
-		--value;
-	else
-	{
-		const string &key = fullKey.empty() ? provider->name : fullKey;
-		provider->setFunction(key, provider->getFunction(key) - 1);
-	}
-	return *this;
-}
-
-
-
-ConditionsStore::ConditionEntry &ConditionsStore::ConditionEntry::operator+=(int64_t val)
-{
-	if(!provider)
-		value += val;
-	else
-	{
-		const string &key = fullKey.empty() ? provider->name : fullKey;
-		provider->setFunction(key, provider->getFunction(key) + val);
-	}
-	return *this;
-}
-
-
-
-ConditionsStore::ConditionEntry &ConditionsStore::ConditionEntry::operator-=(int64_t val)
-{
-	if(!provider)
-		value -= val;
-	else
-	{
-		const string &key = fullKey.empty() ? provider->name : fullKey;
-		provider->setFunction(key, provider->getFunction(key) - val);
-	}
-	return *this;
-}
 
 
 
@@ -207,37 +105,23 @@ int64_t ConditionsStore::Get(const string &name) const
 
 
 // Add a value to a condition. Returns true on success, false on failure.
-bool ConditionsStore::Add(const string &name, int64_t value)
+void ConditionsStore::Add(const string &name, int64_t value)
 {
-	// This code performers 2 lookups of the condition, once for get and
-	// once for set. This might be optimized to a single lookup in a
-	// later version of the code.
-	return Set(name, Get(name) + value);
+	(*this)[name] += value;
 }
 
 
 
 // Set a value for a condition, either for the local value, or by performing
 // a set on the provider.
-bool ConditionsStore::Set(const string &name, int64_t value)
+void ConditionsStore::Set(const string &name, int64_t value)
 {
-	ConditionEntry *ce = GetEntry(name);
-	if(!ce)
-	{
-		(storage[name]).value = value;
-		return true;
-	}
-	if(!ce->provider)
-	{
-		ce->value = value;
-		return true;
-	}
-	return ce->provider->setFunction(name, value);
+	(*this)[name] = value;
 }
 
 
 
-ConditionsStore::ConditionEntry &ConditionsStore::operator[](const string &name)
+ConditionEntry &ConditionsStore::operator[](const string &name)
 {
 	// Search for an exact match and return it if it exists.
 	auto it = storage.find(name);
@@ -246,67 +130,17 @@ ConditionsStore::ConditionEntry &ConditionsStore::operator[](const string &name)
 
 	// Check for a prefix provider.
 	ConditionEntry *ceprov = GetEntry(name);
-	// If no prefix provider is found, then just create a new value entry.
-	if(ceprov == nullptr)
-		return storage[name];
 
-	// Found a matching prefixed entry provider, but no exact match for the entry itself,
-	// let's create the exact match based on the prefix provider.
-	ConditionEntry &ce = storage[name];
-	ce.provider = ceprov->provider;
-	ce.fullKey = name;
-	return ce;
-}
+	// Create the entry (name is used as key, and as ConditionEntry constructor argument.
+	auto emp = storage.emplace(make_pair(name, name));
+	it = emp.first;
 
+	// If a relevant prefix provider is found, then provision this entry with the provider.
+	if(ceprov != nullptr)
+		it->second.provider = ceprov->provider;
 
-
-// Build a provider for a given prefix.
-ConditionsStore::DerivedProvider &ConditionsStore::GetProviderPrefixed(const string &prefix)
-{
-	auto it = providers.emplace(std::piecewise_construct,
-		std::forward_as_tuple(prefix),
-		std::forward_as_tuple(prefix, true));
-	DerivedProvider *provider = &(it.first->second);
-	if(!provider->isPrefixProvider)
-	{
-		Logger::LogError("Error: Rewriting named provider \"" + prefix + "\" to prefixed provider.");
-		provider->isPrefixProvider = true;
-	}
-	if(VerifyProviderLocation(prefix, provider))
-	{
-		storage[prefix].provider = provider;
-		// Check if any matching later entries within the prefixed range use the same provider.
-		auto checkIt = storage.find(prefix);
-		while(checkIt != storage.end() && (0 == checkIt->first.compare(0, prefix.length(), prefix)))
-		{
-			ConditionEntry &ce = checkIt->second;
-			if(ce.provider != provider)
-			{
-				ce.provider = provider;
-				ce.fullKey = checkIt->first;
-				throw runtime_error("Replacing condition entries matching prefixed provider \""
-						+ prefix + "\".");
-			}
-			++checkIt;
-		}
-	}
-	return *provider;
-}
-
-
-
-// Build a provider for the condition identified by the given name.
-ConditionsStore::DerivedProvider &ConditionsStore::GetProviderNamed(const string &name)
-{
-	auto it = providers.emplace(std::piecewise_construct,
-		std::forward_as_tuple(name),
-		std::forward_as_tuple(name, false));
-	DerivedProvider *provider = &(it.first->second);
-	if(provider->isPrefixProvider)
-		Logger::LogError("Error: Retrieving prefixed provider \"" + name + "\" as named provider.");
-	else if(VerifyProviderLocation(name, provider))
-		storage[name].provider = provider;
-	return *provider;
+	// Return the entry created.
+	return it->second;
 }
 
 
@@ -314,8 +148,8 @@ ConditionsStore::DerivedProvider &ConditionsStore::GetProviderNamed(const string
 // Helper to completely remove all data and linked condition-providers from the store.
 void ConditionsStore::Clear()
 {
+	// TODO: This invalidates ConditionEntries. If invalidating is not allowed, then just reset all to zero instead.
 	storage.clear();
-	providers.clear();
 }
 
 
@@ -336,15 +170,15 @@ int64_t ConditionsStore::PrimariesSize() const
 
 
 
-ConditionsStore::ConditionEntry *ConditionsStore::GetEntry(const string &name)
+ConditionEntry *ConditionsStore::GetEntry(const string &name)
 {
 	// Avoid code-duplication between const and non-const function.
-	return const_cast<ConditionsStore::ConditionEntry *>(const_cast<const ConditionsStore *>(this)->GetEntry(name));
+	return const_cast<ConditionEntry *>(const_cast<const ConditionsStore *>(this)->GetEntry(name));
 }
 
 
 
-const ConditionsStore::ConditionEntry *ConditionsStore::GetEntry(const string &name) const
+const ConditionEntry *ConditionsStore::GetEntry(const string &name) const
 {
 	if(storage.empty())
 		return nullptr;
@@ -360,39 +194,10 @@ const ConditionsStore::ConditionEntry *ConditionsStore::GetEntry(const string &n
 		return &(it->second);
 
 	// The entry is also matching when we have a prefix entry and the prefix part in the provider matches.
-	DerivedProvider *provider = it->second.provider;
-	if(provider && provider->isPrefixProvider && !name.compare(0, provider->name.length(), provider->name))
+	ConditionEntry::DerivedProvider *provider = it->second.provider;
+	if(provider && provider->mainEntry && !name.compare(0, provider->mainEntry->name.length(), provider->mainEntry->name))
 		return &(it->second);
 
 	// And otherwise we don't have a match.
 	return nullptr;
-}
-
-
-
-// Helper function to check if we can safely add a provider with the given name.
-bool ConditionsStore::VerifyProviderLocation(const string &name, const DerivedProvider *provider) const
-{
-	auto it = storage.upper_bound(name);
-	if(it == storage.begin())
-		return true;
-
-	--it;
-	const ConditionEntry &ce = it->second;
-
-	// If we find the provider we are trying to add, then it apparently
-	// was safe to add the entry since it was already added before.
-	if(ce.provider == provider)
-		return true;
-
-	if(!ce.provider && it->first == name)
-	{
-		Logger::LogError("Error: overwriting primary condition \"" + name + "\" with derived provider.");
-		return true;
-	}
-
-	if(ce.provider && ce.provider->isPrefixProvider && 0 == name.compare(0, ce.provider->name.length(), ce.provider->name))
-		throw runtime_error("Error: not adding provider for \"" + name + "\""
-				", because it is within range of prefixed derived provider \"" + ce.provider->name + "\".");
-	return true;
 }

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -52,6 +52,15 @@ ConditionsStore::ConditionsStore(const map<string, int64_t> &initialConditions)
 
 
 
+/// A destructor is required to remove ConditionEntries in the correct order.
+ConditionsStore::~ConditionsStore()
+{
+	// Clear removes the ConditionEntries in the correct order.
+	Clear();
+}
+
+
+
 void ConditionsStore::Load(const DataNode &node)
 {
 	for(const DataNode &child : node)
@@ -148,6 +157,11 @@ ConditionEntry &ConditionsStore::operator[](const string &name)
 // Helper to completely remove all data and linked condition-providers from the store.
 void ConditionsStore::Clear()
 {
+	// Reverse clear, to make sure that prefix providers are not cleared before it's users are cleared.
+	for(auto it = storage.rbegin(); it != storage.rend(); ++it)
+		it->second.Clear();
+
+	// Also clear all conditions..
 	// TODO: This invalidates ConditionEntries. If invalidating is not allowed, then just reset all to zero instead.
 	storage.clear();
 }

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -1,5 +1,5 @@
 /* ConditionsStore.h
-Copyright (c) 2020-2022 by Peter van der Meer
+Copyright (c) 2020-2025 by Peter van der Meer
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -19,11 +19,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <functional>
 #include <initializer_list>
 #include <map>
-#include <string>
+
+#include "ConditionEntry.h"
 
 class DataNode;
 class DataWriter;
-
 
 
 // Class that contains storage for conditions. Those conditions can be
@@ -38,66 +38,6 @@ class DataWriter;
 // formulae).
 class ConditionsStore {
 public:
-	// Forward declaration, needed to make ConditionEntry a friend of the
-	// DerivedProvider.
-	class ConditionEntry;
-
-	// Class for DerivedProviders, the (lambda) functions that provide access
-	// to the derived conditions are registered in this class.
-	class DerivedProvider {
-		friend ConditionsStore;
-		friend ConditionEntry;
-
-	public:
-		// Functions to set the lambda functions for accessing the conditions.
-		void SetGetFunction(std::function<int64_t(const std::string &)> newGetFun);
-		void SetSetFunction(std::function<bool(const std::string &, int64_t)> newSetFun);
-
-	public:
-		// This is intended as a private constructor, only to be called from within
-		// ConditionsStore. But we need to keep it public because of how the
-		// DerivedProviders are emplaced in the providers-map-variable.
-		DerivedProvider(const std::string &name, bool isPrefixProvider);
-
-	private:
-		std::string name;
-		bool isPrefixProvider;
-
-		// Lambda functions for accessing the derived conditions, with some sensible
-		// default implementations;
-		std::function<int64_t(const std::string &)> getFunction = [](const std::string &name) { return 0; };
-		std::function<bool(const std::string &, int64_t)> setFunction = [](const std::string &name, int64_t value) {
-			return false; };
-	};
-
-
-	// Storage entry for a condition. Can act as an int64_t proxy when operator[] is used for access
-	// to conditions in the ConditionsStore.
-	class ConditionEntry {
-		friend ConditionsStore;
-
-	public:
-		// int64_t proxy helper functions. Those functions allow access to the conditions
-		// using `operator[]` on ConditionsStore.
-		operator int64_t() const;
-		ConditionEntry &operator=(int64_t val);
-		ConditionEntry &operator++();
-		ConditionEntry &operator--();
-		ConditionEntry &operator+=(int64_t val);
-		ConditionEntry &operator-=(int64_t val);
-
-	private:
-		int64_t value = 0;
-		DerivedProvider *provider = nullptr;
-		// The full keyname for condition we want to access. This full keyname is required
-		// when accessing prefixed providers, because such providers will only know the prefix
-		// part of the key.
-		std::string fullKey;
-	};
-
-
-
-public:
 	// Constructors to initialize this class.
 	ConditionsStore() = default;
 	explicit ConditionsStore(const DataNode &node);
@@ -108,21 +48,16 @@ public:
 	void Load(const DataNode &node);
 	void Save(DataWriter &out) const;
 
-	// Retrieve a "condition" flag from this store (directly or from the
-	// connected provider).
+	// Retrieve a "condition" flag from this store (directly or from a connected provider).
 	int64_t Get(const std::string &name) const;
 
 	// Add a value to a condition or set a value for a condition.
 	// Returns true on success, false on failure.
-	bool Add(const std::string &name, int64_t value);
-	bool Set(const std::string &name, int64_t value);
+	void Add(const std::string &name, int64_t value);
+	void Set(const std::string &name, int64_t value);
 
 	// Direct access to a specific condition (using the ConditionEntry as proxy).
 	ConditionEntry &operator[](const std::string &name);
-
-	// Builds providers for derived conditions based on prefix and name.
-	DerivedProvider &GetProviderPrefixed(const std::string &prefix);
-	DerivedProvider &GetProviderNamed(const std::string &name);
 
 	// Helper to completely remove all data and linked condition-providers from the store.
 	void Clear();
@@ -137,12 +72,8 @@ private:
 	// creation if required).
 	ConditionEntry *GetEntry(const std::string &name);
 	const ConditionEntry *GetEntry(const std::string &name) const;
-	bool VerifyProviderLocation(const std::string &name, const DerivedProvider *provider) const;
-
-
 
 private:
 	// Storage for both the primary conditions as well as the providers.
 	std::map<std::string, ConditionEntry> storage;
-	std::map<std::string, DerivedProvider> providers;
 };

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -43,6 +43,7 @@ public:
 	explicit ConditionsStore(const DataNode &node);
 	explicit ConditionsStore(std::initializer_list<std::pair<std::string, int64_t>> initialConditions);
 	explicit ConditionsStore(const std::map<std::string, int64_t> &initialConditions);
+	~ConditionsStore();
 
 	// Serialization support for this class.
 	void Load(const DataNode &node);

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -44,6 +44,7 @@ public:
 	explicit ConditionsStore(const DataNode &node);
 	explicit ConditionsStore(std::initializer_list<std::pair<std::string, int64_t>> initialConditions);
 	explicit ConditionsStore(const std::map<std::string, int64_t> &initialConditions);
+	/// A destructor is required to remove ConditionEntries in the correct order.
 	~ConditionsStore();
 
 	ConditionsStore(const ConditionsStore &) = delete;
@@ -55,7 +56,7 @@ public:
 	void Load(const DataNode &node);
 	void Save(DataWriter &out) const;
 
-	// Retrieve a "condition" flag from this store (directly or from a connected provider).
+	/// Retrieve a "condition" flag from this store (directly or from a connected provider).
 	int64_t Get(const std::string &name) const;
 
 	/// Adds a value to the given condition. Can (silently) fail to apply when the condition is a readonly derived
@@ -65,7 +66,7 @@ public:
 	/// condition, or when a readwrite derived condition doesn't accept the new value.
 	void Set(const std::string &name, int64_t value);
 
-	// Direct access to a specific condition (using the ConditionEntry as proxy).
+	/// Direct access to a specific condition (using the ConditionEntry as proxy).
 	ConditionEntry &operator[](const std::string &name);
 
 	/// Helper to completely remove all data and linked condition-providers from the store.

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -26,6 +26,7 @@ class DataNode;
 class DataWriter;
 
 
+
 // Class that contains storage for conditions. Those conditions can be
 // set directly in internal storage of this class (primary conditions)
 // and those conditions can also be provided from other locations in the
@@ -78,6 +79,7 @@ private:
 	// creation if required).
 	ConditionEntry *GetEntry(const std::string &name);
 	const ConditionEntry *GetEntry(const std::string &name) const;
+
 
 private:
 	// Storage for both the primary conditions as well as the providers.

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -15,12 +15,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "ConditionEntry.h"
+
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
 #include <map>
-
-#include "ConditionEntry.h"
 
 class DataNode;
 class DataWriter;
@@ -58,15 +58,17 @@ public:
 	// Retrieve a "condition" flag from this store (directly or from a connected provider).
 	int64_t Get(const std::string &name) const;
 
-	// Add a value to a condition or set a value for a condition.
-	// Returns true on success, false on failure.
+	/// Adds a value to the given condition. Can (silently) fail to apply when the condition is a readonly derived
+	/// condition, or when a readwrite derived condition doesn't accept the new value.
 	void Add(const std::string &name, int64_t value);
+	/// Sets a condition to the given value. Can (silently) fail to apply when the condition is a readonly derived
+	/// condition, or when a readwrite derived condition doesn't accept the new value.
 	void Set(const std::string &name, int64_t value);
 
 	// Direct access to a specific condition (using the ConditionEntry as proxy).
 	ConditionEntry &operator[](const std::string &name);
 
-	// Helper to completely remove all data and linked condition-providers from the store.
+	/// Helper to completely remove all data and linked condition-providers from the store.
 	void Clear();
 
 	// Helper for testing; check how many primary conditions are registered.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3259,13 +3259,13 @@ void PlayerInfo::RegisterDerivedConditions()
 	// Bound financial conditions to +/- 4.6 x 10^18 credits, within the range of a 64-bit int.
 	static constexpr int64_t limit = static_cast<int64_t>(1) << 62;
 
-	conditions["net worth"].ProvideNamed([this](const string &name){
+	conditions["net worth"].ProvideNamed([this](const string &name) {
 		return min(limit, max(-limit, accounts.NetWorth())); });
-	conditions["credits"].ProvideNamed([this](const string &name){
+	conditions["credits"].ProvideNamed([this](const string &name) {
 		return min(limit, accounts.Credits()); });
-	conditions["unpaid mortgages"].ProvideNamed([this](const string &name){
+	conditions["unpaid mortgages"].ProvideNamed([this](const string &name) {
 		return min(limit, accounts.TotalDebt("Mortgage")); });
-	conditions["unpaid fines"].ProvideNamed([this](const string &name){
+	conditions["unpaid fines"].ProvideNamed([this](const string &name) {
 		return min(limit, accounts.TotalDebt("Fine")); });
 	conditions["unpaid debts"].ProvideNamed([this](const string &name) {
 		return min(limit, accounts.TotalDebt("Debt")); });
@@ -3361,7 +3361,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		return flagship->Bays().size(); });
 	// The behaviour of this condition while landed is not stable and may change in the future.
 	// It should only be used while in-flight.
-	conditions["flagship bays free"].ProvideNamed([this](const string &name) -> int64_t	{
+	conditions["flagship bays free"].ProvideNamed([this](const string &name) -> int64_t {
 		if(!flagship)
 			return 0;
 		if(GetPlanet())
@@ -3430,7 +3430,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		}
 		return retVal; });
 
-	conditions["name: "].ProvidePrefixed([this](const string &name) -> bool	{
+	conditions["name: "].ProvidePrefixed([this](const string &name) -> bool {
 		return name == "name: " + firstName + " " + lastName; });
 	conditions["first name: "].ProvidePrefixed([this](const string &name) -> bool {
 		return name == "first name: " + firstName; });
@@ -3488,7 +3488,7 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// The number of active, present ships the player has of the given category
 	// (e.g. Heavy Warships).
-	conditions["ships: "].ProvidePrefixed([this](const string &name) -> int64_t	{
+	conditions["ships: "].ProvidePrefixed([this](const string &name) -> int64_t {
 		int64_t retVal = 0;
 		for(const shared_ptr<Ship> &ship : ships)
 			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system
@@ -3737,7 +3737,7 @@ void PlayerInfo::RegisterDerivedConditions()
 			return false;
 		return name == "flagship system: " + flagship->GetSystem()->TrueName(); });
 	conditions["flagship landed"].ProvideNamed([this](const string &name) -> bool {
-		return (flagship && flagship->GetPlanet());	});
+		return (flagship && flagship->GetPlanet()); });
 	conditions["flagship planet: "].ProvidePrefixed([this](const string &name) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;
@@ -3759,7 +3759,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		const Planet *planet = GameData::Planets().Find(name.substr(strlen("landing access: ")));
 		return (planet && flagship) ? planet->CanLand(*flagship) : false; });
 
-	conditions["installed plugin: "].ProvidePrefixed([](const string &name) -> bool	{
+	conditions["installed plugin: "].ProvidePrefixed([](const string &name) -> bool {
 		const Plugin *plugin = Plugins::Get().Find(name.substr(strlen("installed plugin: ")));
 		return plugin ? plugin->IsValid() && plugin->enabled : false; });
 
@@ -3768,7 +3768,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		return person ? person->IsDestroyed() : false; });
 
 	// Read-only navigation conditions.
-	auto HyperspaceTravelDays = [](const System *origin, const System *destination) -> int 
+	auto HyperspaceTravelDays = [](const System *origin, const System *destination) -> int
 	{
 		if(!origin)
 			return -1;
@@ -3827,7 +3827,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	});
 
 	// A condition for returning a random integer in the range [0, 100).
-	conditions["random"].ProvideNamed([](const string &name) -> int64_t	{
+	conditions["random"].ProvideNamed([](const string &name) -> int64_t {
 		return Random::Int(100); });
 
 	// A condition for returning a random integer in the range [0, input). Input may be a number,

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3249,9 +3249,12 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["month"].ProvideNamed([this](const ConditionEntry &ce) { return date.Month(); });
 	conditions["year"].ProvideNamed([this](const ConditionEntry &ce) { return date.Year(); });
 	conditions["weekday"].ProvideNamed([this](const ConditionEntry &ce) { return date.WeekdayNumber(); });
-	conditions["days since year start"].ProvideNamed([this](const ConditionEntry &ce) { return date.DaysSinceYearStart(); });
-	conditions["days until year end"].ProvideNamed([this](const ConditionEntry &ce) { return date.DaysUntilYearEnd(); });
-	conditions["days since epoch"].ProvideNamed([this](const ConditionEntry &ce) { return date.DaysSinceEpoch(); });
+	conditions["days since year start"].ProvideNamed([this](const ConditionEntry &ce) {
+		return date.DaysSinceYearStart(); });
+	conditions["days until year end"].ProvideNamed([this](const ConditionEntry &ce) {
+		return date.DaysUntilYearEnd(); });
+	conditions["days since epoch"].ProvideNamed([this](const ConditionEntry &ce) {
+		return date.DaysSinceEpoch(); });
 	conditions["days since start"].ProvideNamed([this](const ConditionEntry &ce) {
 		return date.DaysSinceEpoch() - StartData().GetDate().DaysSinceEpoch(); });
 
@@ -3335,8 +3338,8 @@ void PlayerInfo::RegisterDerivedConditions()
 			return round(attributes.Mass() * 1000.);
 		return round(attributes.Get(attribute) * 1000.);
 	};
-	conditions["flagship base attribute: "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) -> int64_t {
-		return shipAttributeHelper(this->Flagship(), ce.NameWithoutPrefix(), true); });
+	conditions["flagship base attribute: "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) ->
+		int64_t { return shipAttributeHelper(this->Flagship(), ce.NameWithoutPrefix(), true); });
 	conditions["flagship attribute: "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) -> int64_t {
 		return shipAttributeHelper(this->Flagship(), ce.NameWithoutPrefix(), false); });
 	conditions["flagship bays: "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
@@ -3376,7 +3379,8 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["flagship fuel"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
 		return flagship ? flagship->FuelLevel() : 0; });
 
-	conditions["ship base attribute: "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) -> int64_t {
+	conditions["ship base attribute: "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) ->
+	int64_t {
 		string attribute = ce.NameWithoutPrefix();
 		int64_t retVal = 0;
 		for(const shared_ptr<Ship> &ship : ships)
@@ -3391,8 +3395,8 @@ void PlayerInfo::RegisterDerivedConditions()
 			retVal += shipAttributeHelper(ship.get(), attribute, true);
 		}
 		return retVal; });
-	conditions["ship base attribute (all): "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) -> int64_t
-	{
+	conditions["ship base attribute (all): "].ProvidePrefixed([this, shipAttributeHelper](const ConditionEntry &ce) ->
+	int64_t {
 		string attribute = ce.NameWithoutPrefix();
 		int64_t retVal = 0;
 		for(const shared_ptr<Ship> &ship : ships)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3322,7 +3322,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["flagship model: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship)
 			return false;
-		return ce.NameWithoutPrefix() == flagship->TrueModelName(); });
+		return !ce.NameWithoutPrefix().compare(flagship->TrueModelName()); });
 	conditions["flagship disabled"].ProvideNamed([this](const ConditionEntry &ce) -> bool {
 		return flagship && flagship->IsDisabled(); });
 
@@ -3433,11 +3433,11 @@ void PlayerInfo::RegisterDerivedConditions()
 		return retVal; });
 
 	conditions["name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.NameWithoutPrefix() == firstName + " " + lastName; });
+		return !ce.NameWithoutPrefix().compare(firstName + " " + lastName); });
 	conditions["first name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.NameWithoutPrefix() == firstName; });
+		return !ce.NameWithoutPrefix().compare(firstName); });
 	conditions["last name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.NameWithoutPrefix() == lastName; });
+		return !ce.NameWithoutPrefix().compare(lastName); });
 
 	// Conditions for your fleet's attractiveness to pirates.
 	conditions["cargo attractiveness"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
@@ -3495,7 +3495,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		string category = ce.NameWithoutPrefix();
 		for(const shared_ptr<Ship> &ship : ships)
 			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system
-					&& category == ship->Attributes().Category())
+					&& !category.compare(ship->Attributes().Category()))
 				++retVal;
 		return retVal; });
 	// The number of ships the player has of the given category anywhere in their fleet.
@@ -3503,7 +3503,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		int64_t retVal = 0;
 		string category = ce.NameWithoutPrefix();
 		for(const shared_ptr<Ship> &ship : ships)
-			if(!ship->IsDestroyed() && category == ship->Attributes().Category())
+			if(!ship->IsDestroyed() && !category.compare(ship->Attributes().Category()))
 				++retVal;
 		return retVal; });
 	// The number of ships the player has of the given model active and present.
@@ -3512,7 +3512,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		string model = ce.NameWithoutPrefix();
 		for(const shared_ptr<Ship> &ship : ships)
 			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system
-					&& model == ship->TrueModelName())
+					&& !model.compare(ship->TrueModelName()))
 				++retVal;
 		return retVal; });
 	// The number of ships that the player has of the given model anywhere in their fleet.
@@ -3520,7 +3520,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		int64_t retVal = 0;
 		string model = ce.NameWithoutPrefix();
 		for(const shared_ptr<Ship> &ship : ships)
-			if(!ship->IsDestroyed() && model == ship->TrueModelName())
+			if(!ship->IsDestroyed() && !model.compare(ship->TrueModelName()))
 				++retVal;
 		return retVal; });
 	// The total number of ships the player has active and present.
@@ -3730,24 +3730,24 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// This condition corresponds to the method by which the flagship entered the current system.
 	conditions["entered system by: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.NameWithoutPrefix() == EntryToString(entry); });
+		return !ce.NameWithoutPrefix().compare(EntryToString(entry)); });
 	// This condition corresponds to the last system the flagship was in.
 	conditions["previous system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!previousSystem)
 			return false;
-		return ce.NameWithoutPrefix() == previousSystem->TrueName(); });
+		return !ce.NameWithoutPrefix().compare(previousSystem->TrueName()); });
 
 	// Conditions to determine if flagship is in a system and on a planet.
 	conditions["flagship system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetSystem())
 			return false;
-		return ce.NameWithoutPrefix() == flagship->GetSystem()->TrueName(); });
+		return !ce.NameWithoutPrefix().compare(flagship->GetSystem()->TrueName()); });
 	conditions["flagship landed"].ProvideNamed([this](const ConditionEntry &ce) -> bool {
 		return (flagship && flagship->GetPlanet()); });
 	conditions["flagship planet: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;
-		return ce.NameWithoutPrefix() == flagship->GetPlanet()->TrueName(); });
+		return !ce.NameWithoutPrefix().compare(flagship->GetPlanet()->TrueName()); });
 	conditions["flagship planet attribute: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -104,6 +104,7 @@ public:
 
 
 // #region unit tests
+// TODO: add tests for prefixed Get cornercases (where the prefix-entry exists, but the exact match doesn't).
 SCENARIO( "Creating a ConditionsStore", "[ConditionsStore][Creation]" )
 {
 	GIVEN( "A ConditionStore" )

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -70,7 +70,7 @@ public:
 			verifyAndStripPrefix(prefix, ce.Name());
 			values[ce.Name()] = value;
 			return true;
-		});		
+		});
 	}
 	void SetRONamedProvider(ConditionsStore &store, const std::string &named)
 	{
@@ -80,7 +80,7 @@ public:
 		}, [named](ConditionEntry &ce, int64_t value) {
 			verifyName(named, ce.Name());
 			return false;
-		});		
+		});
 	}
 	void SetRWNamedProvider(ConditionsStore &store, const std::string &named)
 	{
@@ -91,7 +91,7 @@ public:
 			verifyName(named, ce.Name());
 			values[ce.Name()] = value;
 			return true;
-		});		
+		});
 	}
 
 public:

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -53,9 +53,9 @@ class MockConditionsProvider {
 public:
 	void SetROPrefixProvider(ConditionsStore &store, const std::string &prefix)
 	{
-		store[prefix].ProvidePrefixed([this, prefix](const std::string &name) {
-			verifyAndStripPrefix(prefix, name);
-			return getFromMapOrZero(values, name);
+		store[prefix].ProvidePrefixed([this, prefix](const ConditionEntry &ce) {
+			verifyAndStripPrefix(prefix, ce.Name());
+			return getFromMapOrZero(values, ce.Name());
 		}, [prefix](ConditionEntry &ce, int64_t value) {
 			verifyAndStripPrefix(prefix, ce.Name());
 			return false;
@@ -63,9 +63,9 @@ public:
 	}
 	void SetRWPrefixProvider(ConditionsStore &store, const std::string &prefix)
 	{
-		store[prefix].ProvidePrefixed([this, prefix](const std::string &name) {
-			verifyAndStripPrefix(prefix, name);
-			return getFromMapOrZero(values, name);
+		store[prefix].ProvidePrefixed([this, prefix](const ConditionEntry &ce) {
+			verifyAndStripPrefix(prefix, ce.Name());
+			return getFromMapOrZero(values, ce.Name());
 		}, [this, prefix](ConditionEntry &ce, int64_t value) {
 			verifyAndStripPrefix(prefix, ce.Name());
 			values[ce.Name()] = value;
@@ -74,9 +74,9 @@ public:
 	}
 	void SetRONamedProvider(ConditionsStore &store, const std::string &named)
 	{
-		store[named].ProvideNamed([this, named](const std::string &name) {
-			verifyName(named, name);
-			return getFromMapOrZero(values, name);
+		store[named].ProvideNamed([this, named](const ConditionEntry &ce) {
+			verifyName(named, ce.Name());
+			return getFromMapOrZero(values, ce.Name());
 		}, [named](ConditionEntry &ce, int64_t value) {
 			verifyName(named, ce.Name());
 			return false;
@@ -84,9 +84,9 @@ public:
 	}
 	void SetRWNamedProvider(ConditionsStore &store, const std::string &named)
 	{
-		store[named].ProvideNamed([this, named](const std::string &name) {
-			verifyName(named, name);
-			return getFromMapOrZero(values, name);
+		store[named].ProvideNamed([this, named](const ConditionEntry &ce) {
+			verifyName(named, ce.Name());
+			return getFromMapOrZero(values, ce.Name());
 		}, [this, named](ConditionEntry &ce, int64_t value) {
 			verifyName(named, ce.Name());
 			values[ce.Name()] = value;

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -1,5 +1,5 @@
 /* test_conditionsStore.cpp
-Copyright (c) 2022 by petervdmeer
+Copyright (c) 2022-2025 by petervdmeer
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
@@ -53,61 +53,45 @@ class MockConditionsProvider {
 public:
 	void SetROPrefixProvider(ConditionsStore &store, const std::string &prefix)
 	{
-		auto &&conditionsProvider = store.GetProviderPrefixed(prefix);
-		conditionsProvider.SetSetFunction([prefix](const std::string &name, int64_t value)
-		{
-			verifyAndStripPrefix(prefix, name);
-			return false;
-		});
-		conditionsProvider.SetGetFunction([this, prefix](const std::string &name)
-		{
+		store[prefix].ProvidePrefixed([this, prefix](const std::string &name) {
 			verifyAndStripPrefix(prefix, name);
 			return getFromMapOrZero(values, name);
+		}, [prefix](ConditionEntry &ce, int64_t value) {
+			verifyAndStripPrefix(prefix, ce.Name());
+			return false;
 		});
 	}
 	void SetRWPrefixProvider(ConditionsStore &store, const std::string &prefix)
 	{
-		auto &&conditionsProvider = store.GetProviderPrefixed(prefix);
-		conditionsProvider.SetSetFunction([this, prefix](const std::string &name, int64_t value)
-		{
-			verifyAndStripPrefix(prefix, name);
-			values[name] = value;
-			return true;
-		});
-		conditionsProvider.SetGetFunction([this, prefix](const std::string &name)
-		{
+		store[prefix].ProvidePrefixed([this, prefix](const std::string &name) {
 			verifyAndStripPrefix(prefix, name);
 			return getFromMapOrZero(values, name);
-		});
+		}, [this, prefix](ConditionEntry &ce, int64_t value) {
+			verifyAndStripPrefix(prefix, ce.Name());
+			values[ce.Name()] = value;
+			return true;
+		});		
 	}
 	void SetRONamedProvider(ConditionsStore &store, const std::string &named)
 	{
-		auto &&conditionsProvider = store.GetProviderNamed(named);
-		conditionsProvider.SetSetFunction([named](const std::string &name, int64_t value)
-		{
-			verifyName(named, name);
-			return false;
-		});
-		conditionsProvider.SetGetFunction([this, named](const std::string &name)
-		{
+		store[named].ProvideNamed([this, named](const std::string &name) {
 			verifyName(named, name);
 			return getFromMapOrZero(values, name);
-		});
+		}, [named](ConditionEntry &ce, int64_t value) {
+			verifyName(named, ce.Name());
+			return false;
+		});		
 	}
 	void SetRWNamedProvider(ConditionsStore &store, const std::string &named)
 	{
-		auto &&conditionsProvider = store.GetProviderNamed(named);
-		conditionsProvider.SetSetFunction([this, named](const std::string &name, int64_t value)
-		{
-			verifyName(named, name);
-			values[name] = value;
-			return true;
-		});
-		conditionsProvider.SetGetFunction([this, named](const std::string &name)
-		{
+		store[named].ProvideNamed([this, named](const std::string &name) {
 			verifyName(named, name);
 			return getFromMapOrZero(values, name);
-		});
+		}, [this, named](ConditionEntry &ce, int64_t value) {
+			verifyName(named, ce.Name());
+			values[ce.Name()] = value;
+			return true;
+		});		
 	}
 
 public:
@@ -205,7 +189,7 @@ SCENARIO( "Setting conditions", "[ConditionStore][ConditionSetting]" )
 		REQUIRE( store.PrimariesSize() == 0 );
 		WHEN( "a condition is set" )
 		{
-			REQUIRE( store.Set("myFirstVar", 10) );
+			store.Set("myFirstVar", 10);
 			THEN( "stored condition is present and can be retrieved" )
 			{
 				REQUIRE( store.Get("myFirstVar") == 10 );
@@ -217,7 +201,7 @@ SCENARIO( "Setting conditions", "[ConditionStore][ConditionSetting]" )
 			{
 				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store.PrimariesSize() == 1 );
-				REQUIRE( store.Set("myFirstVar", 2000) );
+				store.Set("myFirstVar", 2000);
 				REQUIRE( store.Get("myFirstVar") == 2000 );
 			}
 
@@ -225,7 +209,7 @@ SCENARIO( "Setting conditions", "[ConditionStore][ConditionSetting]" )
 			{
 				REQUIRE( store.Get("myFirstVar") == 10 );
 				REQUIRE( store.PrimariesSize() == 1 );
-				REQUIRE( store.Set("myFirstVar", 0) );
+				store.Set("myFirstVar", 0);
 				REQUIRE( store.Get("myFirstVar") == 0 );
 			}
 		}
@@ -257,13 +241,13 @@ SCENARIO( "Adding and removing on condition values", "[ConditionStore][Condition
 		REQUIRE( store.PrimariesSize() == 1 );
 		WHEN( "adding to the existing primary condition" )
 		{
-			REQUIRE( store.Add("myFirstVar", 10) );
+			store.Add("myFirstVar", 10);
 			THEN( "the condition gets the new value" )
 			{
 				REQUIRE( store.Get("myFirstVar") == 20 );
-				REQUIRE( store.Add("myFirstVar", -15) );
+				store.Add("myFirstVar", -15);
 				REQUIRE( store.Get("myFirstVar") == 5 );
-				REQUIRE( store.Add("myFirstVar", -15) );
+				store.Add("myFirstVar", -15);
 				REQUIRE( store.Get("myFirstVar") == -10 );
 				REQUIRE( store["myFirstVar"] == -10 );
 				++store["myFirstVar"];
@@ -284,13 +268,13 @@ SCENARIO( "Adding and removing on condition values", "[ConditionStore][Condition
 		}
 		WHEN( "adding to another non-existing (primary) condition sets the new value" )
 		{
-			REQUIRE( store.Add("mySecondVar", -30) );
+			store.Add("mySecondVar", -30);
 			THEN( "the new condition exists with the new value" )
 			{
 				REQUIRE( store.Get("mySecondVar") == -30 );
 				REQUIRE( store.PrimariesSize() == 2 );
 				REQUIRE( store.Get("mySecondVar") );
-				REQUIRE( store.Add("mySecondVar", 60) );
+				store.Add("mySecondVar", 60);
 				REQUIRE( store.Get("mySecondVar") == 30 );
 				REQUIRE( store.PrimariesSize() == 2 );
 			}
@@ -307,27 +291,34 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 		auto store = ConditionsStore{ { "myFirstVar", 10 } };
 		mockProvNamed.SetRWNamedProvider(store, "named1");
 		mockProvPrefixA.SetRWPrefixProvider(store, "prefixA: ");
-		REQUIRE( store.Add("named1", -30) );
+		store.Add("named1", -30);
 		REQUIRE( mockProvNamed.values.size() == 1 );
 		REQUIRE( mockProvNamed.values["named1"] == -30 );
 		REQUIRE( store.PrimariesSize() == 1 );
 		REQUIRE( mockProvPrefixA.values.size() == 0 );
-		REQUIRE( store.Add("prefixA: test", -30) );
+		store.Add("prefixA: test", -30);
 		REQUIRE( store.PrimariesSize() == 1 );
 		REQUIRE( mockProvPrefixA.values.size() == 1 );
 		REQUIRE( mockProvPrefixA.values["prefixA: test"] == -30 );
 		REQUIRE( mockProvNamed.values.size() == 1 );
 		REQUIRE( store.PrimariesSize() == 1 );
+		WHEN( "requesting the name of the prefixed entry, without prefix" )
+		{
+			THEN( "the substring should be returned that is unique" )
+			{
+				REQUIRE( store["prefixA: test"].NameWithoutPrefix() == "test" );
+			}
+		}
 		WHEN( "adding to an existing primary condition" )
 		{
 			THEN( "the add should work as-is" )
 			{
 				REQUIRE( store.Get("myFirstVar") == 10 );
-				REQUIRE( store.Add("myFirstVar", 10) );
+				store.Add("myFirstVar", 10);
 				REQUIRE( store.Get("myFirstVar") == 20 );
-				REQUIRE( store.Add("myFirstVar", -15) );
+				store.Add("myFirstVar", -15);
 				REQUIRE( store.Get("myFirstVar") == 5 );
-				REQUIRE( store.Add("myFirstVar", -15) );
+				store.Add("myFirstVar", -15);
 				REQUIRE( store.Get("myFirstVar") == -10 );
 				auto &&sa = store["myFirstVar"];
 				sa += 15;
@@ -342,23 +333,23 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 		{
 			THEN( "such condition should be set properly" )
 			{
-				REQUIRE( store.Add("mySecondVar", -30) );
+				store.Add("mySecondVar", -30);
 				REQUIRE( store.Get("mySecondVar") == -30 );
 				REQUIRE( store.PrimariesSize() == 2 );
 				REQUIRE( store.Get("mySecondVar") );
-				REQUIRE( store.Add("mySecondVar", 60) );
+				store.Add("mySecondVar", 60);
 				REQUIRE( store.Get("mySecondVar") == 30 );
 				REQUIRE( store.PrimariesSize() == 2 );
 			}
 		}
 		WHEN( "adding on a named derived condition" )
 		{
-			REQUIRE( store.Add("named1", -30) );
+			store.Add("named1", -30);
 			THEN( "effects of adding should be on the named condition" )
 			{
 				REQUIRE( store.PrimariesSize() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -60 );
-				REQUIRE( store.Add("named1", -20) );
+				store.Add("named1", -20);
 				REQUIRE( mockProvNamed.values.size() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -80 );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
@@ -377,7 +368,7 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 			THEN( "readonly providers should reject the add and don't change values" )
 			{
 				mockProvNamed.SetRONamedProvider(store, "named1");
-				REQUIRE_FALSE( store.Add("named1", -20) );
+				store.Add("named1", -20);
 				REQUIRE( mockProvNamed.values.size() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -60 );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
@@ -395,11 +386,11 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 			THEN( "readonly providers should not perform any set actions" )
 			{
 				mockProvNamed.SetRONamedProvider(store, "named1");
-				REQUIRE_FALSE( store.Set("named1", 0) );
+				store.Set("named1", 0);
 				REQUIRE( mockProvNamed.values.size() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -60 );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
-				REQUIRE_FALSE( store.Set("named1", 40) );
+				store.Set("named1", 40);
 				REQUIRE( mockProvNamed.values.size() == 1 );
 				REQUIRE( mockProvNamed.values["named1"] == -60 );
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
@@ -415,7 +406,7 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 		}
 		WHEN( "adding on a prefixed derived condition" )
 		{
-			REQUIRE( store.Add("prefixA: test", -30) );
+			store.Add("prefixA: test", -30);
 			THEN( "derived prefixed conditions should be set properly" )
 			{
 				REQUIRE( store.PrimariesSize() == 1 );
@@ -439,7 +430,7 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 			THEN( "read-only prefixed provider should reject further updates" )
 			{
 				mockProvPrefixA.SetROPrefixProvider(store, "prefixA: ");
-				REQUIRE_FALSE( store.Add("prefixA: test", -20) );
+				store.Add("prefixA: test", -20);
 				REQUIRE( mockProvPrefixA.values.size() == 1 );
 				REQUIRE( mockProvPrefixA.values["prefixA: test"] == -60 );
 				REQUIRE( mockProvNamed.values.size() == 1 );
@@ -472,18 +463,18 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 				THEN( "derived prefixed conditions should be set properly" )
 				{
 					REQUIRE( store.PrimariesSize() == 1 );
-					REQUIRE( store.Add("prefixA: test", 30) );
+					store.Add("prefixA: test", 30);
 					REQUIRE( store.PrimariesSize() == 1 );
 					REQUIRE( mockProvPrefixA.values["prefixA: test"] == -30 );
 					REQUIRE( store.Get("prefixA: test") == -30 );
 					REQUIRE( store.Get("myFirstVar") == 10 );
 					mockProvPrefixA.SetROPrefixProvider(store, "prefixA: ");
-					REQUIRE_FALSE( store.Add("prefixA: test", -20) );
+					store.Add("prefixA: test", -20);
 					REQUIRE( mockProvPrefixA.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values["prefixA: test"] == -30 );
 					REQUIRE( store.Get("prefixA: test") == -30 );
 					REQUIRE( store.Get("myFirstVar") == 10 );
-					REQUIRE_FALSE( store.Set("prefixA: test", 0) );
+					store.Set("prefixA: test", 0);
 					REQUIRE( mockProvPrefixA.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values["prefixA: test"] == -30 );
 					REQUIRE( store.Get("prefixA: test") == -30 );
@@ -502,19 +493,19 @@ SCENARIO( "Providing derived conditions", "[ConditionStore][DerivedConditions]" 
 					REQUIRE( mockProvPrefixA.values.size() == 3 );
 					REQUIRE( mockProvPrefixB.values.size() == 0 );
 					mockProvPrefixA.SetRWPrefixProvider(store, "prefixA: ");
-					REQUIRE( store.Set("prefix: beginning", 42) );
+					store.Set("prefix: beginning", 42);
 					REQUIRE( mockProvPrefix.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values.size() == 3 );
 					REQUIRE( mockProvPrefixB.values.size() == 0 );
-					REQUIRE( store.Set("prefixB: ending", 142) );
+					store.Set("prefixB: ending", 142);
 					REQUIRE( mockProvPrefix.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values.size() == 3 );
 					REQUIRE( mockProvPrefixB.values.size() == 1 );
-					REQUIRE( store.Set("prefixA: middle", 40) );
+					store.Set("prefixA: middle", 40);
 					REQUIRE( mockProvPrefix.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values.size() == 4 );
 					REQUIRE( mockProvPrefixB.values.size() == 1 );
-					REQUIRE( store.Set("prefixA: middle2", 90) );
+					store.Set("prefixA: middle2", 90);
 					REQUIRE( mockProvPrefix.values.size() == 1 );
 					REQUIRE( mockProvPrefixA.values.size() == 5 );
 					REQUIRE( mockProvPrefixB.values.size() == 1 );
@@ -546,13 +537,13 @@ SCENARIO( "Providing multiple derived conditions", "[ConditionStore][DerivedMult
 		mockProvPrefixShips.SetRWPrefixProvider(store, "ships: ");
 		WHEN( "adding variables with similar names" )
 		{
-			REQUIRE( store.Add("ships: A", 20) );
+			store.Add("ships: A", 20);
 			REQUIRE( mockProvPrefixShips.values.size() == 1 );
 			REQUIRE( mockProvPrefixShips.values["ships: A"] == 20 );
-			REQUIRE( store.Add("ships: AB", 30) );
+			store.Add("ships: AB", 30);
 			REQUIRE( mockProvPrefixShips.values.size() == 2 );
 			REQUIRE( mockProvPrefixShips.values["ships: AB"] == 30 );
-			REQUIRE( store.Add("ships: C", 40) );
+			store.Add("ships: C", 40);
 			REQUIRE( mockProvPrefixShips.values.size() == 3 );
 			REQUIRE( mockProvPrefixShips.values["ships: C"] == 40 );
 			THEN( "the values should be retrieved as set" )
@@ -569,17 +560,20 @@ SCENARIO( "Providing multiple derived conditions", "[ConditionStore][DerivedMult
 		WHEN( "adding a prefixed provider that is in the subset of the prefixed provider" )
 		{
 			auto mockProvPrefixShipsA = MockConditionsProvider();
-			CHECK_THROWS( mockProvPrefixShipsA.SetRWPrefixProvider(store, "ships: A:") );
+			// Just check that we don't crash.
+			mockProvPrefixShipsA.SetRWPrefixProvider(store, "ships: A:");
 		}
 		WHEN( "adding a named provider that is in the subset of the prefixed provider" )
 		{
 			auto mockProvPrefixShipsA = MockConditionsProvider();
-			CHECK_THROWS( mockProvPrefixShipsA.SetRWNamedProvider(store, "ships: A:") );
+			// Just check that we don't crash.
+			mockProvPrefixShipsA.SetRWNamedProvider(store, "ships: A:");
 		}
 		WHEN( "adding a prefixed provider that is in the superset of the prefixed provider" )
 		{
 			auto mockProvPrefixShi = MockConditionsProvider();
-			CHECK_THROWS( mockProvPrefixShi.SetRWPrefixProvider(store, "shi") );
+			// Just check that we don't crash.
+			mockProvPrefixShi.SetRWPrefixProvider(store, "shi");
 		}
 	}
 	GIVEN( "A pre-existing condition in a store" )
@@ -589,11 +583,13 @@ SCENARIO( "Providing multiple derived conditions", "[ConditionStore][DerivedMult
 		WHEN(" a prefixed provider gets added which has the condition in range")
 		{
 			auto mockProvPrefixShips = MockConditionsProvider();
-			CHECK_THROWS( mockProvPrefixShips.SetRWPrefixProvider(store, "ships: ") );
-			THEN( "Adding a sub-prefix-condition should not be possible")
+			// Just check that we don't crash.
+			mockProvPrefixShips.SetRWPrefixProvider(store, "ships: ");
+			THEN( "Adding a sub-prefix-condition should not cause a crash")
 			{
 				auto mockProvPrefixShipsLarge = MockConditionsProvider();
-				CHECK_THROWS( mockProvPrefixShipsLarge.SetRWPrefixProvider(store, "ships: Large: ") );
+				// Just check that we don't crash.
+				mockProvPrefixShipsLarge.SetRWPrefixProvider(store, "ships: Large: ");
 			}
 		}
 	}


### PR DESCRIPTION
**Feature**

This PR separates the ConditionEntry from ConditionsStore as part of issue #7451 

## Acknowledgement
- [X ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
ConditionEntry becomes it's own stand-alone class (split off from ConditionsStore). ConditionEntry now also contains the derived condition providers directly, and this simplifies the syntax for creating new derived conditions.
ConditionEntry also got a notify function, to prepare for the future subscribe mechanism that is required for #7451.

PR #11318 refers to some of the changes in this PR. (But there are no dependencies between that PR and this one.)

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
The unit-test for ConditionsStore has been updated to reflect the updates (and I ran it).
More complex conditions will be tested by the integration tests on this PR.

## Save File
N/A

## Wiki Update
N/A, this change is not visible for content-writers or end-users.

## Performance Impact
Looking up condition providers might be a little bit faster, but I expect no significant difference.