### PR TITLE
feat(mechanics): Allow outfitters and shipyards to be empty

### DIFF
--- a/source/Engine.h
+++ b/source/Engine.h
@@ -105,7 +105,7 @@ public:
 private:
 	class Outline {
 	public:
-		Outline(const Sprite *sprite, const Point &position, const Point &unit,
+		constexpr Outline(const Sprite *sprite, const Point &position, const Point &unit,
 			const float frame, const Color &color)
 			: sprite(sprite), position(position), unit(unit), frame(frame), color(color)
 		{

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -105,7 +105,7 @@ public:
 private:
 	class Outline {
 	public:
-		constexpr Outline(const Sprite *sprite, const Point &position, const Point &unit,
+		Outline(const Sprite *sprite, const Point &position, const Point &unit,
 			const float frame, const Color &color)
 			: sprite(sprite), position(position), unit(unit), frame(frame), color(color)
 		{

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -446,7 +446,7 @@ bool Planet::IsInhabited() const
 // Check if this planet has a shipyard.
 bool Planet::HasShipyard() const
 {
-	return !shipSales().empty();
+	return !shipSales.empty();
 }
 
 

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -446,6 +446,9 @@ bool Planet::IsInhabited() const
 // Check if this planet has a shipyard.
 bool Planet::HasShipyard() const
 {
+	// A planet shouldn't display empty an empty shipyard. Therefore, even
+	// if this planet contains a named shipyard, that shipyard must still
+	// have contents to it in order for the shipyard to be displayed.
 	return !Shipyard().empty();
 }
 
@@ -466,7 +469,11 @@ const Sale<Ship> &Planet::Shipyard() const
 // Check if this planet has an outfitter.
 bool Planet::HasOutfitter() const
 {
-	return !Outfitter().empty();
+	// A planet is allowed to have an empty outfitter, as the player could
+	// still use it to rearrange the outfits in their fleet. Therefore, all
+	// that's needed to display the outfitter is to have a named outfitter
+	// present.
+	return !outfitSales.empty();
 }
 
 

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -446,10 +446,7 @@ bool Planet::IsInhabited() const
 // Check if this planet has a shipyard.
 bool Planet::HasShipyard() const
 {
-	// A planet shouldn't display empty an empty shipyard. Therefore, even
-	// if this planet contains a named shipyard, that shipyard must still
-	// have contents to it in order for the shipyard to be displayed.
-	return !Shipyard().empty();
+	return !shipSales().empty();
 }
 
 
@@ -469,10 +466,6 @@ const Sale<Ship> &Planet::Shipyard() const
 // Check if this planet has an outfitter.
 bool Planet::HasOutfitter() const
 {
-	// A planet is allowed to have an empty outfitter, as the player could
-	// still use it to rearrange the outfits in their fleet. Therefore, all
-	// that's needed to display the outfitter is to have a named outfitter
-	// present.
 	return !outfitSales.empty();
 }
 

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -269,10 +269,6 @@ void UniverseObjects::CheckReferences()
 	for(auto &&it : outfits)
 		if(it.second.TrueName().empty())
 			NameAndWarn("outfit", it);
-	// Outfitters are never serialized.
-	for(const auto &it : outfitSales)
-		if(it.second.empty() && !deferred["outfitter"].contains(it.first))
-			Logger::LogError("Warning: outfitter \"" + it.first + "\" is referred to, but has no outfits.");
 	// Phrases are never serialized.
 	for(const auto &it : phrases)
 		if(it.second.Name().empty())

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -284,10 +284,6 @@ void UniverseObjects::CheckReferences()
 			it.second.SetTrueModelName(it.first);
 			Warn("ship", it.first);
 		}
-	// Shipyards are never serialized.
-	for(const auto &it : shipSales)
-		if(it.second.empty() && !deferred["shipyard"].contains(it.first))
-			Logger::LogError("Warning: shipyard \"" + it.first + "\" is referred to, but has no ships.");
 	// System names are used by a number of classes.
 	for(auto &&it : systems)
 		if(it.second.TrueName().empty() && !NameIfDeferred(deferred["system"], it))


### PR DESCRIPTION
**Feature**

This PR addresses the feature described during a conversation about new/changed mechanics that could be used for pirate content.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Currently, a planet will only display the outfitter if it has any outfits for sale. This means that even if you list an outfitter under the planet, but that outfitter is empty, the shop won't display in game. UniverseObjects will also log and error about empty outfitters.

This PR makes it so that UniverseObjects no longer log an error for empty outfitters, and the criteria for determining whether the outfitter should display is now whether the planet has any outfitters defined for it, not whether any of those outfitters have something for sale. This allows us to have planets that don't sell anything, but still have the facilities necessary for you to edit the outfits of your fleet or store outfits.

The same is true for shipyards.

## Testing Done + Screenshots

Defined the following outfitter.
```
outfitter "empty"
```
Added it to Mars, which normally doesn't have an outfitter. With this change, the Outfitter button displayed on the planet panel, and I was able to edit the outfits of my fleet and store outfits like I would at any other outfitter.

Check it out.
![image](https://github.com/user-attachments/assets/84477fdf-4c60-451c-ac05-9196801fea54)
![image](https://github.com/user-attachments/assets/b20bc6be-560f-49ff-bf83-1556b2a02490)