### PR TITLE
Allow the color of missions in the missions list to be customized

### DIFF
--- a/source/Color.cpp
+++ b/source/Color.cpp
@@ -15,6 +15,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Color.h"
 
+using namespace std;
+
 
 
 // Greyscale color constructor.
@@ -29,6 +31,7 @@ Color::Color(float i, float a)
 Color::Color(float r, float g, float b, float a)
 	: color{r, g, b, a}
 {
+	isLoaded = true;
 }
 
 
@@ -67,6 +70,20 @@ void Color::Load(double r, double g, double b, double a)
 bool Color::IsLoaded() const
 {
 	return isLoaded;
+}
+
+
+
+void Color::SetName(const string &name)
+{
+	this->name = name;
+}
+
+
+
+const string &Color::Name() const
+{
+	return name;
 }
 
 

--- a/source/Color.h
+++ b/source/Color.h
@@ -15,6 +15,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <string>
+
 
 
 // Class representing an RGBA color (for use by OpenGL). The specified colors
@@ -24,9 +26,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // zero the color's components will be added to whatever is underneath them.
 class Color {
 public:
-	// Constructor for shades of gray, opaque unless an alpha is also given.
+	// Constructor for shades of gray. Opaque unless an alpha is also given.
+	// IsLoaded is false when using this constructor.
 	explicit Color(float i = 1.f, float a = 1.f);
-	// Constructor for colors, opaque unless an alpha is also given.
+	// Constructor for colors. Opaque unless an alpha is also given.
 	Color(float r, float g, float b, float a = 1.f);
 
 	bool operator==(const Color &other) const;
@@ -36,6 +39,8 @@ public:
 	void Load(double r, double g, double b, double a);
 	// Check if Load() has been called for this color.
 	bool IsLoaded() const;
+	void SetName(const std::string &name);
+	const std::string &Name() const;
 	// Get the color as a float vector, suitable for use by OpenGL.
 	const float *Get() const;
 
@@ -60,5 +65,6 @@ private:
 	// Store the color as a float vector for easy interfacing with OpenGL.
 	float color[4];
 
+	std::string name;
 	bool isLoaded = false;
 };

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -146,17 +146,19 @@ void Mission::Load(const DataNode &node)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "name" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "name" && hasValue)
 			displayName = child.Token(1);
-		else if(child.Token(0) == "uuid" && child.Size() >= 2)
+		else if(key == "uuid" && hasValue)
 			uuid = EsUuid::FromString(child.Token(1));
-		else if(child.Token(0) == "description" && child.Size() >= 2)
+		else if(key == "description" && hasValue)
 			description = child.Token(1);
-		else if(child.Token(0) == "blocked" && child.Size() >= 2)
+		else if(key == "blocked" && hasValue)
 			blocked = child.Token(1);
-		else if(child.Token(0) == "deadline" && child.Size() >= 4)
+		else if(key == "deadline" && child.Size() >= 4)
 			deadline = Date(child.Value(1), child.Value(2), child.Value(3));
-		else if(child.Token(0) == "deadline")
+		else if(key == "deadline")
 		{
 			if(child.Size() == 1)
 				deadlineMultiplier += 2;
@@ -165,11 +167,11 @@ void Mission::Load(const DataNode &node)
 			if(child.Size() >= 3)
 				deadlineMultiplier += child.Value(2);
 		}
-		else if(child.Token(0) == "distance calculation settings" && child.HasChildren())
+		else if(key == "distance calculation settings" && child.HasChildren())
 		{
 			distanceCalcSettings.Load(child);
 		}
-		else if(child.Token(0) == "cargo" && child.Size() >= 3)
+		else if(key == "cargo" && child.Size() >= 3)
 		{
 			cargo = child.Token(1);
 			cargoSize = child.Value(2);
@@ -187,7 +189,7 @@ void Mission::Load(const DataNode &node)
 						" They are now mission-level properties:");
 			}
 		}
-		else if(child.Token(0) == "passengers" && child.Size() >= 2)
+		else if(key == "passengers" && hasValue)
 		{
 			passengers = child.Value(1);
 			if(child.Size() >= 3)
@@ -195,32 +197,32 @@ void Mission::Load(const DataNode &node)
 			if(child.Size() >= 4)
 				passengerProb = child.Value(3);
 		}
-		else if(child.Token(0) == "apparent payment" && child.Size() >= 2)
+		else if(key == "apparent payment" && hasValue)
 			paymentApparent = child.Value(1);
 		else if(ParseContraband(child))
 		{
 			// This was an "illegal" or "stealth" entry. It has already been
 			// parsed, so nothing more needs to be done here.
 		}
-		else if(child.Token(0) == "invisible")
+		else if(key == "invisible")
 			isVisible = false;
-		else if(child.Token(0) == "priority")
+		else if(key == "priority")
 			hasPriority = true;
-		else if(child.Token(0) == "non-blocking")
+		else if(key == "non-blocking")
 			isNonBlocking = true;
-		else if(child.Token(0) == "minor")
+		else if(key == "minor")
 			isMinor = true;
-		else if(child.Token(0) == "offer precedence" && child.Size() >= 2)
+		else if(key == "offer precedence" && hasValue)
 			offerPrecedence = child.Value(1);
-		else if(child.Token(0) == "autosave")
+		else if(key == "autosave")
 			autosave = true;
-		else if(child.Token(0) == "job")
+		else if(key == "job")
 			location = JOB;
-		else if(child.Token(0) == "landing")
+		else if(key == "landing")
 			location = LANDING;
-		else if(child.Token(0) == "assisting")
+		else if(key == "assisting")
 			location = ASSISTING;
-		else if(child.Token(0) == "boarding")
+		else if(key == "boarding")
 		{
 			location = BOARDING;
 			for(const DataNode &grand : child)
@@ -229,26 +231,26 @@ void Mission::Load(const DataNode &node)
 				else
 					grand.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "shipyard")
+		else if(key == "shipyard")
 			location = SHIPYARD;
-		else if(child.Token(0) == "outfitter")
+		else if(key == "outfitter")
 			location = OUTFITTER;
-		else if(child.Token(0) == "job board")
+		else if(key == "job board")
 			location = JOB_BOARD;
-		else if(child.Token(0) == "repeat")
+		else if(key == "repeat")
 			repeat = (child.Size() == 1 ? 0 : static_cast<int>(child.Value(1)));
-		else if(child.Token(0) == "clearance")
+		else if(key == "clearance")
 		{
 			clearance = (child.Size() == 1 ? "auto" : child.Token(1));
 			clearanceFilter.Load(child);
 		}
-		else if(child.Size() == 2 && child.Token(0) == "ignore" && child.Token(1) == "clearance")
+		else if(child.Size() == 2 && key == "ignore" && child.Token(1) == "clearance")
 			ignoreClearance = true;
-		else if(child.Token(0) == "infiltrating")
+		else if(key == "infiltrating")
 			hasFullClearance = false;
-		else if(child.Token(0) == "failed")
+		else if(key == "failed")
 			hasFailed = true;
-		else if(child.Token(0) == "to" && child.Size() >= 2)
+		else if(key == "to" && hasValue)
 		{
 			if(child.Token(1) == "offer")
 				toOffer.Load(child);
@@ -261,49 +263,49 @@ void Mission::Load(const DataNode &node)
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "source" && child.Size() >= 2)
+		else if(key == "source" && hasValue)
 		{
 			source = GameData::Planets().Get(child.Token(1));
 			ParseMixedSpecificity(child, "planet", 2);
 		}
-		else if(child.Token(0) == "source")
+		else if(key == "source")
 			sourceFilter.Load(child);
-		else if(child.Token(0) == "destination" && child.Size() == 2)
+		else if(key == "destination" && child.Size() == 2)
 		{
 			destination = GameData::Planets().Get(child.Token(1));
 			ParseMixedSpecificity(child, "planet", 2);
 		}
-		else if(child.Token(0) == "destination")
+		else if(key == "destination")
 			destinationFilter.Load(child);
-		else if(child.Token(0) == "waypoint" && child.Size() >= 2)
+		else if(key == "waypoint" && hasValue)
 		{
 			bool visited = child.Size() >= 3 && child.Token(2) == "visited";
 			set<const System *> &set = visited ? visitedWaypoints : waypoints;
 			set.insert(GameData::Systems().Get(child.Token(1)));
 			ParseMixedSpecificity(child, "system", 2 + visited);
 		}
-		else if(child.Token(0) == "waypoint" && child.HasChildren())
+		else if(key == "waypoint" && child.HasChildren())
 			waypointFilters.emplace_back(child);
-		else if(child.Token(0) == "stopover" && child.Size() >= 2)
+		else if(key == "stopover" && hasValue)
 		{
 			bool visited = child.Size() >= 3 && child.Token(2) == "visited";
 			set<const Planet *> &set = visited ? visitedStopovers : stopovers;
 			set.insert(GameData::Planets().Get(child.Token(1)));
 			ParseMixedSpecificity(child, "planet", 2 + visited);
 		}
-		else if(child.Token(0) == "stopover" && child.HasChildren())
+		else if(key == "stopover" && child.HasChildren())
 			stopoverFilters.emplace_back(child);
-		else if(child.Token(0) == "mark" && child.Size() >= 2)
+		else if(key == "mark" && hasValue)
 		{
 			bool unmarked = child.Size() >= 3 && child.Token(2) == "unmarked";
 			set<const System *> &set = unmarked ? unmarkedSystems : markedSystems;
 			set.insert(GameData::Systems().Get(child.Token(1)));
 		}
-		else if(child.Token(0) == "substitutions" && child.HasChildren())
+		else if(key == "substitutions" && child.HasChildren())
 			substitutions.Load(child);
-		else if(child.Token(0) == "npc")
+		else if(key == "npc")
 			npcs.emplace_back(child);
-		else if(child.Token(0) == "on" && child.Size() >= 2 && child.Token(1) == "enter")
+		else if(key == "on" && child.Size() >= 2 && child.Token(1) == "enter")
 		{
 			// "on enter" nodes may either name a specific system or use a LocationFilter
 			// to control the triggering system.
@@ -315,7 +317,7 @@ void Mission::Load(const DataNode &node)
 			else
 				genericOnEnter.emplace_back(child);
 		}
-		else if(child.Token(0) == "on" && child.Size() >= 2)
+		else if(key == "on" && hasValue)
 		{
 			static const map<string, Trigger> trigger = {
 				{"complete", COMPLETE},
@@ -334,6 +336,24 @@ void Mission::Load(const DataNode &node)
 			auto it = trigger.find(child.Token(1));
 			if(it != trigger.end())
 				actions[it->second].Load(child);
+			else
+				child.PrintTrace("Skipping unrecognized attribute:");
+		}
+		else if(key == "color" && child.Size() >= 3)
+		{
+			auto setColor = [&child](ExclusiveItem<Color> &color) noexcept -> void {
+				if(child.Size() >= 4)
+					color = ExclusiveItem<Color>(Color(child.Value(2), child.Value(3), child.Value(4)));
+				else if(child.Size() >= 3)
+					color = ExclusiveItem<Color>(GameData::Colors().Get(child.Token(2)));
+			};
+			const string &value = child.Token(1);
+			if(value == "unavailable")
+				setColor(unavailable);
+			else if(value == "unselected")
+				setColor(unselected);
+			else if(value == "selected")
+				setColor(selected);
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
@@ -376,6 +396,20 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.Write("stealth");
 		if(!isVisible)
 			out.Write("invisible");
+		auto saveColor = [&out](const ExclusiveItem<Color> &color, string tokenName) noexcept -> void {
+			if(!color->IsLoaded())
+				return;
+			if(!color->Name().empty())
+				out.Write("color", tokenName, color->Name());
+			else
+			{
+				const float *rgba = color->Get();
+				out.Write("color", tokenName, rgba[0], rgba[1], rgba[2], rgba[3]);
+			}
+		};
+		saveColor(unavailable, "unavailable");
+		saveColor(unselected, "unselected");
+		saveColor(selected, "selected");
 		if(hasPriority)
 			out.Write("priority");
 		if(isNonBlocking)
@@ -532,6 +566,32 @@ bool Mission::IsVisible() const
 {
 	return isVisible;
 }
+
+
+
+// The colors that should be used to display the mission name if it is shown
+// in your mission list.
+const ExclusiveItem<Color> &Mission::Unavailable() const
+{
+	return unavailable;
+}
+
+
+
+const ExclusiveItem<Color> &Mission::Unselected() const
+{
+	return unselected;
+}
+
+
+
+const ExclusiveItem<Color> &Mission::Selected() const
+{
+	return selected;
+}
+
+
+
 
 
 
@@ -1309,6 +1369,9 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	// If anything goes wrong below, this mission should not be offered.
 	result.hasFailed = true;
 	result.isVisible = isVisible;
+	result.unavailable = unavailable;
+	result.unselected = unselected;
+	result.selected = selected;
 	result.hasPriority = hasPriority;
 	result.isNonBlocking = isNonBlocking;
 	result.isMinor = isMinor;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -15,10 +15,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "Color.h"
 #include "ConditionSet.h"
 #include "Date.h"
 #include "DistanceCalculationSettings.h"
 #include "EsUuid.h"
+#include "ExclusiveItem.h"
 #include "LocationFilter.h"
 #include "MissionAction.h"
 #include "NPC.h"
@@ -74,6 +76,11 @@ public:
 	// Check if this mission should be shown in your mission list. If not, the
 	// player will not know this mission exists (which is sometimes useful).
 	bool IsVisible() const;
+	// The colors that should be used to display the mission name if it is shown
+	// in your mission list.
+	const ExclusiveItem<Color> &Unavailable() const;
+	const ExclusiveItem<Color> &Unselected() const;
+	const ExclusiveItem<Color> &Selected() const;
 	// Check if this mission should be quarantined due to requiring currently-
 	// undefined ships, planets, or systems (i.e. is from an inactive plugin).
 	bool IsValid() const;
@@ -202,6 +209,11 @@ private:
 	std::string description;
 	std::string blocked;
 	Location location = SPACEPORT;
+
+	// Colors that determine how this mission displays in the MissionPanel.
+	ExclusiveItem<Color> unavailable;
+	ExclusiveItem<Color> unselected;
+	ExclusiveItem<Color> selected;
 
 	EsUuid uuid;
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -858,9 +858,31 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos, const std::li
 		if(it->Deadline())
 			SpriteShader::Draw(fast, pos + Point(-4., 8.));
 
+		const Color *color = nullptr;
 		bool canAccept = (&list == &available ? it->CanAccept(player) : IsSatisfied(*it));
-		font.Draw({it->Name(), {SIDE_WIDTH - 11, Truncate::BACK}},
-			pos, (!canAccept ? dim : isSelected ? selected : unselected));
+		if(!canAccept)
+		{
+			if(it->Unavailable()->IsLoaded())
+				color = &*(it->Unavailable());
+			else
+				color = &dim;
+		}
+		else if(isSelected)
+		{
+			if(it->Selected()->IsLoaded())
+				color = &*(it->Selected());
+			else
+				color = &selected;
+		}
+		else
+		{
+			if(it->Unselected()->IsLoaded())
+				color = &*(it->Unselected());
+			else
+				color = &unselected;
+		}
+
+		font.Draw({it->Name(), {SIDE_WIDTH - 11, Truncate::BACK}}, pos, *color);
 	}
 
 	return pos;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -333,8 +333,11 @@ void UniverseObjects::LoadFile(const filesystem::path &path, bool debugMode)
 	{
 		const string &key = node.Token(0);
 		if(key == "color" && node.Size() >= 5)
-			colors.Get(node.Token(1))->Load(
-				node.Value(2), node.Value(3), node.Value(4), node.Size() >= 6 ? node.Value(5) : 1.);
+		{
+			Color *color = colors.Get(node.Token(1));
+			color->Load(node.Value(2), node.Value(3), node.Value(4), node.Size() >= 6 ? node.Value(5) : 1.);
+			color->SetName(node.Token(1));
+		}
 		else if(key == "swizzle" && node.Size() >= 2)
 			swizzles.Get(node.Token(1))->Load(node);
 		else if(key == "conversation" && node.Size() >= 2)


### PR DESCRIPTION
**Feature**

Another feature discussed w.r.t. pirate content.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds a new node to `mission`.
* `color [unavailable | unselected | selected] ["color name" | #r #g #b]`: Modifies the color used to display the name of a mission in the missions panel. Colors can either be provided by name to refer to root-defined colors, or RGB values can be provided directly. There are three possible color categories that can be edited:
  * `unavailable`: You don't have enough space for the mission, or it's a mission you've accepted but can't complete at the moment due to remaining objectives.
  * `unselected`: You don't have the mission selected in the missions list, and it's available.
  * `selected`: You do have the mission selected in the missions list, and it's available.

## Screenshots
```
color "illegal job: selected" .75 .5 .5 0.
color "illegal job: unselected" .5 .25 .25 0.
color "illegal job: unavailable" .25 .125 .125 0.
```
![image](https://github.com/user-attachments/assets/f2c60d04-6e89-49f1-9fe4-597bc03d2929)
```
color "illegal job: selected" .875 .5 .5 0.
color "illegal job: unselected" .75 .25 .25 0.
color "illegal job: unavailable" .625 .125 .125 0.
```
![image](https://github.com/user-attachments/assets/67e3e6b9-b0bc-4c0f-a87d-d11047476c75)


## Testing Done + Usage examples
I updated all the pirate missions to display in red, as seen above: [pirate jobs.txt](https://github.com/user-attachments/files/19815384/pirate.jobs.txt)

## Wiki Update
WIP
