### PR TITLE
Fix(content): Remove a reference to the player feeling creepy in FW Recon 1

### DIFF
--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -372,7 +372,7 @@ mission "FW Recon 1"
 				goto close
 			label equipment
 			`	He looks awfully pleased with himself. "Yes, I suppose a ship like this is sure to turn a few heads. Next time we're on the same planet, stop by my berth and I'd be glad to give you a... private tour." He winks at you.`
-				goto close
+
 			label close
 			`	You cut the commlink and breathe a sigh of relief that the conversation is over.`
 	

--- a/data/human/free worlds 0 prologue.txt
+++ b/data/human/free worlds 0 prologue.txt
@@ -371,7 +371,7 @@ mission "FW Recon 1"
 			`	He pauses, then adds, "They pay me a thousand credits every time I say that."`
 				goto close
 			label equipment
-			`	He looks awfully pleased with himself. "Yes, I suppose a ship like this is sure to turn a few heads. Next time we're on the same planet, stop by my berth and I'd be glad to give you a... private tour." He winks at you. You feel a little bit creepy.`
+			`	He looks awfully pleased with himself. "Yes, I suppose a ship like this is sure to turn a few heads. Next time we're on the same planet, stop by my berth and I'd be glad to give you a... private tour." He winks at you.`
 				goto close
 			label close
 			`	You cut the commlink and breathe a sigh of relief that the conversation is over.`


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue https://github.com/endless-sky/endless-sky/issues/11319

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR removes the line in FW Recon 1 that says that the player "feel[s] a little bit creepy," as per #11319. It also removes the unnecessary `goto` that follows that line.

## Testing Done
None

## Save File
Nope