### PR TITLE
Make Sunday the first day of the week

### DIFF
--- a/source/Date.cpp
+++ b/source/Date.cpp
@@ -362,15 +362,15 @@ int Date::Year() const
 
 
 
-// Get the current day of the week as a number. Monday is 1, Sunday is 7.
+// Get the current day of the week as a number. Sunday is 1, Saturday is 7.
 int Date::WeekdayNumber() const
 {
 	// WeekdayNumberOffset gives values in the range [0, 6], starting from Saturday.
-	// Add 5 to get values in the range [5, 11].
-	// Modulo 7 to get [0, 6]. Monday through Friday moving from [7, 11] to [0, 4].
+	// Add 6 to get values in the range [6, 12].
+	// Modulo 7 to get [0, 6]. Monday through Friday moving from [8, 12] to [1, 5].
 	// Add 1 for [1, 7].
 	int result = WeekdayNumberOffset(Day(), Month(), Year());
-	result += 5;
+	result += 6;
 	result %= 7;
 	result += 1;
 	return result;

--- a/source/Date.h
+++ b/source/Date.h
@@ -62,7 +62,7 @@ public:
 	int Month() const;
 	int Year() const;
 
-	// Get the current day of the week as a number. Monday is 1, Sunday is 7.
+	// Get the current day of the week as a number. Sunday is 1, Saturday is 7.
 	int WeekdayNumber() const;
 
 


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Historically, Sunday has been generally recognized as the first day of the week in many cultures. Relying on ISO isn't the right decision in my opinion, as most people find ancient politics a more neutral topic than modern-day politics.

## Testing Done
Manually verified that the formula is correct.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/132

## Performance Impact
N/A
