### PR TITLE
Search a CategoryList's internal list when retrieving by name instead of maintaining a separate map

### DIFF
--- a/source/CategoryList.cpp
+++ b/source/CategoryList.cpp
@@ -49,11 +49,7 @@ void CategoryList::Load(const DataNode &node)
 		if(it != list.end())
 			it->precedence = cat.precedence;
 		else
-		{
 			list.push_back(cat);
-			byName.insert(pair<const string, Category>(cat.name, cat));
-		}
-
 	}
 }
 
@@ -80,8 +76,9 @@ bool CategoryList::Contains(const string &name) const
 
 const CategoryList::Category CategoryList::GetCategory(const string &name) const
 {
-	auto it = byName.find(name);
-	if(it != byName.end())
-		return it->second;
+	const auto it = find_if(list.begin(), list.end(),
+		[&name](const Category &c) noexcept -> bool { return name == c.name; });
+	if(it != list.end())
+		return *it;
 	return Category("", numeric_limits<int>::max());
 }

--- a/source/CategoryList.h
+++ b/source/CategoryList.h
@@ -16,7 +16,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include <iterator>
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -74,6 +73,5 @@ public:
 
 private:
 	std::vector<Category> list;
-	std::map<const std::string, Category> byName;
 	int currentPrecedence = 0;
 };


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11325
Fixed #11325

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removes the map of category name to category object from CategoryList. Looking back at #7054 when it was added, it seems like it was just kinda tossed in there. Instead of maintaining a separate map of the categories, just search the list of categories using find_if instead.

## Testing Done
Nope.