### PR TITLE
fix(conditions): Prevent copying conditions stores

### DIFF
--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -104,6 +104,11 @@ public:
 	explicit ConditionsStore(std::initializer_list<std::pair<std::string, int64_t>> initialConditions);
 	explicit ConditionsStore(const std::map<std::string, int64_t> &initialConditions);
 
+	ConditionsStore(const ConditionsStore &) = delete;
+	ConditionsStore &operator=(const ConditionsStore &) = delete;
+	ConditionsStore(ConditionsStore &&) = default;
+	ConditionsStore &operator=(ConditionsStore &&) = default;
+
 	// Serialization support for this class.
 	void Load(const DataNode &node);
 	void Save(DataWriter &out) const;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1494,7 +1494,7 @@ void Engine::EnterSystem()
 				&& fleet.CanTrigger(conditions) : false)
 				fleet.Get()->Place(*system, newShips);
 
-		auto CreateWeather = [this, conditions](const RandomEvent<Hazard> &hazard, Point origin)
+		auto CreateWeather = [this, &conditions](const RandomEvent<Hazard> &hazard, Point origin)
 		{
 			if(hazard.Get()->IsValid() && Random::Int(hazard.Period()) < 60 && hazard.CanTrigger(conditions))
 			{
@@ -2064,7 +2064,7 @@ void Engine::SpawnPersons()
 void Engine::GenerateWeather()
 {
 	ConditionsStore &conditions = player.Conditions();
-	auto CreateWeather = [this, conditions](const RandomEvent<Hazard> &hazard, Point origin)
+	auto CreateWeather = [this, &conditions](const RandomEvent<Hazard> &hazard, Point origin)
 	{
 		if(hazard.Get()->IsValid() && !Random::Int(hazard.Period()) && hazard.CanTrigger(conditions))
 		{


### PR DESCRIPTION
**Refactor**

This PR addresses the bug/feature described in issue #11335

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Deletes the copy constructor and copy assignment operator of ConditionsStore to prevent copying objects of that type.
Replaces two places where ConditionsStores are unnecessarily copied (repeatedly) with references.
Explicitly default the move constructor and move assignment operator because PlayerInfo can be moved and needs to move its ConditionsStore.

## Testing Done
Compiles

## Performance Impact
I will be very surprised if this isn't an improvement, but probably minimal, given that we don't actually use the feature that involved copying the object in vanilla.
