### PR TITLE
Allow NPC "on board" conversations to destroy the ship

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -811,7 +811,7 @@ void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, U
 					return it != shipEvents.end() && (it->second & requiredEvents) && !(it->second & excludedEvents);
 				}))
 		{
-			it->second.Do(player, ui, caller);
+			it->second.Do(player, ui, caller, trigger == Trigger::BOARD ? event.Target() : nullptr);
 		}
 	}
 }

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -811,7 +811,7 @@ void NPC::DoActions(const ShipEvent &event, bool newEvent, PlayerInfo &player, U
 					return it != shipEvents.end() && (it->second & requiredEvents) && !(it->second & excludedEvents);
 				}))
 		{
-			it->second.Do(player, ui, caller, trigger == Trigger::BOARD ? event.Target() : nullptr);
+			it->second.Do(player, ui, caller, event.Target());
 		}
 	}
 }

--- a/source/NPCAction.cpp
+++ b/source/NPCAction.cpp
@@ -77,14 +77,14 @@ string NPCAction::Validate() const
 
 
 
-void NPCAction::Do(PlayerInfo &player, UI *ui, const Mission *caller)
+void NPCAction::Do(PlayerInfo &player, UI *ui, const Mission *caller, const shared_ptr<Ship> &target)
 {
 	// All actions are currently one-time-use. Actions that are used
 	// are marked as triggered, and cannot be used again.
 	if(triggered)
 		return;
 	triggered = true;
-	action.Do(player, ui, caller);
+	action.Do(player, ui, caller, nullptr, target);
 }
 
 

--- a/source/NPCAction.h
+++ b/source/NPCAction.h
@@ -45,7 +45,7 @@ public:
 	std::string Validate() const;
 
 	// Perform this action.
-	void Do(PlayerInfo &player, UI *ui = nullptr, const Mission *caller = nullptr);
+	void Do(PlayerInfo &player, UI *ui, const Mission *caller, const std::shared_ptr<Ship> &target);
 
 	// "Instantiate" this action by filling in the wildcard text for the actual
 	// destination, payment, cargo, etc.


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
@beccabunny noticed recently that an NPC "on board" conversation cannot destroy the boarded ship when using the "launch", "flee", or "depart" endpoints (in this context, all three do the same thing because there's nothing to defer or accept here).
This PR makes it so that conversations from an NPC "on board" trigger will be able to destroy the boarded ship with these conversation endpoints. More generally, these conversations will act more similarly to conversations that occur as part of the "on offer" trigger of a "boarding" mission, so will use the boarded ship's name in the "\<ship\>" substitution, for example.

## Usage examples
```
mission "whatever"
    npc
        ship "whoever"
        on board
            conversation
                `However`
                    launch
```

## Testing Done
Not one bit.

## Wiki Update
I don't even know.

## Performance Impact
Immeasurable
