### PR TITLE
Fix "Remnant: Cognizance 24" completing unexpectedly on reloading save

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1525,6 +1525,7 @@ mission "Remnant: Cognizance 34"
 			`	Dusk looks around, and then gestures. "Captain <first>, please go investigate what is going on out there. Just take a good look around and then report back."`
 				accept
 	on enter "Postverta"
+		set "remnant: saw changed postverta"
 		conversation
 			`Just like the Remnant said, the system appears to be full of life. Where once there was just asteroids and a fairly empty system, there is now life signs everywhere. As you dodge among the asteroids, you note that most of them appear to have something growing on them: plants. Moss or fungus might be a better word, although you are fairly certain that nothing in the current classifications of life can adequately categorize what you can see outside. The sudden appearance of all this life is only compounded when your sensors light up to notify you that it is tracking several flocks of void sprites.`
 			`	As you move away from the station you continue to spot signs of life and activity everywhere: flitting among the rocks, soaring along the solar winds, and hunting amongst clouds. What is unclear, however, is where it came from. The only hint might be in the fact that your ship instruments report a sudden spike in the ambient energy in the surrounding area.`

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1514,7 +1514,6 @@ mission "Remnant: Cognizance 34"
 	name "Observe changes in Postverta"
 	description "Something is going on outside, and Dusk would like you to take a look."
 	source "Ssil Vida"
-	waypoint "Postverta"
 	to offer
 		has "Remnant: Cognizance 33: done"
 	on offer

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1530,7 +1530,7 @@ mission "Remnant: Cognizance 34"
 			`	As you move away from the station you continue to spot signs of life and activity everywhere: flitting among the rocks, soaring along the solar winds, and hunting amongst clouds. What is unclear, however, is where it came from. The only hint might be in the fact that your ship instruments report a sudden spike in the ambient energy in the surrounding area.`
 	to complete
 		has "remnant: saw changed postverta"
- 	on complete
+	on complete
 		clear "remnant: saw changed postverta"
 		conversation
 			`Back on the station Dusk, Gavriil, and many of the Remnant on the station meet you in the docking bay. Dusk and several of the others just came back from walking out on the hull of <origin>, and they report seeing void sprites passing close to the station. They quickly pull the data from your ship sensors and throw it up on a holographic display. Everyone gathers around, intently drinking in the data and footage. They stand, stare, and ponder with intense concentration as the data continues to stream in from the station.`

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1529,6 +1529,8 @@ mission "Remnant: Cognizance 34"
 		conversation
 			`Just like the Remnant said, the system appears to be full of life. Where once there was just asteroids and a fairly empty system, there is now life signs everywhere. As you dodge among the asteroids, you note that most of them appear to have something growing on them: plants. Moss or fungus might be a better word, although you are fairly certain that nothing in the current classifications of life can adequately categorize what you can see outside. The sudden appearance of all this life is only compounded when your sensors light up to notify you that it is tracking several flocks of void sprites.`
 			`	As you move away from the station you continue to spot signs of life and activity everywhere: flitting among the rocks, soaring along the solar winds, and hunting amongst clouds. What is unclear, however, is where it came from. The only hint might be in the fact that your ship instruments report a sudden spike in the ambient energy in the surrounding area.`
+	to complete
+		has "remnant: saw changed postverta"
 	on complete
 		conversation
 			`Back on the station Dusk, Gavriil, and many of the Remnant on the station meet you in the docking bay. Dusk and several of the others just came back from walking out on the hull of <origin>, and they report seeing void sprites passing close to the station. They quickly pull the data from your ship sensors and throw it up on a holographic display. Everyone gathers around, intently drinking in the data and footage. They stand, stare, and ponder with intense concentration as the data continues to stream in from the station.`

--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1530,7 +1530,8 @@ mission "Remnant: Cognizance 34"
 			`	As you move away from the station you continue to spot signs of life and activity everywhere: flitting among the rocks, soaring along the solar winds, and hunting amongst clouds. What is unclear, however, is where it came from. The only hint might be in the fact that your ship instruments report a sudden spike in the ambient energy in the surrounding area.`
 	to complete
 		has "remnant: saw changed postverta"
-	on complete
+ 	on complete
+		clear "remnant: saw changed postverta"
 		conversation
 			`Back on the station Dusk, Gavriil, and many of the Remnant on the station meet you in the docking bay. Dusk and several of the others just came back from walking out on the hull of <origin>, and they report seeing void sprites passing close to the station. They quickly pull the data from your ship sensors and throw it up on a holographic display. Everyone gathers around, intently drinking in the data and footage. They stand, stare, and ponder with intense concentration as the data continues to stream in from the station.`
 			`	Without warning, something clicks in your mind. Suddenly there is a hum of hundreds of conversations crowding your thoughts and a momentary feeling of seeing the system through thousands of eyes. You feel a wave of curiosity, and a glimpse of <origin> as it might have been once - shiny and gleaming. The image ages like a fast-forward video of untold thousands of orbits as the station wears and the sky changes around it. Then the image freezes on what appears to be the present day. A feeling of appreciation replaces the sense of curiosity, followed by a blurry image of the <ship> leaving the station and heading in a dozen different directions simultaneously, as if watching it splinter into ghosts.`


### PR DESCRIPTION
**Bug fix**

Thanks to `ubriefnotawalrus` on Discord for reporting this.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This mission ("Remnant: Cognizance 24") is offered from the planet "Ssil Vida", in the "Postverta" system.
It also uses "Postverta" as a waypoint.
A waypoint for the system a mission is offered in is immediately marked as visited (before the mission has actually even been fully instantiated). As a result, this mission doesn't actually require you to take off and enter the system, it is always ready to complete.
This means that loading a save file where this mission was just offered (such as reloading immediately after getting the mission) will immediately complete it, without the player actually seeing the conversation they were supposed to get upon taking off. It also means that the next mission won't be available until after they take off and land again because it cannot be offered until this mission is done and so has not yet been instantiated.
The mission doesn't complete immediately when being offered because missions are all "stepped" before new missions are created and offered, so by the time this mission is being given, no more mission "stepping" will occur without taking off or reloading.

This PR sets a condition in the "on enter Postverta" trigger of this mission and then requires that condition in order to complete.

Also, removed the "waypoint" from the mission because it's not actually doing anything.

## Testing Done
Use the attached save file.
1. Take off from Fertriary.
2. Land on Ssil Vida.
3. Proceed through the conversations for completing "Remnant: Cognizance 23" and then being offered "Remnant: Cognizance 24".
4. Reload the save file.

Without this PR, the "on complete" conversation from "Remnant: Cognizance 24" is presented, inappropriately because we haven't yet taken off. The next mission will also not be offered until you take off and land again.
With this PR, nothing happens. The mission is still active. You still have to take off, see the "on enter" conversation, then land again.

## Save File
This save file can be used to test these changes:
[warpest core~3027-12-22.txt](https://github.com/user-attachments/files/19817794/warpest.core.3027-12-22.txt)
