### PR TITLE
Move the flagship autoconditions test out of the Ember Waste

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_attribute_autoconditions.txt
@@ -16,8 +16,8 @@ test-data "Flagship Attribute Autoconditions Save"
 	contents
 		pilot Bobbi Bughunter
 		date 11 7 3014
-		system Pantica
-		planet Aventine
+		system Sol
+		planet Earth
 		clearance
 		# What you own:
 		ship Peregrine
@@ -111,8 +111,8 @@ test-data "Flagship Attribute Autoconditions Save"
 			explode "small explosion" 25
 			explode "tiny explosion" 10
 			"final explode" "final explosion medium" 1
-			system Pantica
-			planet Aventine
+			system Sol
+			planet Earth
 		cargo
 			outfits
 				"Heavy Laser" 1
@@ -120,8 +120,8 @@ test-data "Flagship Attribute Autoconditions Save"
 			credits 131000
 			score 400
 			history
-		visited Pantica
-		"visited planet" Aventine
+		visited Sol
+		"visited planet" Earth
 
 
 test "Flagship Attribute Autoconditions"
@@ -178,12 +178,12 @@ test "Flagship Attribute Autoconditions"
 			"flagship fuel" == 1100
 			"flagship mass" - 15 == "flagship attribute: mass" / 1000
 		navigate
-			travel Arculus
+			travel Vega
 		input
 			command jump
-		label "not arculus"
-		branch "not arculus"
-			not "flagship system: Arculus"
+		label "not vega"
+		branch "not vega"
+			not "flagship system: Vega"
 		assert
 			"flagship fuel" == 900
 


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug described in the comments of #11321

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The flagship attributes autocondition test had the flagship located in the Ember Waste. One of the things this test did was read the autocondition for the flagship's shields. Since the Ember Waste contains ion storms that can damage your ship's shields, the assert on the shields condition could fail if an ion storm was active when the check occurred,

I've moved this test to instead launch from Earth.

## Testing Done
It tests itself.
