### PR TITLE
fix(audio): Place sounds in front of the listener

### DIFF
--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -650,10 +650,10 @@ namespace {
 	void Source::Move(const QueueEntry &entry) const
 	{
 		Point angle = entry.sum / entry.weight;
-		// The source should be along the vector (angle.X(), angle.Y(), 1).
+		// The source should be along the vector (angle.X(), angle.Y(), -1).
 		// The length of the vector should be sqrt(1 / weight).
 		double scale = sqrt(1. / (entry.weight * (angle.LengthSquared() + 1.)));
-		alSource3f(source, AL_POSITION, angle.X() * scale, angle.Y() * scale, scale);
+		alSource3f(source, AL_POSITION, angle.X() * scale, angle.Y() * scale, -scale);
 	}
 
 


### PR DESCRIPTION
**Bug fix**


## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

With a stereo layout, I don't think this will change anything. With a quad (or other surround sound) layout, this moves sounds from the rear speakers to the front speakers.

https://github.com/kcat/openal-soft/blob/2175689979558a64e21e2285904db4175e5ab5a2/include/AL/al.h#L163-L177
> Z points towards the viewer/camera (middle finger)

This can be tested without a real surround sound system by creating an [alsoft config
file](https://github.com/kcat/openal-soft/blob/master/alsoftrc.sample) like this:

```ini
[general]
drivers = wave
channels = quad
[wave]
file = /path/to/file.wav
```

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
I played briefly with a quad speaker layout.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A, I think?

## Performance Impact
N/A, I think?
