### PR TITLE
Cache the "danger" value for each system

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -564,6 +564,9 @@ void System::UpdateSystem(const Set<System> &systems, const set<double> &neighbo
 		minimumFleetPeriod = min<int>(minimumFleetPeriod, event.Period());
 	if(minimumFleetPeriod == numeric_limits<int>::max())
 		minimumFleetPeriod = 0;
+
+	// Recalculate the system's danger value.
+	RecalcDanger();
 }
 
 
@@ -1023,14 +1026,24 @@ const vector<RandomEvent<Hazard>> &System::Hazards() const
 // in per frame).
 double System::Danger() const
 {
-	double danger = 0.;
+	return danger;
+}
+
+
+
+// Recalculate the expected danger of the system (for use on load and when
+// data values change).
+void System::RecalcDanger()
+{
+	double newDanger = 0.;
 	for(const auto &fleet : fleets)
 	{
 		auto *gov = fleet.Get()->GetGovernment();
 		if(gov && gov->IsEnemy())
-			danger += static_cast<double>(fleet.Get()->Strength()) / fleet.Period();
+			newDanger += static_cast<double>(fleet.Get()->Strength()) / fleet.Period();
 	}
-	return danger;
+
+	danger = newDanger;
 }
 
 

--- a/source/System.h
+++ b/source/System.h
@@ -177,6 +177,8 @@ public:
 	// Check how dangerous this system is (credits worth of enemy ships jumping
 	// in per frame).
 	double Danger() const;
+	// Recalculate the danger value of the system (in case an event changes its fleets).
+	void RecalcDanger();
 
 	// The smallest arrival period of a fleet (or 0 if no fleets arrive)
 	int MinimumFleetPeriod() const;
@@ -275,6 +277,9 @@ private:
 	// The minimum distances from the system center to jump out of the system.
 	double jumpDepartureDistance = 0.;
 	double hyperDepartureDistance = 0.;
+
+	// The cached danger value for the system.
+	double danger = 0;
 
 	// Commodity prices.
 	std::map<std::string, Price> trade;


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR takes the existing `System::Danger()` method and caches its result, rather than having to calculate it on the fly every time. This is called by the code that calculates routes, which is called multiple times per frame, so while the calculation may not be super-expensive each time, cacheing it is a nice low-hanging fruit to slightly improve performance. 

The calculation itself is moved to a `RecalcDanger()` method, which is called within `UpdateSystem()`. That will ensure that any time the system data changes (for instance, to edit its fleets or its government), the danger value is also updated.

## Testing Done
Ran the game with the change, played for a while; everything acted normal so far as I could tell.

## Performance Impact
While the change should not be detectable in any circumstances I'm aware of, this should marginally improve performance.