### PR TITLE
feat(content): Readjust Pirate Variant stats for more uniqeness

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -826,10 +826,10 @@ ship "Bulwark"
 		"engine capacity" 120
 		"threshold percentage" .08
 		weapon
-			"blast radius" 120
-			"shield damage" 1200
-			"hull damage" 600
-			"hit force" 1800
+			"blast radius" 145
+			"shield damage" 1450
+			"hull damage" 725
+			"hit force" 2175
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
@@ -860,14 +860,13 @@ ship "Bulwark"
 	turret -35.5 29.5 "Quad Blaster Turret"
 	turret 35.5 29.5 "Quad Blaster Turret"
 	leak "leak" 40 50
-	leak "flame" 40 80
-	leak "big leak" 70 30
-	explode "tiny explosion" 5
+	leak "flame" 50 80
+	leak "big leak" 70 40
 	explode "small explosion" 15
-	explode "medium explosion" 30
+	explode "medium explosion" 40
 	explode "large explosion" 20
 	"final explode" "final explosion medium"
-	description `The Bulwark is basically what you get by welding a bunch of scrap metal on to a Bastion. It is a tough, slow brawler that is most often used by warlords to protect their properties, whether it'd be their ships or hideouts from raids by either the authorities or their rivals. Due to their lack of speed and cargo space these ships rarely participate in raiding merchant convoys outside their home system.`
+#	description `The Bulwark is basically what you get by welding a bunch of scrap metal on to a Bastion. It is a tough, slow brawler that is most often used by warlords to protect their properties, whether it'd be their ships or hideouts from raids by either the authorities or their rivals. Due to their lack of speed and cargo space these ships rarely participate in raiding merchant convoys outside their home system.`
 
 
 
@@ -1363,33 +1362,30 @@ ship "Cutthroat"
 	attributes
 		category "Light Warship"
 		"cost" 1100000
-		"shields" 2800
-		"hull" 600
-		"required crew" 4
-		"bunks" 6
-		"mass" 252
+		"shields" 3000
+		"hull" 1000
+		"required crew" 3
+		"bunks" 5
+		"mass" 202
 		"drag" 3.9
 		"heat dissipation" .7
-		"fuel capacity" 500
-		"cargo space" 27
-		"outfit space" 282
-		"weapon capacity" 60
+		"fuel capacity" 800
+		"cargo space" 82
+		"outfit space" 255
+		"weapon capacity" 32
 		"engine capacity" 111
-		weapon
-			"blast radius" 36
-			"shield damage" 360
-			"hull damage" 180
-			"hit force" 540
+#		weapon
+			"blast radius" 40
+			"shield damage" 400
+			"hull damage" 200
+			"hit force" 600
 	outfits
-		"Twin Modified Blaster" 2
-		"Torpedo Pod" 2
-		"Torpedo Storage Rack"
-		"Torpedo" 21
+		"Gatling Gun" 4
+		"Gatling Gun Ammo" 12000
 		
-		"Fission Reactor"
+		"S3 Thermionic"
 		"LP036a Battery Pack"
-		"Water Coolant System"
-		"D23-QP Shield Generator"
+		"D41-HY Shield Generator"
 		"Laser Rifle" 5
 		
 		"A370 Atomic Thruster"
@@ -1405,13 +1401,13 @@ ship "Cutthroat"
 	gun 21.5 -18 "Torpedo Pod"
 	gun -11 -8.5 "Twin Modified Blaster"
 	gun 11 -8.5 "Twin Modified Blaster"
-	leak "leak" 60 50
-	leak "flame" 50 80
-	explode "tiny explosion" 15
-	explode "small explosion" 20
+	leak "leak" 70 50
+	leak "flame" 60 80
+	explode "tiny explosion" 10
+	explode "small explosion" 25
 	explode "medium explosion" 10
 	"final explode" "final explosion small"
-	description `Pirates call this heavily modified Clipper the "Cutthroat." With an extra pair of engine pods bolted on for the sole purpose of maximizing speed, it can catch or outrun all but the most fine-tuned ships in the sky.`
+#	description `Cutthroat.`
 
 
 
@@ -2581,10 +2577,10 @@ ship "Mammoth"
 		"engine capacity" 114
 		"scan interference" 2
 		weapon
-			"blast radius" 140
-			"shield damage" 1400
-			"hull damage" 780
-			"hit force" 2100
+			"blast radius" 136
+			"shield damage" 1360
+			"hull damage" 680
+			"hit force" 2040
 	outfits
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 90
@@ -2622,12 +2618,12 @@ ship "Mammoth"
 	turret 47.5 33.5 "Proton Turret"
 	turret -22 66.5 "Anti-Missile Turret"
 	turret 22 66.5 "Anti-Missile Turret"
-	leak "leak" 30 50
-	leak "flame" 30 80
+	leak "leak" 40 50
+	leak "flame" 40 80
 	leak "big leak" 50 30
 	explode "small explosion" 15
-	explode "medium explosion" 25
-	explode "large explosion" 35
+	explode "medium explosion" 20
+	explode "large explosion" 40
 	explode "huge explosion" 20
 	"final explode" "final explosion large"
 	description "This is a rare, extensively modified Behemoth used by some pirates and smugglers to transport large amounts of goods. It is armed well enough to handle even a Navy Frigate if caught and fast enough to dash away from anything bigger."
@@ -2921,36 +2917,37 @@ ship "Nighthawk"
 	thumbnail "thumbnail/pirate nighthawk"
 	attributes
 		category "Transport"
-		"cost" 2530000
+		"cost" 2630000
 		"shields" 4000
 		"hull" 1100
-		"required crew" 4
-		"bunks" 28
-		"mass" 424
+		"required crew" 6
+		"bunks" 39
+		"mass" 400
 		"drag" 6.5
 		"heat dissipation" .52
 		"fuel capacity" 700
 		"cargo space" 16
-		"outfit space" 362
-		"weapon capacity" 102
+		"outfit space" 340
+		"weapon capacity" 72
 		"engine capacity" 123
+		"outfit scan opacity" 200
 		weapon
-			"blast radius" 60
-			"shield damage" 600
-			"hull damage" 300
-			"hit force" 900
+			"blast radius" 51
+			"shield damage" 510
+			"hull damage" 255
+			"hit force" 765
 	outfits
-		"Quad Blaster Turret" 2
-		"Heavy Anti-Missile Turret"
+		"Quad Blaster Turret"
+		"Anti-Missile Turret" 2
 		
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Array" 3
 		"LP072a Battery Pack"
 		"D23-QP Shield Generator"
 		"Large Radar Jammer"
-		"Tactical Scanner"
 		"Laser Rifle" 24
 		"Nerve Gas" 10
+		"Brig" 1
 		
 		"Impala Plasma Thruster"
 		"Impala Plasma Steering"
@@ -2960,17 +2957,17 @@ ship "Nighthawk"
 	engine 42.5 63 .8
 	engine -24 68 .6
 	engine 24 68 .6
-	turret 0 -6 "Heavy Anti-Missile Turret"
-	turret -26 15 "Quad Blaster Turret"
-	turret 26 15 "Quad Blaster Turret"
-	leak "leak" 50 50
+	turret 0 -6 "Quad Blaster Turret"
+	turret -26 15 "Anti-Missile Turret"
+	turret 26 15 "Anti-Missile Turret"
+	leak "leak" 40 50
 	leak "flame" 70 80
-	explode "tiny explosion" 15
-	explode "small explosion" 34
-	explode "medium explosion" 18
+	explode "tiny explosion" 20
+	explode "small explosion" 30
+	explode "medium explosion" 15
 	explode "large explosion" 2
 	"final explode" "final explosion small"
-	description "This is a modified Blackbird for ground raids and slave trading. It comes with an extra turret mount for suppressive fire on ground operations and additional hull reinforcement to resist returning fire."
+	description "Nighthawk."
 
 
 
@@ -3919,20 +3916,20 @@ ship "Valkyrie"
 		"shields" 4800
 		"hull" 2800
 		"required crew" 9
-		"bunks" 26
+		"bunks" 19
 		"mass" 436
 		"drag" 7.4
 		"heat dissipation" .42
 		"fuel capacity" 500
-		"cargo space" 41
+		"cargo space" 81
 		"outfit space" 400
-		"weapon capacity" 170
-		"engine capacity" 76
+		"weapon capacity" 180
+		"engine capacity" 105
 		weapon
-			"blast radius" 80
-			"shield damage" 800
-			"hull damage" 400
-			"hit force" 1200
+			"blast radius" 76
+			"shield damage" 760
+			"hull damage" 380
+			"hit force" 1140
 	outfits
 		"Quad Blaster Turret" 2
 		"Particle Cannon" 2
@@ -3947,8 +3944,8 @@ ship "Valkyrie"
 		"Laser Rifle" 18
 		"Nerve Gas" 3
 		
-		"Greyhound Plasma Thruster"
-		"Greyhound Plasma Steering"
+		"X3700 Ion Thruster"
+		"X3200 Ion Steering"
 		"Hyperdrive"
 		
 	engine 15 97
@@ -3969,7 +3966,7 @@ ship "Valkyrie"
 	explode "medium explosion" 25
 	explode "large explosion" 10
 	"final explode" "final explosion medium"
-	description "Valkyries are pirate Aeries converted into more of a standalone warship than a support carrier. Losing a turret and a few bunks in place of increased armor protection, as well as boasting two more gun mounts, allows Valkyries to both take and put out noticeable amounts of damage. However, due to the extra weight, they are somewhat slower and lose a bit of shield efficiency."
+#	description "Valkyries are pirate Aeries converted into more of a standalone warship than a support carrier. Losing a turret and a few bunks in place of increased armor protection, as well as boasting two more gun mounts, allows Valkyries to both take and put out noticeable amounts of damage. However, due to the extra weight, they are somewhat slower and lose a bit of shield efficiency."
 
 
 


### PR DESCRIPTION
**Balance**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The pirate variant ships in the files still are planned to be used rarely amongst pirate spaces in future expanded content. However, their current stats are a bit bland, being essentially slightly worse Marauder ships overall. Some of them seem appropriate, but others could have more unique roles. This PR revisits those ships and helps give them a bit more of an identity for their future use.

* Bulwark - No changes were deemed necessary. It serves as a beefier Bastion for defense, but is weaker in other aspects such as speed. More of a "fortress" or "system defender" than a MW that can multi-role.
* Cutthroat - Previously, this was a hit-and-run beefed-up version of the Clipper. Now, it's more of a blockade runner to get supplies quickly through hostiles and defenses, with decently more health and speed and utility, but at the cost of weapon capability.
* Mammoth - No changes were deemed necessary, as although it's a capable large ship, it's meant to be very rare. It will likely be a sort of exception to the "area-specific" role and be more of a smuggler to each area in a sense.
* Nighthawk - Was meant to be a sort of "slave runner" or transport. It has been shifted away from its "bunk" role as a Blackhawk and leans more into cargo transportation, with a bit more apparent weaknesses elsewhere and more appropriate internals.
* Valkyrie - No changes have been made, however the ship's existence is somewhat questioned as the North don't need another warship or new ship when they have plenty in what already exists + possibly the upcoming (old) Monitor. However, perhaps it could still be used as a boss ship or something.

Explosions have also been updated (they were using defaults of the basic ships).

### Future Implementation

***This PR only changes the stats - implementation will come in a future PR. These variants are still planned to be rare and not a common spawn, or might even be reserved for a few mission pilots, depending. They will generally be used in certain areas of the map, and not be spread across all of human space.

## Save File
This save file can be used to test these changes:
If a save is needed to test the balance I can procure one.

