### PR TITLE
feat(ui): Resize dialogs dynamically

### DIFF
--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -170,9 +170,53 @@ void Dialog::Draw()
 	const Sprite *bottom = SpriteSet::Get(isWide ? "ui/dialog bottom wide" : "ui/dialog bottom");
 	const Sprite *cancel = SpriteSet::Get("ui/dialog cancel");
 
-	// Get the position of the top of this dialog, and of the input.
-	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5);
-	Point inputPos = Point(0., -(cancel->Height() + INPUT_HEIGHT)) - pos;
+	// If the dialog is too tall, then switch to wide mode.
+	Point textRectSize(Width() - HORIZONTAL_PADDING, 0);
+	int maxHeight = Screen::Height() * 3 / 4;
+	if(text->GetTextHeight(false) > maxHeight)
+	{
+		textRectSize.Y() = maxHeight;
+		isWide = true;
+		// Re-wrap with the new width.
+		textRectSize.X() = Width() - HORIZONTAL_PADDING;
+		text->SetRect(Rectangle(Point{}, textRectSize));
+
+		if(text->GetLongestLineWidth() <= top->Width() - HORIZONTAL_MARGIN - HORIZONTAL_PADDING)
+		{
+			// Formatted text is long and skinny (e.g. scan result dialog). Go back
+			// to using the default width, since the wide width doesn't help.
+			isWide = false;
+			textRectSize.X() = Width() - HORIZONTAL_PADDING;
+			text->SetRect(Rectangle(Point{}, textRectSize));
+		}
+	}
+	else
+		textRectSize.Y() = text->GetTextHeight(false);
+
+	// The height of the bottom sprite without the included button's height.
+	const int realBottomHeight = bottom->Height() - cancel->Height();
+
+	int height = TOP_PADDING + textRectSize.Y() + BOTTOM_PADDING +
+			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
+	// Determine how many extension panels we need.
+	if(height <= realBottomHeight + top->Height())
+		extensionCount = 0;
+	else
+		extensionCount = (height - middle->Height()) / middle->Height();
+
+	// Now that we know how big we want to render the text, position the text area.
+
+	// Get the position of the top of this dialog.
+	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5f);
+	// Resize textRectSize to match the visual height of the dialog, which will
+	// be rounded up from the actual text height by the number of panels that
+	// were added. This helps correctly position the TextArea scroll buttons.
+	textRectSize.Y() = (top->Height() + realBottomHeight - VERTICAL_PADDING) + extensionCount * middle->Height() -
+			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
+
+	Point textPos(Width() * -.5 + LEFT_PADDING, pos.Y() + VERTICAL_PADDING);
+	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
+	text->SetRect(textRect);
 
 	// Draw the top section of the dialog box.
 	pos.Y() += top->Height() * .5;
@@ -216,6 +260,7 @@ void Dialog::Draw()
 	}
 
 	// Draw the input, if any.
+	Point inputPos = Point(0., -(cancel->Height() + INPUT_HEIGHT)) - pos;
 	if(!isMission && (intFun || stringFun))
 	{
 		FillShader::Fill(inputPos, Point(Width() - HORIZONTAL_PADDING, INPUT_HEIGHT), back);
@@ -385,59 +430,6 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	text->SetTruncate(truncate);
 	text->SetText(message);
 	AddChild(text);
-
-	const Sprite *top = SpriteSet::Get("ui/dialog top");
-	// If the dialog is too tall, then switch to wide mode.
-	int maxHeight = Screen::Height() * 3 / 4;
-	if(text->GetTextHeight(false) > maxHeight)
-	{
-		textRectSize.Y() = maxHeight;
-		isWide = true;
-		// Re-wrap with the new width
-		textRectSize.X() = Width() - HORIZONTAL_PADDING;
-		text->SetRect(Rectangle(Point{}, textRectSize));
-
-		if(text->GetLongestLineWidth() <= top->Width() - HORIZONTAL_MARGIN - HORIZONTAL_PADDING)
-		{
-			// Formatted text is long and skinny (e.g. scan result dialog). Go back
-			// to using the default width, since the wide width doesn't help.
-			isWide = false;
-			textRectSize.X() = Width() - HORIZONTAL_PADDING;
-			text->SetRect(Rectangle(Point{}, textRectSize));
-		}
-	}
-	else
-		textRectSize.Y() = text->GetTextHeight(false);
-
-	top = SpriteSet::Get(isWide ? "ui/dialog top wide" : "ui/dialog top");
-	const Sprite *middle = SpriteSet::Get(isWide ? "ui/dialog middle wide" : "ui/dialog middle");
-	const Sprite *bottom = SpriteSet::Get(isWide ? "ui/dialog bottom wide" : "ui/dialog bottom");
-	const Sprite *cancel = SpriteSet::Get("ui/dialog cancel");
-	// The height of the bottom sprite without the included button's height.
-	const int realBottomHeight = bottom->Height() - cancel->Height();
-
-	int height = TOP_PADDING + textRectSize.Y() + BOTTOM_PADDING +
-			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
-	// Determine how many extension panels we need.
-	if(height <= realBottomHeight + top->Height())
-		extensionCount = 0;
-	else
-		extensionCount = (height - middle->Height()) / middle->Height();
-
-	// Now that we know how big we want to render the text, position the text
-	// area and add it to the UI.
-
-	// Get the position of the top of this dialog, and of the text and input.
-	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5f);
-	Point textPos(Width() * -.5 + LEFT_PADDING, pos.Y() + VERTICAL_PADDING);
-	// Resize textRectSize to match the visual height of the dialog, which will
-	// be rounded up from the actual text height by the number of panels that
-	// were added. This helps correctly position the TextArea scroll buttons.
-	textRectSize.Y() = (top->Height() + realBottomHeight - VERTICAL_PADDING) + extensionCount * middle->Height() -
-			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
-
-	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
-	text->SetRect(textRect);
 }
 
 

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -206,8 +206,9 @@ void Dialog::Draw()
 
 	// Now that we know how big we want to render the text, position the text area.
 
-	// Get the position of the top of this dialog.
+	// Get the position of the top of this dialog, and of the input.
 	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5f);
+	Point inputPos = Point(0., -(cancel->Height() + INPUT_HEIGHT)) - pos;
 	// Resize textRectSize to match the visual height of the dialog, which will
 	// be rounded up from the actual text height by the number of panels that
 	// were added. This helps correctly position the TextArea scroll buttons.
@@ -260,7 +261,6 @@ void Dialog::Draw()
 	}
 
 	// Draw the input, if any.
-	Point inputPos = Point(0., -(cancel->Height() + INPUT_HEIGHT)) - pos;
 	if(!isMission && (intFun || stringFun))
 	{
 		FillShader::Fill(inputPos, Point(Width() - HORIZONTAL_PADDING, INPUT_HEIGHT), back);


### PR DESCRIPTION
**Feature**/**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Since https://github.com/endless-sky/endless-sky/commit/f4f787b5c9b3717f9c983c75b437f6988805b620, the height of `TextArea`s can change after the initialization, which can cause unwanted offset if not handled properly, so we need to move the dialog resizing code from `Init` to `Draw`.

As a side effect, this also makes dialogs change their form (adding or removing scroll bars, or switching between the normal and double width) if the game window is resized.

## Screenshots
Before:
![a](https://github.com/user-attachments/assets/72ff4ba2-5f17-4dab-8b1e-4becd99a0aa3)

After:
![b](https://github.com/user-attachments/assets/5778a084-6013-4931-a15c-0c19df65cb17)

## Testing Done
Tested with the snapshot dialog above to make sure everything is being positioned properly, and a scan results dialog to check window resizing.

## Wiki Update
N/A

## Performance Impact
In theory considerable, but nothing else really happens in Dialog, so not really important.
