### PR TITLE
style(code): Remove incorrect comments

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -264,12 +264,8 @@ void GameWindow::Quit()
 	SDL_ShowCursor(true);
 
 	// Clean up in the reverse order that everything is launched.
-//#ifndef _WIN32
-	// Under windows, this cleanup code causes intermittent crashes.
 	if(context)
 		SDL_GL_DeleteContext(context);
-//#endif
-
 	if(mainWindow)
 		SDL_DestroyWindow(mainWindow);
 


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
We don't get any reports that the Windows version of the game crashes at exit, so the comment is incorrect. And I don't think we allow commented-out code just for archival purposes, that's what git blame is for.

## Testing Done
0