### PR TITLE
feat(enhancement): Generalize font shader

### DIFF
--- a/shaders/font.vert
+++ b/shaders/font.vert
@@ -21,6 +21,8 @@ uniform vec2 position;
 uniform int glyph;
 // Aspect ratio of rendered glyph (unity by default).
 uniform float aspect;
+// Glyph size (in pixels).
+uniform vec2 glyphSize;
 
 // Inputs from the VBO.
 in vec2 vert;
@@ -32,5 +34,6 @@ out vec2 texCoord;
 // Pick the proper glyph out of the texture.
 void main() {
 	texCoord = vec2((float(glyph) + corner.x) / 98.f, corner.y);
-	gl_Position = vec4((aspect * vert.x + position.x) * scale.x, (vert.y + position.y) * scale.y, 0.f, 1.f);
+	vec2 pos = vert * glyphSize;
+	gl_Position = vec4((aspect * pos.x + position.x) * scale.x, (pos.y + position.y) * scale.y, 0.f, 1.f);
 }

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -311,12 +311,13 @@ void Font::SetUpShader(float glyphW, float glyphH)
 	glyphHeight = glyphH * .5f;
 
 	shader = GameData::Shaders().Get("font");
-	glUseProgram(shader->Object());
-	glUniform1i(shader->Uniform("tex"), 0);
-	glUseProgram(0);
 	// Initialize the shared parameters only once
 	if(!vao)
 	{
+		glUseProgram(shader->Object());
+		glUniform1i(shader->Uniform("tex"), 0);
+		glUseProgram(0);
+
 		// Create the VAO and VBO.
 		glGenVertexArrays(1, &vao);
 		glBindVertexArray(vao);

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -40,6 +40,13 @@ namespace {
 	/// Shared VAO and VBO quad (0,0) -> (1,1)
 	GLuint vao = 0;
 	GLuint vbo = 0;
+
+	GLint colorI = 0;
+	GLint scaleI = 0;
+	GLint glyphSizeI = 0;
+	GLint glyphI = 0;
+	GLint aspectI = 0;
+	GLint positionI = 0;
 }
 
 
@@ -336,18 +343,18 @@ void Font::SetUpShader(float glyphW, float glyphH)
 
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 		glBindVertexArray(0);
+
+		colorI = shader->Uniform("color");
+		scaleI = shader->Uniform("scale");
+		glyphSizeI = shader->Uniform("glyphSize");
+		glyphI = shader->Uniform("glyph");
+		aspectI = shader->Uniform("aspect");
+		positionI = shader->Uniform("position");
 	}
 
 	// We must update the screen size next time we draw.
 	screenWidth = 0;
 	screenHeight = 0;
-
-	colorI = shader->Uniform("color");
-	scaleI = shader->Uniform("scale");
-	glyphSizeI = shader->Uniform("glyphSize");
-	glyphI = shader->Uniform("glyph");
-	aspectI = shader->Uniform("aspect");
-	positionI = shader->Uniform("position");
 }
 
 

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -36,12 +36,11 @@ using namespace std;
 namespace {
 	bool showUnderlines = false;
 	const int KERN = 2;
+
+	/// Shared VAO and VBO quad (0,0) -> (1,1)
+	GLuint vao = 0;
+	GLuint vbo = 0;
 }
-
-
-
-GLuint Font::vao = 0;
-GLuint Font::vbo = 0;
 
 
 

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -73,11 +73,6 @@ private:
 	std::string TruncateMiddle(const std::string &str, int &width) const;
 
 private:
-	/// Shared VAO and VBO quad (0,0) -> (1,1)
-	static GLuint vao;
-	static GLuint vbo;
-
-private:
 	const Shader *shader;
 	GLuint texture = 0;
 

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -76,13 +76,6 @@ private:
 	const Shader *shader;
 	GLuint texture = 0;
 
-	GLint colorI = 0;
-	GLint scaleI = 0;
-	GLint glyphSizeI = 0;
-	GLint glyphI = 0;
-	GLint aspectI = 0;
-	GLint positionI = 0;
-
 	int height = 0;
 	int space = 0;
 	mutable int screenWidth = 0;

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -72,15 +72,18 @@ private:
 	std::string TruncateFront(const std::string &str, int &width) const;
 	std::string TruncateMiddle(const std::string &str, int &width) const;
 
+private:
+	/// Shared VAO and VBO quad (0,0) -> (1,1)
+	static GLuint vao;
+	static GLuint vbo;
 
 private:
 	const Shader *shader;
 	GLuint texture = 0;
-	GLuint vao = 0;
-	GLuint vbo = 0;
 
 	GLint colorI = 0;
 	GLint scaleI = 0;
+	GLint glyphSizeI = 0;
 	GLint glyphI = 0;
 	GLint aspectI = 0;
 	GLint positionI = 0;
@@ -89,6 +92,9 @@ private:
 	int space = 0;
 	mutable int screenWidth = 0;
 	mutable int screenHeight = 0;
+	mutable GLfloat scale[2]{0.0f, 0.0f};
+	GLfloat glyphWidth = 0.f;
+	GLfloat glyphHeight = 0.f;
 
 	static const int GLYPHS = 98;
 	int advance[GLYPHS * GLYPHS] = {};

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -72,6 +72,7 @@ private:
 	std::string TruncateFront(const std::string &str, int &width) const;
 	std::string TruncateMiddle(const std::string &str, int &width) const;
 
+
 private:
 	const Shader *shader;
 	GLuint texture = 0;
@@ -80,7 +81,7 @@ private:
 	int space = 0;
 	mutable int screenWidth = 0;
 	mutable int screenHeight = 0;
-	mutable GLfloat scale[2]{0.0f, 0.0f};
+	mutable GLfloat scale[2]{0.f, 0.f};
 	GLfloat glyphWidth = 0.f;
 	GLfloat glyphHeight = 0.f;
 


### PR DESCRIPTION
**Feature**

This PR fixes #11364

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Previously, every font size required a different shader, as the glyph sizes were baked into the VBO. I moved the glyph size into a parameter, so now we can reuse the same shader with multiple font sizes.

This also fixes a bug where the scale would not be properly reset between calls to the font shader.

## Testing Done
I tested that the bug can no longer be reproduced.

## Performance Impact
We pass two more uniforms to the shader and do an extra multiplication, but that shouldn't be a problem.