### PR TITLE
feat(content): New descriptions for Remnant and Wanderer Licenses

### DIFF
--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -983,4 +983,4 @@ outfit "Remnant Capital License"
 	series "Licenses"
 	index 03020
 	thumbnail "outfit/remnant capital license"
-	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum, the frequency of which can carry over vast distances while on a planet, allowing captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid, should they ever become stranded."
+	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum, the frequency of which can carry over vast distances while on a planet, allowing captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid should they ever become stranded."

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -976,11 +976,11 @@ outfit "Remnant License"
 	series "Licenses"
 	index 03010
 	thumbnail "outfit/remnant license"
-	description "In addition to serving as a handy IFF verification and personal identification tool, this object consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beautiful blend of classical music tracks."
+	description "In addition to serving as a handy IFF verification and personal identification tool, this device consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beautiful blend of classical music tracks."
 
 outfit "Remnant Capital License"
 	category "Licenses"
 	series "Licenses"
 	index 03020
 	thumbnail "outfit/remnant capital license"
-	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum, the frequency of which can carry over vast distances while on a planet, allowing captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid should they ever become stranded."
+	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum, the frequency of which can carry over vast distances while on a planet. This humming allows captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid should they ever become stranded."

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -976,7 +976,7 @@ outfit "Remnant License"
 	series "Licenses"
 	index 03010
 	thumbnail "outfit/remnant license"
-	description "Not too dissimilar from a Rubik's cube, this object consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beautiful blend of classical music tracks."
+	description "In addition to serving as a handy IFF verification and personal identification tool, this object consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beautiful blend of classical music tracks."
 
 outfit "Remnant Capital License"
 	category "Licenses"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -983,4 +983,4 @@ outfit "Remnant Capital License"
 	series "Licenses"
 	index 03020
 	thumbnail "outfit/remnant capital license"
-	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum, the frequency of which can carry over vast distances while on a planet. This humming allows captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid should they ever become stranded."
+	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum which can carry over vast distances on a planet. This humming allows captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid should they ever become stranded."

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -976,7 +976,7 @@ outfit "Remnant License"
 	series "Licenses"
 	index 03010
 	thumbnail "outfit/remnant license"
-	description "In addition to serving as a handy IFF verification and personal identification tool, this device consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beautiful blend of classical music tracks."
+	description "In addition to serving as a handy IFF verifier, personal identification tool, and license to purchase Remnant technology, this device features movable parts that mechanically click with every adjustment. When the pieces are switched in a specific order and rhythm, the series of clicks produce a surprisingly beautiful blend of classical music tracks."
 
 outfit "Remnant Capital License"
 	category "Licenses"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -976,11 +976,11 @@ outfit "Remnant License"
 	series "Licenses"
 	index 03010
 	thumbnail "outfit/remnant license"
-	description "The prefects have reached a consensus that you should be considered a valuable friend of the Remnant, and shall be given permission to purchase their ships and technology."
+	description "Not too dissimilar from a Rubik's cube, this object consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beatiful blend of classical music tracks."
 
 outfit "Remnant Capital License"
 	category "Licenses"
 	series "Licenses"
 	index 03020
 	thumbnail "outfit/remnant capital license"
-	description "The prefects have decided that you should be trusted with their largest ships, and the valuable resources that go into making them."
+	description "While seemingly innocuous at first, this device shows the brilliant simplicity of Remnant engineering. Tapping either edge produces a brief, faint hum, the frequency of which can carry over vast distances while on a planet, allowing captains who have been entrusted with the Remnant's most valuable technology to call nearby patrols for aid, should they ever become stranded."

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -976,7 +976,7 @@ outfit "Remnant License"
 	series "Licenses"
 	index 03010
 	thumbnail "outfit/remnant license"
-	description "In addition to serving as a handy IFF verifier, personal identification tool, and license to purchase Remnant technology, this device features movable parts that mechanically click with every adjustment. When the pieces are switched in a specific order and rhythm, the series of clicks produce a surprisingly beautiful blend of classical music tracks."
+	description "In addition to serving as a handy IFF verifier, personal identification tool, and license to purchase Remnant technology, this device features movable parts that mechanically click with every adjustment. When the pieces are switched in a specific order and rhythm, the series of clicks produces a surprisingly beautiful blend of classical music tracks."
 
 outfit "Remnant Capital License"
 	category "Licenses"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -976,7 +976,7 @@ outfit "Remnant License"
 	series "Licenses"
 	index 03010
 	thumbnail "outfit/remnant license"
-	description "Not too dissimilar from a Rubik's cube, this object consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beatiful blend of classical music tracks."
+	description "Not too dissimilar from a Rubik's cube, this object consists of several movable parts, with every move triggering a mechanical click. If one switches the pieces' positions and orientation in a specific order, in the right rhythm, the series of clicks produced is a surprisingly beautiful blend of classical music tracks."
 
 outfit "Remnant Capital License"
 	category "Licenses"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -624,7 +624,7 @@ outfit "Wanderer Outfits License"
 	series "Licenses"
 	index 09010
 	thumbnail "outfit/wanderer outfits license"
-	description "This oddly shaped dish holds a collection of perfectly preserved seeds of one Sentinel Skirtgrass, a sensitive yet robust species the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods. Each seed carries a built-in generational limit, ensuring the grass disappears after a few lifecycles so that it doesn't compete with native flora. These seeds symbolize the beginnings of both terraforming and goodwill, granting their owner the right to acquire Wanderer outfits."
+	description "This oddly shaped dish holds a collection of perfectly preserved seeds of one Sentinel Skirtgrass, a sensitive yet robust species the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods. Each seed carries a built-in generational limit, ensuring the grass disappears after a few lifecycles so that it doesn't compete with native flora. These seeds symbolize the beginning of both terraforming and goodwill, granting their owner the right to acquire Wanderer outfits."
 
 outfit "Wanderer License"
 	category "Licenses"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -624,18 +624,18 @@ outfit "Wanderer Outfits License"
 	series "Licenses"
 	index 09010
 	thumbnail "outfit/wanderer outfits license"
-	description "This oddly shaped dish holds a collection of perfectly preserved seeds of one Sentinel Skirtgrass, a sensitive yet robust species the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods. Each seed carries a built-in generational limit, ensuring the grass disappears after a few lifecycles so that it doesn't compete with native flora."
+	description "This oddly shaped dish holds a collection of perfectly preserved seeds of one Sentinel Skirtgrass, a sensitive yet robust species the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods. Each seed carries a built-in generational limit, ensuring the grass disappears after a few lifecycles so that it doesn't compete with native flora. These seeds symbolize the beginnings of both terraforming and goodwill, granting their owner the right to acquire Wanderer outfits."
 
 outfit "Wanderer License"
 	category "Licenses"
 	series "Licenses"
 	index 09020
 	thumbnail "outfit/wanderer license"
-	description "Intact within an amber shell, this leafy branch of the Noble Watchwood - rumored to come from the Wanderer's original home planet - symbolizes the their pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem."
+	description "Intact within an amber shell, this leafy branch of the Noble Watchwood - rumored to come from the Wanderer's original home planet - symbolizes their pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem. As a symbol of peace akin to Earth's olive branch, it grants its bearer the right to purchase non-military Wanderer ships."
 
 outfit "Wanderer Military License"
 	category "Licenses"
 	series "Licenses"
 	index 09030
 	thumbnail "outfit/wanderer military license"
-	description "The history of the Wanderers is not without hardship and failure. Immortalized in a bronze mold, this withered branch recalls the time the Wanderers could not save a world, for skilled as they may be, they cannot stop destruction when it is actively sought after by others mightier than them. The fall of the Noble Watchwood, their cherished emblem, now stands as a solemn vow: when peace fails, they too must prepare to fight."
+	description "The history of the Wanderers is not without hardship and failure. Immortalized in a bronze mold, this withered branch recalls the time the Wanderers could not save a world, for skilled as they may be, they cannot stop destruction when it is actively sought after by others mightier than them. The fall of the Noble Watchwood, their cherished emblem, now stands as a solemn vow: when peace fails, they too must prepare to fight. To stand and fight with the Wanderers, this license grants access to their greatest warships."

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -631,11 +631,11 @@ outfit "Wanderer License"
 	series "Licenses"
 	index 09020
 	thumbnail "outfit/wanderer license"
-	description "Intact within an amber shell, this leafy branch of the Uesoqai Antgiega symbolizes the Wanderers' pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem."
+	description "Intact within an amber shell, this leafy branch of the Noble Watchwood - rumored to come from the Wanderer's original home planet - symbolizes the their pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem."
 
 outfit "Wanderer Military License"
 	category "Licenses"
 	series "Licenses"
 	index 09030
 	thumbnail "outfit/wanderer military license"
-	description "The history of the Wanderers is not without hardship and failure. Immortalized in a bronze mold, this shape of a withered, burnt branch is the token of a time the Wanderers could not save a world, for skilled as they may be, they cannot stop destruction when it is actively sought after by others mightier than them. The loss of the exotic Cariauara Galoatinisfu serves as a reminder that they, too, must prepare to fight when necessary."
+	description "The history of the Wanderers is not without hardship and failure. Immortalized in a bronze mold, this withered branch recalls the time the Wanderers could not save a world, for skilled as they may be, they cannot stop destruction when it is actively sought after by others mightier than them. The fall of the Noble Watchwood, their cherished emblem, now stands as a solemn vow: when peace fails, they too must prepare to fight."

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -624,7 +624,7 @@ outfit "Wanderer Outfits License"
 	series "Licenses"
 	index 09010
 	thumbnail "outfit/wanderer outfits license"
-	description "This oddly shaped dish holds a perfectly preserved set of seeds of one Poaognod Nidadolen, a hardy species of grass that the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods."
+	description "This oddly shaped dish holds a collection of perfectly preserved seeds of one Sentinel Skirtgrass, a sensitive yet robust species the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods. Each seed carries a built-in generational limit, ensuring the grass disappears after a few lifecycles so that it doesn't compete with native flora."
 
 outfit "Wanderer License"
 	category "Licenses"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -624,18 +624,18 @@ outfit "Wanderer Outfits License"
 	series "Licenses"
 	index 09010
 	thumbnail "outfit/wanderer outfits license"
-	description "Spoke with a Wanderer ambassador named Iktat Rek using the translation device and received permission to purchase some of their technology, but not their ships."
+	description "This oddly shaped dish holds a perfectly preserved set of seeds of one Poaognod Nidadolen, a hardy species of grass that the Wanderers use during their initial terraforming efforts to gauge how well a world is responding to their methods."
 
 outfit "Wanderer License"
 	category "Licenses"
 	series "Licenses"
 	index 09020
 	thumbnail "outfit/wanderer license"
-	description "Managed to broker a temporary ceasefire between the Unfettered Hai and the Wanderers. Was granted access to purchase the non-military Wanderer ships, as a reward."
+	description "Intact within an amber shell, this leafy branch of the Uesoqai Antgiega symbolizes the Wanderers' pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem."
 
 outfit "Wanderer Military License"
 	category "Licenses"
 	series "Licenses"
 	index 09030
 	thumbnail "outfit/wanderer military license"
-	description "Received permission to purchase warships from the Wanderers, including a new one called the Tempest."
+	description "The history of the Wanderers is not without hardship and failure. Immortalized in a bronze mold, this shape of a withered, burnt branch is the token of a time the Wanderers could not save a world, for skilled as they may be, they cannot stop destruction when it is actively sought after by others mightier than them. The loss of the exotic Cariauara Galoatinisfu serves as a reminder that they, too, must prepare to fight when necessary."

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -631,7 +631,7 @@ outfit "Wanderer License"
 	series "Licenses"
 	index 09020
 	thumbnail "outfit/wanderer license"
-	description "Intact within an amber shell, this leafy branch of the Noble Watchwood - rumored to come from the Wanderer's original home planet - symbolizes their pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem. As a symbol of peace akin to Earth's olive branch, it grants its bearer the right to purchase non-military Wanderer ships."
+	description "Intact within an amber shell, this leafy branch of the Noble Watchwood - rumored to come from the Wanderers' original home planet - symbolizes their pride and joy, the total revitalization of a planet. While unmatched in size and formidable to behold, the tree is quite fragile to even the slightest alterations in climate, so the growth of one such specimen to maturity is seen as a sign of a healed ecosystem. As a symbol of peace akin to Earth's olive branch, it grants its bearer the right to purchase non-military Wanderer ships."
 
 outfit "Wanderer Military License"
 	category "Licenses"


### PR DESCRIPTION
**Content (Outfit Descriptions)**

This PR seeks to continue the work of https://github.com/endless-sky/endless-sky/pull/10584 , by addressing the other Licenses mentioned there (the existing Remnant and Wanderer Licenses), providing them with new descriptions, instead of the current copied logbook entries.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR changes the descriptions of the following outfits:

- Remnant License
- Remnant Capital License
- Wanderer Outfits License
- Wanderer License
- Wanderer Military License

Like with the change to the Coalition License in https://github.com/endless-sky/endless-sky/pull/10584 , these new descriptions seek to provide lore tidbits about their respective factions. 

For the Remnant ones, I tried to focus on the "music" seen in various instances for the initial license, and on a more practical usage for the more advanced license.

The Wanderer licenses now have descriptions that go a bit into their history and terraforming process. The idea for the Military License is to backshadow on how they first got to developing the "ugly" warships and weapons they come to rely upon again, while the other two licenses seek to go a bit into their terraforming process and how they may use some benchmark organisms to evaluate a planet's development (the intent isn't that they just spam these two organisms everywhere and overrun local flora, just that they use them to gauge how the recovery of the planet is doing).

I thought it could be neat to have the Wanderer licenses show scientific names for these fictional plants. The ones I picked are anagrams of the following species:

*Adopogon dandelion*, *Sequoia gigantea*, *Araucaria angustifolia*

Any and all suggested changes are welcome.