### PR TITLE
Fix improper click handling in the mission panel sometimes

### DIFF
--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -164,7 +164,7 @@ void TextArea::Draw()
 
 bool TextArea::Click(int x, int y, int clicks)
 {
-	if(scrollBar.SyncClick(scroll, x, y, clicks))
+	if(scroll.Scrollable() && scrollBar.SyncClick(scroll, x, y, clicks))
 	{
 		bufferIsValid = false;
 		return true;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11372

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This is quite the journey.

When you click on the game, the SDL event for the click gets passed into the game's UI stack (which contains the collection of all active "Panel" objects) via `UI::Handle`.
This method than calls the relevant method (for this case, `Panel::DoClick`) on each `Panel` object in the stack, until one reports that it handled the event (click).
(Well, actually, first `UI::Handle` passes the click into a `Panel`'s `ZoneClick` method, before giving it to that `Panel`'s `DoClick` method, but that's not relevant here, so we'll ignore it.)
`Panel::DoClick` then passes the parameters to `Panel::EventVisit` as well as telling it to call `Panel::Click`.
`Panel::EventVisit` is a helper function. It traverses this `Panel`'s collection of "child" panels (`Panel::children`) and recursively calls their `EventVisit` method, with the same parameters. If there are no "children", or none of them handle the event, `Panel::EventVisit` will then call this object's `Click` method.

In this case, the topmost `Panel` in the `UI` stack, and hence the first place `UI::Handle` calls `Panel::DoClick` is the `MissionPanel` object. This class extends `MapPanel`, but that doesn't matter right now.
`MissionPanel` has recently gained a "child" `Panel`, the `TextArea` that is used to provide the scrollable mission description.
So, `UI::Handle` calls `Panel::DoClick` on the `MissionPanel`. From there, we go to `Panel::EventVisit` in that `MissionPanel` object. Which calls `Panel::EventVisit` on the `TextArea` child of `MissionPanel`.
`TextArea` has no "children", so we go to its own `Click` method.
`TextArea::Click` passes the click to its `ScrollBar` object, which is supposed to check if the click was within its bounds and handle it if so, or return false if not.
This is where our problem occurs. `ScrollBar` has two `Point`s, `from` and `to`, which I assume represent its endpoints, which it compares the coordinates of the click to. If the click is very close to these points (within ten pixels), it considers the click to have been on itself and handles it. The `ScrollBar` in the `TextArea` used for mission descriptions appears to have default values for these `Point`s, that is, they are both (0, 0). This means that it will handle clicks close to the centre of the screen, preventing `MissionPanel::Click` from ever being told about that click.
And, since selecting a mission from the list will centre the map on its relevant system, the system's hitbox is within the region that the `ScrollBar` will handle.
If, for example, you pan the map before trying to click the selected system, as long as the selected system is no longer near the centre of the screen, you will see the expected behaviour, instead of the bug (try it).
In general, if you are on the mission panel and have a mission selected, you won't be able to click any system that happens to be at the centre of the window.

So, why does the `ScrollBar` in the `TextArea` have (0, 0) as its `from` and `to` values? Probably because it is constructed with default values and is expecting to have at least its `from` value set correctly by a call to `ScrollBar::SyncDraw` in `TextArea::Draw`, but that call is only made if the `TextArea` actually needs the scroll bar, which this one doesn't. There may be other places that are supposed to set it, but I don't want to look at it anymore.

A simple solution is for `TextArea::Click` to only call `ScrollBar::SyncClick` if it is currently scrollable (the same way it only calls `ScrollBar::SyncDraw` if it is scrollable).

Which is what this PR does.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
The steps described in the issue. The stuff works correctly now.

## Save File
This save file can be used to test these changes:
Just make a new pilot or use one you already have.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Immeasurable, probably.
