### PR TITLE
fix(ui): Fix dialog flickering

### DIFF
--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -235,6 +235,7 @@ void TextArea::Invalidate()
 {
 	bufferIsValid = false;
 	textIsValid = false;
+	scrollable = false;
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in https://github.com/endless-sky/endless-sky/pull/11362#issuecomment-2844354046.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The actual scrollability of the Dialog TextArea can change independently of the cached flag, throwing the dialog into an infinite readjusting loop, if we don't reset the flag properly.

## Testing Done
Tested on the dialog provided by the OP (installing engines without enough engine space), and the snapshot creation dialog.

## Performance Impact
N/A I think
