### PR TITLE
fix(ui): Fully clear the jump fuel attribute

### DIFF
--- a/source/Dictionary.cpp
+++ b/source/Dictionary.cpp
@@ -82,3 +82,12 @@ double Dictionary::Get(const string &key) const
 {
 	return Get(key.c_str());
 }
+
+
+
+void Dictionary::Erase(const char *key)
+{
+	auto [pos, exists] = Search(key, *this);
+	if(exists)
+		erase(next(this->begin(), pos));
+}

--- a/source/Dictionary.h
+++ b/source/Dictionary.h
@@ -33,6 +33,8 @@ public:
 	// Get the value of a key, or 0 if it does not exist:
 	double Get(const char *key) const;
 	double Get(const std::string &key) const;
+	// Erase the given element.
+	void Erase(const char *key);
 
 	// Expose certain functions from the underlying vector:
 	using std::vector<std::pair<const char *, double>>::empty;

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -345,7 +345,7 @@ void Outfit::Load(const DataNode &node)
 		attributes["jump drive fuel"] = (jumpFuel > 0. ? jumpFuel : DEFAULT_JUMP_DRIVE_COST);
 	}
 	if(attributes.Get("jump fuel"))
-		attributes["jump fuel"] = 0.;
+		attributes.Erase("jump fuel");
 
 	// Only outfits with the jump drive and jump range attributes can
 	// use the jump range, so only keep track of the jump range on


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in https://github.com/endless-sky/endless-sky/issues/11128#issuecomment-2706424798.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
I think I've tested #10771, but maybe not, or something broke in the meantime, idk. Anyways, as the author of the linked comment mentioned, we need to remove the attribute entry from the dictionary completely instead of just zeroing it.

## Screenshots
Before:
![before](https://github.com/user-attachments/assets/6405960b-f455-4d08-aff3-dcad0decb61d)
After:
![after](https://github.com/user-attachments/assets/f2e60efe-9ed6-4d17-8416-2c71fbd9ed42)

## Testing Done
Tested on the Hyperdrive, as shown on the screenshots above.

## Performance Impact
N/A
