### PR TITLE
feat(build): Use external pkgconf only when needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,19 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 
 # Find the zip-reading component of zlib.
 find_package(ZLIB REQUIRED)
-find_package(PkgConfig REQUIRED PkgConfig PkgConf)
 
 # Minizip has a different target name in vcpkg.
 if(ES_USE_VCPKG)
 	find_package(unofficial-minizip CONFIG REQUIRED)
 	set(MINIZIP_LIBRARIES "unofficial::minizip::minizip")
 else()
-	pkg_check_modules(MINIZIP REQUIRED minizip)
+	if(CMAKE_VERSION VERSION_LESS 3.31)
+		find_package(PkgConfig REQUIRED PkgConfig PkgConf)
+		pkg_check_modules(MINIZIP REQUIRED minizip)
+	else()
+		cmake_pkg_config(EXTRACT minizip REQUIRED)
+		set(MINIZIP_LIBRARIES "minizip")
+	endif()
 endif()
 
 # Find the MinGW runtime DLLs.

--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -63,7 +63,7 @@ If you want to build the libraries from source instead of using Homebrew, you ca
 You can use your favorite package manager to install the needed dependencies. If you're using a slower moving distro like Ubuntu or Debian (or any derivatives thereof), make sure to use at least Ubuntu 22.04 LTS or Debian 12.
 If your distro does not provide up-to-date version of these libraries, you can use vcpkg to build the necessary libraries from source by passing `-DES_USE_VCPKG=ON`. Older versions of Ubuntu and Debian, for example, will need this. Additional dependencies will likely need to be installed to build the libraries from source as well.
 
-In addition to the below dependencies, you will also need CMake 3.16 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you can also consider installing [ccache](https://ccache.dev/) to speed up rebuilds after switching branches.
+In addition to the below dependencies, you will also need CMake 3.19 or newer, however 3.21 or newer is strongly recommended. You can get the latest version from the [official website](https://cmake.org/download/). If you are often switching branches, then you can also consider installing [ccache](https://ccache.dev/) to speed up rebuilds after switching branches.
 
 
 <details>
@@ -71,6 +71,10 @@ In addition to the below dependencies, you will also need CMake 3.16 or newer, h
 
 ```
 g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libminizip-dev libopenal-dev libmad0-dev uuid-dev
+```
+If your CMake version is less than 3.31, you will also need
+```
+pkgconf
 ```
 Additionally, if you want to build unit tests:
 ```
@@ -86,6 +90,10 @@ While sufficient versions of other dependencies are available, Ubuntu 22.04 does
 
 ```
 gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel minizip-devel openal-soft-devel libmad-devel libuuid-devel
+```
+If your CMake version is less than 3.31, you will also need
+```
+pkgconf
 ```
 Additionally, if you want to build unit tests:
 ```


### PR DESCRIPTION
**Feature**/**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
CMake 3.31 added a native replacement for pkg-config, which makes requiring pkg-config unnecessary on certain systems. Also added the missing dependency to the build instructions (on brew I think it may not be needed, as it already provides CMake 4.0).
Additionally, fixed the minimal required CMake version in the docs.

## Testing Done
Compiles locally, we'll see what CI says.

## Performance Impact
N/A
