### PR TITLE
fix(conditions): Replace manual memory management

### DIFF
--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -77,5 +77,6 @@ private:
 	/// Lambda function to set the value for a condition entry.
 	std::function<void(ConditionEntry &, int64_t)> setFunction;
 
-	const ConditionEntry *providingEntry = nullptr; /// conditionEntry that provides the prefixed condition, or nullptr if this is a regular or named condition.
+	/// conditionEntry that provides the prefixed condition, or nullptr if this is a regular or named condition.
+	const ConditionEntry *providingEntry = nullptr;
 };

--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -33,14 +33,11 @@ class ConditionEntry {
 
 public:
 	ConditionEntry(const std::string &name);
-	~ConditionEntry();
 
 	// Prevent copying of ConditionEntries. We cannot safely copy the references to the provider, since we depend on the
 	// conditionsStore to set prefix providers.
 	ConditionEntry(ConditionEntry &) = delete;
 	ConditionEntry &operator=(const ConditionEntry &) = delete;
-
-	void Clear();
 
 	const std::string &Name() const;
 	const std::string NameWithoutPrefix() const;
@@ -67,39 +64,18 @@ public:
 	void ProvideNamed(std::function<int64_t(const ConditionEntry &)> getFunction,
 		std::function<void(ConditionEntry &, int64_t)> setFunction);
 
-
 	/// Notify all subscribed listeners that the value of the condition changed.
 	void NotifyUpdate(uint64_t value);
 
 
 private:
-	// Helper class for DerivedProviders, the (lambda) functions that provide access to the derived conditions are
-	// registered in this class.
-	class DerivedProvider {
-		friend ConditionEntry;
-
-	public:
-		/// Sets up a derived provider
-		///
-		/// @param mainEntry is nullptr for named providers, and the prefixed entry for prefix providers.
-		DerivedProvider(ConditionEntry *mainEntry);
-
-
-	public:
-		/// Get function to get the value of the ConditionEntry. GetFunctions are required for any derived provider.
-		std::function<int64_t(const ConditionEntry &)> getFunction;
-
-		/// Lambda function to set the value for a condition entry.
-		std::function<void(ConditionEntry &, int64_t)> setFunction;
-
-		/// Toplevel entry for prefixed providers, nullptr for named (non-prefixed) providers.
-		ConditionEntry *mainEntry;
-	};
-
-
-private:
 	std::string name; ///< Name of this entry, set during construction of the entry object.
 	int64_t value = 0; ///< Value of this condition, in case of direct access.
-	DerivedProvider *provider = nullptr; ///< Provider, if this is a named or prefixed derived condition.
 
+	/// Get function to get the value of the ConditionEntry. GetFunctions are required for any derived provider.
+	std::function<int64_t(const ConditionEntry &)> getFunction;
+	/// Lambda function to set the value for a condition entry.
+	std::function<void(ConditionEntry &, int64_t)> setFunction;
+
+	const ConditionEntry *providingEntry = nullptr; /// conditionEntry that provides the prefixed condition, or nullptr if this is a regular or named condition.
 };

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -52,14 +52,6 @@ ConditionsStore::ConditionsStore(const map<string, int64_t> &initialConditions)
 
 
 
-ConditionsStore::~ConditionsStore()
-{
-	// Clear removes the ConditionEntries in the correct order.
-	Clear();
-}
-
-
-
 void ConditionsStore::Load(const DataNode &node)
 {
 	for(const DataNode &child : node)
@@ -79,7 +71,7 @@ void ConditionsStore::Save(DataWriter &out) const
 	for(const auto &it : storage)
 	{
 		// We don't need to save derived conditions that have a provider.
-		if(it.second.provider)
+		if(it.second.getFunction || it.second.providingEntry)
 			continue;
 		// If the condition's value is 0, don't write it at all.
 		if(!it.second.value)
@@ -114,7 +106,7 @@ int64_t ConditionsStore::Get(const string &name) const
 	// If the name doesn't match exactly, then we are dealing with a prefixed provider that doesn't have an exactly
 	// matching entry. Get is const, so isn't supposed to add such an entry; use a temporary object for access.
 	ConditionEntry ceAccessor(name);
-	ceAccessor.provider = ce->provider;
+	ceAccessor.providingEntry = ce;
 	return ceAccessor.operator int64_t();
 }
 
@@ -150,23 +142,10 @@ ConditionEntry &ConditionsStore::operator[](const string &name)
 
 	// If a relevant prefix provider is found, then provision this entry with the provider.
 	if(ceprov != nullptr)
-		it->second.provider = ceprov->provider;
+		it->second.providingEntry = ceprov;
 
 	// Return the entry created.
 	return it->second;
-}
-
-
-
-void ConditionsStore::Clear()
-{
-	// Reverse clear, to make sure that prefix providers are not cleared before it's users are cleared.
-	for(auto it = storage.rbegin(); it != storage.rend(); ++it)
-		it->second.Clear();
-
-	// Also clear all conditions..
-	// TODO: This invalidates ConditionEntries. If invalidating is not allowed, then just reset all to zero instead.
-	storage.clear();
 }
 
 
@@ -177,7 +156,7 @@ int64_t ConditionsStore::PrimariesSize() const
 	for(const auto &it : storage)
 	{
 		// We only count primary conditions; conditions that don't have a provider.
-		if(it.second.provider)
+		if(it.second.providingEntry || it.second.getFunction)
 			continue;
 		++result;
 	}
@@ -209,10 +188,10 @@ const ConditionEntry *ConditionsStore::GetEntry(const string &name) const
 	if(name == it->first)
 		return &(it->second);
 
-	// The entry is also matching when we have a prefix entry and the prefix part in the provider matches.
-	ConditionEntry::DerivedProvider *provider = it->second.provider;
-	if(provider && provider->mainEntry && !name.compare(0, provider->mainEntry->name.length(), provider->mainEntry->name))
-		return &(it->second);
+	// If we don't have an exact match, but we have a matching prefix-provider, then we return that one.
+	const ConditionEntry *ceProv = it->second.providingEntry;
+	if(ceProv && !name.compare(0, ceProv->name.length(), ceProv->name))
+		return ceProv;
 
 	// And otherwise we don't have a match.
 	return nullptr;

--- a/source/ConditionsStore.h
+++ b/source/ConditionsStore.h
@@ -44,8 +44,6 @@ public:
 	explicit ConditionsStore(const DataNode &node);
 	explicit ConditionsStore(std::initializer_list<std::pair<std::string, int64_t>> initialConditions);
 	explicit ConditionsStore(const std::map<std::string, int64_t> &initialConditions);
-	/// A destructor is required to remove ConditionEntries in the correct order.
-	~ConditionsStore();
 
 	ConditionsStore(const ConditionsStore &) = delete;
 	ConditionsStore &operator=(const ConditionsStore &) = delete;
@@ -68,9 +66,6 @@ public:
 
 	/// Direct access to a specific condition (using the ConditionEntry as proxy).
 	ConditionEntry &operator[](const std::string &name);
-
-	/// Helper to completely remove all data and linked condition-providers from the store.
-	void Clear();
 
 	// Helper for testing; check how many primary conditions are registered.
 	int64_t PrimariesSize() const;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -139,8 +139,6 @@ void PlayerInfo::Clear()
 	GameData::Revert();
 	Messages::Reset();
 
-	conditions.Clear();
-
 	delete transactionSnapshot;
 	transactionSnapshot = nullptr;
 }


### PR DESCRIPTION
**Bug fix**

This PR should addresses the double free part of the bug/feature described in issue #11378

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
ConditionEntry contained some manual memory management. That was not working well, especially when entries got copied (since the copy actions duplicated pointers, and this duplication was not expected).

This PR does not address the copy action itself, but it replaces the manual memory allocation. This should prevent the double-free as seen in #11378. (Since ConditionEntry objects should be copy-able just fine now).

This PR might also be useful just to prevent access to the provider on object-destruction of ConditionEntries. The stacktrace in https://github.com/endless-sky/endless-sky/issues/11378 shows that the provider object itself gets freed when the ConditionEntry gets destructed. That is not really nice, since other ConditionEntries might still refer to a prefix-provider after it gets freed (which can lead to reading of non-allocated memory).
This PR fixes that by simply not accessing rawpointers on ConditionEntry object-destruction.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
The unit-tests and integration tests test the main functionality of the ConditionsStore and the ConditionEntry.

The specific interaction that lead to #11378 was not triggered during those earlier tests, but I have seen very similar double free issues due to copying of ConditionEntry objects, so I consider it very likely that this PR solves the double free.

## Save File
N/A (#11378 has a reproduction scenario, but I didn't see that happen yet).

## Performance Impact
ConditionEntry objects now use a little bit more memory. We can probably optimize that away later, but that requires a lot of rework, and fixing the master branch now feels like a higher priority than saving a little bit of memory.