### PR TITLE
fix(conditions): Fix const on ConditionEntry and prevent moving

### DIFF
--- a/source/ConditionEntry.h
+++ b/source/ConditionEntry.h
@@ -32,13 +32,16 @@ class ConditionEntry {
 	friend ConditionsStore;
 
 public:
-	ConditionEntry(const std::string &name);
+	explicit ConditionEntry(const std::string &name);
 	~ConditionEntry();
 
 	// Prevent copying of ConditionEntries. We cannot safely copy the references to the provider, since we depend on the
 	// conditionsStore to set prefix providers.
-	ConditionEntry(ConditionEntry &) = delete;
+	ConditionEntry(const ConditionEntry &) = delete;
 	ConditionEntry &operator=(const ConditionEntry &) = delete;
+	// Also prevent moving, the provider uses a pointer to the entry, so the entry should stay where it is.
+	ConditionEntry(ConditionEntry &&) = delete;
+	ConditionEntry &operator=(ConditionEntry &&) = delete;
 
 	void Clear();
 


### PR DESCRIPTION
**Bug fix**

This PR addresses an issue with deleted constructors, found while analyzing the bug from in issue #11378

## Acknowledgement

- [X ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
A copy constructor needs the object-to-be-copied as const parameter, this was not done correctly in ConditionEntry, so the copy constructor was not properly deleted.
This PR makes that parameter const, and it also removes the move-constructor and move-assignment for ConditionEntries.

## Testing Done
The main test is compilation, if the compiler can compile the code then no copy and move constructors and assignments are done in code. Further testing is done by unit-tests and integration tests.

## Wiki Update
N/A

## Performance Impact
None expected. (All copying of ConditionsStores was already fixed earlier.)