### PR TITLE
Adjust Base-Prices of Human Drones, Fighters and Interceptors

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -390,7 +390,7 @@ ship "Barb"
 	thumbnail "thumbnail/barb"
 	attributes
 		category "Fighter"
-		"cost" 50000
+		"cost" 87000
 		"shields" 800
 		"hull" 200
 		"required crew" 1
@@ -560,7 +560,7 @@ ship "Berserker"
 	thumbnail "thumbnail/berserker"
 	attributes
 		category "Interceptor"
-		"cost" 520000
+		"cost" 550000
 		"shields" 2200
 		"hull" 500
 		"required crew" 1
@@ -1121,7 +1121,7 @@ ship "Combat Drone"
 		category "Drone"
 		licenses
 			Navy
-		"cost" 83000
+		"cost" 41000
 		"hull" 700
 		"automaton" 1
 		"mass" 20
@@ -1420,7 +1420,7 @@ ship "Dagger"
 	thumbnail "thumbnail/dagger"
 	attributes
 		category "Fighter"
-		"cost" 129000
+		"cost" 119000
 		"shields" 1000
 		"hull" 300
 		"required crew" 1
@@ -1698,7 +1698,7 @@ ship "Finch"
 	thumbnail "thumbnail/finch"
 	attributes
 		category "Fighter"
-		"cost" 126000
+		"cost" 146000
 		"shields" 1100
 		"hull" 200
 		"required crew" 1
@@ -1969,7 +1969,7 @@ ship "Fury"
 	thumbnail "thumbnail/fury"
 	attributes
 		category "Interceptor"
-		"cost" 490000
+		"cost" 391000
 		"shields" 2000
 		"hull" 400
 		"required crew" 1
@@ -2259,7 +2259,7 @@ ship "Hawk"
 	thumbnail "thumbnail/hawk"
 	attributes
 		category "Interceptor"
-		"cost" 670000
+		"cost" 611000
 		"shields" 2500
 		"hull" 500
 		"required crew" 1
@@ -2460,7 +2460,7 @@ ship "Lance"
 	thumbnail "thumbnail/lance"
 	attributes
 		category "Fighter"
-		"cost" 93000
+		"cost" 122000
 		"shields" 800
 		"hull" 400
 		"required crew" 1
@@ -3442,7 +3442,7 @@ ship "Scrapper"
 	thumbnail "thumbnail/pirate scrapper"
 	attributes
 		category "Interceptor"
-		"cost" 60000
+		"cost" 123000
 		"shields" 450
 		"hull" 520
 		"required crew" 1
@@ -4043,7 +4043,7 @@ ship "Wasp"
 	thumbnail "thumbnail/wasp"
 	attributes
 		category "Interceptor"
-		"cost" 400000
+		"cost" 305000
 		"shields" 1500
 		"hull" 500
 		"required crew" 1

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -390,7 +390,7 @@ ship "Barb"
 	thumbnail "thumbnail/barb"
 	attributes
 		category "Fighter"
-		"cost" 87000
+		"cost" 95000
 		"shields" 800
 		"hull" 200
 		"required crew" 1
@@ -560,7 +560,7 @@ ship "Berserker"
 	thumbnail "thumbnail/berserker"
 	attributes
 		category "Interceptor"
-		"cost" 550000
+		"cost" 520000
 		"shields" 2200
 		"hull" 500
 		"required crew" 1
@@ -1420,7 +1420,7 @@ ship "Dagger"
 	thumbnail "thumbnail/dagger"
 	attributes
 		category "Fighter"
-		"cost" 119000
+		"cost" 131000
 		"shields" 1000
 		"hull" 300
 		"required crew" 1
@@ -1698,7 +1698,7 @@ ship "Finch"
 	thumbnail "thumbnail/finch"
 	attributes
 		category "Fighter"
-		"cost" 146000
+		"cost" 131000
 		"shields" 1100
 		"hull" 200
 		"required crew" 1
@@ -1969,7 +1969,7 @@ ship "Fury"
 	thumbnail "thumbnail/fury"
 	attributes
 		category "Interceptor"
-		"cost" 391000
+		"cost" 430000
 		"shields" 2000
 		"hull" 400
 		"required crew" 1
@@ -3442,7 +3442,7 @@ ship "Scrapper"
 	thumbnail "thumbnail/pirate scrapper"
 	attributes
 		category "Interceptor"
-		"cost" 123000
+		"cost" 111000
 		"shields" 450
 		"hull" 520
 		"required crew" 1


### PR DESCRIPTION
## Balancing the Base-Pricing of Human Drones, Fighters and Interceptors ##

### Issue ###

The base-pricing in the aforementioned categories is partly very inconsistent. The most succinct and obvious example:

| | Combat Drone | Lance
|--------------|----------|--------------|
| Shield | 0 | 800 |
| Hull | 700 | 400 |
| Outfit Space | 58 | 100 |
| Price | 83k | 93k |

Note, that the Combat Drone doesn't even need a life support system. When looking at *all* drones, fighters and interceptors, one will note further inconsistencies, even if applying a lore factor.

This PR tries to solve this issue, especially because human ships are for the early games phase, where people still count their coins. At that description-wise lore shall be reflected in the price.

Note, that it's not an argument anymore, that the Combat Drone or the Lance are hidden behind a license, as people are used en masse to install corresponding plugins.

### Methodology ###

We focus on combat ships, i.e. Boxwing, Dropship, Mining Drone, and Surveillance Drone are excluded here.

Further, I suggest to apply a basic formula to calculate the price of a ship in relation to a reference ship.
![21eb4b88eb164603-equation](https://github.com/user-attachments/assets/04a7607e-a5aa-4291-9737-3d63f8438bd2)
at that it is
```
x   : ship we're interested in
ref : reference ship
p   : price
s   : shields
h   : hull
p   : outfitspace
L   : lore factor (up to +/- 10%)
```
For reference we'll take the Sparrow, as it's a starting ship which price we preferrably don't want to change.

We could apply the following Lore Factors:
| Ship | L | Reason |
|---------|--------|---------|
|  Barb | 1.1 | Turret mount, bigger than usual weapon space |
| Dagger | 1.1 | Extra lightweight |
| Finch | 0.9 | Derived from Sparrow, such saving costs |
| Lance | 1.0 | Standard Navy fighter |
| Combat Drone | 1.0 | Standard Navy drone |
| Berserker | 0.95 | Oldie |
| Fury | 1.1 | More than usual gun ports |
| Hawk | 1.0 | Nothing unusual |
| Scapper | 0.9 | Junk |
| Sparrow | 1.0 | Starting ship |
| Wasp | 1.0 | De-facto Syndicate standard |


### Results ###

Prices in multiples of thousand credits.

| Ship         | Before | After | Difference |
|--------------|--------|-------|------------|
| Barb         | 85     | 95    | +12%       |
| Dagger       | 129    | 131   | +2%        |
| Finch        | 126    | 131   | +4%        |
| Lance        | 93     | 122   | +31%       |
| Combat Drone | 83     | 41    | -51%       |
| Berserker    | 520    | 520   | 0          |
| Fury         | 490    | 430   | -7%        |
| Hawk         | 670    | 611   | -9%        |
| Scrapper     | 60     | 111   | +85%       |
| Sparrow      | 225    | 225   | 0          |
| Wasp         | 400    | 305   | -24%       |

Note, that: 

 - The *interceptor* Scrapper is still cheaper than all *fighters* except the Barb.
 - Lance, Combat Drone, Wasp and Barb have now more reasonable prices. Also, in RL, drones are significantly cheaper than fighters.
 - Popular Hawk or Fury farming is now slightly nerfed.
 - Dagger, Finch and Berserker have (almost) not changed.