### PR TITLE
Don't constantly refresh engine sounds while paused

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1633,6 +1633,8 @@ void Engine::CalculateStep()
 			if(ship.get() != flagship)
 			{
 				DrawShipSprites(*ship);
+				if(timePaused)
+					continue;
 				if(ship->IsThrusting() && !ship->EnginePoints().empty())
 				{
 					for(const auto &it : ship->Attributes().FlareSounds())

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1656,8 +1656,9 @@ void Engine::CalculateStep()
 		}
 
 	if(flagship && showFlagship)
-	{
 		DrawShipSprites(*flagship);
+	if(!timePaused && flagship && showFlagship)
+	{
 		if(flagship->IsThrusting() && !flagship->EnginePoints().empty())
 		{
 			for(const auto &it : flagship->Attributes().FlareSounds())


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
@TomGoodIdea reported on Discord that where you:
1. Pause the game (with the "p" key (by default), not by opening the main menu) while a looping sound (like engines) is playing;
2. Open a panel, like the map;
3. And then close that panel;
You hear the engine sounds again even though you haven't unpaused the game.

First, when you pause the game with "p", it pauses audio. This involves Audio::Step going through every source that's playing right now and marking it as AL_PAUSED, instead of AL_PLAYING.
After this, while the main panel is still on top, Engine::CalculateStep is still constantly telling Audio to play the engine sounds.
Audio::Step takes this to mean that the looping sounds are still active and keeps them in the list of active sources, but they remain paused.
When you open the map panel, Engine::CalculateStep is no longer repeatedly telling Audio to play these sounds. So, those sources are moved to endingSources (because they are looping sounds that have ended and so should be removed after their playback is completed).
After the map panel is closed, Engine::CalculateStep begins telling Audio to play those sounds again.
This leads Audio to create new sources for those sounds. And these sources are playing, not paused.

This PR fixes this by having `Engine::CalculateStep` not constantly refresh those engine sounds while it is paused.

I also have an alternative solution that involves having `Audio` not move paused `sources` to the `endingSources` collection, but I think this is probably a better thing to do than that.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
1. Take off.
2. Start thrusting.
3. Pause the game (not with the main menu) while thrusting. Thrusting sounds stop.
4. No longer thrust.
5. Open the map.
6. Close the map.

Without this PR, the thrusting sounds start playing again.
With this PR, they do not start playing until the game is unpaused.

## Save File
Just create a new save. You don't need any special situation.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
One more branch based on a `bool` for every ship in your system in every frame. Probably not measurable.
