### PR TITLE
Fix sounds resuming when switching map panel modes

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "text/Alignment.h"
 #include "Angle.h"
+#include "audio/Audio.h"
 #include "Color.h"
 #include "Command.h"
 #include "CoreStartData.h"
@@ -103,6 +104,8 @@ MapDetailPanel::MapDetailPanel(PlayerInfo &player, const System *system, bool fr
 MapDetailPanel::MapDetailPanel(const MapPanel &panel, bool isStars)
 	: MapPanel(panel), isStars(isStars)
 {
+	Audio::Pause();
+
 	// Use whatever map coloring is specified in the PlayerInfo.
 	commodity = isStars ? -8 : player.MapColoring();
 

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "MapSalesPanel.h"
 
+#include "audio/Audio.h"
 #include "CategoryList.h"
 #include "CategoryType.h"
 #include "Command.h"
@@ -67,6 +68,8 @@ MapSalesPanel::MapSalesPanel(const MapPanel &panel, bool isOutfitters)
 	isOutfitters(isOutfitters),
 	collapsed(player.Collapsed(isOutfitters ? "outfitter map" : "shipyard map"))
 {
+	Audio::Pause();
+
 	commodity = SHOW_SPECIAL;
 }
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "MissionPanel.h"
 
 #include "text/Alignment.h"
+#include "audio/Audio.h"
 #include "Command.h"
 #include "CoreStartData.h"
 #include "Dialog.h"
@@ -166,6 +167,8 @@ MissionPanel::MissionPanel(const MapPanel &panel)
 	acceptedIt(player.AvailableJobs().empty() ? accepted.begin() : accepted.end()),
 	availableScroll(0), acceptedScroll(0), dragSide(0)
 {
+	Audio::Pause();
+
 	// Re-do job sorting since something could have changed
 	player.SortAvailable();
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When opening the map and then switching to another mode, sounds become unpaused, even though you're still in the map.

The different map panels (ports, named "detail" internally, missions, shipyard, and outfitter) all extend a common base "MapPanel" class. (The shipyard and outfitter have an intermediate "MapSalesPanel" class).
When first opening the map from a non-map panel, all of these classes use the explicitly defined constructor of "MapPanel" in their own constructors. This constructor pauses sounds, which are then resumed in the destructor of "MapPanel", which all of its children must call when they are destructed.
However, when switching from one map mode to another, the new panel initialises itself by copying the previously open panel, via the implicitly defined copy constructor of "MapPanel". They do not call the explicitly defined constructor of "MapPanel".
This means that these panels are not pausing sounds when they are created, but the map panel that was previously opened resumed sounds upon destruction. As a result, when switching from one map panel to another directly, sounds resume.

This PR modifies the constructors of "MapDetailPanel", "MapSalesPanel", and "MissionPanel" that do not call the explicit "MapPanel" constructor and instead use the implicit copy constructor to call "Audio::Pause" themselves, so that audio is not resumed erroneously.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
1. Load a save.
2. Quickly open the map or the job board before the "landing" sound finishes. Opening that panel pauses the sound.
3. Switch to another map mode, like the shipyard or outfitter.

Without this PR, the "landing" sound resumes.
With this PR, it does not.

## Save File
Just create a new save file. Or use one you already have. You don't need anything special.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Immeasurable, I expect. Even if it can be measured, it'll be tiny, and is not at a performance sensitive time.
