### PR TITLE
refactor(strings): replace uses of std::string::compare with starts_with or ends_with

### DIFF
--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -190,7 +190,7 @@ const ConditionEntry *ConditionsStore::GetEntry(const string &name) const
 
 	// If we don't have an exact match, but we have a matching prefix-provider, then we return that one.
 	const ConditionEntry *ceProv = it->second.providingEntry;
-	if(ceProv && !name.compare(0, ceProv->name.length(), ceProv->name))
+	if(ceProv && name.starts_with(ceProv->name))
 		return ceProv;
 
 	// And otherwise we don't have a match.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -926,9 +926,9 @@ const string &GameData::Tooltip(const string &label)
 	auto it = objects.tooltips.find(label);
 	// Special case: the "cost" and "sells for" labels include the percentage of
 	// the full price, so they will not match exactly.
-	if(it == objects.tooltips.end() && !label.compare(0, 4, "cost"))
+	if(it == objects.tooltips.end() && label.starts_with("cost"))
 		it = objects.tooltips.find("cost:");
-	if(it == objects.tooltips.end() && !label.compare(0, 9, "sells for"))
+	if(it == objects.tooltips.end() && label.starts_with("sells for"))
 		it = objects.tooltips.find("sells for:");
 	return (it == objects.tooltips.end() ? EMPTY : it->second);
 }

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -885,10 +885,7 @@ void OutfitterPanel::DrawOutfit(const Outfit &outfit, const Point &center, bool 
 
 bool OutfitterPanel::IsLicense(const string &name) const
 {
-	static const string &LICENSE = " License";
-	if(name.length() < LICENSE.length())
-		return false;
-	return !name.ends_with(LICENSE);
+	return name.ends_with(" License");
 }
 
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -888,10 +888,7 @@ bool OutfitterPanel::IsLicense(const string &name) const
 	static const string &LICENSE = " License";
 	if(name.length() < LICENSE.length())
 		return false;
-	if(name.compare(name.length() - LICENSE.length(), LICENSE.length(), LICENSE))
-		return false;
-
-	return true;
+	return !name.ends_with(LICENSE);
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3320,7 +3320,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["flagship model: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship)
 			return false;
-		return ce.Name().ends_with(flagship->TrueModelName()); });
+		return !ce.NameWithoutPrefix().compare(flagship->TrueModelName()); });
 	conditions["flagship disabled"].ProvideNamed([this](const ConditionEntry &ce) -> bool {
 		return flagship && flagship->IsDisabled(); });
 
@@ -3459,11 +3459,11 @@ void PlayerInfo::RegisterDerivedConditions()
 			return retVal; });
 
 	conditions["name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.Name().ends_with(firstName + " " + lastName); });
+		return !ce.NameWithoutPrefix().compare(firstName + " " + lastName); });
 	conditions["first name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.Name().ends_with(firstName); });
+		return !ce.NameWithoutPrefix().compare(firstName); });
 	conditions["last name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.Name().ends_with(lastName); });
+		return !ce.NameWithoutPrefix().compare(lastName); });
 
 	// Conditions for your fleet's attractiveness to pirates.
 	conditions["cargo attractiveness"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
@@ -3756,24 +3756,24 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// This condition corresponds to the method by which the flagship entered the current system.
 	conditions["entered system by: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return ce.Name().ends_with(EntryToString(entry)); });
+		return !ce.NameWithoutPrefix().compare(EntryToString(entry)); });
 	// This condition corresponds to the last system the flagship was in.
 	conditions["previous system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!previousSystem)
 			return false;
-		return ce.Name().ends_with(previousSystem->TrueName()); });
+		return !ce.NameWithoutPrefix().compare(previousSystem->TrueName()); });
 
 	// Conditions to determine if flagship is in a system and on a planet.
 	conditions["flagship system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetSystem())
 			return false;
-		return ce.Name().ends_with(flagship->GetSystem()->TrueName()); });
+		return !ce.NameWithoutPrefix().compare(flagship->GetSystem()->TrueName()); });
 	conditions["flagship landed"].ProvideNamed([this](const ConditionEntry &ce) -> bool {
 		return (flagship && flagship->GetPlanet()); });
 	conditions["flagship planet: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;
-		return ce.Name().ends_with(flagship->GetPlanet()->TrueName()); });
+		return !ce.NameWithoutPrefix().compare(flagship->GetPlanet()->TrueName()); });
 	conditions["flagship planet attribute: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3320,7 +3320,7 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["flagship model: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship)
 			return false;
-		return !ce.NameWithoutPrefix().compare(flagship->TrueModelName()); });
+		return ce.Name().ends_with(flagship->TrueModelName()); });
 	conditions["flagship disabled"].ProvideNamed([this](const ConditionEntry &ce) -> bool {
 		return flagship && flagship->IsDisabled(); });
 
@@ -3459,11 +3459,11 @@ void PlayerInfo::RegisterDerivedConditions()
 			return retVal; });
 
 	conditions["name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return !ce.NameWithoutPrefix().compare(firstName + " " + lastName); });
+		return ce.Name().ends_with(firstName + " " + lastName); });
 	conditions["first name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return !ce.NameWithoutPrefix().compare(firstName); });
+		return ce.Name().ends_with(firstName); });
 	conditions["last name: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return !ce.NameWithoutPrefix().compare(lastName); });
+		return ce.Name().ends_with(lastName); });
 
 	// Conditions for your fleet's attractiveness to pirates.
 	conditions["cargo attractiveness"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
@@ -3756,24 +3756,24 @@ void PlayerInfo::RegisterDerivedConditions()
 
 	// This condition corresponds to the method by which the flagship entered the current system.
 	conditions["entered system by: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
-		return !ce.NameWithoutPrefix().compare(EntryToString(entry)); });
+		return ce.Name().ends_with(EntryToString(entry)); });
 	// This condition corresponds to the last system the flagship was in.
 	conditions["previous system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!previousSystem)
 			return false;
-		return !ce.NameWithoutPrefix().compare(previousSystem->TrueName()); });
+		return ce.Name().ends_with(previousSystem->TrueName()); });
 
 	// Conditions to determine if flagship is in a system and on a planet.
 	conditions["flagship system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetSystem())
 			return false;
-		return !ce.NameWithoutPrefix().compare(flagship->GetSystem()->TrueName()); });
+		return ce.Name().ends_with(flagship->GetSystem()->TrueName()); });
 	conditions["flagship landed"].ProvideNamed([this](const ConditionEntry &ce) -> bool {
 		return (flagship && flagship->GetPlanet()); });
 	conditions["flagship planet: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;
-		return !ce.NameWithoutPrefix().compare(flagship->GetPlanet()->TrueName()); });
+		return ce.Name().ends_with(flagship->GetPlanet()->TrueName()); });
 	conditions["flagship planet attribute: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!flagship || !flagship->GetPlanet())
 			return false;

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -1090,10 +1090,10 @@ void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool 
 		object.LoadSprite(node);
 		if(removing)
 			return;
-		object.isStar = !node.Token(1).compare(0, 5, "star/");
+		object.isStar = node.Token(1).starts_with("star/");
 		if(!object.isStar)
 		{
-			object.isStation = !node.Token(1).compare(0, 14, "planet/station");
+			object.isStation = node.Token(1).starts_with("planet/station");
 			object.isMoon = (!object.isStation && object.parent >= 0 && !objects[object.parent].IsStar());
 		}
 	}

--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -227,9 +227,9 @@ void ImageSet::Load() noexcept(false)
 	// Warn about a "high-profile" image that will be blurry due to rendering at 50% scale.
 	bool willBlur = (buffer[0].Width() & 1) || (buffer[0].Height() & 1);
 	if(willBlur && (
-			(name.length() > 5 && name.starts_with("ship/"))
-			|| (name.length() > 7 && name.starts_with("outfit/"))
-			|| (name.length() > 10 && name.starts_with("thumbnail/"))
+			name.starts_with("ship/")
+			|| name.starts_with("outfit/")
+			|| name.starts_with("thumbnail/")
 	))
 		Logger::LogError("Warning: image \"" + name + "\" will be blurry since width and/or height are not even ("
 			+ to_string(buffer[0].Width()) + "x" + to_string(buffer[0].Height()) + ").");

--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -226,11 +226,7 @@ void ImageSet::Load() noexcept(false)
 
 	// Warn about a "high-profile" image that will be blurry due to rendering at 50% scale.
 	bool willBlur = (buffer[0].Width() & 1) || (buffer[0].Height() & 1);
-	if(willBlur && (
-			name.starts_with("ship/")
-			|| name.starts_with("outfit/")
-			|| name.starts_with("thumbnail/")
-	))
+	if(willBlur && (name.starts_with("ship/") || name.starts_with("outfit/") || name.starts_with("thumbnail/")))
 		Logger::LogError("Warning: image \"" + name + "\" will be blurry since width and/or height are not even ("
 			+ to_string(buffer[0].Width()) + "x" + to_string(buffer[0].Height()) + ").");
 }

--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -227,9 +227,9 @@ void ImageSet::Load() noexcept(false)
 	// Warn about a "high-profile" image that will be blurry due to rendering at 50% scale.
 	bool willBlur = (buffer[0].Width() & 1) || (buffer[0].Height() & 1);
 	if(willBlur && (
-			(name.length() > 5 && !name.compare(0, 5, "ship/"))
-			|| (name.length() > 7 && !name.compare(0, 7, "outfit/"))
-			|| (name.length() > 10 && !name.compare(0, 10, "thumbnail/"))
+			(name.length() > 5 && name.starts_with("ship/"))
+			|| (name.length() > 7 && name.starts_with("outfit/"))
+			|| (name.length() > 10 && name.starts_with("thumbnail/"))
 	))
 		Logger::LogError("Warning: image \"" + name + "\" will be blurry since width and/or height are not even ("
 			+ to_string(buffer[0].Width()) + "x" + to_string(buffer[0].Height()) + ").");

--- a/source/image/SpriteSet.cpp
+++ b/source/image/SpriteSet.cpp
@@ -45,7 +45,7 @@ void SpriteSet::CheckReferences()
 		const Sprite &sprite = pair.second;
 		if(sprite.Height() == 0 && sprite.Width() == 0)
 			// Landscapes are allowed to still be empty.
-			if(pair.first.compare(0, 5, "land/") != 0)
+			if(!pair.first.starts_with("land/"))
 				Logger::LogError("Warning: image \"" + pair.first + "\" is referred to, but has no pixels.");
 	}
 }

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -36,7 +36,7 @@ void verifyName(const std::string &name1, const std::string &name2)
 
 std::string verifyAndStripPrefix(const std::string &prefix, const std::string &inputString)
 {
-	if(inputString.size() < prefix.size() || (0 != inputString.compare(0, prefix.size(), prefix)))
+	if(inputString.size() < prefix.size() || !inputString.starts_with(prefix))
 		throw std::runtime_error("String \"" + inputString + "\" does not start with prefix \"" + prefix + "\"");
 	return inputString.substr(prefix.size());
 }

--- a/tests/unit/src/test_conditionsStore.cpp
+++ b/tests/unit/src/test_conditionsStore.cpp
@@ -36,7 +36,7 @@ void verifyName(const std::string &name1, const std::string &name2)
 
 std::string verifyAndStripPrefix(const std::string &prefix, const std::string &inputString)
 {
-	if(inputString.size() < prefix.size() || !inputString.starts_with(prefix))
+	if(!inputString.starts_with(prefix))
 		throw std::runtime_error("String \"" + inputString + "\" does not start with prefix \"" + prefix + "\"");
 	return inputString.substr(prefix.size());
 }


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
`std::string::compare` is a method that can be used for comparing part of all of a string to some other string.
In a lot of cases, we are using it to compare the beginning or end of a string to another string.
In C++20 (maybe also 17), there are two other member methods of `std::string` that do this and only this: `std::string::starts_with` and `std::string::ends_with`.
Making a call to one of these functions is a lot easier to read than a call to `std::string::compare` that does the same thing (see the diff for examples).
So, I've replaced all applicable calls to `std::string::compare` with calls to one of these newer methods, as appropriate.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Builds (and unit tests pass)/

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Very small, but should not be worse.
