### PR TITLE
Symlink compilation database to build for LSP discoverability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,6 @@ endif()
 
 # Create symlink to compile_commands.json from build/ so it's LSP-discoverable.
 execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_BINARY_DIR}/compile_commands.json
-        ${CMAKE_CURRENT_SOURCE_DIR}/build/compile_commands.json)
+	COMMAND ${CMAKE_COMMAND} -E create_symlink
+	${CMAKE_BINARY_DIR}/compile_commands.json
+	${CMAKE_CURRENT_SOURCE_DIR}/build/compile_commands.json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,9 +324,7 @@ elseif(UNIX)
 	install(FILES license.txt DESTINATION share/doc/endless-sky)
 endif()
 
-# Create symlink to compile_commands.json from build/ so it's LSP-discoverable
-#
-# CMake create_symlink works on all platforms as of CMake 3.13, so this shouldn't need to be conditional 
+# Create symlink to compile_commands.json from build/ so it's LSP-discoverable.
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E create_symlink
         ${CMAKE_BINARY_DIR}/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,3 +323,11 @@ elseif(UNIX)
 	install(FILES changelog DESTINATION share/doc/endless-sky)
 	install(FILES license.txt DESTINATION share/doc/endless-sky)
 endif()
+
+# Create symlink to compile_commands.json from build/ so it's LSP-discoverable
+#
+# CMake create_symlink works on all platforms as of CMake 3.13, so this shouldn't need to be conditional 
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+        ${CMAKE_BINARY_DIR}/compile_commands.json
+        ${CMAKE_CURRENT_SOURCE_DIR}/build/compile_commands.json)


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11393

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Add a task in CMakeLists to symlink `build/<preset>/compile_commands.json` to `build/compile_commands.json`, making the configuration discoverable to (clangd) LSP so that it is able to provide correct diagnostics. 

## Testing Done
I simply re-ran `cmake --preset linux` and verified that everything still compiled and that the LSP issue was resolved. This change has _zero_ impact on the actual game code, so it would be rather impressive if it managed to break the game in any way. I do not have access to Windows or MacOS machines to verify that the fix doesn't break compilation in that instance, but it shouldn't make a difference.

## Performance Impact
It arguably did change code, but not game code, just build system code, so performance should be identical.