### PR TITLE
Repricing Navy Combat Drone

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -1121,7 +1121,7 @@ ship "Combat Drone"
 		category "Drone"
 		licenses
 			Navy
-		"cost" 83000
+		"cost" 63000
 		"hull" 700
 		"automaton" 1
 		"mass" 20


### PR DESCRIPTION
As discussed in [PR #11389](https://github.com/endless-sky/endless-sky/pull/11389), the price of the Combat Drone is unreasonably high, even excessive.

This PR sets the hull price to 63k instead of 83k, as suggested by Quantumshark.