### PR TITLE
Customizable Shop Prices

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -265,7 +265,6 @@ target_sources(EndlessSkyLib PRIVATE
 	Set.h
 	Ship.cpp
 	Ship.h
-	Shop.h
 	ShipEvent.cpp
 	ShipEvent.h
 	ShipInfoDisplay.cpp
@@ -280,8 +279,11 @@ target_sources(EndlessSkyLib PRIVATE
 	ShipNameDialog.h
 	ShipyardPanel.cpp
 	ShipyardPanel.h
+	Shop.h
 	ShopPanel.cpp
 	ShopPanel.h
+	ShopPricing.cpp
+	ShopPricing.h
 	SpaceportPanel.cpp
 	SpaceportPanel.h
 	StartConditions.cpp
@@ -290,6 +292,8 @@ target_sources(EndlessSkyLib PRIVATE
 	StartConditionsPanel.h
 	StellarObject.cpp
 	StellarObject.h
+	Stock.h
+	StockItem.h
 	StringInterner.cpp
 	StringInterner.h
 	Swizzle.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -255,6 +255,8 @@ target_sources(EndlessSkyLib PRIVATE
 	RoutePlan.cpp
 	RoutePlan.h
 	Sale.h
+	SaleManager.cpp
+	SaleManager.h
 	SavedGame.cpp
 	SavedGame.h
 	Screen.cpp

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -311,17 +311,50 @@ double Depreciation::ValueFraction(const Outfit *outfit, int day, int count) con
 
 
 
+int Depreciation::NumberOld(const Ship *ship, int day, int count) const
+{
+	ship = GameData::Ships().Get(ship->TrueModelName());
+	auto recordIt = ships.find(ship);
+	if(recordIt == ships.end() || recordIt->second.empty())
+		return isStock ? 0 : count;
+
+	int old = 0;
+	map<int, int> record = recordIt->second;
+	for(const auto &it : record)
+		if(it.first < day)
+			old += it.second;
+	return min(old, count);
+}
+
+
+
+int Depreciation::NumberOld(const Outfit *outfit, int day, int count) const
+{
+	auto recordIt = outfits.find(outfit);
+	if(recordIt == outfits.end() || recordIt->second.empty())
+		return isStock ? 0 : count;
+
+	int old = 0;
+	map<int, int> record = recordIt->second;
+	for(const auto &it : record)
+		if(it.first < day)
+			old += it.second;
+	return min(old, count);
+}
+
+
+
 int Depreciation::NumberNew(const Ship *ship, int day, int count) const
 {
 	ship = GameData::Ships().Get(ship->TrueModelName());
 	auto recordIt = ships.find(ship);
 	if(recordIt == ships.end() || recordIt->second.empty())
-		return 0;
+		return isStock ? count : 0;
 
 	map<int, int> record = recordIt->second;
 	auto dayIt = record.find(day);
 	if(dayIt == record.end())
-		return 0;
+		return isStock ? count : 0;
 	return min(dayIt->second, count);
 }
 
@@ -331,12 +364,12 @@ int Depreciation::NumberNew(const Outfit *outfit, int day, int count) const
 {
 	auto recordIt = outfits.find(outfit);
 	if(recordIt == outfits.end() || recordIt->second.empty())
-		return 0;
+		return isStock ? count : 0;
 
 	map<int, int> record = recordIt->second;
 	auto dayIt = record.find(day);
 	if(dayIt == record.end())
-		return 0;
+		return isStock ? count : 0;
 	return min(dayIt->second, count);
 }
 

--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -228,59 +228,6 @@ void Depreciation::Buy(const Outfit *outfit, int day, Depreciation *source)
 
 
 
-// Get the value of an entire fleet.
-int64_t Depreciation::Value(const vector<shared_ptr<Ship>> &fleet, int day, bool chassisOnly) const
-{
-	map<const Ship *, int> shipCount;
-	map<const Outfit *, int> outfitCount;
-
-	for(const shared_ptr<Ship> &ship : fleet)
-	{
-		const Ship *base = GameData::Ships().Get(ship->TrueModelName());
-		++shipCount[base];
-
-		if(!chassisOnly)
-			for(const auto &it : ship->Outfits())
-				outfitCount[it.first] += it.second;
-	}
-
-	int64_t value = 0;
-	for(const auto &it : shipCount)
-		value += Value(it.first, day, it.second);
-	for(const auto &it : outfitCount)
-		value += Value(it.first, day, it.second);
-	return value;
-}
-
-
-
-// Get the value of a ship, along with all its outfits.
-int64_t Depreciation::Value(const Ship &ship, int day) const
-{
-	int64_t value = Value(&ship, day);
-	for(const auto &it : ship.Outfits())
-		value += Value(it.first, day, it.second);
-	return value;
-}
-
-
-
-// Get the value just of the chassis of a ship.
-int64_t Depreciation::Value(const Ship *ship, int day, int count) const
-{
-	return ValueFraction(ship, day, count) * ship->ChassisCost();
-}
-
-
-
-// Get the value of an outfit.
-int64_t Depreciation::Value(const Outfit *outfit, int day, int count) const
-{
-	return ValueFraction(outfit, day, count) * outfit->Cost();
-}
-
-
-
 double Depreciation::ValueFraction(const Ship *ship, int day, int count) const
 {
 	// Check whether a record exists for this ship. If not, its value is full

--- a/source/Depreciation.h
+++ b/source/Depreciation.h
@@ -61,6 +61,21 @@ public:
 	// Get the value of an outfit.
 	int64_t Value(const Outfit *outfit, int day, int count = 1) const;
 
+	// Get the amount of depreciation that is applied to an item for the given count.
+	// The returned fraction is the multiplier applied to the base cost of a single item
+	// of the given type. For example, if ValueFraction was called with a count of 2 and
+	// no depreciation is applied to the item, then the returned value would be 2 since
+	// buying 2 of that item costs twice as much as the base cost. But if both items were
+	// fully depreciated to 25% value, the returned value would be 0.5.
+	// The Ship ValueFraction only returns the value of the chassis of the ship.
+	double ValueFraction(const Ship *ship, int day, int count = 1) const;
+	double ValueFraction(const Outfit *outfit, int day, int count = 1) const;
+
+	// If the player is selling some number of items, return how many of those items are
+	// new (i.e. they were just purchased today).
+	int NumberNew(const Ship *ship, int day, int count = 1) const;
+	int NumberNew(const Outfit *outfit, int day, int count = 1) const;
+
 
 private:
 	// "Sell" an item, removing it from the given record and returning the base
@@ -83,6 +98,7 @@ private:
 	// Check if any data has been loaded.
 	bool isLoaded = false;
 
+	// The inner map is a map of day to the number of items purchased on that day.
 	std::map<const Ship *, std::map<int, int>> ships;
 	std::map<const Outfit *, std::map<int, int>> outfits;
 };

--- a/source/Depreciation.h
+++ b/source/Depreciation.h
@@ -71,8 +71,14 @@ public:
 	double ValueFraction(const Ship *ship, int day, int count = 1) const;
 	double ValueFraction(const Outfit *outfit, int day, int count = 1) const;
 
+	// If the player is buying some number of items, return how many of those items are
+	// old (i.e. they were bought previously but sold today). This is used so that items
+	// that were just sold can be bought back at the same price.
+	int NumberOld(const Ship *ship, int day, int count = 1) const;
+	int NumberOld(const Outfit *outfit, int day, int count = 1) const;
 	// If the player is selling some number of items, return how many of those items are
-	// new (i.e. they were just purchased today).
+	// new (i.e. they were just purchased today). This is used so that items that were
+	// just bought can be sold back at the same price.
 	int NumberNew(const Ship *ship, int day, int count = 1) const;
 	int NumberNew(const Outfit *outfit, int day, int count = 1) const;
 

--- a/source/Depreciation.h
+++ b/source/Depreciation.h
@@ -52,15 +52,6 @@ public:
 	// Add a single outfit to the depreciation record.
 	void Buy(const Outfit *outfit, int day, Depreciation *source = nullptr);
 
-	// Get the value of an entire fleet.
-	int64_t Value(const std::vector<std::shared_ptr<Ship>> &fleet, int day, bool chassisOnly = false) const;
-	// Get the value of a ship, along with all its outfits.
-	int64_t Value(const Ship &ship, int day) const;
-	// Get the value just of the chassis of a ship.
-	int64_t Value(const Ship *ship, int day, int count = 1) const;
-	// Get the value of an outfit.
-	int64_t Value(const Outfit *outfit, int day, int count = 1) const;
-
 	// Get the amount of depreciation that is applied to an item for the given count.
 	// The returned fraction is the multiplier applied to the base cost of a single item
 	// of the given type. For example, if ValueFraction was called with a count of 2 and

--- a/source/FleetCargo.cpp
+++ b/source/FleetCargo.cpp
@@ -38,9 +38,10 @@ namespace {
 		{
 			for(const StellarObject &object : here->Objects())
 			{
+				// TODO: Use the conditional stocks instead of the permanent sales.
 				const Planet *planet = object.GetPlanet();
 				if(planet && planet->IsValid() && planet->HasOutfitter())
-					outfits.Add(planet->OutfitterStock());
+					outfits.Add(planet->OutfitterSales());
 			}
 		}
 		return outfits;
@@ -63,7 +64,7 @@ namespace {
 			}
 			else
 				for(const auto outfitter : outfitters)
-					choices.Add(outfitter->Stock());
+					choices.Add(outfitter->Sales());
 
 			if(!choices.empty())
 			{

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -357,8 +357,9 @@ bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 			return false;
 
 	// If outfits are specified, make sure they can be bought here.
+	// TODO: Use the conditional stocks instead of the permanent sales.
 	for(const set<const Outfit *> &outfitList : outfits)
-		if(!SetsIntersect(outfitList, planet->OutfitterStock()))
+		if(!SetsIntersect(outfitList, planet->OutfitterSales()))
 			return false;
 
 	return Matches(planet->GetSystem(), origin, true);

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -151,7 +151,8 @@ double MapOutfitterPanel::SystemValue(const System *system) const
 			const auto storage = planetStorage.find(object.GetPlanet());
 			if(storage != planetStorage.end() && storage->second.Get(selected))
 				return .5;
-			const auto &outfitter = object.GetPlanet()->OutfitterStock();
+			// TODO: Use conditional stocks instead of permanent sales.
+			const auto &outfitter = object.GetPlanet()->OutfitterSales();
 			if(outfitter.Has(selected))
 				return 1.;
 			if(!outfitter.empty())
@@ -242,7 +243,10 @@ void MapOutfitterPanel::DrawItems()
 						if(pit != storage.end())
 							storedInSystem += pit->second.Get(outfit);
 					}
-					if(planet.OutfitterStock().Has(outfit))
+					// TODO: Use conditional stocks instead of permanent sales.
+					// TODO: Use StockItems from the selected system so that we
+					// can see the buy/sell price at the selected planet.
+					if(planet.OutfitterSales().Has(outfit))
 					{
 						isForSale = true;
 						break;
@@ -276,9 +280,10 @@ void MapOutfitterPanel::Init()
 	set<const Outfit *> seen;
 
 	// Add all outfits sold by outfitters of planets from viewable systems.
+	// TODO: Use conditional stocks instead of permanent sales.
 	for(auto &&it : GameData::Planets())
 		if(it.second.IsValid() && player.CanView(*it.second.GetSystem()))
-			for(const Outfit *outfit : it.second.OutfitterStock())
+			for(const Outfit *outfit : it.second.OutfitterSales())
 				if(!seen.contains(outfit))
 				{
 					catalog[outfit->Category()].push_back(outfit);

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -24,6 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
+#include "SaleManager.h"
 #include "Screen.h"
 #include "image/Sprite.h"
 #include "StellarObject.h"
@@ -109,7 +110,8 @@ void MapOutfitterPanel::Select(int index)
 	else
 	{
 		selected = list[index];
-		selectedInfo.Update(*selected, player);
+		// TODO: This should have a pointer to the stock of the selected planet.
+		selectedInfo.Update(*selected, player, SaleManager(player));
 	}
 	UpdateCache();
 }
@@ -123,7 +125,8 @@ void MapOutfitterPanel::Compare(int index)
 	else
 	{
 		compare = list[index];
-		compareInfo.Update(*compare, player);
+		// TODO: This should have a pointer to the stock of the selected planet.
+		compareInfo.Update(*compare, player, SaleManager(player));
 	}
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1069,18 +1069,20 @@ void MapPanel::UpdateCache()
 				}
 				else if(commodity == SHOW_SHIPYARD)
 				{
+					// TODO: Use conditional stocks instead of permanent sales.
 					double size = 0;
 					for(const StellarObject &object : system.Objects())
 						if(object.HasSprite() && object.HasValidPlanet())
-							size += object.GetPlanet()->ShipyardStock().size();
+							size += object.GetPlanet()->ShipyardSales().size();
 					value = size ? min(10., size) / 10. : -1.;
 				}
 				else if(commodity == SHOW_OUTFITTER)
 				{
+					// TODO: Use conditional stocks instead of permanent sales.
 					double size = 0;
 					for(const StellarObject &object : system.Objects())
 						if(object.HasSprite() && object.HasValidPlanet())
-							size += object.GetPlanet()->OutfitterStock().size();
+							size += object.GetPlanet()->OutfitterSales().size();
 					value = size ? min(60., size) / 60. : -1.;
 				}
 				else if(commodity == SHOW_VISITED)

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -155,7 +155,8 @@ double MapShipyardPanel::SystemValue(const System *system) const
 		for(const StellarObject &object : system->Objects())
 			if(object.HasSprite() && object.HasValidPlanet())
 			{
-				const auto &shipyard = object.GetPlanet()->ShipyardStock();
+				// TODO: Use conditional stocks instead of permanent sales.
+				const auto &shipyard = object.GetPlanet()->ShipyardSales();
 				if(shipyard.Has(selected))
 					return 1.;
 				if(!shipyard.empty())
@@ -219,10 +220,13 @@ void MapShipyardPanel::DrawItems()
 			unsigned parkedInSystem = 0;
 			if(player.CanView(*selectedSystem))
 			{
+				// TODO: Use conditional stocks instead of permanent sales.
+				// TODO: Use StockItems from the selected system so that we
+				// can see the buy/sell price at the selected planet.
 				isForSale = false;
 				for(const StellarObject &object : selectedSystem->Objects())
 					if(object.HasSprite() && object.HasValidPlanet()
-							&& object.GetPlanet()->ShipyardStock().Has(ship))
+							&& object.GetPlanet()->ShipyardSales().Has(ship))
 					{
 						isForSale = true;
 						break;
@@ -265,9 +269,10 @@ void MapShipyardPanel::Init()
 {
 	catalog.clear();
 	set<const Ship *> seen;
+	// TODO: Use conditional stocks instead of permanent sales.
 	for(const auto &it : GameData::Planets())
 		if(it.second.IsValid() && player.CanView(*it.second.GetSystem()))
-			for(const Ship *ship : it.second.ShipyardStock())
+			for(const Ship *ship : it.second.ShipyardSales())
 				if(!seen.contains(ship))
 				{
 					catalog[ship->Attributes().Category()].push_back(ship);

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -22,6 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
+#include "SaleManager.h"
 #include "Screen.h"
 #include "Ship.h"
 #include "image/Sprite.h"
@@ -117,7 +118,8 @@ void MapShipyardPanel::Select(int index)
 	else
 	{
 		selected = list[index];
-		selectedInfo.Update(*selected, player);
+		// TODO: This should have a pointer to the stock of the selected planet.
+		selectedInfo.Update(*selected, player, SaleManager(player));
 	}
 	UpdateCache();
 }
@@ -131,7 +133,8 @@ void MapShipyardPanel::Compare(int index)
 	else
 	{
 		compare = list[index];
-		compareInfo.Update(*compare, player);
+		// TODO: This should have a pointer to the stock of the selected planet.
+		compareInfo.Update(*compare, player, SaleManager(player));
 	}
 }
 

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -286,7 +286,7 @@ void Outfit::Load(const DataNode &node)
 			description += '\n';
 		}
 		else if(child.Token(0) == "cost" && child.Size() >= 2)
-			cost = child.Value(1);
+			cost = max<int64_t>(0, child.Value(1));
 		else if(child.Token(0) == "mass" && child.Size() >= 2)
 			mass = child.Value(1);
 		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -15,11 +15,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "OutfitInfoDisplay.h"
 
-#include "Depreciation.h"
 #include "text/Format.h"
 #include "GameData.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
+#include "SaleManager.h"
 
 #include <algorithm>
 #include <cmath>
@@ -250,19 +250,12 @@ namespace {
 
 
 
-OutfitInfoDisplay::OutfitInfoDisplay(const Outfit &outfit, const PlayerInfo &player,
-		bool canSell, bool descriptionCollapsed)
-{
-	Update(outfit, player, canSell, descriptionCollapsed);
-}
-
-
-
 // Call this every time the ship changes.
-void OutfitInfoDisplay::Update(const Outfit &outfit, const PlayerInfo &player, bool canSell, bool descriptionCollapsed)
+void OutfitInfoDisplay::Update(const Outfit &outfit, const PlayerInfo &player, const SaleManager &saleManager,
+	bool canSell, bool descriptionCollapsed)
 {
 	UpdateDescription(outfit.Description(), outfit.Licenses(), false);
-	UpdateRequirements(outfit, player, canSell, descriptionCollapsed);
+	UpdateRequirements(outfit, player, canSell, descriptionCollapsed, saleManager);
 	UpdateAttributes(outfit);
 
 	maximumHeight = max(descriptionHeight, max(requirementsHeight, attributesHeight));
@@ -285,16 +278,15 @@ void OutfitInfoDisplay::DrawRequirements(const Point &topLeft) const
 
 
 void OutfitInfoDisplay::UpdateRequirements(const Outfit &outfit, const PlayerInfo &player,
-		bool canSell, bool descriptionCollapsed)
+	bool canSell, bool descriptionCollapsed, const SaleManager &saleManager)
 {
 	requirementLabels.clear();
 	requirementValues.clear();
 	requirementsHeight = 20;
 
-	int day = player.GetDate().DaysSinceEpoch();
 	int64_t cost = outfit.Cost();
-	int64_t buyValue = player.StockDepreciation().Value(&outfit, day);
-	int64_t sellValue = player.FleetDepreciation().Value(&outfit, day);
+	int64_t buyValue = saleManager.BuyValue(&outfit);
+	int64_t sellValue = saleManager.SellValue(&outfit);
 
 	for(const string &license : outfit.Licenses())
 	{

--- a/source/OutfitInfoDisplay.h
+++ b/source/OutfitInfoDisplay.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+class SaleManager;
 class Outfit;
 class PlayerInfo;
 class Point;
@@ -32,11 +33,10 @@ class Point;
 class OutfitInfoDisplay : public ItemInfoDisplay {
 public:
 	OutfitInfoDisplay() = default;
-	OutfitInfoDisplay(const Outfit &outfit, const PlayerInfo &player,
-			bool canSell = false, bool descriptionCollapsed = true);
 
 	// Call this every time the ship changes.
-	void Update(const Outfit &outfit, const PlayerInfo &player, bool canSell = false, bool descriptionCollapsed = true);
+	void Update(const Outfit &outfit, const PlayerInfo &player, const SaleManager &saleManager,
+		bool canSell = false, bool descriptionCollapsed = true);
 
 	// Provided by ItemInfoDisplay:
 	// int PanelWidth();
@@ -52,7 +52,7 @@ public:
 
 
 private:
-	void UpdateRequirements(const Outfit &outfit, const PlayerInfo &player, bool canSell, bool descriptionCollapsed);
+	void UpdateRequirements(const Outfit &outfit, const PlayerInfo &player, bool canSell, bool descriptionCollapsed, const SaleManager &saleManager);
 	void AddRequirementAttribute(std::string label, double value);
 	void UpdateAttributes(const Outfit &outfit);
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -78,7 +78,7 @@ namespace {
 
 
 
-OutfitterPanel::OutfitterPanel(PlayerInfo &player, Sale<Outfit> stock)
+OutfitterPanel::OutfitterPanel(PlayerInfo &player, Stock<Outfit> stock)
 	: ShopPanel(player, true), outfitter(stock)
 {
 	for(const pair<const string, Outfit> &it : GameData::Outfits())

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -399,7 +399,7 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 	if(!onlyOwned)
 	{
 		// Determine what you will have to pay to buy this outfit.
-		int64_t cost = player.StockDepreciation().Value(selectedOutfit, day);
+		int64_t cost = saleManager.BuyValue(selectedOutfit);
 		int64_t credits = player.Accounts().Credits();
 
 		if(cost > credits)
@@ -557,7 +557,7 @@ void OutfitterPanel::Buy(bool onlyOwned)
 				if(!outfitter.Has(selectedOutfit) && player.Stock(selectedOutfit) <= 0)
 					continue;
 				player.Cargo().Add(selectedOutfit);
-				int64_t price = player.StockDepreciation().Value(selectedOutfit, day);
+				int64_t price = saleManager.BuyValue(selectedOutfit);
 				player.Accounts().AddCredits(-price);
 				player.AddStock(selectedOutfit, -1);
 				continue;
@@ -580,7 +580,7 @@ void OutfitterPanel::Buy(bool onlyOwned)
 				break;
 			else
 			{
-				int64_t price = player.StockDepreciation().Value(selectedOutfit, day);
+				int64_t price = saleManager.BuyValue(selectedOutfit);
 				player.Accounts().AddCredits(-price);
 				player.AddStock(selectedOutfit, -1);
 			}
@@ -630,7 +630,7 @@ void OutfitterPanel::Sell(bool toStorage)
 		}
 		else
 		{
-			int64_t price = player.FleetDepreciation().Value(selectedOutfit, day);
+			int64_t price = saleManager.SellValue(selectedOutfit);
 			player.Accounts().AddCredits(price);
 			player.AddStock(selectedOutfit, 1);
 		}
@@ -665,7 +665,7 @@ void OutfitterPanel::Sell(bool toStorage)
 			}
 			else
 			{
-				int64_t price = player.FleetDepreciation().Value(selectedOutfit, day);
+				int64_t price = saleManager.SellValue(selectedOutfit);
 				player.Accounts().AddCredits(price);
 				player.AddStock(selectedOutfit, 1);
 			}
@@ -686,7 +686,7 @@ void OutfitterPanel::Sell(bool toStorage)
 						mustSell -= storage.Add(ammo, mustSell);
 					if(mustSell)
 					{
-						int64_t price = player.FleetDepreciation().Value(ammo, day, mustSell);
+						int64_t price = saleManager.SellValue(ammo, mustSell);
 						player.Accounts().AddCredits(price);
 						player.AddStock(ammo, mustSell);
 					}
@@ -699,7 +699,7 @@ void OutfitterPanel::Sell(bool toStorage)
 	if(!toStorage && storage.Get(selectedOutfit))
 	{
 		storage.Remove(selectedOutfit);
-		int64_t price = player.FleetDepreciation().Value(selectedOutfit, day);
+		int64_t price = saleManager.SellValue(selectedOutfit, day);
 		player.Accounts().AddCredits(price);
 		player.AddStock(selectedOutfit, 1);
 	}
@@ -947,7 +947,7 @@ void OutfitterPanel::CheckRefill()
 		it.second = max(0, it.second - player.Cargo().Get(it.first) - player.Storage().Get(it.first));
 		if(!outfitter.Has(it.first))
 			it.second = min(it.second, max(0, player.Stock(it.first)));
-		cost += player.StockDepreciation().Value(it.first, day, it.second);
+		cost += saleManager.BuyValue(it.first, it.second);
 	}
 	if(!needed.empty() && cost < player.Accounts().Credits())
 	{
@@ -985,7 +985,7 @@ void OutfitterPanel::Refill()
 				int available = outfitter.Has(outfit) ? neededAmmo : min<int>(neededAmmo, max<int>(0, player.Stock(outfit)));
 				if(neededAmmo && available > 0)
 				{
-					int64_t price = player.StockDepreciation().Value(outfit, day, available);
+					int64_t price = saleManager.BuyValue(outfit, available);
 					player.Accounts().AddCredits(-price);
 					player.AddStock(outfit, -available);
 				}

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -78,8 +78,8 @@ namespace {
 
 
 
-OutfitterPanel::OutfitterPanel(PlayerInfo &player, Stock<Outfit> stock)
-	: ShopPanel(player, true), outfitter(stock)
+OutfitterPanel::OutfitterPanel(PlayerInfo &player, Stock<Outfit> &stock, SaleManager saleManager)
+	: ShopPanel(player, true, std::move(saleManager)), outfitter(stock)
 {
 	for(const pair<const string, Outfit> &it : GameData::Outfits())
 		catalog[it.second.Category()].push_back(it.first);
@@ -271,7 +271,7 @@ double OutfitterPanel::DrawDetails(const Point &center)
 
 	if(selectedOutfit)
 	{
-		outfitInfo.Update(*selectedOutfit, player, CanSell(), collapsed.contains(DESCRIPTION));
+		outfitInfo.Update(*selectedOutfit, player, saleManager, CanSell(), collapsed.contains(DESCRIPTION));
 		selectedItem = selectedOutfit->DisplayName();
 
 		const Sprite *thumbnail = selectedOutfit->Thumbnail();

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -30,6 +30,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
+#include "SaleManager.h"
 #include "Screen.h"
 #include "Ship.h"
 #include "image/Sprite.h"
@@ -78,8 +79,8 @@ namespace {
 
 
 
-OutfitterPanel::OutfitterPanel(PlayerInfo &player, Stock<Outfit> &stock, SaleManager saleManager)
-	: ShopPanel(player, true, std::move(saleManager)), outfitter(stock)
+OutfitterPanel::OutfitterPanel(PlayerInfo &player, Stock<Outfit> &stock, const SaleManager &saleManager)
+	: ShopPanel(player, true, saleManager), outfitter(stock)
 {
 	for(const pair<const string, Outfit> &it : GameData::Outfits())
 		catalog[it.second.Category()].push_back(it.first);

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class Outfit;
 class PlayerInfo;
 class Point;
+class SaleManager;
 class Ship;
 
 
@@ -40,7 +41,7 @@ class Ship;
 // configured in such a way that it cannot fly (e.g. no engines or steering).
 class OutfitterPanel : public ShopPanel {
 public:
-	explicit OutfitterPanel(PlayerInfo &player, Stock<Outfit> stock);
+	explicit OutfitterPanel(PlayerInfo &player, Stock<Outfit> &stock, SaleManager saleManager);
 
 	virtual void Step() override;
 
@@ -89,7 +90,7 @@ private:
 	// Allow toggling whether outfits in cargo are shown.
 	bool showCargo = true;
 
-	Stock<Outfit> outfitter;
+	Stock<Outfit> &outfitter;
 
 	// Keep track of how many of the outfitter help screens have been shown
 	bool checkedHelp = false;

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -41,7 +41,7 @@ class Ship;
 // configured in such a way that it cannot fly (e.g. no engines or steering).
 class OutfitterPanel : public ShopPanel {
 public:
-	explicit OutfitterPanel(PlayerInfo &player, Stock<Outfit> &stock, SaleManager saleManager);
+	explicit OutfitterPanel(PlayerInfo &player, Stock<Outfit> &stock, const SaleManager &saleManager);
 
 	virtual void Step() override;
 

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -17,7 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "ShopPanel.h"
 
-#include "Sale.h"
+#include "Stock.h"
 
 #include <map>
 #include <set>
@@ -40,7 +40,7 @@ class Ship;
 // configured in such a way that it cannot fly (e.g. no engines or steering).
 class OutfitterPanel : public ShopPanel {
 public:
-	explicit OutfitterPanel(PlayerInfo &player, Sale<Outfit> stock);
+	explicit OutfitterPanel(PlayerInfo &player, Stock<Outfit> stock);
 
 	virtual void Step() override;
 
@@ -89,7 +89,7 @@ private:
 	// Allow toggling whether outfits in cargo are shown.
 	bool showCargo = true;
 
-	Sale<Outfit> outfitter;
+	Stock<Outfit> outfitter;
 
 	// Keep track of how many of the outfitter help screens have been shown
 	bool checkedHelp = false;

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -452,11 +452,11 @@ bool Planet::HasShipyard() const
 
 
 // Get the list of ships in the permanent shipyard.
-const Sale<Ship> &Planet::ShipyardStock() const
+const Sale<Ship> &Planet::ShipyardSales() const
 {
 	shipyard.clear();
 	for(const Shop<Ship> *sale : shipSales)
-		shipyard.Add(sale->Stock());
+		shipyard.Add(sale->Sales());
 
 	return shipyard;
 }
@@ -485,11 +485,11 @@ bool Planet::HasOutfitter() const
 
 
 // Get the list of outfits available from the permanent outfitter.
-const Sale<Outfit> &Planet::OutfitterStock() const
+const Sale<Outfit> &Planet::OutfitterSales() const
 {
 	outfitter.clear();
 	for(const Shop<Outfit> *sale : outfitSales)
-		outfitter.Add(sale->Stock());
+		outfitter.Add(sale->Sales());
 
 	return outfitter;
 }

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Port.h"
 #include "Sale.h"
 #include "Shop.h"
+#include "Stock.h"
 
 #include <list>
 #include <memory>
@@ -102,7 +103,7 @@ public:
 	// Check if this planet has a permanent shipyard.
 	bool HasShipyard() const;
 	// Get the list of ships in the permanent shipyard.
-	const Sale<Ship> &ShipyardStock() const;
+	const Sale<Ship> &ShipyardSales() const;
 	// Get the list of shipyards currently available on this planet.
 	// This will include conditionally available shops.
 	std::set<const Shop<Ship> *> Shipyards() const;
@@ -110,7 +111,7 @@ public:
 	// Check if this planet has a permanent outfitter.
 	bool HasOutfitter() const;
 	// Get the list of outfits available from the permanent outfitter.
-	const Sale<Outfit> &OutfitterStock() const;
+	const Sale<Outfit> &OutfitterSales() const;
 	// Get the list of outitters available on this planet.
 	// This will include conditionally available shops.
 	std::set<const Shop<Outfit> *> Outfitters() const;

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -188,6 +188,14 @@ void PlanetPanel::Draw()
 
 
 
+void PlanetPanel::EnterShipyard()
+{
+	SaleManager saleManager(player, &outfitterStock, &shipyardStock);
+	GetUI()->Push(new ShipyardPanel(player, shipyardStock, saleManager));
+}
+
+
+
 // Only override the ones you need; the default action is to return false.
 bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -57,7 +57,7 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	planet(*player.GetPlanet()), system(*player.GetSystem()),
 	ui(*GameData::Interfaces().Get("planet")), saleManager(SaleManager(player, &outfitterStock, &shipyardStock))
 {
-	trading.reset(new TradingPanel(player));
+	trading.reset(new TradingPanel(player, saleManager));
 	bank.reset(new BankPanel(player));
 	spaceport.reset(new SpaceportPanel(player));
 	hiring.reset(new HiringPanel(player));

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -511,7 +511,8 @@ void PlanetPanel::TakeOff(const bool distributeCargo)
 {
 	flightChecks.clear();
 	player.Save();
-	if(player.TakeOff(GetUI(), distributeCargo))
+	SaleManager saleManager(player, &outfitterStock, &shipyardStock);
+	if(player.TakeOff(GetUI(), distributeCargo, saleManager))
 	{
 		if(callback)
 			callback();

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -118,12 +118,12 @@ void PlanetPanel::Step()
 		for(const Shop<Ship> *shop : planet.Shipyards())
 		{
 			hasShipyard = true;
-			shipyardStock.Add(shop->Stock());
+			shipyardStock.Add(shop->InstantiateStock());
 		}
 		for(const Shop<Outfit> *shop : planet.Outfitters())
 		{
 			hasOutfitter = true;
-			outfitterStock.Add(shop->Stock());
+			outfitterStock.Add(shop->InstantiateStock());
 		}
 	}
 

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -225,12 +225,14 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	}
 	else if(key == 's' && hasAccess && hasShipyard)
 	{
-		GetUI()->Push(new ShipyardPanel(player, shipyardStock));
+		SaleManager saleManager(player, &outfitterStock, &shipyardStock);
+		GetUI()->Push(new ShipyardPanel(player, shipyardStock, saleManager));
 		return true;
 	}
 	else if(key == 'o' && hasAccess && hasOutfitter)
 	{
-		GetUI()->Push(new OutfitterPanel(player, outfitterStock));
+		SaleManager saleManager(player, &outfitterStock, &shipyardStock);
+		GetUI()->Push(new OutfitterPanel(player, outfitterStock, saleManager));
 		return true;
 	}
 	else if(key == 'j' && hasAccess && planet.GetPort().HasService(Port::ServicesType::JobBoard))

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -55,7 +55,7 @@ using namespace std;
 PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	: player(player), callback(callback),
 	planet(*player.GetPlanet()), system(*player.GetSystem()),
-	ui(*GameData::Interfaces().Get("planet"))
+	ui(*GameData::Interfaces().Get("planet")), saleManager(SaleManager(player, &outfitterStock, &shipyardStock))
 {
 	trading.reset(new TradingPanel(player));
 	bank.reset(new BankPanel(player));
@@ -190,7 +190,6 @@ void PlanetPanel::Draw()
 
 void PlanetPanel::EnterShipyard()
 {
-	SaleManager saleManager(player, &outfitterStock, &shipyardStock);
 	GetUI()->Push(new ShipyardPanel(player, shipyardStock, saleManager));
 }
 
@@ -233,13 +232,11 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	}
 	else if(key == 's' && hasAccess && hasShipyard)
 	{
-		SaleManager saleManager(player, &outfitterStock, &shipyardStock);
 		GetUI()->Push(new ShipyardPanel(player, shipyardStock, saleManager));
 		return true;
 	}
 	else if(key == 'o' && hasAccess && hasOutfitter)
 	{
-		SaleManager saleManager(player, &outfitterStock, &shipyardStock);
 		GetUI()->Push(new OutfitterPanel(player, outfitterStock, saleManager));
 		return true;
 	}
@@ -511,7 +508,6 @@ void PlanetPanel::TakeOff(const bool distributeCargo)
 {
 	flightChecks.clear();
 	player.Save();
-	SaleManager saleManager(player, &outfitterStock, &shipyardStock);
 	if(player.TakeOff(GetUI(), distributeCargo, saleManager))
 	{
 		if(callback)

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -17,7 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Panel.h"
 
-#include "Sale.h"
+#include "Stock.h"
 
 #include <functional>
 #include <map>
@@ -74,8 +74,8 @@ private:
 	bool initializedShops = false;
 	bool hasShipyard = false;
 	bool hasOutfitter = false;
-	Sale<Ship> shipyardStock;
-	Sale<Outfit> outfitterStock;
+	Stock<Ship> shipyardStock;
+	Stock<Outfit> outfitterStock;
 
 	std::shared_ptr<Panel> trading;
 	std::shared_ptr<Panel> bank;

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Panel.h"
 
+#include "SaleManager.h"
 #include "Stock.h"
 
 #include <functional>
@@ -79,6 +80,7 @@ private:
 	bool hasOutfitter = false;
 	Stock<Ship> shipyardStock;
 	Stock<Outfit> outfitterStock;
+	SaleManager saleManager;
 
 	std::shared_ptr<Panel> trading;
 	std::shared_ptr<Panel> bank;

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -47,6 +47,9 @@ public:
 	virtual void Step() override;
 	virtual void Draw() override;
 
+	// Allow the StartConditionsPanel to tell the PlanetPanel to enter the ShipyardPanel.
+	void EnterShipyard();
+
 
 protected:
 	// Only override the ones you need; the default action is to return false.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1662,7 +1662,7 @@ void PlayerInfo::Land(UI *ui)
 
 // Load the cargo back into your ships. This may require selling excess, in
 // which case a message will be returned.
-bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
+bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo, const SaleManager &saleManager)
 {
 	// This can only be done while landed.
 	if(!system || !planet)
@@ -1842,7 +1842,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 				// Compute the total value for each type of excess outfit.
 				if(!outfit.second)
 					continue;
-				int64_t cost = depreciation.Value(outfit.first, day, outfit.second);
+				int64_t cost = saleManager.SellValue(outfit.first, outfit.second);
 				for(int i = 0; i < outfit.second; ++i)
 					stockDepreciation.Buy(outfit.first, day, &depreciation);
 				income += cost;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -917,7 +917,7 @@ void PlayerInfo::DoAccounting()
 	// calculation of yearly income to determine maximum mortgage amounts.
 	// Net worth only accounts for the base sell value of the player's fleet,
 	// unaffected by any dynamic shop prices.
-	int64_t assets = depreciation.Value(ships, date.DaysSinceEpoch());
+	int64_t assets = SaleManager(*this).SellValue(ships);
 	for(const shared_ptr<Ship> &ship : ships)
 		assets += ship->Cargo().Value(system);
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -196,7 +196,7 @@ public:
 	// Switch cargo from being stored in ships to being stored here.
 	void Land(UI *ui);
 	// Make ships ready for take off. This may require selling excess cargo.
-	bool TakeOff(UI *ui, bool distributeCargo);
+	bool TakeOff(UI *ui, bool distributeCargo, const SaleManager &saleManager);
 	// Pool cargo from local ships.
 	void PoolCargo();
 	// Distribute cargo to local ships. Returns a reference to the player's cargo.

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -41,6 +41,7 @@ class Outfit;
 class Planet;
 class RaidFleet;
 class Rectangle;
+class SaleManager;
 class Ship;
 class ShipEvent;
 class StartConditions;
@@ -164,9 +165,9 @@ public:
 	void AddShip(const std::shared_ptr<Ship> &ship);
 	// Buy, receive or sell a ship.
 	// In the case of a gift, return a pointer to the newly instantiated ship.
-	void BuyShip(const Ship *model, const std::string &name);
+	void BuyShip(const Ship *model, const std::string &name, const SaleManager &saleManager);
 	const Ship *GiftShip(const Ship *model, const std::string &name, const std::string &id);
-	void SellShip(const Ship *selected, bool storeOutfits = false);
+	void SellShip(const Ship *selected, const SaleManager &saleManager, bool storeOutfits = false);
 	// Take the ship from the player, if a model is specified this will permanently remove outfits in said model,
 	// instead of allowing the player to buy them back by putting them in the stock.
 	void TakeShip(const Ship *shipToTake, const Ship *model = nullptr, bool takeOutfits = false);

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -56,7 +56,7 @@ namespace {
 		cout << DataWriter::Quote(itemNoun) << ',' << DataWriter::Quote(saleNoun) << '\n';
 		map<string, set<string>> itemSales;
 		for(auto &saleIt : sales)
-			for(auto &itemIt : saleIt.second.Stock())
+			for(auto &itemIt : saleIt.second.Sales())
 				itemSales[ObjectName(*itemIt)].insert(saleIt.first);
 		for(auto &itemIt : items)
 		{
@@ -79,7 +79,7 @@ namespace {
 		{
 			cout << DataWriter::Quote(saleIt.first);
 			int index = 0;
-			for(auto &item : saleIt.second.Stock())
+			for(auto &item : saleIt.second.Sales())
 				cout << (index++ ? ';' : ',') << DataWriter::Quote(ObjectName(*item));
 			cout << '\n';
 		}

--- a/source/Sale.h
+++ b/source/Sale.h
@@ -23,8 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 
-// Class representing a set of items that are for sale on a given planet.
-// Multiple sale sets can be merged together into a single one.
+// Class representing a set of items that can be sold from a Shop.
+// Sales get instantiated into Stocks when in use.
 template <class Item>
 class Sale : public std::set<const Item *> {
 public:

--- a/source/SaleManager.cpp
+++ b/source/SaleManager.cpp
@@ -53,7 +53,7 @@ int64_t SaleManager::BuyValue(const Outfit *outfit, int count) const
 			// If an item was just sold, we want to buy it at the same value it was sold
 			// at. Determine how many of this item being bought are old, and for those old items,
 			// use the selling price. For all remaining items, use the buying price.
-			int oldCount = stockDepreciation.NumberOld(outfit, count);
+			int oldCount = stockDepreciation.NumberOld(outfit, day, count);
 			if(oldCount)
 			{
 				count -= oldCount;
@@ -94,7 +94,7 @@ int64_t SaleManager::SellValue(const Outfit *outfit, int count) const
 			// If an item was just bought, we want to sell it at the same value it was bought
 			// at. Determine how many of this item being sold are new, and for those new items,
 			// use the buying price. For all remaining items, use the selling price.
-			int newCount = fleetDepreciation.NumberNew(outfit, count);
+			int newCount = fleetDepreciation.NumberNew(outfit, day, count);
 			if(newCount)
 			{
 				count -= newCount;
@@ -139,7 +139,7 @@ int64_t SaleManager::BuyValue(const Ship *ship, int count, bool chassisOnly) con
 			// If an item was just sold, we want to buy it at the same value it was sold
 			// at. Determine how many of this item being bought are old, and for those old items,
 			// use the selling price. For all remaining items, use the buying price.
-			int oldCount = stockDepreciation.NumberOld(ship, count);
+			int oldCount = stockDepreciation.NumberOld(ship, day, count);
 			if(oldCount)
 			{
 				count -= oldCount;
@@ -187,7 +187,7 @@ int64_t SaleManager::SellValue(const Ship *ship, int count) const
 			// If an item was just bought, we want to sell it at the same value it was bought
 			// at. Determine how many of this item being sold are new, and for those new items,
 			// use the buying price. For all remaining items, use the selling price.
-			int newCount = fleetDepreciation.NumberNew(ship, count);
+			int newCount = fleetDepreciation.NumberNew(ship, day, count);
 			if(newCount)
 			{
 				count -= newCount;

--- a/source/SaleManager.cpp
+++ b/source/SaleManager.cpp
@@ -37,6 +37,20 @@ SaleManager::SaleManager(const PlayerInfo &player, const Stock<Outfit> *outfitte
 
 
 
+bool SaleManager::Has(const Outfit *outfit) const
+{
+	return outfitter && outfitter->Has(outfit);
+}
+
+
+
+bool SaleManager::Has(const Ship *ship) const
+{
+	return shipyard && shipyard->Has(ship);
+}
+
+
+
 int64_t SaleManager::BuyValue(const Outfit *outfit, int count) const
 {
 	if(!outfit || count <= 0)

--- a/source/SaleManager.cpp
+++ b/source/SaleManager.cpp
@@ -1,0 +1,217 @@
+/* SaleManager.cpp
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "SaleManager.h"
+
+#include "Date.h"
+#include "Depreciation.h"
+#include "GameData.h"
+#include "Outfit.h"
+#include "PlayerInfo.h"
+#include "Ship.h"
+#include "Shop.h"
+#include "ShopPricing.h"
+#include "StockItem.h"
+
+using namespace std;
+
+
+
+SaleManager::SaleManager(const PlayerInfo &player, const Stock<Outfit> *outfitter, const Stock<Ship> *shipyard)
+	: player(player), outfitter(outfitter), shipyard(shipyard), day(player.GetDate().DaysSinceEpoch()),
+	fleetDepreciation(player.FleetDepreciation()), stockDepreciation(player.StockDepreciation())
+{
+}
+
+
+
+int64_t SaleManager::BuyValue(const Outfit *outfit, int count) const
+{
+	if(!outfit || count <= 0)
+		return 0;
+
+	int64_t baseCost = outfit->Cost();
+	double fraction = stockDepreciation.ValueFraction(outfit, day, count);
+
+	if(outfitter)
+	{
+		// If this item is for sale from the outfitter, use the outfitter's price modifier.
+		const StockItem<Outfit> *stock = outfitter->Get(outfit);
+		if(stock)
+		{
+			const ShopPricing &modifier = stock->BuyModifier();
+			return modifier.Value(baseCost, fraction, count);
+		}
+	}
+
+	// Otherwise, just return the outfit cost with normal appreciation applied.
+	return baseCost * fraction;
+}
+
+
+
+int64_t SaleManager::SellValue(const Outfit *outfit, int count) const
+{
+	if(!outfit || count <= 0)
+		return 0;
+
+	int64_t baseCost = outfit->Cost();
+
+	if(outfitter)
+	{
+		// If this item is for sale from the outfitter, use the outfitter's price modifier.
+		const StockItem<Outfit> *stock = outfitter->Get(outfit);
+		if(stock)
+		{
+			// If an item was just purchased, we want to sell it at the same value it was
+			// purchased at. Determine how many of this item being sold are brand new,
+			// and for those new items, use the buying price. For all remaining items,
+			// use the modified selling price.
+			int newCount = fleetDepreciation.NumberNew(outfit, count);
+			count -= newCount;
+			int64_t value = 0;
+			if(newCount)
+				value += BuyValue(outfit, newCount);
+			if(count)
+			{
+				double fraction = fleetDepreciation.ValueFraction(outfit, day, count);
+				const ShopPricing &modifier = stock->SellModifier();
+				value += modifier.Value(baseCost, fraction, count);
+			}
+			return value;
+		}
+	}
+
+	// Otherwise, just return the base cost with normal depreciation applied.
+	double fraction = fleetDepreciation.ValueFraction(outfit, day, count);
+	return baseCost * fraction;
+}
+
+
+
+int64_t SaleManager::BuyValue(const Ship *ship, int count, bool chassisOnly) const
+{
+	if(!ship || count <= 0)
+		return 0;
+
+	ship = GameData::Ships().Get(ship->TrueModelName());
+	int64_t baseCost = ship->ChassisCost();
+	double fraction = stockDepreciation.ValueFraction(ship, day, count);
+
+	int64_t value = 0;
+	const StockItem<Ship> *stock = nullptr;
+	if(shipyard)
+	{
+		// If this item is for sale from the shipyard, use the shipyard's price modifier.
+		// Note: The shipyard should always have a StockItem for the given ship, at least
+		// unless we make it so that selling a ship stores its chassis in the shipyard.
+		stock = shipyard->Get(ship);
+		if(stock)
+		{
+			const ShopPricing &modifier = stock->BuyModifier();
+			value += modifier.Value(baseCost, fraction, count);
+		}
+	}
+	if(!shipyard && !stock)
+	{
+		// Otherwise, just use the ship cost with normal appreciation applied.
+		value += baseCost * fraction;
+	}
+
+	if(!chassisOnly)
+		for(const auto &it : ship->Outfits())
+			value += BuyValue(it.first, it.second);
+	return value;
+}
+
+
+
+int64_t SaleManager::SellValue(const Ship *ship, int count) const
+{
+	if(!ship || count <= 0)
+		return 0;
+
+	ship = GameData::Ships().Get(ship->TrueModelName());
+	int64_t baseCost = ship->ChassisCost();
+
+	if(shipyard)
+	{
+		// If this item is for sale from the shipyard, use the shipyard's price modifier.
+		const StockItem<Ship> *stock = shipyard->Get(ship);
+		if(stock)
+		{
+			// If an item was just purchased, we want to sell it at the same value it was
+			// purchased at. Determine how many of this item being sold are brand new,
+			// and for those new items, use the buying price. For all remaining items,
+			// use the modified selling price.
+			int newCount = fleetDepreciation.NumberNew(ship, count);
+			count -= newCount;
+			int64_t value = 0;
+			if(newCount)
+				value += BuyValue(ship, newCount);
+			if(count)
+			{
+				double fraction = fleetDepreciation.ValueFraction(ship, day, count);
+				const ShopPricing &modifier = stock->SellModifier();
+				value += modifier.Value(baseCost, fraction, count);
+			}
+			return value;
+		}
+	}
+
+	// Otherwise, just return the base cost with normal depreciation applied.
+	double fraction = fleetDepreciation.ValueFraction(ship, day, count);
+	return baseCost * fraction;
+}
+
+
+
+int64_t SaleManager::SellValue(const Ship &ship) const
+{
+	int64_t value = SellValue(&ship);
+	for(const auto &it : ship.Outfits())
+		value += SellValue(it.first, it.second);
+	return value;
+}
+
+
+
+int64_t SaleManager::SellValue(const vector<shared_ptr<Ship>> &fleet, bool chassisOnly) const
+{
+	if(fleet.empty())
+		return 0;
+
+	// Determine how many of each ship and outfit is being sold.
+	map<const Ship *, int> shipCount;
+	map<const Outfit *, int> outfitCount;
+
+	for(const shared_ptr<Ship> &ship : fleet)
+	{
+		const Ship *base = GameData::Ships().Get(ship->TrueModelName());
+		++shipCount[base];
+
+		if(!chassisOnly)
+			for(const auto &it : ship->Outfits())
+				outfitCount[it.first] += it.second;
+	}
+
+	// Add up the value across all ship chassis and outfits being sold.
+	int64_t value = 0;
+	for(const auto &it : shipCount)
+		value += SellValue(it.first, it.second);
+	for(const auto &it : outfitCount)
+		value += SellValue(it.first, it.second);
+	return value;
+}

--- a/source/SaleManager.h
+++ b/source/SaleManager.h
@@ -1,0 +1,65 @@
+/* SaleManager.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Stock.h"
+
+#include <memory>
+#include <vector>
+
+class Depreciation;
+class Outfit;
+class PlayerInfo;
+class Ship;
+
+
+
+// A class for managing the buying and selling of items in a shop.
+class SaleManager {
+public:
+	SaleManager(const PlayerInfo &player, const Stock<Outfit> *outfitter = nullptr,
+		const Stock<Ship> *shipyard = nullptr);
+
+	// The buy value of an outfit in the outfitter.
+	int64_t BuyValue(const Outfit *outfit, int count = 1) const;
+	// The sell value of an outfit in the outfitter. May equal the buy value if the
+	// shop has no modifiers, or the outfit was just purchased and is being sold back
+	// to the shop at its full price.
+	int64_t SellValue(const Outfit *outfit, int count = 1) const;
+
+	// The buy value of a ship in the shipyard.
+	int64_t BuyValue(const Ship *ship, int count = 1, bool chassisOnly = false) const;
+	// The sell value of a ship in the shipyard. May equal the buy value if the
+	// shop has no modifiers, or the ship was just purchased and is being sold back
+	// to the shop at its full price. This is only the value of the chassis.
+	int64_t SellValue(const Ship *ship, int count = 1) const;
+
+	// The sell value of one of the player's ships, chassis and outfits included.
+	int64_t SellValue(const Ship &ship) const;
+	// The sell value from a collection of the player's ships.
+	int64_t SellValue(const std::vector<std::shared_ptr<Ship>> &fleet, bool chassisOnly = false) const;
+
+
+private:
+	const PlayerInfo &player;
+	const Stock<Outfit> *outfitter = nullptr;
+	const Stock<Ship> *shipyard = nullptr;
+
+	// The current number of days since the epoch, for determining depreciation.
+	int day;
+	const Depreciation &fleetDepreciation;
+	const Depreciation &stockDepreciation;
+};

--- a/source/SaleManager.h
+++ b/source/SaleManager.h
@@ -33,6 +33,13 @@ public:
 	SaleManager(const PlayerInfo &player, const Stock<Outfit> *outfitter = nullptr,
 		const Stock<Ship> *shipyard = nullptr);
 
+	// Whether the given item is available in the shops tracked by this SaleManager.
+	// Currently only accounts for permanent stock. That is, items not for sale in
+	// the shop and only present because the player sold them are not accounted
+	// for by these functions.
+	bool Has(const Outfit *outfit) const;
+	bool Has(const Ship *ship) const;
+
 	// The buy value of an outfit in the outfitter.
 	int64_t BuyValue(const Outfit *outfit, int count = 1) const;
 	// The sell value of an outfit in the outfitter. May equal the buy value if the

--- a/source/ShipInfoDisplay.h
+++ b/source/ShipInfoDisplay.h
@@ -20,9 +20,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
-class Depreciation;
 class PlayerInfo;
 class Point;
+class SaleManager;
 class Ship;
 
 
@@ -34,11 +34,10 @@ class Ship;
 class ShipInfoDisplay : public ItemInfoDisplay {
 public:
 	ShipInfoDisplay() = default;
-	ShipInfoDisplay(const Ship &ship, const PlayerInfo &player, bool descriptionCollapsed = true);
 
 	// Call this every time the ship changes.
-	void Update(const Ship &ship, const PlayerInfo &player, bool descriptionCollapsed = true,
-		bool scrollingPanel = false);
+	void Update(const Ship &ship, const PlayerInfo &player, const SaleManager &saleManager,
+		bool descriptionCollapsed = true, bool scrollingPanel = false);
 
 	// Provided by ItemInfoDisplay:
 	// int PanelWidth();
@@ -56,8 +55,9 @@ public:
 
 
 private:
-	void UpdateAttributes(const Ship &ship, const PlayerInfo &player, bool descriptionCollapsed, bool scrollingPanel);
-	void UpdateOutfits(const Ship &ship, const PlayerInfo &player, const Depreciation &depreciation);
+	void UpdateAttributes(const Ship &ship, const PlayerInfo &player, bool descriptionCollapsed,
+		bool scrollingPanel, const SaleManager &saleManager);
+	void UpdateOutfits(const Ship &ship, const PlayerInfo &player, const SaleManager &saleManager);
 
 
 private:

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -36,6 +36,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "PlayerInfo.h"
 #include "PlayerInfoPanel.h"
 #include "Rectangle.h"
+#include "SaleManager.h"
 #include "Ship.h"
 #include "ShipNameDialog.h"
 #include "image/Sprite.h"
@@ -55,10 +56,14 @@ namespace {
 	constexpr int COLUMN_WIDTH = static_cast<int>(WIDTH) - 20;
 }
 
+
+
 ShipInfoPanel::ShipInfoPanel(PlayerInfo &player)
 	: ShipInfoPanel(player, InfoPanelState(player))
 {
 }
+
+
 
 ShipInfoPanel::ShipInfoPanel(PlayerInfo &player, InfoPanelState state)
 	: player(player), panelState(std::move(state))
@@ -332,7 +337,7 @@ void ShipInfoPanel::UpdateInfo()
 		return;
 
 	const Ship &ship = **shipIt;
-	info.Update(ship, player);
+	info.Update(ship, player, SaleManager(player));
 	if(player.Flagship() && ship.GetSystem() == player.GetSystem() && &ship != player.Flagship())
 	{
 		player.Flagship()->SetTargetShip(*shipIt);
@@ -786,7 +791,7 @@ void ShipInfoPanel::Dump()
 	selectedCommodity.clear();
 	selectedPlunder = nullptr;
 
-	info.Update(**shipIt, player);
+	info.Update(**shipIt, player, SaleManager(player));
 	if(loss)
 		Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
 			, Messages::Importance::High);
@@ -802,7 +807,7 @@ void ShipInfoPanel::DumpPlunder(int count)
 	{
 		loss += count * selectedPlunder->Cost();
 		(*shipIt)->Jettison(selectedPlunder, count);
-		info.Update(**shipIt, player);
+		info.Update(**shipIt, player, SaleManager(player));
 
 		if(loss)
 			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
@@ -822,7 +827,7 @@ void ShipInfoPanel::DumpCommodities(int count)
 		loss += basis;
 		player.AdjustBasis(selectedCommodity, -basis);
 		(*shipIt)->Jettison(selectedCommodity, count);
-		info.Update(**shipIt, player);
+		info.Update(**shipIt, player, SaleManager(player));
 
 		if(loss)
 			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -53,7 +53,7 @@ namespace {
 
 
 
-ShipyardPanel::ShipyardPanel(PlayerInfo &player, Sale<Ship> stock)
+ShipyardPanel::ShipyardPanel(PlayerInfo &player, Stock<Ship> stock)
 	: ShopPanel(player, false), modifier(0), shipyard(stock)
 {
 	for(const auto &it : GameData::Ships())

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -53,8 +53,8 @@ namespace {
 
 
 
-ShipyardPanel::ShipyardPanel(PlayerInfo &player, Stock<Ship> stock)
-	: ShopPanel(player, false), modifier(0), shipyard(stock)
+ShipyardPanel::ShipyardPanel(PlayerInfo &player, Stock<Ship> &stock, SaleManager saleManager)
+	: ShopPanel(player, false, std::move(saleManager)), modifier(0), shipyard(stock)
 {
 	for(const auto &it : GameData::Ships())
 		catalog[it.second.Attributes().Category()].push_back(it.first);
@@ -125,7 +125,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 
 	if(selectedShip)
 	{
-		shipInfo.Update(*selectedShip, player, collapsed.contains(DESCRIPTION), true);
+		shipInfo.Update(*selectedShip, player, saleManager, collapsed.contains(DESCRIPTION), true);
 		selectedItem = selectedShip->DisplayModelName();
 
 		const Point spriteCenter(center.X(), center.Y() + 20 + TileSize() / 2);

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -31,6 +31,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
+#include "SaleManager.h"
 #include "Screen.h"
 #include "Ship.h"
 #include "ShipNameDialog.h"
@@ -53,8 +54,8 @@ namespace {
 
 
 
-ShipyardPanel::ShipyardPanel(PlayerInfo &player, Stock<Ship> &stock, SaleManager saleManager)
-	: ShopPanel(player, false, std::move(saleManager)), modifier(0), shipyard(stock)
+ShipyardPanel::ShipyardPanel(PlayerInfo &player, Stock<Ship> &stock, const SaleManager &saleManager)
+	: ShopPanel(player, false, saleManager), modifier(0), shipyard(stock)
 {
 	for(const auto &it : GameData::Ships())
 		catalog[it.second.Attributes().Category()].push_back(it.first);

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -193,7 +193,7 @@ ShopPanel::BuyResult ShipyardPanel::CanBuy(bool onlyOwned) const
 	if(!selectedShip)
 		return false;
 
-	int64_t cost = player.StockDepreciation().Value(*selectedShip, day);
+	int64_t cost = saleManager.BuyValue(selectedShip);
 
 	// Check that the player has any necessary licenses.
 	int64_t licenseCost = LicenseCost(&selectedShip->Attributes());
@@ -207,7 +207,7 @@ ShopPanel::BuyResult ShipyardPanel::CanBuy(bool onlyOwned) const
 	{
 		// Check if ships could be sold to pay for the new ship.
 		for(const auto &it : player.Ships())
-			cost -= player.FleetDepreciation().Value(*it, day);
+			cost -= saleManager.SellValue(*it);
 
 		if(player.Accounts().Credits() >= cost)
 		{
@@ -308,7 +308,7 @@ void ShipyardPanel::Sell(bool toStorage)
 	vector<shared_ptr<Ship>> toSell;
 	for(const auto &it : playerShips)
 		toSell.push_back(it->shared_from_this());
-	int64_t total = player.FleetDepreciation().Value(toSell, day, toStorage);
+	int64_t total = saleManager.SellValue(toSell, toStorage);
 
 	message += ((initialCount > 2) ? "\nfor " : " for ") + Format::CreditString(total) + "?";
 
@@ -351,7 +351,7 @@ void ShipyardPanel::BuyShip(const string &name)
 		else if(modifier > 1)
 			shipName += " " + to_string(i);
 
-		player.BuyShip(selectedShip, shipName);
+		player.BuyShip(selectedShip, shipName, saleManager);
 	}
 
 	playerShip = &*player.Ships().back();
@@ -379,7 +379,7 @@ void ShipyardPanel::SellShipChassis()
 void ShipyardPanel::SellShip(bool toStorage)
 {
 	for(Ship *ship : playerShips)
-		player.SellShip(ship, toStorage);
+		player.SellShip(ship, saleManager, toStorage);
 	playerShips.clear();
 	playerShip = nullptr;
 	for(const shared_ptr<Ship> &ship : player.Ships())

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -17,7 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "ShopPanel.h"
 
-#include "Sale.h"
+#include "Stock.h"
 
 #include <string>
 
@@ -34,7 +34,7 @@ class Ship;
 // a government that is particularly repressive of independent pilots.)
 class ShipyardPanel : public ShopPanel {
 public:
-	explicit ShipyardPanel(PlayerInfo &player, Sale<Ship> stock);
+	explicit ShipyardPanel(PlayerInfo &player, Stock<Ship> stock);
 
 	virtual void Step() override;
 
@@ -64,5 +64,5 @@ private:
 private:
 	int modifier;
 
-	Sale<Ship> shipyard;
+	Stock<Ship> shipyard;
 };

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class PlayerInfo;
 class Point;
+class SaleManager;
 class Ship;
 
 
@@ -34,7 +35,7 @@ class Ship;
 // a government that is particularly repressive of independent pilots.)
 class ShipyardPanel : public ShopPanel {
 public:
-	explicit ShipyardPanel(PlayerInfo &player, Stock<Ship> stock);
+	explicit ShipyardPanel(PlayerInfo &player, Stock<Ship> &stock, SaleManager saleManager);
 
 	virtual void Step() override;
 
@@ -64,5 +65,5 @@ private:
 private:
 	int modifier;
 
-	Stock<Ship> shipyard;
+	Stock<Ship> &shipyard;
 };

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -35,7 +35,7 @@ class Ship;
 // a government that is particularly repressive of independent pilots.)
 class ShipyardPanel : public ShopPanel {
 public:
-	explicit ShipyardPanel(PlayerInfo &player, Stock<Ship> &stock, SaleManager saleManager);
+	explicit ShipyardPanel(PlayerInfo &player, Stock<Ship> &stock, const SaleManager &saleManager);
 
 	virtual void Step() override;
 

--- a/source/Shop.h
+++ b/source/Shop.h
@@ -125,9 +125,14 @@ void Shop<Item>::Load(const DataNode &node, const Set<Item> &items, const Condit
 				stock.clear();
 			}
 			if(remove)
-				stock.clear();
+			{
+				if(child.HasChildren())
+					stock.Remove(child, items);
+				else
+					stock.clear();
+			}
 			else
-				stock.Load(child, items, true);
+				stock.Add(child, items);
 		}
 		else
 			stock.LoadSingle(child, items);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -36,6 +36,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "shader/PointerShader.h"
 #include "Preferences.h"
 #include "Sale.h"
+#include "SaleManager.h"
 #include "Screen.h"
 #include "ScrollBar.h"
 #include "ScrollVar.h"
@@ -100,10 +101,9 @@ namespace {
 
 
 
-ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter, SaleManager saleManager)
-	: player(player), day(player.GetDate().DaysSinceEpoch()),
-	planet(player.GetPlanet()), isOutfitter(isOutfitter), saleManager(std::move(saleManager)),
-	playerShip(player.Flagship()),
+ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter, const SaleManager &saleManager)
+	: player(player), day(player.GetDate().DaysSinceEpoch()), planet(player.GetPlanet()),
+	isOutfitter(isOutfitter), saleManager(saleManager), playerShip(player.Flagship()),
 	categories(GameData::GetCategory(isOutfitter ? CategoryType::OUTFIT : CategoryType::SHIP)),
 	collapsed(player.Collapsed(isOutfitter ? "outfitter" : "shipyard"))
 {

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -100,9 +100,10 @@ namespace {
 
 
 
-ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
+ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter, SaleManager saleManager)
 	: player(player), day(player.GetDate().DaysSinceEpoch()),
-	planet(player.GetPlanet()), isOutfitter(isOutfitter), playerShip(player.Flagship()),
+	planet(player.GetPlanet()), isOutfitter(isOutfitter), saleManager(std::move(saleManager)),
+	playerShip(player.Flagship()),
 	categories(GameData::GetCategory(isOutfitter ? CategoryType::OUTFIT : CategoryType::SHIP)),
 	collapsed(player.Collapsed(isOutfitter ? "outfitter" : "shipyard"))
 {
@@ -1130,7 +1131,7 @@ void ShopPanel::DrawMain()
 
 int ShopPanel::DrawPlayerShipInfo(const Point &point)
 {
-	shipInfo.Update(*playerShip, player, collapsed.contains("description"), true);
+	shipInfo.Update(*playerShip, player, saleManager, collapsed.contains("description"), true);
 	shipInfo.DrawAttributes(point, !isOutfitter);
 	const int attributesHeight = shipInfo.GetAttributesHeight(!isOutfitter);
 	shipInfo.DrawOutfits(Point(point.X(), point.Y() + attributesHeight));

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -702,7 +702,8 @@ int64_t ShopPanel::LicenseCost(const Outfit *outfit, bool onlyOwned) const
 	if((owned && onlyOwned) || player.Stock(outfit) > 0)
 		return 0;
 
-	const Sale<Outfit> &available = player.GetPlanet()->OutfitterStock();
+	// TODO: Use conditional stocks instead of permanent sales.
+	const Sale<Outfit> &available = player.GetPlanet()->OutfitterSales();
 
 	int64_t cost = 0;
 	for(const string &name : outfit->Licenses())

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -703,17 +703,17 @@ int64_t ShopPanel::LicenseCost(const Outfit *outfit, bool onlyOwned) const
 	if((owned && onlyOwned) || player.Stock(outfit) > 0)
 		return 0;
 
-	// TODO: Use conditional stocks instead of permanent sales.
-	const Sale<Outfit> &available = player.GetPlanet()->OutfitterSales();
-
 	int64_t cost = 0;
 	for(const string &name : outfit->Licenses())
 		if(!player.HasLicense(name))
 		{
 			const Outfit *license = GameData::Outfits().Find(name + " License");
-			if(!license || !license->Cost() || !available.Has(license))
+			if(!license || !saleManager.Has(license))
 				return -1;
-			cost += license->Cost();
+			int64_t licenseCost = saleManager.BuyValue(license);
+			if(!licenseCost)
+				return -1;
+			cost += licenseCost;
 		}
 	return cost;
 }

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Mission.h"
 #include "OutfitInfoDisplay.h"
 #include "Point.h"
+#include "SaleManager.h"
 #include "ScrollBar.h"
 #include "ScrollVar.h"
 #include "ShipInfoDisplay.h"
@@ -42,7 +43,7 @@ class Ship;
 // outfitter panel (e.g. the sidebar with the ships you own).
 class ShopPanel : public Panel {
 public:
-	explicit ShopPanel(PlayerInfo &player, bool isOutfitter);
+	explicit ShopPanel(PlayerInfo &player, bool isOutfitter, SaleManager saleManager);
 
 	virtual void Step() override;
 	virtual void Draw() override;
@@ -150,6 +151,7 @@ protected:
 	int day;
 	const Planet *planet = nullptr;
 	const bool isOutfitter;
+	SaleManager saleManager;
 
 	// The player-owned ship that was first selected in the sidebar (or most recently purchased).
 	Ship *playerShip = nullptr;

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -21,7 +21,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Mission.h"
 #include "OutfitInfoDisplay.h"
 #include "Point.h"
-#include "SaleManager.h"
 #include "ScrollBar.h"
 #include "ScrollVar.h"
 #include "ShipInfoDisplay.h"
@@ -35,6 +34,7 @@ class CategoryList;
 class Outfit;
 class Planet;
 class PlayerInfo;
+class SaleManager;
 class Ship;
 
 
@@ -43,7 +43,7 @@ class Ship;
 // outfitter panel (e.g. the sidebar with the ships you own).
 class ShopPanel : public Panel {
 public:
-	explicit ShopPanel(PlayerInfo &player, bool isOutfitter, SaleManager saleManager);
+	explicit ShopPanel(PlayerInfo &player, bool isOutfitter, const SaleManager &saleManager);
 
 	virtual void Step() override;
 	virtual void Draw() override;
@@ -151,7 +151,7 @@ protected:
 	int day;
 	const Planet *planet = nullptr;
 	const bool isOutfitter;
-	SaleManager saleManager;
+	const SaleManager &saleManager;
 
 	// The player-owned ship that was first selected in the sidebar (or most recently purchased).
 	Ship *playerShip = nullptr;

--- a/source/ShopPricing.cpp
+++ b/source/ShopPricing.cpp
@@ -1,0 +1,93 @@
+/* ShopPricing.cpp
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "ShopPricing.h"
+
+#include "DataNode.h"
+
+#include <cmath>
+
+using namespace std;
+
+
+
+ShopPricing::ShopPricing(const DataNode &node)
+{
+	Load(node);
+}
+
+
+
+void ShopPricing::Load(const DataNode &node)
+{
+	isLoaded = true;
+
+	for(const DataNode &child : node)
+	{
+		const string &key = child.Token(0);
+		const bool hasValue = child.Size() > 1;
+		if(key == "ignore depreciation")
+			ignoreDepreciation = true;
+		else if(key == "multiplier" && hasValue)
+			multiplier = max<double>(0., child.Value(1));
+		else if(key == "offset" && hasValue)
+			offset = child.Value(1);
+		else if(key == "precedence" && hasValue)
+			precedence = child.Value(1);
+		else
+			child.PrintTrace("Skipping unrecognized attribute:");
+	}
+}
+
+
+
+bool ShopPricing::IsLoaded() const
+{
+	return isLoaded;
+}
+
+
+
+void ShopPricing::Combine(const ShopPricing &other)
+{
+	if(other.precedence < precedence)
+		return;
+
+	if(other.precedence > precedence)
+	{
+		precedence = other.precedence;
+		multiplier = other.multiplier;
+		offset = other.offset;
+		ignoreDepreciation = other.ignoreDepreciation;
+		return;
+	}
+
+	multiplier *= other.multiplier;
+	offset += other.offset;
+	ignoreDepreciation |= other.ignoreDepreciation;
+}
+
+
+
+int64_t ShopPricing::ActualCost(int64_t cost, double depreciation) const
+{
+	int64_t modified = cost * multiplier + offset;
+	// If the offset caused the value to go negative, return 0.
+	if(modified <= 0)
+		return 0;
+	if(!ignoreDepreciation)
+		modified *= depreciation;
+	return modified;
+}

--- a/source/ShopPricing.cpp
+++ b/source/ShopPricing.cpp
@@ -81,7 +81,7 @@ void ShopPricing::Combine(const ShopPricing &other)
 
 
 
-int64_t ShopPricing::Value(int64_t cost, double depreciation, int count) const
+int64_t ShopPricing::Value(int64_t cost, int count, double depreciation) const
 {
 	int64_t value = cost * multiplier + offset;
 	// If the offset caused the value to go negative, return 0.

--- a/source/ShopPricing.cpp
+++ b/source/ShopPricing.cpp
@@ -81,13 +81,16 @@ void ShopPricing::Combine(const ShopPricing &other)
 
 
 
-int64_t ShopPricing::ActualCost(int64_t cost, double depreciation) const
+int64_t ShopPricing::Value(int64_t cost, double depreciation, int count) const
 {
-	int64_t modified = cost * multiplier + offset;
+	int64_t value = cost * multiplier + offset;
 	// If the offset caused the value to go negative, return 0.
-	if(modified <= 0)
+	if(value <= 0)
 		return 0;
-	if(!ignoreDepreciation)
-		modified *= depreciation;
-	return modified;
+	// If ignoring depreciation, return the base value multiplied by the item count.
+	if(ignoreDepreciation)
+		return value * count;
+	// If depreciation is applied, the provided depreciation fraction will already
+	// account for the item count.
+	return value * depreciation;
 }

--- a/source/ShopPricing.h
+++ b/source/ShopPricing.h
@@ -39,9 +39,8 @@ public:
 	//   - Depreciation is ignored if either modifier ignores depreciation.
 	void Combine(const ShopPricing &other);
 
-	// Given the current cost of an item, return its actual cost
-	// according to this price modifier.
-	int64_t ActualCost(int64_t cost, double depreciation) const;
+	// Calculate the value of an item according to this modifier.
+	int64_t Value(int64_t cost, double depreciation, int count) const;
 
 
 private:

--- a/source/ShopPricing.h
+++ b/source/ShopPricing.h
@@ -40,7 +40,7 @@ public:
 	void Combine(const ShopPricing &other);
 
 	// Calculate the value of an item according to this modifier.
-	int64_t Value(int64_t cost, double depreciation, int count) const;
+	int64_t Value(int64_t cost, int count, double depreciation) const;
 
 
 private:

--- a/source/ShopPricing.h
+++ b/source/ShopPricing.h
@@ -1,0 +1,62 @@
+/* ShopPricing.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+class DataNode;
+
+
+
+// Class representing price modifications to items in a shop.
+class ShopPricing {
+public:
+	ShopPricing() noexcept = default;
+	ShopPricing(const DataNode &node);
+
+	void Load(const DataNode &node);
+	bool IsLoaded() const;
+
+	// Combine this price modifier with a different price modifier.
+	// - If the other modifier's precedence is lower than this one, do nothing.
+	// - If the other modifier's precedence is higher than this one, take on its values.
+	// - If the precedences match:
+	//   - Multipliers are multiplied together.
+	//   - Offsets are added together.
+	//   - Depreciation is ignored if either modifier ignores depreciation.
+	void Combine(const ShopPricing &other);
+
+	// Given the current cost of an item, return its actual cost
+	// according to this price modifier.
+	int64_t ActualCost(int64_t cost, double depreciation) const;
+
+
+private:
+	bool isLoaded = false;
+
+	// A multiplier applied to the cost of an item.
+	double multiplier = 1.;
+	// An offset that can be added to or subtracted from the cost.
+	// This is applied after the multiplier.
+	int64_t offset = 0;
+	// If true, the reduced cost incurred by depreciation is ignored.
+	bool ignoreDepreciation = false;
+	// A value used to determine which pricing modifiers should be
+	// applied to an outfit if there are multiple modifiers present.
+	// Modifiers with the same precedence value are combined. The modifier
+	// with the highest precedence is then what gets used.
+	int precedence = 0;
+};

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -246,9 +246,9 @@ void StartConditionsPanel::OnConversationEnd(int)
 	// If the starting conditions don't specify any ships, let the player buy one.
 	if(player.Ships().empty())
 	{
-		Sale<Ship> shipyardStock;
+		Stock<Ship> shipyardStock;
 		for(const Shop<Ship> *shop : player.GetPlanet()->Shipyards())
-			shipyardStock.Add(shop->Stock());
+			shipyardStock.Add(shop->InstantiateStock());
 		gamePanels.Push(new ShipyardPanel(player, shipyardStock));
 		gamePanels.StepAll();
 	}

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Interface.h"
 #include "MainPanel.h"
 #include "Planet.h"
+#include "PlanetPanel.h"
 #include "PlayerInfo.h"
 #include "Preferences.h"
 #include "Rectangle.h"
@@ -247,13 +248,8 @@ void StartConditionsPanel::OnConversationEnd(int)
 	// If the starting conditions don't specify any ships, let the player buy one.
 	if(player.Ships().empty())
 	{
-		Stock<Ship> shipyardStock;
-		Stock<Outfit> outfitterStock;
-		for(const Shop<Ship> *shop : player.GetPlanet()->Shipyards())
-			shipyardStock.Add(shop->InstantiateStock());
-		for(const Shop<Outfit> *shop : player.GetPlanet()->Outfitters())
-			outfitterStock.Add(shop->InstantiateStock());
-		gamePanels.Push(new ShipyardPanel(player, shipyardStock, SaleManager(player, &outfitterStock, &shipyardStock)));
+		PlanetPanel *planetPanel = static_cast<PlanetPanel *>(gamePanels.Top().get());
+		planetPanel->EnterShipyard();
 		gamePanels.StepAll();
 	}
 	if(parent)

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -30,6 +30,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "PlayerInfo.h"
 #include "Preferences.h"
 #include "Rectangle.h"
+#include "SaleManager.h"
 #include "Ship.h"
 #include "ShipyardPanel.h"
 #include "Shop.h"
@@ -247,9 +248,12 @@ void StartConditionsPanel::OnConversationEnd(int)
 	if(player.Ships().empty())
 	{
 		Stock<Ship> shipyardStock;
+		Stock<Outfit> outfitterStock;
 		for(const Shop<Ship> *shop : player.GetPlanet()->Shipyards())
 			shipyardStock.Add(shop->InstantiateStock());
-		gamePanels.Push(new ShipyardPanel(player, shipyardStock));
+		for(const Shop<Outfit> *shop : player.GetPlanet()->Outfitters())
+			outfitterStock.Add(shop->InstantiateStock());
+		gamePanels.Push(new ShipyardPanel(player, shipyardStock, SaleManager(player, &outfitterStock, &shipyardStock)));
 		gamePanels.StepAll();
 	}
 	if(parent)

--- a/source/Stock.h
+++ b/source/Stock.h
@@ -1,0 +1,72 @@
+/* Stock.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "StockItem.h"
+
+#include <algorithm>
+#include <set>
+
+
+
+// Class representing a set of items that are for sale on a given planet.
+// Multiple Stock sets can be merged together into a single one.
+template <class Item>
+class Stock : public std::set<StockItem<Item>> {
+public:
+	void Add(const Stock<Item> &other);
+	bool Has(const Item *item) const;
+	const StockItem<Item> *Get(const Item *item) const;
+};
+
+
+
+template <class Item>
+void Stock<Item>::Add(const Stock<Item> &other)
+{
+	// When adding two Stock sets together, items that exist
+	// in both sets are combined.
+	for(const StockItem<Item> &item : other)
+	{
+		auto node = this->extract(item);
+		if(!node.empty())
+		{
+			node.value().Combine(item);
+			this->insert(std::move(node));
+		}
+		else
+			this->insert(item);
+	}
+}
+
+
+
+template <class Item>
+bool Stock<Item>::Has(const Item *item) const
+{
+	return find(this->begin(), this->end(), item) != this->end();
+}
+
+
+
+template <class Item>
+const StockItem<Item> *Stock<Item>::Get(const Item *item) const
+{
+	auto it = find(this->begin(), this->end(), item);
+	if(it == this->end())
+		return nullptr;
+	return &*it;
+}

--- a/source/StockItem.h
+++ b/source/StockItem.h
@@ -96,7 +96,7 @@ void StockItem<Item>::Combine(const StockItem<Item> &other)
 template <class Item>
 bool StockItem<Item>::operator==(const StockItem<Item> &other) const
 {
-	return other.item == item;
+	return this->item == other.item;
 }
 
 
@@ -112,5 +112,5 @@ bool StockItem<Item>::operator==(const Item *item) const
 template <class Item>
 bool StockItem<Item>::operator<(const StockItem<Item> &other) const
 {
-	return this->item < item;
+	return this->item < other.item;
 }

--- a/source/StockItem.h
+++ b/source/StockItem.h
@@ -1,0 +1,116 @@
+/* StockItem.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "ShopPricing.h"
+
+
+
+// Class representing a particular item for sale in a shop.
+// Includes the price modifiers for the item being sold. Multiple
+// StockItems that represent the same item for sale can be combined,
+// merging the price modifiers from both items.
+template <class Item>
+class StockItem {
+public:
+	StockItem(const Item *item, ShopPricing buyModifier, ShopPricing sellModifier);
+
+	const Item *GetItem() const;
+
+	const ShopPricing &BuyModifier() const;
+	const ShopPricing &SellModifier() const;
+
+	// Combine StockItems that contain the same item.
+	void Combine(const StockItem<Item> &other);
+
+	// Two StockItems are equal if they contain the same item and have the same precedence.
+	bool operator==(const StockItem<Item> &other) const;
+	bool operator==(const Item *item) const;
+	// For storing in sorted containers.
+	bool operator<(const StockItem<Item> &other) const;
+
+
+private:
+	const Item *item = nullptr;
+
+	ShopPricing buyModifier;
+	ShopPricing sellModifier;
+};
+
+
+
+template <class Item>
+StockItem<Item>::StockItem(const Item *item, ShopPricing buyModifier, ShopPricing sellModifier)
+	: item(item), buyModifier(buyModifier), sellModifier(sellModifier)
+{
+}
+
+
+
+template <class Item>
+const Item *StockItem<Item>::GetItem() const
+{
+	return item;
+}
+
+
+
+template <class Item>
+const ShopPricing &StockItem<Item>::BuyModifier() const
+{
+	return buyModifier;
+}
+
+
+
+template <class Item>
+const ShopPricing &StockItem<Item>::SellModifier() const
+{
+	return sellModifier;
+}
+
+
+
+template <class Item>
+void StockItem<Item>::Combine(const StockItem<Item> &other)
+{
+	this->buyModifier.Combine(other.buyModifier);
+	this->sellModifier.Combine(other.sellModifier);
+}
+
+
+
+template <class Item>
+bool StockItem<Item>::operator==(const StockItem<Item> &other) const
+{
+	return other.item == item;
+}
+
+
+
+template <class Item>
+bool StockItem<Item>::operator==(const Item *item) const
+{
+	return this->item == item;
+}
+
+
+
+template <class Item>
+bool StockItem<Item>::operator<(const StockItem<Item> &other) const
+{
+	return this->item < item;
+}

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Messages.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
+#include "SaleManager.h"
 #include "System.h"
 #include "UI.h"
 
@@ -56,8 +57,9 @@ namespace {
 
 
 
-TradingPanel::TradingPanel(PlayerInfo &player)
-	: player(player), system(*player.GetSystem()), COMMODITY_COUNT(GameData::Commodities().size())
+TradingPanel::TradingPanel(PlayerInfo &player, const SaleManager &saleManager)
+	: player(player), system(*player.GetSystem()), saleManager(saleManager),
+	COMMODITY_COUNT(GameData::Commodities().size())
 {
 	SetTrapAllEvents(false);
 }
@@ -263,7 +265,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;
 
-			int64_t value = player.FleetDepreciation().Value(outfit, day, amount);
+			int64_t value = saleManager.SellValue(outfit, amount);
 			profit += value;
 			tonsSold += static_cast<int>(amount * outfit->Mass());
 

--- a/source/TradingPanel.h
+++ b/source/TradingPanel.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Panel.h"
 
 class PlayerInfo;
+class SaleManager;
 class System;
 
 
@@ -28,7 +29,7 @@ class System;
 // will need to select them individually in the outfitter panel.
 class TradingPanel : public Panel {
 public:
-	explicit TradingPanel(PlayerInfo &player);
+	explicit TradingPanel(PlayerInfo &player, const SaleManager &saleManager);
 	~TradingPanel();
 
 	virtual void Step() override;
@@ -48,6 +49,7 @@ private:
 private:
 	PlayerInfo &player;
 	const System &system;
+	const SaleManager &saleManager;
 	const int COMMODITY_COUNT;
 
 	// Remember whether the "sell all" button will sell all outfits, or sell


### PR DESCRIPTION
**Feature**

This PR addresses one of the features described in issue #11374,

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Feature Summary
This PR adds a new child node to `shipyard` and `outfitter`:
```html
(shipyard | outfitter) <name>
	"price modifier" [(buying | selling)]
		multiplier <value#>
		offset <value#>
		"ignore depreciation"
		precedence <value#>
```

* `"price modifier"`: This node defines custom price changes that a shop applies to the items that are for sale in the shop. If this token is provided without a value, then the modified price applies to both buying and selling of items. If the `buying` or `selling` value are provided, then the price modifier will only apply to items that the player buys or sells respectively.
  * Note that for shipyards, the price modifier is only applied to the chassis of the ships. If an outfitter on the planet has price modifiers for the outfits that are sold with a ship, then those outfits will take on the price modifiers of the outfitter.
  * If you purchase any item, you can sell that item for the same value you just purchased it at, even if the sell modifier would normally make the selling value lower. And if you just sold an item, you can purchase it back at the same value you sold it, even if the buy modifier would normally make the buying value higher. This is so that you don't gain or lose net worth when repeatedly buying and selling the same item.
  * For both shops, price modifiers are ONLY applied to items that are sold by the shop. So if there are two outfitters on a planet that have completely different sets of outfits, the price modifiers from each outfitter will only influence the items that shop sells.
* `multiplier`: A float value from [0, +inf) that multiplies the price of items for sale. The default value is 1.
* `offset`: An integer value that adds to the price of items for sale. The default value is 0. This value can be negative, but it will not push an item's value below 0.
* `"ignore depreciation"`: A valueless tag that, if present, causes value loss due to depreciation to be ignored.
* `precedence`: It is possible that multiple shops at the same planet can offer the same items for sale. If this is the case, and both shops have a price modifier, then the price modifiers are combined with one another. Multiplier values are multiplied together, offset values are added together, and if any shop has `"ignore depreciation"`, then depreciation is ignored. This combining of price modifiers only occurs for modifiers with the same precedence value, though. If you want one shop to overrule another, then you would give that shop a higher precedence value. The final price modification applied to items in shops is then the combination of all price modifiers with the highest precedence.

## Code Summary

In order to implement this feature, I had to do some heavy refactoring of the buying and selling logic. That has resulted in the following changes to the codebase:
* Shops are still defined with a Sales set of items for sale, but when a Shop is being used in a way that displays what items are for sale, the Sales set gets instantiated into a Stock set.
* Stock sets are a collection of StockItem objects. A StockItem is a representation of the item for sale, along with its price modifiers.
* Created a SaleManager class that has functions for returning the buying and selling value of any given outfit or ship. This SaleManager is instantiated with pointers to the Stock sets from the Shops on the current planet. If you are not on a planet, such as when you are viewing your ships in the player info panel, then the SaleManager can be instantiated with nullptr for each Stock set. This class then uses the Depreciation objects from the player and the ShopPricing objects from the StockItems to determine what the final value of an item is when buying or selling.

And an aside that I have made it so that Outfits can't have a negative cost. This was something that was allowed, but I wouldn't say it was a feature that we were expecting to support.

## Usage Examples + Testing Done + Screenshots
I updated the Basic Outfits outfitter to have a 10% increase in buying value, and a 5% decrease in selling value.
```
outfitter "Basic Outfits"
	"price modifier" buying
		multiplier 1.1
	"price modifier" selling
		multiplier 0.95
```
I started a new game, automatically sending me to the shipyard. Given that the outfits sold from the outfitter cost more than usual, that increase in price was passed on to the ships in the shipyard, but only for the outfits that are in the outfitter.
![image](https://github.com/user-attachments/assets/b46b396d-eced-4ddb-814d-ba55123299e1)
Upon purchasing my ship, the sell value matched the buy value. This is because even though the outfitter has the sell value set to a lower amount, outfits are sold at the same value they were purchased if they are brand new. I repeatedly sold and rebought the ship to verify that I didn't gain or lose net worth from the repeated transactions.
![image](https://github.com/user-attachments/assets/beb76ad4-fb9e-4cc7-84e4-30dd5197aac5)

In the outfitter, I saw that the outfits correctly reported a 10% increase in price. I again repeatedly bought and sold an energy blaster to confirm that my net worth didn't change from the repeated transactions.
![image](https://github.com/user-attachments/assets/a29597f6-56b6-4a56-a24b-c2abf0250ef6)

New Boston also has the "Ammo South" outfitter. Outfits from this outfitter were unchanged in their price.
![image](https://github.com/user-attachments/assets/3aaa707e-1154-4e13-a46c-3a703a4e60cf)

I then took off and immediately landed. This resulted in my ship dropping in total value.
![image](https://github.com/user-attachments/assets/722a3cab-4bb2-437d-b1e6-a986f456741f)

This is due to the fact that, since the outfits I have are no longer brand new, they are now sold and their normal selling value instead of being sold at the buying value.
![image](https://github.com/user-attachments/assets/4124a0d3-0206-4b63-8bdc-2829af195bd0)

I sold one of my outfits and noted that I could repurchase the outfit at the same value I sold it at. Buying the blaster back resulted in the prices matching the image directly above again.
![image](https://github.com/user-attachments/assets/914283d5-e7a6-4a0f-9b64-c963e7612cbc)

Without the blaster on my ship, my ship's value is 330.1k. This is with a completely stock set of outfits.
![image](https://github.com/user-attachments/assets/0e013df4-0f64-415b-ac60-1bd45e8be0d8)

I am then able to repurchase my ship at the exact same value, since the shipyard knowns to use the value of the old outfits.
![image](https://github.com/user-attachments/assets/259d5b05-83ed-410a-86b5-dff705ca46ce)

Rebuying the shuttle puts the buy value of a brand new shuttle back to what it was in the first screenshot, since the lower value outfits are no longer available.

I then jumped around for a few days so that depreciation kicked in. My ship and outfits further decreased in value.
![image](https://github.com/user-attachments/assets/c6b87fc1-5078-489a-a0c3-51ce7cc1e138)
![image](https://github.com/user-attachments/assets/0f3d0925-4a8e-48ac-b007-26e2b7ba2f4c)

I closed the game and updated the price modifiers to ignore depreciation.
```
outfitter "Basic Outfits"
	"price modifier" buying
		multiplier 1.1
		"ignore depreciation"
	"price modifier" selling
		multiplier 0.95
		"ignore depreciation"
```

This then resulted in my ship's chassis still being depreciated, but the value of my outfits returned to what it was before.
![image](https://github.com/user-attachments/assets/77ea33e2-1dac-431e-b5e7-7eebe78bbde5)
![image](https://github.com/user-attachments/assets/0ac7a342-97d8-455c-9cb6-e3c49a3dc7ee)

I then created a second outfitter that was an exact duplicate of the Basic Outfits outfitter called Basic Outfits 2. I added this outfitter to New Boston. Since the price modifiers of both outfitters have the same default precedence of 0, the values stacked together, resulting in a buying multiplier of 1.1 * 1.1 = 1.21 and a selling multiplier of 0.95 * 0.95 = 0.9025.

![image](https://github.com/user-attachments/assets/220ac0d1-e9e9-4b74-aff1-6c22ff279942)

I then updated "Basic Outfits" to have a higher precedence on its price modifiers, meaning that "Basic Outfits 2" would no longer apply its price modifiers to the outfits.
```
outfitter "Basic Outfits"
	"price modifier" buying
		multiplier 1.1
		"ignore depreciation"
		precedence 1
	"price modifier" selling
		multiplier 0.95
		"ignore depreciation"
		precedence 1
```

![image](https://github.com/user-attachments/assets/348db118-51fc-4091-87c8-8210bec6e71f)

## TODO List

These are things that aren't done yet, but that I might consider putting off until a separate PR due to the complexity that this PR already provides. The main goal of this PR was not only to get dynamic pricing in place, but also lay the groundwork for the rest of the features in #11374.
- [ ] The shipyard and outfitter sale maps should display the buying value of the selected item on the planet you have selected. I've left TODO comments in locations that will need updated. Making this change could also make it so that conditional shops can effect what is shown on the map.
- [ ] If depreciation is ignored, then the buying/selling order of items should be reversed to maximize your net worth gain. (Noted by @petervdmeer in #11374.)

## Wiki Update
WIP

## Performance Impact
At the moment, nothing of note. If we look at dynamic pricing in the map shop panels, we'll be running a lot more conditions sets when you open the map, but that would all be cached, so it'd only be a one frame thing.
