### PR TITLE
fix(mechanics): Update fleet cargo cache on auto unpark

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -115,16 +115,6 @@ namespace {
 		};
 		return any_of(player.Missions().begin(), player.Missions().end(), CheckClearance);
 	}
-
-	void HandleFlagshipParking(Ship *oldFirstShip, Ship *newFirstShip, const System *system)
-	{
-		if(newFirstShip != oldFirstShip && Preferences::Has("Automatically unpark flagship")
-						&& newFirstShip->CanBeFlagship() && newFirstShip->GetSystem() == system && newFirstShip->IsParked())
-		{
-			newFirstShip->SetIsParked(false);
-			oldFirstShip->SetIsParked(true);
-		}
-	}
 }
 
 
@@ -1371,7 +1361,7 @@ void PlayerInfo::ReorderShip(int fromIndex, int toIndex)
 	ships.insert(ships.begin() + toIndex, ship);
 	auto newFirstShip = ships[0];
 	// Check if the ship in the first position can be a flagship and is in the current system.
-	HandleFlagshipParking(oldFirstShip.get(), newFirstShip.get(), system);
+	HandleFlagshipParking(oldFirstShip.get(), newFirstShip.get());
 	flagship.reset();
 }
 
@@ -1387,7 +1377,7 @@ void PlayerInfo::SetShipOrder(const vector<shared_ptr<Ship>> &newOrder)
 		Ship *newFirstShip = ships.front().get();
 		// Check if the position of the flagship has changed, and the ship in the first position
 		// can be a flagship and is in the current system.
-		HandleFlagshipParking(oldFirstShip, newFirstShip, system);
+		HandleFlagshipParking(oldFirstShip, newFirstShip);
 		flagship.reset();
 	}
 	else
@@ -4605,6 +4595,19 @@ void PlayerInfo::Fine(UI *ui)
 		}
 		else
 			ui->Push(new Dialog(message));
+	}
+}
+
+
+
+void PlayerInfo::HandleFlagshipParking(Ship *oldFirstShip, Ship *newFirstShip)
+{
+	if(Preferences::Has("Automatically unpark flagship") && newFirstShip != oldFirstShip
+		&& newFirstShip->CanBeFlagship() && newFirstShip->GetSystem() == system && newFirstShip->IsParked())
+	{
+		newFirstShip->SetIsParked(false);
+		oldFirstShip->SetIsParked(true);
+		UpdateCargoCapacities();
 	}
 }
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -365,6 +365,8 @@ private:
 	// Set the flagship (on departure or during flight).
 	void SetFlagship(Ship &other);
 
+	void HandleFlagshipParking(Ship *oldFirstShip, Ship *newFirstShip);
+
 	// Helper function to update the ship selection.
 	void SelectShip(const std::shared_ptr<Ship> &ship, bool *first);
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1369354602939420712).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The auto flagship unpark helper sets parked flags directly instead of using the PlayerInfo::ParkShip wrapper, so it needs to call UpdateCargoCapacities on its own.

## Testing Done
yes™.

## Save File
See the original report.

## Performance Impact
N/A