### PR TITLE
feat(mechanics): Relinquish tribute on government change

### DIFF
--- a/source/Planet.h
+++ b/source/Planet.h
@@ -117,6 +117,7 @@ public:
 
 	// Get this planet's government. If not set, returns the system's government.
 	const Government *GetGovernment() const;
+	void SetGovernment(const Government *government, bool keepTribute = false);
 	// You need this good a reputation with this system's government to land here.
 	double RequiredReputation() const;
 	// This is what fraction of your fleet's value you must pay as a bribe in


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in https://github.com/endless-sky/endless-sky/pull/10995#issuecomment-2678264195.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a planet's government is changed, the player's domination over this planet will be reset, unless you add a special keyword (see the data below). To inform the player about this, a highest importance message will be posted.

## Testing Done
<details>
<summary>Test data</summary>

```
event "normal"
	planet "New Boston"
		government "Free Worlds"

event "keep tribute"
	planet "New Boston"
		government Syndicate
			"keep tribute"

mission "normal"
	name "Change government"
	description "Disable the Scrapper to change the government while keeping your tribute, destroy it to change the government again, this time losing your tribute."
	job
	destination Earth
	on accept
		"tribute: New Boston" = 100
	npc
		ship Scrapper
		government "Test Dummy"
		on disable
			event "keep tribute" 0
		on destroy
			event "normal" 0
```

</details>

## Wiki Update
soon™.

## Performance Impact
N/A
