### PR TITLE
fix(ui): Update planet labels if the planet's data has changed

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -741,7 +741,7 @@ void Engine::Step(bool isActive)
 			}
 		// Update the planet label positions.
 		for(PlanetLabel &label : labels)
-			label.Update(center, zoom);
+			label.Update(center, zoom, labels, *player.GetSystem());
 	}
 
 	if(flagship && flagship->IsOverheated())

--- a/source/PlanetLabel.h
+++ b/source/PlanetLabel.h
@@ -31,12 +31,13 @@ class PlanetLabel {
 public:
 	PlanetLabel(const std::vector<PlanetLabel> &labels, const System &system, const StellarObject &object);
 
-	void Update(const Point &center, double zoom);
+	void Update(const Point &center, double zoom, const std::vector<PlanetLabel> &labels, const System &system);
 
 	void Draw() const;
 
 
 private:
+	void UpdateData(const std::vector<PlanetLabel> &labels, const System &system);
 	// Overlap detection.
 	void SetBoundingBox(const Point &labelDimensions, double angle);
 	Rectangle GetBoundingBox(double zoom) const;


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a planet's display name or government is changed via a 0-day event, its engine label should be updated. This PR does it every frame (instead of just on entering the system, which obviously doesn't work with 0-days), but tries to avoid recalculating the overlap bounding boxes if the strings happen to be the same as before.

## Testing Done
See #11406.

## Wiki Update
N/A

## Performance Impact
Tried to minimize it; seems N/A.
