### PR TITLE
Replace the "weekday" number condition with a "weekday: <day>" true/false condition

### DIFF
--- a/source/Date.cpp
+++ b/source/Date.cpp
@@ -20,24 +20,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// Figure out the day of the week of the given date.
-	int WeekdayNumberOffset(int day, int month, int year)
-	{
-		// Zeller's congruence.
-		if(month < 3)
-		{
-			--year;
-			month += 12;
-		}
-		return (day + (13 * (month + 1)) / 5 + year + year / 4 + 6 * (year / 100) + year / 400) % 7;
-	}
-
-	const string &Weekday(int day, int month, int year)
-	{
-		static const string DAY[] = {"Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri"};
-		return DAY[WeekdayNumberOffset(day, month, year)];
-	}
-
 	// Convert an integer to a string where single-digit integers have a leading zero.
 	string ZeroPad(int i)
 	{
@@ -84,15 +66,14 @@ const string &Date::ToString() const
 		static const string MONTH[] = {
 				"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
-		const string &weekdayStr = Weekday(day, month, year);
 		const string &monthStr = MONTH[month - 1];
 
 		if(dateFormat == Preferences::DateFormat::YMD)
 			str = to_string(year) + "-" + ZeroPad(month) + "-" + ZeroPad(day);
 		else if(dateFormat == Preferences::DateFormat::MDY)
-			str = weekdayStr + " " + monthStr + " " + to_string(day) + ", " + to_string(year);
+			str = Weekday() + " " + monthStr + " " + to_string(day) + ", " + to_string(year);
 		else if(dateFormat == Preferences::DateFormat::DMY)
-			str = weekdayStr + ", " + to_string(day) + " " + monthStr + " " + to_string(year);
+			str = Weekday() + ", " + to_string(day) + " " + monthStr + " " + to_string(year);
 	}
 
 	return str;
@@ -362,16 +343,25 @@ int Date::Year() const
 
 
 
-// Get the current day of the week as a number. Sunday is 1, Saturday is 7.
-int Date::WeekdayNumber() const
+int Date::WeekdayNumberOffset() const
 {
-	// WeekdayNumberOffset gives values in the range [0, 6], starting from Saturday.
-	// Add 6 to get values in the range [6, 12].
-	// Modulo 7 to get [0, 6]. Monday through Friday moving from [8, 12] to [1, 5].
-	// Add 1 for [1, 7].
-	int result = WeekdayNumberOffset(Day(), Month(), Year());
-	result += 6;
-	result %= 7;
-	result += 1;
-	return result;
+	int day = Day();
+	int month = Month();
+	int year = Year();
+
+	// Zeller's congruence.
+	if(month < 3)
+	{
+		--year;
+		month += 12;
+	}
+	return (day + (13 * (month + 1)) / 5 + year + year / 4 + 6 * (year / 100) + year / 400) % 7;
+}
+
+
+
+const string &Date::Weekday() const
+{
+	static const string DAY[] = {"Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri"};
+	return DAY[WeekdayNumberOffset()];
 }

--- a/source/Date.h
+++ b/source/Date.h
@@ -62,8 +62,14 @@ public:
 	int Month() const;
 	int Year() const;
 
-	// Get the current day of the week as a number. Sunday is 1, Saturday is 7.
-	int WeekdayNumber() const;
+	// Figure out the day of the week of the given date. Uses Zeller's congruence, meaning that
+	// 0 is Saturday and 6 is Friday.
+	int WeekdayNumberOffset() const;
+
+
+private:
+	// Get the abbreviation of the current weekday (e.g. Sun for Sunday, Mon for Monday, etc.).
+	const std::string &Weekday() const;
 
 
 private:

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3237,7 +3237,9 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["year"].ProvideNamed([this](const ConditionEntry &ce) { return date.Year(); });
 	conditions["weekday: "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
 		string day = ce.NameWithoutPrefix();
-		int number = date.WeekdayNumber();
+		int number = date.WeekdayNumberOffset();
+		if(day == "saturday")
+			return number == 0;
 		if(day == "sunday")
 			return number == 1;
 		if(day == "monday")
@@ -3250,8 +3252,6 @@ void PlayerInfo::RegisterDerivedConditions()
 			return number == 5;
 		if(day == "friday")
 			return number == 6;
-		if(day == "saturday")
-			return number == 7;
 		return 0;
 	});
 	conditions["days since year start"].ProvideNamed([this](const ConditionEntry &ce) {

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -40,7 +40,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "SavedGame.h"
 #include "Ship.h"
 #include "ShipEvent.h"
-#include "ShipJumpNavigation.h"
 #include "StartConditions.h"
 #include "StellarObject.h"
 #include "System.h"
@@ -3236,7 +3235,25 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["day"].ProvideNamed([this](const ConditionEntry &ce) { return date.Day(); });
 	conditions["month"].ProvideNamed([this](const ConditionEntry &ce) { return date.Month(); });
 	conditions["year"].ProvideNamed([this](const ConditionEntry &ce) { return date.Year(); });
-	conditions["weekday"].ProvideNamed([this](const ConditionEntry &ce) { return date.WeekdayNumber(); });
+	conditions["weekday: "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
+		string day = ce.NameWithoutPrefix();
+		int number = date.WeekdayNumber();
+		if(day == "sunday")
+			return number == 1;
+		if(day == "monday")
+			return number == 2;
+		if(day == "tuesday")
+			return number == 3;
+		if(day == "wednesday")
+			return number == 4;
+		if(day == "thursday")
+			return number == 5;
+		if(day == "friday")
+			return number == 6;
+		if(day == "saturday")
+			return number == 7;
+		return 0;
+	});
 	conditions["days since year start"].ProvideNamed([this](const ConditionEntry &ce) {
 		return date.DaysSinceYearStart(); });
 	conditions["days until year end"].ProvideNamed([this](const ConditionEntry &ce) {


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

https://github.com/endless-sky/endless-sky/pull/11346#issuecomment-2818386591

## Testing Done + Usage Examples

I created the following mission and observed that the correct day would output 1 on each landing, and all other days would output 0.
```
mission "testing"
	repeat
	landing
	on offer
		conversation
			`What day is it?`
			`	Sunday: &[weekday: sunday]`
			`	Monday: &[weekday: monday]`
			`	Tuesday: &[weekday: tuesday]`
			`	Wednesday: &[weekday: wednesday]`
			`	Thursday: &[weekday: thursday]`
			`	Friday: &[weekday: friday]`
			`	Saturday: &[weekday: saturday]`
				decline
```

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/144