### PR TITLE
fix(typo): Fix a couple more typos

### DIFF
--- a/shaders/line.frag
+++ b/shaders/line.frag
@@ -47,7 +47,7 @@ void main() {
 	float dist;
 	if (cap == 1) {
 		// Rounded caps can shortcut to a segment sdf.
-		// Segment sdf only provides a distance fromt the line itself so we manually subtract it from the width.
+		// Segment sdf only provides a distance from the line itself so we manually subtract it from the width.
 		dist = width - sdSegment(pos, start, end);
 	} else {
 		// Subtract from 1 here to add some AA.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3915,7 +3915,7 @@ void PlayerInfo::CreateMissions()
 	if(availableMissions.empty())
 		return;
 
-	// This list is already in alphabetical order by virture of the way that the Set
+	// This list is already in alphabetical order by virtue of the way that the Set
 	// class stores objects, so stable sorting on the offer precedence will maintain
 	// the alphabetical ordering for missions with the same precedence.
 	availableMissions.sort([](const Mission &a, const Mission &b)


### PR DESCRIPTION
**Typo fix**

~~This PR addresses the bug/feature described in issue #{{insert number}}~~

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Found via codespell

## Screenshots
n/a

## Usage examples
n/a/

## Testing Done
n/a

## Save File
n/a

## Artwork Checklist
(If any artwork was added or changed by this PR, the following must be provided.)
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}

## Wiki Update
n/a

## Performance Impact
n/a