### PR TITLE
Create attributes for multiplying shield generation/hull repair while cloaked

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -399,6 +399,9 @@ tip "hull protection:"
 tip "hull repair multiplier:"
 	`Modifies the amount of hull strength repaired per second by the given factor.`
 
+tip "cloaked repair multiplier:"
+	`Modifies the amount of hull strength repaired per second by the given factor while a cloaking device is active.`
+
 tip "illegal:"
 	`Amount of credits you can be fined for carrying this outfit.`
 
@@ -644,6 +647,9 @@ tip "delayed shield generation:"
 
 tip "shield generation multiplier:"
 	`Modifies the amount of shield points recharged per second by the given factor.`
+
+tip "cloaked regen multiplier:"
+	`Modifies the amount of shield points recharged per second by the given factor while a cloaking device is active.`
 
 tip "high shield permeability:"
 	`This percentage of all incoming damage bypasses shields and applies directly to the hull when at full shields.`

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -165,11 +165,13 @@ namespace {
 		{"hull energy multiplier", -1.},
 		{"hull fuel multiplier", -1.},
 		{"hull heat multiplier", -1.},
+		{"cloaked repair multiplier", -1. },
 		{"shield multiplier", -1. },
 		{"shield generation multiplier", -1.},
 		{"shield energy multiplier", -1.},
 		{"shield fuel multiplier", -1.},
 		{"shield heat multiplier", -1.},
+		{"cloaked regen multiplier", -1. },
 		{"acceleration multiplier", -1.},
 		{"turn multiplier", -1.},
 		{"turret turn multiplier", -1.}

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -190,6 +190,8 @@ namespace {
 		{"high shield permeability", 3},
 		{"low shield permeability", 3},
 		{"cloaked shield permeability", 3},
+		{"cloaked regen multiplier", 3},
+		{"cloaked repair multiplier", 3},
 		{"acceleration multiplier", 3},
 		{"turn multiplier", 3},
 		{"turret turn multiplier", 3},

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4061,8 +4061,8 @@ void Ship::DoGeneration()
 
 		const double hullAvailable = (attributes.Get("hull repair rate")
 			+ (hullDelay ? 0 : attributes.Get("delayed hull repair rate")))
-			* (1. + attributes.Get("hull repair multiplier")
-				+ attributes.Get("cloaked repair multiplier") * Cloaking());
+			* (1. + attributes.Get("hull repair multiplier"))
+			* (1. + attributes.Get("cloaked repair multiplier") * Cloaking());
 		const double hullEnergy = (attributes.Get("hull energy")
 			+ (hullDelay ? 0 : attributes.Get("delayed hull energy")))
 			* (1. + attributes.Get("hull energy multiplier")) / hullAvailable;
@@ -4078,8 +4078,8 @@ void Ship::DoGeneration()
 
 		const double shieldsAvailable = (attributes.Get("shield generation")
 			+ (shieldDelay ? 0 : attributes.Get("delayed shield generation")))
-			* (1. + attributes.Get("shield generation multiplier")
-				+ attributes.Get("cloaked regen multiplier") * Cloaking());
+			* (1. + attributes.Get("shield generation multiplier"))
+			* (1. + attributes.Get("cloaked regen multiplier") * Cloaking());
 		const double shieldsEnergy = (attributes.Get("shield energy")
 			+ (shieldDelay ? 0 : attributes.Get("delayed shield energy")))
 			* (1. + attributes.Get("shield energy multiplier")) / shieldsAvailable;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4061,7 +4061,8 @@ void Ship::DoGeneration()
 
 		const double hullAvailable = (attributes.Get("hull repair rate")
 			+ (hullDelay ? 0 : attributes.Get("delayed hull repair rate")))
-			* (1. + attributes.Get("hull repair multiplier"));
+			* (1. + attributes.Get("hull repair multiplier")
+				+ attributes.Get("cloaked repair multiplier") * Cloaking());
 		const double hullEnergy = (attributes.Get("hull energy")
 			+ (hullDelay ? 0 : attributes.Get("delayed hull energy")))
 			* (1. + attributes.Get("hull energy multiplier")) / hullAvailable;
@@ -4077,7 +4078,8 @@ void Ship::DoGeneration()
 
 		const double shieldsAvailable = (attributes.Get("shield generation")
 			+ (shieldDelay ? 0 : attributes.Get("delayed shield generation")))
-			* (1. + attributes.Get("shield generation multiplier"));
+			* (1. + attributes.Get("shield generation multiplier")
+				+ attributes.Get("cloaked regen multiplier") * Cloaking());
 		const double shieldsEnergy = (attributes.Get("shield energy")
 			+ (shieldDelay ? 0 : attributes.Get("delayed shield energy")))
 			* (1. + attributes.Get("shield energy multiplier")) / shieldsAvailable;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds two new attributes to the game:

* `"cloaked regen multiplier"`: A multiplier applied to your shield generation while your cloaking device is active.
* `"cloaked repair multiplier"`: A multiplier applied to your hull repair while your cloaking device is active.

As noted in #11343, the existing cloaked shield/hull delay attributes can't really be used for what they were originally intended for as a result of #9771.

## Usage examples

See #11343.

## Testing Done

Tested the cloaking device in #11343.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/146