### PR TITLE
feat(conditions): Add support for min and max keywords in conditionSets

### DIFF
--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -45,6 +45,8 @@ public:
 		MUL, ///< Multiplies ( * ) all sub-expressions with each-other.
 		DIV, ///< (Integer) Divides ( / ) the first sub-expression by all later ones.
 		MOD, ///< Modulo ( % ) by the second and later sub-expressions on the first one.
+		MIN, ///< 'min' operator, returns the minimum value over all children.
+		MAX, ///< 'max' operator, returns the maximum value over all children.
 
 		// Boolean equality operators, return 0 or 1
 		EQ, ///< Tests for equality ( == ).

--- a/tests/unit/src/test_conditionSet.cpp
+++ b/tests/unit/src/test_conditionSet.cpp
@@ -210,10 +210,21 @@ SCENARIO( "Determining if condition requirements are met", "[ConditionSet][Usage
 
 			// Tests for and and or conditions, the first one is the implicit version.
 			{"3\n\t2\n\t5", 3},
-			{"and\n\t\t11\n\t\t2\n\\tt5", 11},
-			{"and\n\t\t14\n\t\t0\n\\tt5", 0},
-			{"or\n\t\t8\n\t\t2\n\\tt5", 8},
-			{"or\n\t\t9\n\t\t0\n\\tt5", 9},
+			{"and\n\t\t11\n\t\t2\n\t\t5", 11},
+			{"and\n\t\t14\n\t\t0\n\t\t5", 0},
+			{"or\n\t\t8\n\t\t2\n\t\t5", 8},
+			{"or\n\t\t9\n\t\t0\n\t\t5", 9},
+
+			// Tests for min and max conditions.
+			{"max\n\t\t1\n\t\t10", 10},
+			{"min\n\t\t1\n\t\t10", 1},
+			{"max\n\t\t-30\n\t\t11", 11},
+			{"min\n\t\t-30\n\t\t11", -30},
+
+			{"max\n\t\t-30\n\t\t11\n\t\t5", 11},
+			{"min\n\t\t-30\n\t\t11\n\t\t5", -30},
+			{"max\n\t\t20", 20},
+			{"min\n\t\t20", 20},
 
 			// Black magic below; parser might need to handle this, but nobody should ever write comparisons like this.
 			{"1 > 2 == 0", 1},


### PR DESCRIPTION
**Feature**

This PR adds the keywords "min" and "max" to conditionSets

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Allow conditions to use "min" and "max" as keywords.

## Screenshots
N/A

## Usage examples
```
to <some_condition>
	max
		10
		20

to <some_other_condition>
	min
		10
		20
```

## Testing Done
I added a unit-test that passes. Could use a little bit more testing.

## Save File
N/A

## Wiki Update
Not yet

## Performance Impact
This is just a new condition node. Should have about the same performance as other nodes.