### PR TITLE
feat(enhancement): Make messages more customizable

### DIFF
--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -19,15 +19,6 @@ help "bank advanced"
 	`When entering a credit value at the bank, you can put in an exact number, or use the suffixes K, M, B, and T as shorthand for thousands, millions, billions, and trillions. For example, entering a value such as "100k" would count as 100,000 credits.`
 	`Entering a number that is higher than what you or the bank have available will default to the maximum available value. For example, entering "1m" to pay off a 100,000 credit loan will completely pay off the loan without giving extra, should you have available credits.`
 
-help "basics 1"
-	`Press <View star map> to bring up your map. Select a destination, then close the map and press <Initiate hyperspace jump> to jump. Press <Land on planet / station> to land.`
-
-help "basics 2"
-	`For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
-
-help "basics 3"
-	`To see a help message again, press <Show help>. To see all help messages again, go to the main menu, select Preferences, then go to Settings. Navigate to page two, then select "Reactivate first-time help."`
-
 help "dead"
 	`Uh-oh! You just died. The universe can be a dangerous place for new captains!`
 	`Fortunately, your game is automatically saved every time you leave a planet. To load your most recent saved game, press <Show main menu> to return to the main menu, then click on "Manage Pilots" and "Enter Ship."`

--- a/data/_ui/messages.txt
+++ b/data/_ui/messages.txt
@@ -1,0 +1,156 @@
+# Copyright (c) 2025 by TomGoodIdea
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+
+
+# Categories:
+
+# The category used for most important system messages.
+"message category" "high"
+	"main color" "message importance highest"
+	"log color" "message log importance highest"
+	important
+
+# The default category used for most engine messages, including hails.
+"message category" "normal"
+	"main color" "message importance high"
+	"log color" "message log importance high"
+
+# The category used for messages that generate a lot of spam
+# (for example, ones that are sent continuously every frame).
+"message category" "low"
+	"main color" "message importance low"
+	"log color" "message log importance low"
+	"aggressive deduplication"
+
+# The category used for system messages that require more attention.
+"message category" "info"
+	"main color" "message importance info"
+	"log color" "message log importance info"
+	important
+
+# The special category used to mark day beginning for easier navigation in the log.
+"message category" "daily"
+	"main color" "message importance daily"
+	"log color" "message log importance daily"
+	important
+
+# Same as the default one, but always adds the message to the log.
+"message category" "force log"
+	"main color" "message importance high"
+	"log color" "message log importance high"
+	"no log deduplication"
+
+
+
+# Engine messages:
+
+message "no formations available"
+	text "No formations available."
+
+message "disengaging autopilot"
+	text "Disengaging autopilot."
+
+message "coming to a stop"
+	text "Coming to a stop."
+
+message "engaging cloaking device"
+	text "Engaging cloaking device."
+
+message "disengaging cloaking device"
+	text "Disengaging cloaking device."
+
+message "no landables"
+	text "There are no planets in this system that you can land on."
+	category "high"
+
+message "no hyperdrive"
+	text "You do not have a hyperdrive installed."
+	category "high"
+
+message "cannot jump"
+	text "You cannot jump to the selected system."
+	category "high"
+
+message "no fuel"
+	text "You do not have enough fuel to make a hyperspace jump."
+	category "high"
+
+message "cannot jump while landing"
+	text "You cannot jump while landing."
+	category "high"
+
+message "undercrewed flagship"
+	text "Your ship is moving erratically because you do not have enough crew to pilot it."
+	category "low"
+
+message "cannot board while cloaked"
+	text "You cannot board a ship while cloaked."
+	category "high"
+
+message "overheated"
+	text "Your ship has overheated."
+	category "high"
+
+message "basics 1"
+	text `Press <View star map> to bring up your map. Select a destination, then close the map and press <Initiate hyperspace jump> to jump. Press <Land on planet / station> to land.`
+
+message "basics 2"
+	text `For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
+
+message "basics 3"
+	text `To see a help message again, press <Show help>. To see all help messages again, go to the main menu, select Preferences, then go to Settings. Navigate to page two, then select "Reactivate first-time help."`
+
+message "map received"
+	text "You received a map of nearby systems."
+
+message "turret tracking focused"
+	text "Turret tracking mode set to: focused."
+
+message "turret tracking opportunistic"
+	text "Turret tracking mode set to: opportunistic."
+
+message "expend ammo frugally"
+	text "Your escorts will now expend ammo: frugally."
+
+message "expend ammo always"
+	text "Your escorts will now expend ammo: always."
+
+message "expend ammo never"
+	text "Your escorts will now expend ammo: never."
+
+message "cannot hail while jumping"
+	text "Unable to send hail: your flagship is entering hyperspace."
+	category "high"
+
+message "cannot hail while cloaked"
+	text "Unable to send hail: your flagship is cloaked."
+	category "high"
+
+message "cannot hail"
+	text "Unable to send hail."
+	category "high"
+
+message "wormhole hail"
+	phrase "wormhole hail"
+	category "high"
+
+message "cannot hail without target"
+	text "Unable to send hail: no target selected."
+	category "high"
+
+message "fired single crew member for passenger space"
+	text "You fired a crew member to free up a bunk for a passenger."
+
+message "fired single crew member for no bunks"
+	text "You fired a crew member because you have no bunk for them."

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -176,6 +176,8 @@ target_sources(EndlessSkyLib PRIVATE
 	MenuAnimationPanel.h
 	MenuPanel.cpp
 	MenuPanel.h
+	Message.cpp
+	Message.h
 	MessageLogPanel.cpp
 	MessageLogPanel.h
 	Messages.cpp

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -128,7 +128,7 @@ namespace {
 		else
 			tag = ship->DisplayModelName() + " (" + gov + "): ";
 
-		Messages::Add(tag + message, Messages::Importance::High);
+		Messages::Add({tag + message, GameData::MessageCategories().Get("normal")});
 	}
 
 	Point FlareCurve(double x)
@@ -745,7 +745,7 @@ void Engine::Step(bool isActive)
 	}
 
 	if(flagship && flagship->IsOverheated())
-		Messages::Add("Your ship has overheated.", Messages::Importance::Highest);
+		Messages::Add(*GameData::Messages().Get("overheated"));
 
 	// Clear the HUD information from the previous frame.
 	info = Information();
@@ -1259,7 +1259,7 @@ void Engine::Draw() const
 				break;
 		}
 		float alpha = (it->step + 1000 - step) * .001f;
-		messageLine.Draw(messagePoint, Messages::GetColor(it->importance, false)->Additive(alpha));
+		messageLine.Draw(messagePoint, it->category->MainColor().Additive(alpha));
 		if(messagesReversed)
 			messagePoint.Y() += height;
 	}
@@ -1422,9 +1422,10 @@ void Engine::EnterSystem()
 	Audio::PlayMusic(system->MusicName());
 	GameData::SetHaze(system->Haze(), false);
 
-	Messages::Add("Entering the " + system->DisplayName() + " system on "
+	Messages::Add({"Entering the " + system->DisplayName() + " system on "
 		+ today.ToString() + (system->IsInhabited(flagship) ?
-			"." : ". No inhabited planets detected."), Messages::Importance::Daily);
+		"." : ". No inhabited planets detected."),
+		GameData::MessageCategories().Get("daily")});
 
 	// Preload landscapes and determine if the player used a wormhole.
 	// (It is allowed for a wormhole's exit point to have no sprite.)
@@ -1519,9 +1520,9 @@ void Engine::EnterSystem()
 				if(Random::Real() < attraction)
 				{
 					raidFleet.GetFleet()->Place(*system, newShips);
-					Messages::Add("Your fleet has attracted the interest of a "
-							+ raidFleet.GetFleet()->GetGovernment()->GetName() + " raiding party.",
-							Messages::Importance::Highest);
+					Messages::Add({"Your fleet has attracted the interest of a "
+						+ raidFleet.GetFleet()->GetGovernment()->GetName() + " raiding party.",
+						GameData::MessageCategories().Get("high")});
 				}
 	}
 
@@ -1543,9 +1544,9 @@ void Engine::EnterSystem()
 	// since the new player ships can make at most four jumps before landing.
 	if(today <= player.StartData().GetDate() + 4)
 	{
-		Messages::Add(GameData::HelpMessage("basics 1"), Messages::Importance::High);
-		Messages::Add(GameData::HelpMessage("basics 2"), Messages::Importance::High);
-		Messages::Add(GameData::HelpMessage("basics 3"), Messages::Importance::High);
+		Messages::Add(*GameData::Messages().Get("basics 1"));
+		Messages::Add(*GameData::Messages().Get("basics 2"));
+		Messages::Add(*GameData::Messages().Get("basics 3"));
 	}
 }
 
@@ -2231,12 +2232,13 @@ void Engine::HandleMouseClicks()
 					if(&object == flagship->GetTargetStellar())
 					{
 						if(!planet->CanLand(*flagship))
-							Messages::Add("The authorities on " + planet->DisplayName()
-									+ " refuse to let you land.", Messages::Importance::Highest);
+							Messages::Add({"The authorities on " + planet->DisplayName()
+								+ " refuse to let you land.", GameData::MessageCategories().Get("high")});
 						else if(!flagship->IsDestroyed())
 						{
 							activeCommands |= Command::LAND;
-							Messages::Add("Landing on " + planet->DisplayName() + ".", Messages::Importance::High);
+							Messages::Add({"Landing on " + planet->DisplayName() + ".",
+								GameData::MessageCategories().Get("normal")});
 						}
 					}
 					else
@@ -2664,7 +2666,7 @@ void Engine::DoCollection(Flotsam &flotsam)
 		message += ".)";
 	else
 		message += ", " + Format::MassString(total) + " in fleet.)";
-	Messages::Add(message, Messages::Importance::High);
+	Messages::Add({message, GameData::MessageCategories().Get("normal")});
 }
 
 

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -45,7 +45,7 @@ namespace {
 			bool mapMinables = outfit->Get("map minables");
 			if(!player.HasMapped(mapSize, mapMinables))
 				player.Map(mapSize, mapMinables);
-			Messages::Add("You received a map of nearby systems.", Messages::Importance::High);
+			Messages::Add(*GameData::Messages().Get("map received"));
 			return;
 		}
 
@@ -119,7 +119,7 @@ namespace {
 			message += "cargo hold.";
 		else
 			message += "flagship.";
-		Messages::Add(message, Messages::Importance::High);
+		Messages::Add({message, GameData::MessageCategories().Get("normal")});
 	}
 }
 

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -694,6 +694,20 @@ const Set<Interface> &GameData::Interfaces()
 
 
 
+const Set<Message::Category> &GameData::MessageCategories()
+{
+	return objects.messageCategories;
+}
+
+
+
+const Set<Message> &GameData::Messages()
+{
+	return objects.messages;
+}
+
+
+
 const Set<Minable> &GameData::Minables()
 {
 	return objects.minables;

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "CategoryType.h"
+#include "Message.h"
 #include "Set.h"
 #include "Shop.h"
 #include "Swizzle.h"
@@ -131,6 +132,8 @@ public:
 	static const Set<Government> &Governments();
 	static const Set<Hazard> &Hazards();
 	static const Set<Interface> &Interfaces();
+	static const Set<Message::Category> &MessageCategories();
+	static const Set<Message> &Messages();
 	static const Set<Minable> &Minables();
 	static const Set<Mission> &Missions();
 	static const Set<News> &SpaceportNews();

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -394,17 +394,17 @@ bool HailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				{
 					bribed = ship->GetGovernment();
 					bribed->Bribe();
-					Messages::Add("You bribed a " + bribed->GetName() + " ship "
-						+ Format::CreditString(bribe) + " to refrain from attacking you today."
-							, Messages::Importance::High);
+					Messages::Add({"You bribed a " + bribed->GetName() + " ship "
+						+ Format::CreditString(bribe) + " to refrain from attacking you today.",
+						GameData::MessageCategories().Get("normal")});
 				}
 			}
 			else
 			{
 				planet->Bribe();
-				Messages::Add("You bribed the authorities on " + planet->DisplayName() + " "
-					+ Format::CreditString(bribe) + " to permit you to land."
-						, Messages::Importance::High);
+				Messages::Add({"You bribed the authorities on " + planet->DisplayName() + " "
+					+ Format::CreditString(bribe) + " to permit you to land.",
+					GameData::MessageCategories().Get("normal")});
 			}
 		}
 		else
@@ -435,6 +435,6 @@ void HailPanel::SetMessage(const string &text)
 {
 	message = text;
 	if(!message.empty())
-		Messages::AddLog("(Response to your hail) " + header + " " + message,
-			Messages::Importance::High);
+		Messages::AddLog({"(Response to your hail) " + header + " " + message,
+			GameData::MessageCategories().Get("normal")});
 }

--- a/source/Message.cpp
+++ b/source/Message.cpp
@@ -1,0 +1,189 @@
+/* Message.cpp
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Message.h"
+
+#include "Command.h"
+#include "DataNode.h"
+#include "text/Format.h"
+#include "GameData.h"
+#include "Phrase.h"
+#include "TextReplacements.h"
+
+using namespace std;
+
+
+
+void Message::Category::Load(const DataNode &node)
+{
+	if(node.Size() < 2)
+		return;
+	name = node.Token(1);
+	isLoaded = true;
+
+	auto setColor = [](const DataNode &node, ExclusiveItem<Color> &color) noexcept -> void {
+		if(node.Size() >= 4)
+			color = ExclusiveItem<Color>{{
+				static_cast<float>(node.Value(1)),
+				static_cast<float>(node.Value(2)),
+				static_cast<float>(node.Value(3))}};
+		else
+			color = ExclusiveItem<Color>{GameData::Colors().Get(node.Token(1))};
+	};
+
+	for(const auto &child : node)
+	{
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+
+		if(key == "main color" && hasValue)
+			setColor(child, mainColor);
+		else if(key == "log color" && hasValue)
+			setColor(child, logColor);
+		else if(key == "aggressive deduplication")
+			aggressiveDeduplication = true;
+		else if(key == "no log deduplication")
+			logDeduplication = false;
+		else if(key == "important")
+			isImportant = true;
+		else
+			child.PrintTrace("Skipping unrecognized attribute:");
+	}
+}
+
+
+
+bool Message::Category::IsLoaded() const
+{
+	return isLoaded;
+}
+
+
+
+const string &Message::Category::Name() const
+{
+	return name;
+}
+
+
+
+const Color &Message::Category::MainColor() const
+{
+	return *mainColor;
+}
+
+
+
+const Color &Message::Category::LogColor() const
+{
+	return *logColor;
+}
+
+
+
+bool Message::Category::AggressiveDeduplication() const
+{
+	return aggressiveDeduplication;
+}
+
+
+
+bool Message::Category::LogDeduplication() const
+{
+	return logDeduplication;
+}
+
+
+
+bool Message::Category::IsImportant() const
+{
+	return isImportant;
+}
+
+
+
+Message::Message(const string &text, const Category *category)
+	: text{text}, category{category}
+{
+}
+
+
+
+void Message::Load(const DataNode &node)
+{
+	if(node.Size() >= 2)
+		name = node.Token(1);
+	isLoaded = true;
+
+	for(const auto &child : node)
+	{
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+
+		if(key == "text" && hasValue)
+		{
+			text = child.Token(1);
+			isPhrase = false;
+		}
+		else if(key == "phrase" && hasValue)
+		{
+			text = child.Token(1);
+			isPhrase = true;
+		}
+		else if(key == "category" && hasValue)
+			category = GameData::MessageCategories().Get(child.Token(1));
+		else
+			child.PrintTrace("Skipping unrecognized attribute:");
+	}
+
+	if(!category)
+		category = GameData::MessageCategories().Get("normal");
+}
+
+
+
+bool Message::IsLoaded() const
+{
+	return isLoaded;
+}
+
+
+
+const string &Message::Name() const
+{
+	return name;
+}
+
+
+
+string Message::Text() const
+{
+	if(isPhrase)
+		return GameData::Phrases().Get(text)->Get();
+
+	map<string, string> subs;
+	GameData::GetTextReplacements().Substitutions(subs);
+	for(const auto &[key, value] : subs)
+		subs[key] = Phrase::ExpandPhrases(value);
+	Format::Expand(subs);
+	return Command::ReplaceNamesWithKeys(Format::Replace(Phrase::ExpandPhrases(text), subs));
+}
+
+
+
+const Message::Category *Message::GetCategory() const
+{
+	return category;
+}

--- a/source/Message.h
+++ b/source/Message.h
@@ -1,0 +1,77 @@
+/* Message.h
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Color.h"
+#include "ExclusiveItem.h"
+
+#include <string>
+
+class DataNode;
+
+
+
+// Class containing message data. It's different than the Messages::Entry class,
+// which represents entries in the list view.
+class Message {
+public:
+	class Category {
+	public:
+		void Load(const DataNode &node);
+		bool IsLoaded() const;
+
+		const std::string &Name() const;
+		const Color &MainColor() const;
+		const Color &LogColor() const;
+		bool AggressiveDeduplication() const;
+		bool LogDeduplication() const;
+		bool IsImportant() const;
+
+	private:
+		bool isLoaded = false;
+		std::string name;
+		// The color used in the main panel.
+		ExclusiveItem<Color> mainColor;
+		// The color used in the message log panel.
+		ExclusiveItem<Color> logColor;
+		// Avoid duplicates in the list on the main panel.
+		bool aggressiveDeduplication = false;
+		// Avoid duplicating the last log entry.
+		bool logDeduplication = true;
+		// Whether to include this category in the message log panel's filter.
+		bool isImportant = false;
+	};
+
+
+public:
+	Message() = default;
+	Message(const std::string &text, const Category *category);
+	void Load(const DataNode &node);
+	bool IsLoaded() const;
+
+	const std::string &Name() const;
+	std::string Text() const;
+	const Category *GetCategory() const;
+
+
+private:
+	bool isLoaded = false;
+	std::string name;
+	// The text, or the name of the phrase used to generate the message.
+	std::string text;
+	bool isPhrase = false;
+	const Category *category = nullptr;
+};

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -86,15 +86,15 @@ void MessageLogPanel::Draw()
 
 		// Draw messages.
 		Point pos = Screen::BottomLeft() + Point(PAD, scroll);
-		for(const auto &it : messages)
+		for(const auto &[text, category] : messages)
 		{
-			if(importantOnly && (it.second == Messages::Importance::Low || it.second == Messages::Importance::High))
+			if(importantOnly && !category->IsImportant())
 				continue;
 
-			messageLine.Wrap(it.first);
+			messageLine.Wrap(text);
 			pos.Y() -= messageLine.Height();
 			if(pos.Y() >= Screen::Top() - 3 * font.Height())
-				messageLine.Draw(pos, *Messages::GetColor(it.second, true));
+				messageLine.Draw(pos, category->LogColor());
 		}
 
 		maxScroll = max(0., scroll - pos.Y() + Screen::Top());

--- a/source/MessageLogPanel.h
+++ b/source/MessageLogPanel.h
@@ -38,7 +38,7 @@ protected:
 
 
 private:
-	const std::deque<std::pair<std::string, Messages::Importance>> &messages;
+	const std::deque<std::pair<std::string, const Message::Category *>> &messages;
 
 	const double width;
 	bool importantOnly = false;

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -27,31 +27,36 @@ namespace {
 
 	mutex incomingMutex;
 
-	vector<pair<string, Messages::Importance>> incoming;
+	vector<pair<string, const Message::Category *>> incoming;
 	vector<Messages::Entry> recent;
-	deque<pair<string, Messages::Importance>> logged;
+	deque<pair<string, const Message::Category *>> logged;
 }
 
 
 
-// Add a message to the list along with its level of importance
-// When forced, the message is forcibly added to the log, but not to the list.
-void Messages::Add(const string &message, Importance importance, bool force)
+// Add a message to the list along with its level of importance.
+void Messages::Add(const Message &message)
 {
+	AddLog(message);
+	const Message::Category *category = message.GetCategory();
+	if(!category)
+		return;
 	lock_guard<mutex> lock(incomingMutex);
-	incoming.emplace_back(message, importance);
-	AddLog(message, importance, force);
+	incoming.emplace_back(message.Text(), category);
 }
 
 
 
 // Add a message to the log. For messages meant to be shown
 // also on the main panel, use Add instead.
-void Messages::AddLog(const string &message, Importance importance, bool force)
+void Messages::AddLog(const Message &message)
 {
-	if(force || logged.empty() || message != logged.front().first)
+	const Message::Category *category = message.GetCategory();
+	if(!category)
+		return;
+	if(!category->LogDeduplication() || logged.empty() || message.Text() != logged.front().first)
 	{
-		logged.emplace_front(message, importance);
+		logged.emplace_front(message.Text(), category);
 		if(logged.size() > MAX_LOG)
 			logged.pop_back();
 	}
@@ -67,14 +72,11 @@ const vector<Messages::Entry> &Messages::Get(int step)
 	lock_guard<mutex> lock(incomingMutex);
 
 	// Load the incoming messages.
-	for(const pair<string, Importance> &item : incoming)
+	for(const auto &[message, category] : incoming)
 	{
-		const string &message = item.first;
-		Importance importance = item.second;
-
 		// If this message is not important and it is already being shown in the
 		// list, ignore it.
-		if(importance == Importance::Low)
+		if(category->AggressiveDeduplication())
 		{
 			bool skip = false;
 			for(const Messages::Entry &entry : recent)
@@ -92,12 +94,12 @@ const vector<Messages::Entry> &Messages::Get(int step)
 			// limit how many of them appear at once.
 			it->step -= 60;
 			// Also erase messages that have reached the end of their lifetime.
-			if((importance != Importance::Low && it->message == message) || it->step < step - 1000)
+			if((!category->AggressiveDeduplication() && it->message == message) || it->step < step - 1000)
 				it = recent.erase(it);
 			else
 				++it;
 		}
-		recent.emplace_back(step, message, importance);
+		recent.emplace_back(step, message, category);
 	}
 	incoming.clear();
 	return recent;
@@ -105,7 +107,7 @@ const vector<Messages::Entry> &Messages::Get(int step)
 
 
 
-const deque<pair<string, Messages::Importance>> &Messages::GetLog()
+const deque<pair<string, const Message::Category *>> &Messages::GetLog()
 {
 	return logged;
 }
@@ -119,26 +121,4 @@ void Messages::Reset()
 	incoming.clear();
 	recent.clear();
 	logged.clear();
-}
-
-
-
-// Get color that should be used for drawing messages of given importance.
-const Color *Messages::GetColor(Importance importance, bool isLogPanel)
-{
-	string prefix = isLogPanel ? "message log importance " : "message importance ";
-	switch(importance)
-	{
-		case Messages::Importance::Highest:
-			return GameData::Colors().Get(prefix + "highest");
-		case Messages::Importance::High:
-			return GameData::Colors().Get(prefix + "high");
-		case Messages::Importance::Info:
-			return GameData::Colors().Get(prefix + "info");
-		case Messages::Importance::Daily:
-			return GameData::Colors().Get(prefix + "daily");
-		case Messages::Importance::Low:
-		default:
-			return GameData::Colors().Get(prefix + "low");
-	}
 }

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -15,6 +15,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "Message.h"
+
 #include <cstdint>
 #include <deque>
 #include <string>
@@ -32,42 +34,31 @@ class Color;
 // to keep repeated messages from filling up the whole screen.
 class Messages {
 public:
-	enum class Importance : uint_least8_t {
-		Highest,
-		High,
-		Info,
-		Daily,
-		Low
-	};
-
 	class Entry {
 	public:
 		Entry() = default;
-		Entry(int step, const std::string &message, Importance importance)
-			: step(step), message(message), importance(importance) {}
+		Entry(int step, const std::string &message, const Message::Category *category)
+			: step(step), message(message), category(category) {}
 
 		int step;
 		std::string message;
-		Importance importance;
+		const Message::Category *category;
 	};
 
+
 public:
-	// Add a message to the list along with its level of importance
-	// When forced, the message is forcibly added to the log, but not to the list.
-	static void Add(const std::string &message, Importance importance = Importance::Low, bool force = false);
+	// Add a message to the list along with its level of importance.
+	static void Add(const Message &message);
 	// Add a message to the log. For messages meant to be shown
 	// also on the main panel, use Add instead.
-	static void AddLog(const std::string &message, Importance importance = Importance::Low, bool force = false);
+	static void AddLog(const Message &message);
 
 	// Get the messages for the given game step. Any messages that are too old
 	// will be culled out, and new ones that have just been added will have
 	// their "step" set to the given value.
 	static const std::vector<Entry> &Get(int step);
-	static const std::deque<std::pair<std::string, Messages::Importance>> &GetLog();
+	static const std::deque<std::pair<std::string, const Message::Category *>> &GetLog();
 
 	// Reset the messages (i.e. because a new game was loaded).
 	static void Reset();
-
-	// Get color that should be used for drawing messages of given importance.
-	static const Color *GetColor(Importance importance, bool isLogPanel);
 };

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1273,7 +1273,8 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI *ui)
 		{
 			hasFailed = true;
 			if(isVisible)
-				Messages::Add(message + "Mission failed: \"" + displayName + "\".", Messages::Importance::Highest);
+				Messages::Add({message + "Mission failed: \"" + displayName + "\".",
+					GameData::MessageCategories().Get("high")});
 		}
 	}
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -515,8 +515,8 @@ void NPC::Do(const ShipEvent &event, PlayerInfo &player, UI *ui, const Mission *
 
 	// Check if the success status has changed. If so, display a message.
 	if(isVisible && !alreadyFailed && HasFailed())
-		Messages::Add("Mission failed" + (caller ? ": \"" + caller->Name() + "\"" : "") + ".",
-			Messages::Importance::Highest);
+		Messages::Add({"Mission failed" + (caller ? ": \"" + caller->Name() + "\"" : "") + ".",
+			GameData::MessageCategories().Get("high")});
 	else if(ui && !alreadySucceeded && HasSucceeded(player.GetSystem(), false))
 	{
 		// If "completing" this NPC displays a conversation, reference

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -736,8 +736,8 @@ void PlayerInfo::AdvanceDate(int amount)
 		for(Mission &mission : missions)
 		{
 			if(mission.CheckDeadline(date) && mission.IsVisible())
-				Messages::Add("You failed to meet the deadline for the mission \"" + mission.Name() + "\".",
-					Messages::Importance::Highest);
+				Messages::Add({"You failed to meet the deadline for the mission \"" + mission.Name() + "\".",
+					GameData::MessageCategories().Get("high")});
 			if(!mission.IsFailed())
 				mission.Do(Mission::DAILY, *this);
 		}
@@ -896,7 +896,7 @@ void PlayerInfo::DoAccounting()
 			message += Format::CreditString(balance.assetsReturns) + " based on outfits and ships";
 		}
 		message += ".";
-		Messages::Add(message, Messages::Importance::High, true);
+		Messages::Add({message, GameData::MessageCategories().Get("force log")});
 		accounts.AddCredits(salariesIncome + tributeIncome + balance.assetsReturns);
 	}
 
@@ -910,7 +910,7 @@ void PlayerInfo::DoAccounting()
 	// summarizes the payments that were made.
 	string message = accounts.Step(assets, Salaries(), balance.maintenanceCosts);
 	if(!message.empty())
-		Messages::Add(message, Messages::Importance::High, true);
+		Messages::Add({message, GameData::MessageCategories().Get("force log")});
 }
 
 
@@ -1633,9 +1633,10 @@ void PlayerInfo::Land(UI *ui)
 		if(added > 0)
 		{
 			flagship->AddCrew(added);
-			Messages::Add("You hire " + to_string(added) + (added == 1
-					? " extra crew member to fill your now-empty bunk."
-					: " extra crew members to fill your now-empty bunks."), Messages::Importance::High);
+			Messages::Add({"You hire " + to_string(added) + (added == 1
+				? " extra crew member to fill your now-empty bunk."
+				: " extra crew members to fill your now-empty bunks."),
+				GameData::MessageCategories().Get("normal")});
 		}
 	}
 
@@ -1703,10 +1704,10 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 		{
 			flagship->AddCrew(-extra);
 			if(extra == 1)
-				Messages::Add("You fired a crew member to free up a bunk for a passenger.", Messages::Importance::High);
+				Messages::Add(*GameData::Messages().Get("fired single crew member for passenger space"));
 			else
-				Messages::Add("You fired " + to_string(extra) + " crew members to free up bunks for passengers.",
-						Messages::Importance::High);
+				Messages::Add({"You fired " + to_string(extra) + " crew members to free up bunks for passengers.",
+					GameData::MessageCategories().Get("normal")});
 			flagship->Cargo().SetBunks(flagship->Attributes().Get("bunks") - flagship->Crew());
 			cargo.TransferAll(flagship->Cargo());
 		}
@@ -1717,10 +1718,10 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 	{
 		flagship->AddCrew(-extra);
 		if(extra == 1)
-			Messages::Add("You fired a crew member because you have no bunk for them.", Messages::Importance::High);
+			Messages::Add(*GameData::Messages().Get("fired single crew member for no bunks"));
 		else
-			Messages::Add("You fired " + to_string(extra) + " crew members because you have no bunks for them.",
-					Messages::Importance::High);
+			Messages::Add({"You fired " + to_string(extra) + " crew members because you have no bunks for them.",
+				GameData::MessageCategories().Get("normal")});
 		flagship->Cargo().SetBunks(flagship->Attributes().Get("bunks") - flagship->Crew());
 	}
 
@@ -1762,7 +1763,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 		{
 			// The remaining uncarried ships are launched alongside the player.
 			string message = (uncarried > 1) ? "Some escorts were" : "One escort was";
-			Messages::Add(message + " unable to dock with a carrier.", Messages::Importance::High);
+			Messages::Add({message + " unable to dock with a carrier.", GameData::MessageCategories().Get("normal")});
 		}
 	}
 
@@ -1774,18 +1775,18 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 		if(it.second)
 		{
 			if(it.first->IsVisible())
-				Messages::Add("Mission \"" + it.first->Name()
-					+ "\" aborted because you do not have space for the cargo."
-						, Messages::Importance::Highest);
+				Messages::Add({"Mission \"" + it.first->Name()
+					+ "\" aborted because you do not have space for the cargo.",
+					GameData::MessageCategories().Get("high")});
 			missionsToRemove.push_back(it.first);
 		}
 	for(const auto &it : cargo.PassengerList())
 		if(it.second)
 		{
 			if(it.first->IsVisible())
-				Messages::Add("Mission \"" + it.first->Name()
-					+ "\" aborted because you do not have enough passenger bunks free."
-						, Messages::Importance::Highest);
+				Messages::Add({"Mission \"" + it.first->Name()
+					+ "\" aborted because you do not have enough passenger bunks free.",
+					GameData::MessageCategories().Get("high")});
 			missionsToRemove.push_back(it.first);
 
 		}
@@ -1865,7 +1866,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 			out << "stored " << Format::CargoString(stored, "outfits") << " you could not carry";
 		}
 		out << ".";
-		Messages::Add(out.str(), Messages::Importance::High);
+		Messages::Add({out.str(), GameData::MessageCategories().Get("normal")});
 	}
 
 	return true;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1990,11 +1990,11 @@ int Ship::Scan(const PlayerInfo &player)
 	if(startedScanning && isYours)
 	{
 		if(!target->Name().empty())
-			Messages::Add("Attempting to scan the " + target->Noun() + " \"" + target->Name() + "\"."
-				, Messages::Importance::Low);
+			Messages::Add({"Attempting to scan the " + target->Noun() + " \"" + target->Name() + "\".",
+				GameData::MessageCategories().Get("low")});
 		else
-			Messages::Add("Attempting to scan the selected " + target->Noun() + "."
-				, Messages::Importance::Low);
+			Messages::Add({"Attempting to scan the selected " + target->Noun() + ".",
+				GameData::MessageCategories().Get("low")});
 
 		if(target->GetGovernment()->IsProvokedOnScan() && target->CanSendHail(player))
 		{
@@ -2005,26 +2005,26 @@ int Ship::Scan(const PlayerInfo &player)
 				tag = gov + " " + target->Noun() + " \"" + target->Name() + "\": ";
 			else
 				tag = target->DisplayModelName() + " (" + gov + "): ";
-			Messages::Add(tag + "Please refrain from scanning us or we will be forced to take action.",
-				Messages::Importance::Highest);
+			Messages::Add({tag + "Please refrain from scanning us or we will be forced to take action.",
+				GameData::MessageCategories().Get("high")});
 		}
 	}
 	else if(startedScanning && target->isYours && isImportant)
-		Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-				+ Name() + "\" is attempting to scan your ship \"" + target->Name() + "\".",
-				Messages::Importance::Low);
+		Messages::Add({"The " + government->GetName() + " " + Noun() + " \""
+			+ Name() + "\" is attempting to scan your ship \"" + target->Name() + "\".",
+			GameData::MessageCategories().Get("low")});
 
 	if(target->isYours && !isYours && isImportant)
 	{
 		if(result & ShipEvent::SCAN_CARGO)
-			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + "\" completed its cargo scan of your ship \"" + target->Name() + "\".",
-					Messages::Importance::High);
+			Messages::Add({"The " + government->GetName() + " " + Noun() + " \""
+				+ Name() + "\" completed its cargo scan of your ship \"" + target->Name() + "\".",
+				GameData::MessageCategories().Get("normal")});
 		if(result & ShipEvent::SCAN_OUTFITS)
-			Messages::Add("The " + government->GetName() + " " + Noun() + " \""
-					+ Name() + "\" completed its outfit scan of your ship \"" + target->Name()
-					+ (target->Attributes().Get("inscrutable") > 0. ? "\" with no useful results." : "\"."),
-					Messages::Importance::High);
+			Messages::Add({"The " + government->GetName() + " " + Noun() + " \""
+				+ Name() + "\" completed its outfit scan of your ship \"" + target->Name()
+				+ (target->Attributes().Get("inscrutable") > 0. ? "\" with no useful results." : "\"."),
+				GameData::MessageCategories().Get("normal")});
 	}
 
 	// Some governments are provoked when a scan is completed on one of their ships.
@@ -3243,8 +3243,8 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 		type |= ShipEvent::DESTROY;
 
 		if(IsYours())
-			Messages::Add("Your " + DisplayModelName() +
-				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
+			Messages::Add({"Your " + DisplayModelName() + " \"" + Name() + "\" has been destroyed.",
+				GameData::MessageCategories().Get("high")});
 	}
 
 	// Inflicted heat damage may also disable a ship, but does not trigger a "DISABLE" event.
@@ -4715,11 +4715,10 @@ void Ship::StepPilot()
 		if(isYours || personality.IsEscort())
 		{
 			if(!parent.lock())
-				Messages::Add("Your ship is moving erratically because you do not have enough crew to pilot it."
-					, Messages::Importance::Low);
+				Messages::Add(*GameData::Messages().Get("undercrewed flagship"));
 			else if(Preferences::Has("Extra fleet status messages"))
-				Messages::Add("The " + name + " is moving erratically because there are not enough crew to pilot it."
-					, Messages::Importance::Low);
+				Messages::Add({"The " + name + " is moving erratically because there are not enough crew to pilot it.",
+					GameData::MessageCategories().Get("low")});
 		}
 	}
 	else
@@ -4985,7 +4984,7 @@ void Ship::StepTargeting()
 					// boarding sequence (including locking on to the ship) but
 					// not to actually board, if they are cloaked, except if they have "cloaked boarding".
 					if(isYours)
-						Messages::Add("You cannot board a ship while cloaked.", Messages::Importance::Highest);
+						Messages::Add(*GameData::Messages().Get("cannot board while cloaked"));
 				}
 				else
 				{
@@ -4993,8 +4992,9 @@ void Ship::StepTargeting()
 					bool isEnemy = government->IsEnemy(target->government);
 					if(isEnemy && Random::Real() < target->Attributes().Get("self destruct"))
 					{
-						Messages::Add("The " + target->DisplayModelName() + " \"" + target->Name()
-							+ "\" has activated its self-destruct mechanism.", Messages::Importance::High);
+						Messages::Add({"The " + target->DisplayModelName() + " \"" + target->Name()
+							+ "\" has activated its self-destruct mechanism.",
+							GameData::MessageCategories().Get("high")});
 						GetTargetShip()->SelfDestruct();
 					}
 					else

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -788,8 +788,8 @@ void ShipInfoPanel::Dump()
 
 	info.Update(**shipIt, player);
 	if(loss)
-		Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
-			, Messages::Importance::High);
+		Messages::Add({"You jettisoned " + Format::CreditString(loss) + " worth of cargo.",
+			GameData::MessageCategories().Get("normal")});
 }
 
 
@@ -805,8 +805,8 @@ void ShipInfoPanel::DumpPlunder(int count)
 		info.Update(**shipIt, player);
 
 		if(loss)
-			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
-				, Messages::Importance::High);
+			Messages::Add({"You jettisoned " + Format::CreditString(loss) + " worth of cargo.",
+				GameData::MessageCategories().Get("normal")});
 	}
 }
 
@@ -825,8 +825,8 @@ void ShipInfoPanel::DumpCommodities(int count)
 		info.Update(**shipIt, player);
 
 		if(loss)
-			Messages::Add("You jettisoned " + Format::CreditString(loss) + " worth of cargo."
-				, Messages::Importance::High);
+			Messages::Add({"You jettisoned " + Format::CreditString(loss) + " worth of cargo.",
+				GameData::MessageCategories().Get("normal")});
 	}
 }
 

--- a/source/ShipManager.cpp
+++ b/source/ShipManager.cpp
@@ -125,9 +125,10 @@ void ShipManager::Do(PlayerInfo &player) const
 		for(const auto &ship : toTake)
 			player.TakeShip(ship.get(), model, takeOutfits);
 	}
-	Messages::Add((count == 1 ? "The " + model->DisplayModelName() + " \"" + shipName + "\" was " :
+	Messages::Add({(count == 1 ? "The " + model->DisplayModelName() + " \"" + shipName + "\" was " :
 		to_string(count) + " " + model->PluralModelName() + " were ") +
-		(Giving() ? "added to" : "removed from") + " your fleet.", Messages::Importance::High);
+		(Giving() ? "added to" : "removed from") + " your fleet.",
+		GameData::MessageCategories().Get("normal")});
 }
 
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -75,7 +75,7 @@ TradingPanel::~TradingPanel()
 		else
 			message += "for a total profit of " + Format::CreditString(profit) + ".";
 
-		Messages::Add(message, Messages::Importance::High);
+		Messages::Add({message, GameData::MessageCategories().Get("normal")});
 	}
 }
 

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -311,6 +311,12 @@ void UniverseObjects::CheckReferences()
 	for(const auto &it : swizzles)
 		if(!it.second.IsLoaded())
 			Warn("swizzle", it.first);
+	for(const auto &it : messageCategories)
+		if(!it.second.IsLoaded())
+			Warn("message category", it.first);
+	for(const auto &it : messages)
+		if(!it.second.IsLoaded())
+			Warn("message", it.first);
 }
 
 
@@ -477,6 +483,10 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 			wormholes.Get(node.Token(1))->Load(node);
 		else if(key == "gamerules" && node.HasChildren())
 			gamerules.Load(node);
+		else if(key == "message category")
+			messageCategories.Get(node.Token(1))->Load(node);
+		else if(key == "message")
+			messages.Get(node.Token(1))->Load(node);
 		else if(key == "disable" && hasValue)
 		{
 			static const set<string> canDisable = {"mission", "event", "person"};

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -31,6 +31,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Government.h"
 #include "Hazard.h"
 #include "Interface.h"
+#include "Message.h"
 #include "Minable.h"
 #include "Mission.h"
 #include "News.h"
@@ -117,6 +118,8 @@ private:
 	Set<Government> governments;
 	Set<Hazard> hazards;
 	Set<Interface> interfaces;
+	Set<Message::Category> messageCategories;
+	Set<Message> messages;
 	Set<Minable> minables;
 	Set<Mission> missions;
 	Set<News> news;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
You can now make custom message categories, defining their colors in the main and log panels, the behavior that should be applied when there are duplicates (two data flags that mirror the old code), and decide whether they should be included in the important only view in the log panel.

Defined every old hardcoded Importance level in this new format:
 - Highest -> `"high"`,
 - High -> `"normal"` (because that's what it really was, just normal messages),
 - Low -> `"low"`,
 - Daily -> `"daily"`,
 - Info -> `"info"`, and a new type needed for the force flag -> `"force log"`.

If some messages ended up in the wrong category, it's most likely a typo, and pointing that out in the reviewing is much welcome.

You can also redefine some engine messages (for now, I've moved most of the hardcoded single-string ones that don't require any complex substitutions system, but I'm planning to do it also for the rest of the engine messages). You can assign a category (see above), with `"normal"` being the default. The messages can have either a `text` (with phrases and replacements), or a `phrase`; there are both types in vanilla.

Finally, moved the non-dialog messages that were previously help messages to the new messages data file.

## Screenshots
N/A

## Testing Done
Did some basic playtesting.

## Wiki Update
soon™.

## Performance Impact
Haven't measured.