### PR TITLE
Don't check the offer location when filtering non-priority missions

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -18,7 +18,7 @@ event "remembrance day"
 
 mission "remembrance day"
 	landing
-	priority
+	non-blocking
 	source
 		government "Republic"
 		attributes "spaceport"
@@ -148,7 +148,7 @@ event "war begins"
 
 mission "event: war begins"
 	landing
-	priority
+	non-blocking
 	source
 		government "Republic" "Syndicate" "Free Worlds"
 		attributes "spaceport"

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -18,6 +18,7 @@ event "remembrance day"
 
 mission "remembrance day"
 	landing
+	priority
 	source
 		government "Republic"
 		attributes "spaceport"
@@ -147,6 +148,7 @@ event "war begins"
 
 mission "event: war begins"
 	landing
+	priority
 	source
 		government "Republic" "Syndicate" "Free Worlds"
 		attributes "spaceport"

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -358,8 +358,6 @@ void Mission::Load(const DataNode &node, const ConditionsStore *playerConditions
 
 	if(displayName.empty())
 		displayName = name;
-	if(hasPriority && location == LANDING)
-		node.PrintTrace("Warning: \"priority\" tag has no effect on \"landing\" missions:");
 }
 
 
@@ -616,9 +614,8 @@ bool Mission::IsValid() const
 
 
 
-// Check if this mission has high priority. If any high-priority missions
-// are available, no others will be shown at landing or in the spaceport.
-// This is to be used for missions that are part of a series.
+// Check if this mission has high priority. If any priority missions
+// are available, only other priority missions can offer alongside it.
 bool Mission::HasPriority() const
 {
 	return hasPriority;

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -624,7 +624,8 @@ bool Mission::HasPriority() const
 
 
 // Check if this mission is a "non-blocking" mission.
-// Such missions will not prevent minor missions from being offered alongside them.
+// Such missions will not prevent minor missions from being offered alongside them,
+// and will not be prevented from offering by priority missions.
 bool Mission::IsNonBlocking() const
 {
 	return isNonBlocking;

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -672,7 +672,7 @@ bool Mission::IsValid() const
 
 
 // Check if this mission has high priority. If any priority missions
-// are available, only other priority missions can offer alongside it.
+// are available, only other priority missions and non-blocking ones can offer alongside it.
 bool Mission::HasPriority() const
 {
 	return hasPriority;

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -86,7 +86,7 @@ public:
 	// undefined ships, planets, or systems (i.e. is from an inactive plugin).
 	bool IsValid() const;
 	// Check if this mission has high priority. If any priority missions
-	// are available, only other priority missions can offer alongside it.
+	// are available, only other priority missions and non-blocking ones can offer alongside it.
 	bool HasPriority() const;
 	// Check if this mission is a "non-blocking" mission.
 	// Such missions will not prevent minor missions from being offered alongside them,

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -78,9 +78,8 @@ public:
 	// Check if this mission should be quarantined due to requiring currently-
 	// undefined ships, planets, or systems (i.e. is from an inactive plugin).
 	bool IsValid() const;
-	// Check if this mission has high priority. If any high-priority missions
-	// are available, no others will be shown at landing or in the spaceport.
-	// This is to be used for missions that are part of a series.
+	// Check if this mission has high priority. If any priority missions
+	// are available, only other priority missions can offer alongside it.
 	bool HasPriority() const;
 	// Check if this mission is a "non-blocking" mission.
 	// Such missions will not prevent minor missions from being offered alongside them.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -82,7 +82,8 @@ public:
 	// are available, only other priority missions can offer alongside it.
 	bool HasPriority() const;
 	// Check if this mission is a "non-blocking" mission.
-	// Such missions will not prevent minor missions from being offered alongside them.
+	// Such missions will not prevent minor missions from being offered alongside them,
+	// and will not be prevented from offering by priority missions.
 	bool IsNonBlocking() const;
 	// Check if this mission is a "minor" mission. Minor missions will only be
 	// offered if no other non-blocking missions (minor or otherwise) are being offered.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3943,20 +3943,7 @@ void PlayerInfo::CreateMissions()
 	// If any of the available missions are "priority" missions, no other
 	// special missions will be offered in the spaceport.
 	if(hasPriorityMissions)
-	{
-		auto it = availableMissions.begin();
-		while(it != availableMissions.end())
-		{
-			bool hasLowerPriorityLocation = it->IsAtLocation(Mission::SPACEPORT)
-				|| it->IsAtLocation(Mission::SHIPYARD)
-				|| it->IsAtLocation(Mission::OUTFITTER)
-				|| it->IsAtLocation(Mission::JOB_BOARD);
-			if(hasLowerPriorityLocation && !it->HasPriority())
-				it = availableMissions.erase(it);
-			else
-				++it;
-		}
-	}
+		erase_if(availableMissions, [](const Mission &m) noexcept -> bool { return !m.HasPriority(); });
 	else if(availableMissions.size() > 1 + nonBlockingMissions)
 	{
 		// Minor missions only get offered if no other missions (including other

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3941,9 +3941,12 @@ void PlayerInfo::CreateMissions()
 		});
 
 	// If any of the available missions are "priority" missions, then only priority
-	// missions are allowed to offer.
+	// and non-blocking missions are allowed to offer.
 	if(hasPriorityMissions)
-		erase_if(availableMissions, [](const Mission &m) noexcept -> bool { return !m.HasPriority(); });
+		erase_if(availableMissions, [](const Mission &m) noexcept -> bool
+			{
+				return !m.HasPriority() && !m.IsNonBlocking();
+			});
 	else if(availableMissions.size() > 1 + nonBlockingMissions)
 	{
 		// Minor missions only get offered if no other missions (including other

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3940,8 +3940,8 @@ void PlayerInfo::CreateMissions()
 			return a.OfferPrecedence() > b.OfferPrecedence();
 		});
 
-	// If any of the available missions are "priority" missions, no other
-	// special missions will be offered in the spaceport.
+	// If any of the available missions are "priority" missions, then only priority
+	// missions are allowed to offer.
 	if(hasPriorityMissions)
 		erase_if(availableMissions, [](const Mission &m) noexcept -> bool { return !m.HasPriority(); });
 	else if(availableMissions.size() > 1 + nonBlockingMissions)


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

In https://github.com/endless-sky/endless-sky/pull/11388#discussion_r2082801463 I called out how, for some reason, the code that runs when you have a `priority` mission has a boolean that is true for every location except for the LANDING location. What this actually means in practice is that if any one `priority` mission is present, all `landing` missions are implicitly treated like priority missions. This even includes landing missions that are also marked as `minor`, since the code that runs to exclude `minor` missions when other missions are available is not run.

This has been the behavior of the `priority` tag ever since it was implemented (see https://github.com/endless-sky/endless-sky/commit/ccf4dc315a64515e25ff3f0df1d9ba06c12a8da6, and note that at the time the only available mission locations were SPACEPORT, LANDING, and JOB, and the JOB missions don't reach this point in the code, and the later BOARDING and ASSIST locations likewise don't touch this code). The `priority` tag is used very sparingly, though. The only missions that make use of it are the intro missions... as well as "Syndicate Business 4", "Syndicate Business 5", and "Timothy Radrickson 3a: Rescue the Convoy", for some reason. And given the fact that we rarely mix `landing` and `minor`, this bug was likely never encountered, although the fact that `priority` and `landing` don't really mix is something we added to the wiki, as pointed out by @TheGiraffe3.

Upon speaking with the other devs today, none of us could figure out why this is the case. The only reason I can think of at the moment is that it was made this way so that the Remembrance Day and maybe also the War Begins conversations, which occur as landing missions, could still offer even if you also had one of James' missions being offered in the spaceport (assuming the player just took a really long time to do the intro missions). I was originally going to mark these missions as `priority` because of this, but I realized that this meant that if you were trying to continue a storyline onto the next mission at the same time that either of these conversations appeared, the Remembrance Day or War Begins missions would block the storyline from continuing. As such, I've instead decided to give these missions the `non-blocking` tag, and update the behavior of `non-blocking` to also prevent such missions from being blocked by `priority` missions.

## Testing Done

No.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/147
