### PR TITLE
Allow outfits and ships to have conditional descriptions

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -119,9 +119,12 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "system")
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+
+		if(key == "system")
 		{
-			if(child.Size() >= 2)
+			if(hasValue)
 			{
 				if(child.Token(1) == "destination")
 					isAtDestination = true;
@@ -131,30 +134,29 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			else
 				location.Load(child);
 		}
-		else if(child.Token(0) == "uuid" && child.Size() >= 2)
+		else if(key == "uuid" && hasValue)
 			uuid = EsUuid::FromString(child.Token(1));
-		else if(child.Token(0) == "planet" && child.Size() >= 2)
+		else if(key == "planet" && hasValue)
 			planet = GameData::Planets().Get(child.Token(1));
-		else if(child.Token(0) == "succeed" && child.Size() >= 2)
+		else if(key == "succeed" && hasValue)
 			succeedIf = child.Value(1);
-		else if(child.Token(0) == "fail" && child.Size() >= 2)
+		else if(key == "fail" && hasValue)
 			failIf = child.Value(1);
-		else if(child.Token(0) == "evade")
+		else if(key == "evade")
 			mustEvade = true;
-		else if(child.Token(0) == "accompany")
+		else if(key == "accompany")
 			mustAccompany = true;
-		else if(child.Token(0) == "government" && child.Size() >= 2)
+		else if(key == "government" && hasValue)
 			government = GameData::Governments().Get(child.Token(1));
-		else if(child.Token(0) == "personality")
+		else if(key == "personality")
 			personality.Load(child);
-		else if(child.Token(0) == "cargo settings" && child.HasChildren())
+		else if(key == "cargo settings" && child.HasChildren())
 		{
 			cargo.Load(child);
 			overrideFleetCargo = true;
 		}
-		else if(child.Token(0) == "dialog")
+		else if(key == "dialog")
 		{
-			bool hasValue = (child.Size() > 1);
 			// Dialog text may be supplied from a stock named phrase, a
 			// private unnamed phrase, or directly specified.
 			if(hasValue && child.Token(1) == "phrase")
@@ -175,11 +177,11 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			else
 				Dialog::ParseTextNode(child, 1, dialogText);
 		}
-		else if(child.Token(0) == "conversation" && child.HasChildren())
+		else if(key == "conversation" && child.HasChildren())
 			conversation = ExclusiveItem<Conversation>(Conversation(child, playerConditions));
-		else if(child.Token(0) == "conversation" && child.Size() > 1)
+		else if(key == "conversation" && child.Size() > 1)
 			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(child.Token(1)));
-		else if(child.Token(0) == "to" && child.Size() >= 2)
+		else if(key == "to" && hasValue)
 		{
 			if(child.Token(1) == "spawn")
 				toSpawn.Load(child, playerConditions);
@@ -188,7 +190,7 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "on" && child.Size() >= 2)
+		else if(key == "on" && hasValue)
 		{
 			static const map<string, Trigger> trigger = {
 				{"assist", Trigger::ASSIST},
@@ -208,18 +210,18 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
-		else if(child.Token(0) == "ship")
+		else if(key == "ship")
 		{
 			if(child.HasChildren() && child.Size() == 2)
 			{
 				// Loading an NPC from a save file, or an entire ship specification.
 				// The latter may result in references to non-instantiated outfits.
-				ships.emplace_back(make_shared<Ship>(child));
+				ships.emplace_back(make_shared<Ship>(child, playerConditions));
 				for(const DataNode &grand : child)
 					if(grand.Token(0) == "actions" && grand.Size() >= 2)
 						shipEvents[ships.back().get()] = grand.Value(1);
 			}
-			else if(child.Size() >= 2)
+			else if(hasValue)
 			{
 				// Loading a ship managed by GameData, i.e. "base models" and variants.
 				stockShips.push_back(GameData::Ships().Get(child.Token(1)));
@@ -235,12 +237,12 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 				child.PrintTrace(message);
 			}
 		}
-		else if(child.Token(0) == "fleet")
+		else if(key == "fleet")
 		{
 			if(child.HasChildren())
 			{
 				fleets.emplace_back(ExclusiveItem<Fleet>(Fleet(child)));
-				if(child.Size() >= 2)
+				if(hasValue)
 				{
 					// Copy the custom fleet in lieu of reparsing the same DataNode.
 					size_t numAdded = child.Value(1);
@@ -248,7 +250,7 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 						fleets.push_back(fleets.back());
 				}
 			}
-			else if(child.Size() >= 2)
+			else if(hasValue)
 			{
 				auto fleet = ExclusiveItem<Fleet>(GameData::Fleets().Get(child.Token(1)));
 				if(child.Size() >= 3 && child.Value(2) > 1.)

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -207,7 +207,7 @@ namespace {
 
 
 
-void Outfit::Load(const DataNode &node)
+void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 {
 	if(node.Size() >= 2)
 		trueName = node.Token(1);
@@ -216,83 +216,83 @@ void Outfit::Load(const DataNode &node)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "display name" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+
+		if(key == "display name" && hasValue)
 			displayName = child.Token(1);
-		else if(child.Token(0) == "category" && child.Size() >= 2)
+		else if(key == "category" && hasValue)
 			category = child.Token(1);
-		else if(child.Token(0) == "series" && child.Size() >= 2)
+		else if(key == "series" && hasValue)
 			series = child.Token(1);
-		else if(child.Token(0) == "index" && child.Size() >= 2)
+		else if(key == "index" && hasValue)
 			index = child.Value(1);
-		else if(child.Token(0) == "plural" && child.Size() >= 2)
+		else if(key == "plural" && hasValue)
 			pluralName = child.Token(1);
-		else if(child.Token(0) == "flare sprite" && child.Size() >= 2)
+		else if(key == "flare sprite" && hasValue)
 		{
 			flareSprites.emplace_back(Body(), 1);
 			flareSprites.back().first.LoadSprite(child);
 		}
-		else if(child.Token(0) == "reverse flare sprite" && child.Size() >= 2)
+		else if(key == "reverse flare sprite" && hasValue)
 		{
 			reverseFlareSprites.emplace_back(Body(), 1);
 			reverseFlareSprites.back().first.LoadSprite(child);
 		}
-		else if(child.Token(0) == "steering flare sprite" && child.Size() >= 2)
+		else if(key == "steering flare sprite" && hasValue)
 		{
 			steeringFlareSprites.emplace_back(Body(), 1);
 			steeringFlareSprites.back().first.LoadSprite(child);
 		}
-		else if(child.Token(0) == "flare sound" && child.Size() >= 2)
+		else if(key == "flare sound" && hasValue)
 			++flareSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "reverse flare sound" && child.Size() >= 2)
+		else if(key == "reverse flare sound" && hasValue)
 			++reverseFlareSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "steering flare sound" && child.Size() >= 2)
+		else if(key == "steering flare sound" && hasValue)
 			++steeringFlareSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "afterburner effect" && child.Size() >= 2)
+		else if(key == "afterburner effect" && hasValue)
 			++afterburnerEffects[GameData::Effects().Get(child.Token(1))];
-		else if(child.Token(0) == "jump effect" && child.Size() >= 2)
+		else if(key == "jump effect" && hasValue)
 			++jumpEffects[GameData::Effects().Get(child.Token(1))];
-		else if(child.Token(0) == "hyperdrive sound" && child.Size() >= 2)
+		else if(key == "hyperdrive sound" && hasValue)
 			++hyperSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "hyperdrive in sound" && child.Size() >= 2)
+		else if(key == "hyperdrive in sound" && hasValue)
 			++hyperInSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "hyperdrive out sound" && child.Size() >= 2)
+		else if(key == "hyperdrive out sound" && hasValue)
 			++hyperOutSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "jump sound" && child.Size() >= 2)
+		else if(key == "jump sound" && hasValue)
 			++jumpSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "jump in sound" && child.Size() >= 2)
+		else if(key == "jump in sound" && hasValue)
 			++jumpInSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "jump out sound" && child.Size() >= 2)
+		else if(key == "jump out sound" && hasValue)
 			++jumpOutSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "cargo scan sound" && child.Size() >= 2)
+		else if(key == "cargo scan sound" && hasValue)
 			++cargoScanSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "outfit scan sound" && child.Size() >= 2)
+		else if(key == "outfit scan sound" && hasValue)
 			++outfitScanSounds[Audio::Get(child.Token(1))];
-		else if(child.Token(0) == "flotsam sprite" && child.Size() >= 2)
+		else if(key == "flotsam sprite" && hasValue)
 			flotsamSprite = SpriteSet::Get(child.Token(1));
-		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
+		else if(key == "thumbnail" && hasValue)
 			thumbnail = SpriteSet::Get(child.Token(1));
-		else if(child.Token(0) == "weapon")
+		else if(key == "weapon")
 			LoadWeapon(child);
-		else if(child.Token(0) == "ammo" && child.Size() >= 2)
+		else if(key == "ammo" && hasValue)
 		{
 			// Non-weapon outfits can have ammo so that storage outfits
 			// properly remove excess ammo when the storage is sold, instead
 			// of blocking the sale of the outfit until the ammo is sold first.
 			ammo = make_pair(GameData::Outfits().Get(child.Token(1)), 0);
 		}
-		else if(child.Token(0) == "description" && child.Size() >= 2)
-		{
-			description += child.Token(1);
-			description += '\n';
-		}
-		else if(child.Token(0) == "cost" && child.Size() >= 2)
+		else if(key == "description")
+			description.Load(child, playerConditions);
+		else if(key == "cost" && hasValue)
 			cost = child.Value(1);
-		else if(child.Token(0) == "mass" && child.Size() >= 2)
+		else if(key == "mass" && hasValue)
 			mass = child.Value(1);
-		else if(child.Token(0) == "licenses" && (child.HasChildren() || child.Size() >= 2))
+		else if(key == "licenses" && (child.HasChildren() || hasValue))
 		{
 			// Add any new licenses that were specified "inline".
-			if(child.Size() >= 2)
+			if(hasValue)
 			{
 				for(auto it = ++begin(child.Tokens()); it != end(child.Tokens()); ++it)
 					AddLicense(*it);
@@ -301,13 +301,13 @@ void Outfit::Load(const DataNode &node)
 			for(const DataNode &grand : child)
 				AddLicense(grand.Token(0));
 		}
-		else if(child.Token(0) == "jump range" && child.Size() >= 2)
+		else if(key == "jump range" && hasValue)
 		{
 			// Jump range must be positive.
-			attributes[child.Token(0)] = max(0., child.Value(1));
+			attributes[key] = max(0., child.Value(1));
 		}
-		else if(child.Size() >= 2)
-			attributes[child.Token(0)] = child.Value(1);
+		else if(hasValue)
+			attributes[key] = child.Value(1);
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -459,9 +459,9 @@ const int Outfit::Index() const
 
 
 
-const string &Outfit::Description() const
+string Outfit::Description() const
 {
-	return description;
+	return description.ToString();
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Weapon.h"
 
 #include "Dictionary.h"
+#include "Paragraphs.h"
 
 #include <map>
 #include <string>
@@ -25,6 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 class Body;
+class ConditionsStore;
 class DataNode;
 class Effect;
 class Sound;
@@ -51,7 +53,7 @@ public:
 public:
 	// An "outfit" can be loaded from an "outfit" node or from a ship's
 	// "attributes" node.
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, const ConditionsStore *playerConditions);
 	bool IsDefined() const;
 
 	const std::string &TrueName() const;
@@ -61,7 +63,7 @@ public:
 	const std::string &Category() const;
 	const std::string &Series() const;
 	const int Index() const;
-	const std::string &Description() const;
+	std::string Description() const;
 	int64_t Cost() const;
 	double Mass() const;
 	// Get the licenses needed to buy or operate this ship.
@@ -124,8 +126,8 @@ private:
 	// The series that this outfit is a part of and its index within that series.
 	// Used for sorting within shops.
 	std::string series;
-	int index;
-	std::string description;
+	int index = 0;
+	Paragraphs description;
 	const Sprite *thumbnail = nullptr;
 	int64_t cost = 0;
 	double mass = 0.;

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -26,30 +26,33 @@ using namespace std;
 
 
 
-void Person::Load(const DataNode &node)
+void Person::Load(const DataNode &node, const ConditionsStore *playerConditions)
 {
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "system")
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+
+		if(key == "system")
 			location.Load(child);
-		else if(child.Token(0) == "frequency" && child.Size() >= 2)
+		else if(key == "frequency" && hasValue)
 			frequency = child.Value(1);
-		else if(child.Token(0) == "formation" && child.Size() >= 2)
+		else if(key == "formation" && hasValue)
 			formationPattern = GameData::Formations().Get(child.Token(1));
-		else if(child.Token(0) == "ship" && child.Size() >= 2)
+		else if(key == "ship" && hasValue)
 		{
 			// Name ships that are not the flagship with the name provided, if any.
 			// The flagship, and any unnamed fleet members, will be given the name of the Person.
 			bool setName = !ships.empty() && child.Size() >= 3;
-			ships.emplace_back(make_shared<Ship>(child));
+			ships.emplace_back(make_shared<Ship>(child, playerConditions));
 			if(setName)
 				ships.back()->SetName(child.Token(2));
 		}
-		else if(child.Token(0) == "government" && child.Size() >= 2)
+		else if(key == "government" && hasValue)
 			government = GameData::Governments().Get(child.Token(1));
-		else if(child.Token(0) == "personality")
+		else if(key == "personality")
 			personality.Load(child);
-		else if(child.Token(0) == "phrase")
+		else if(key == "phrase")
 			hail.Load(child);
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/Person.h
+++ b/source/Person.h
@@ -22,6 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <list>
 #include <memory>
 
+class ConditionsStore;
 class DataNode;
 class FormationPattern;
 class Government;
@@ -33,7 +34,7 @@ class System;
 // A unique individual who may appear at random times in the game.
 class Person {
 public:
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, const ConditionsStore *playerConditions);
 	// Finish loading all the ships in this person specification.
 	void FinishLoading();
 	// Prevent this person from being spawned in any system.

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -268,7 +268,7 @@ void PlayerInfo::Load(const filesystem::path &path)
 		else if(child.Token(0) == "ship")
 		{
 			// Ships owned by the player have various special characteristics:
-			ships.push_back(make_shared<Ship>(child));
+			ships.push_back(make_shared<Ship>(child, &conditions));
 			ships.back()->SetIsSpecial();
 			ships.back()->SetIsYours();
 			// Defer finalizing this ship until we have processed all changes to game state.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -225,14 +225,14 @@ namespace {
 
 
 // Construct and Load() at the same time.
-Ship::Ship(const DataNode &node)
+Ship::Ship(const DataNode &node, const ConditionsStore *playerConditions)
 {
-	Load(node);
+	Load(node, playerConditions);
 }
 
 
 
-void Ship::Load(const DataNode &node)
+void Ship::Load(const DataNode &node, const ConditionsStore *playerConditions)
 {
 	if(node.Size() >= 2)
 		trueModelName = node.Token(1);
@@ -258,8 +258,9 @@ void Ship::Load(const DataNode &node)
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
 		bool add = (key == "add");
-		if(add && (child.Size() < 2 || child.Token(1) != "attributes"))
+		if(add && (!hasValue || child.Token(1) != "attributes"))
 		{
 			child.PrintTrace("Skipping invalid use of 'add' with " + (child.Size() < 2
 					? "no key." : "key: " + child.Token(1)));
@@ -267,30 +268,30 @@ void Ship::Load(const DataNode &node)
 		}
 		if(key == "sprite")
 			LoadSprite(child);
-		else if(child.Token(0) == "thumbnail" && child.Size() >= 2)
+		else if(key == "thumbnail" && hasValue)
 			thumbnail = SpriteSet::Get(child.Token(1));
-		else if(key == "name" && child.Size() >= 2)
+		else if(key == "name" && hasValue)
 			name = child.Token(1);
-		else if(key == "display name" && child.Size() >= 2)
+		else if(key == "display name" && hasValue)
 			displayModelName = child.Token(1);
-		else if(key == "plural" && child.Size() >= 2)
+		else if(key == "plural" && hasValue)
 			pluralModelName = child.Token(1);
-		else if(key == "variant map name" && child.Size() >= 2)
+		else if(key == "variant map name" && hasValue)
 			variantMapShopName = child.Token(1);
-		else if(key == "noun" && child.Size() >= 2)
+		else if(key == "noun" && hasValue)
 			noun = child.Token(1);
-		else if(key == "swizzle" && child.Size() >= 2)
+		else if(key == "swizzle" && hasValue)
 			customSwizzleName = child.Token(1);
-		else if(key == "uuid" && child.Size() >= 2)
+		else if(key == "uuid" && hasValue)
 			uuid = EsUuid::FromString(child.Token(1));
 		else if(key == "attributes" || add)
 		{
 			if(!add)
-				baseAttributes.Load(child);
+				baseAttributes.Load(child, playerConditions);
 			else
 			{
 				addAttributes = true;
-				attributes.Load(child);
+				attributes.Load(child, playerConditions);
 			}
 		}
 		else if((key == "engine" || key == "reverse engine" || key == "steering engine") && child.Size() >= 3)
@@ -350,7 +351,7 @@ void Ship::Load(const DataNode &node)
 			}
 			else
 			{
-				if(child.Size() >= 2)
+				if(hasValue)
 					outfit = GameData::Outfits().Get(child.Token(1));
 			}
 			Hardpoint::BaseAttributes attributes;
@@ -479,7 +480,7 @@ void Ship::Load(const DataNode &node)
 					}
 				}
 		}
-		else if(key == "leak" && child.Size() >= 2)
+		else if(key == "leak" && hasValue)
 		{
 			if(!hasLeak)
 			{
@@ -493,7 +494,7 @@ void Ship::Load(const DataNode &node)
 				leak.closePeriod = child.Value(3);
 			leaks.push_back(leak);
 		}
-		else if(key == "explode" && child.Size() >= 2)
+		else if(key == "explode" && hasValue)
 		{
 			if(!hasExplode)
 			{
@@ -505,7 +506,7 @@ void Ship::Load(const DataNode &node)
 			explosionEffects[GameData::Effects().Get(child.Token(1))] += count;
 			explosionTotal += count;
 		}
-		else if(key == "final explode" && child.Size() >= 2)
+		else if(key == "final explode" && hasValue)
 		{
 			if(!hasFinalExplode)
 			{
@@ -546,40 +547,39 @@ void Ship::Load(const DataNode &node)
 		}
 		else if(key == "cargo")
 			cargo.Load(child);
-		else if(key == "crew" && child.Size() >= 2)
+		else if(key == "crew" && hasValue)
 			crew = static_cast<int>(child.Value(1));
-		else if(key == "fuel" && child.Size() >= 2)
+		else if(key == "fuel" && hasValue)
 			fuel = child.Value(1);
-		else if(key == "shields" && child.Size() >= 2)
+		else if(key == "shields" && hasValue)
 			shields = child.Value(1);
-		else if(key == "hull" && child.Size() >= 2)
+		else if(key == "hull" && hasValue)
 			hull = child.Value(1);
 		else if(key == "position" && child.Size() >= 3)
 			position = Point(child.Value(1), child.Value(2));
-		else if(key == "system" && child.Size() >= 2)
+		else if(key == "system" && hasValue)
 			currentSystem = GameData::Systems().Get(child.Token(1));
-		else if(key == "planet" && child.Size() >= 2)
+		else if(key == "planet" && hasValue)
 		{
 			zoom = 0.;
 			landingPlanet = GameData::Planets().Get(child.Token(1));
 		}
-		else if(key == "destination system" && child.Size() >= 2)
+		else if(key == "destination system" && hasValue)
 			targetSystem = GameData::Systems().Get(child.Token(1));
 		else if(key == "parked")
 			isParked = true;
-		else if(key == "description" && child.Size() >= 2)
+		else if(key == "description")
 		{
 			if(!hasDescription)
 			{
-				description.clear();
+				description.Clear();
 				hasDescription = true;
 			}
-			description += child.Token(1);
-			description += '\n';
+			description.Load(child, playerConditions);
 		}
-		else if(key == "formation" && child.Size() >= 2)
+		else if(key == "formation" && hasValue)
 			formationPattern = GameData::Formations().Get(child.Token(1));
-		else if(key == "remove" && child.Size() >= 2)
+		else if(key == "remove" && hasValue)
 		{
 			if(child.Token(1) == "bays")
 				removeBays = true;
@@ -659,7 +659,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			finalExplosions = base->finalExplosions;
 		if(outfits.empty())
 			outfits = base->outfits;
-		if(description.empty())
+		if(description.IsEmpty())
 			description = base->description;
 
 		bool hasHardpoints = false;
@@ -1245,9 +1245,9 @@ const string &Ship::Noun() const
 
 
 // Get this ship's description.
-const string &Ship::Description() const
+string Ship::Description() const
 {
-	return description;
+	return description.ToString();
 }
 
 
@@ -3895,7 +3895,7 @@ void Ship::Linger()
 
 
 
-bool Ship::Immitates(const Ship &other) const
+bool Ship::Imitates(const Ship &other) const
 {
 	return displayModelName == other.DisplayModelName() && outfits == other.Outfits();
 }

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -24,6 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "EsUuid.h"
 #include "FireCommand.h"
 #include "Outfit.h"
+#include "Paragraphs.h"
 #include "Personality.h"
 #include "Point.h"
 #include "Port.h"
@@ -38,6 +39,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+class ConditionsStore;
 class DamageDealt;
 class DataNode;
 class DataWriter;
@@ -149,10 +151,10 @@ public:
 
 	Ship() = default;
 	// Construct and Load() at the same time.
-	Ship(const DataNode &node);
+	Ship(const DataNode &node, const ConditionsStore *playerConditions);
 
 	// Load data for a type of ship:
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, const ConditionsStore *playerConditions);
 	// When loading a ship, some of the outfits it lists may not have been
 	// loaded yet. So, wait until everything has been loaded, then call this.
 	void FinishLoading(bool isNewInstance);
@@ -180,7 +182,7 @@ public:
 	// Get the generic noun (e.g. "ship") to be used when describing this ship.
 	const std::string &Noun() const;
 	// Get this ship's description.
-	const std::string &Description() const;
+	std::string Description() const;
 	// Get the shipyard thumbnail for this ship.
 	const Sprite *Thumbnail() const;
 	// Get this ship's cost.
@@ -537,7 +539,7 @@ public:
 	void Linger();
 
 	// Check if this ship looks the same as another, based on model display names and outfits.
-	bool Immitates(const Ship &other) const;
+	bool Imitates(const Ship &other) const;
 
 
 private:
@@ -608,7 +610,7 @@ private:
 	std::string variantName;
 	std::string variantMapShopName;
 	std::string noun;
-	std::string description;
+	Paragraphs description;
 	const Sprite *thumbnail = nullptr;
 	// Characteristics of this particular ship:
 	EsUuid uuid;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -1261,7 +1261,7 @@ void ShopPanel::SideSelect(Ship *ship, int clicks)
 			{
 				if(!CanShowInSidebar(*it, player.GetPlanet()))
 					continue;
-				if(it.get() != ship && it->Immitates(*ship))
+				if(it.get() != ship && it->Imitates(*ship))
 					playerShips.insert(it.get());
 			}
 	}
@@ -1277,7 +1277,7 @@ void ShopPanel::SideSelect(Ship *ship, int clicks)
 			{
 				if(!CanShowInSidebar(*it, player.GetPlanet()))
 					continue;
-				if(it.get() != ship && it->Immitates(*ship))
+				if(it.get() != ship && it->Imitates(*ship))
 				{
 					similarShips.push_back(it.get());
 					unselect &= playerShips.contains(it.get());

--- a/source/StartConditions.cpp
+++ b/source/StartConditions.cpp
@@ -117,7 +117,7 @@ void StartConditions::Load(const DataNode &node, const ConditionsStore *globalCo
 			// a 3rd token (i.e. this will be treated as though it were a ship variant definition,
 			// without making the variant available to the rest of GameData).
 			if(child.HasChildren() || child.Size() >= add + 3)
-				ships.emplace_back(child);
+				ships.emplace_back(child, playerConditions);
 			// If there's only 2 tokens & there's no child nodes, the created instance would be ill-formed.
 			else
 				child.PrintTrace("Skipping unsupported use of a \"stock\" ship (a full definition is required):");

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -369,11 +369,11 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 		else if(key == "mission" && hasValue)
 			missions.Get(node.Token(1))->Load(node, playerConditions);
 		else if(key == "outfit" && hasValue)
-			outfits.Get(node.Token(1))->Load(node);
+			outfits.Get(node.Token(1))->Load(node, playerConditions);
 		else if(key == "outfitter" && hasValue)
 			outfitSales.Get(node.Token(1))->Load(node, outfits, playerConditions);
 		else if(key == "person" && hasValue)
-			persons.Get(node.Token(1))->Load(node);
+			persons.Get(node.Token(1))->Load(node, playerConditions);
 		else if(key == "phrase" && hasValue)
 			phrases.Get(node.Token(1))->Load(node);
 		else if(key == "planet" && hasValue)
@@ -382,7 +382,7 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 		{
 			// Allow multiple named variants of the same ship model.
 			const string &name = node.Token((node.Size() > 2) ? 2 : 1);
-			ships.Get(name)->Load(node);
+			ships.Get(name)->Load(node, playerConditions);
 		}
 		else if(key == "shipyard" && hasValue)
 			shipSales.Get(node.Token(1))->Load(node, ships, playerConditions);


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #7138 and recently brought up on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR extends the condition description mechanic that was added to planets/spaceports in #8187 to the descriptions of outfits and ships.

## Testing Done + Usage Examples

I added the following to both the Shuttle and the Hyperdrive. I started a new save file and observed that this did not appear in the description of either item. After the war begins conversation appeared, this line also began to appear in the description of these items.
```
description `	War has begun.`
	to display
		has "event: war begins"

```

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/148
