### PR TITLE
(balance): Lower the mass of the Modified Dromedary

### DIFF
--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -282,7 +282,7 @@ ship "Modified Dromedary"
 		"hull" 9600
 		"required crew" 95
 		"bunks" 300
-		"mass" 4732
+		"mass" 2366
 		"drag" 28.7
 		"heat dissipation" .22
 		"fuel capacity" 900


### PR DESCRIPTION
**Balance**

This PR cuts the mass of the Modified Dromedary in half.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When the mass of ships was rebalanced, the Modified Dromedary was not changed. The original idea behind the Modified Dromedary's mass, as I understand it, was to make it into a slow ship, without risking it becoming unreasonably fast due to tinkering with its large outfit space.

After the Mass Rebalance, however, this ship stands as an outlier in that it is *unerasonably slow*.

The Modified Dromedary is **extremely** similar to the Bactrian, not only in looks but also in stats:

```
ship "Modified Dromedary"
        "shields" 15100
        "hull" 9600
        "required crew" 95
        "bunks" 300
        "mass" 4732
        "drag" 28.7
        "heat dissipation" .22
        "fuel capacity" 900
        "cargo space" 550
        "outfit space" 740
        "weapon capacity" 270
        "engine capacity" 195

ship "Bactrian"
        "shields" 17500
        "hull" 8600
        "required crew" 70
        "bunks" 245
        "mass" 2450
        "drag" 30.6
        "heat dissipation" .22
        "fuel capacity" 700
        "cargo space" 530
        "outfit space" 740
        "weapon capacity" 300
        "engine capacity" 180
```

The only stat between both ships where a huge discrepancy is found is the mass. It's sprite is shorter than the Bactrian's by a bit, and wider by a bit, it's barely got more space than the Bactrian in anything, 1k more hull but 2.4k less shields, a bit more cargo and bunks, a bit more engine capacity, a bit less weapon capacity, same outfit space and yet outweighs the Bactrian by **nearly 2x in mass**. It has some built-in stuff like scanning and solar but that seems very little for being so abysmally slower in acceleration and turning.

Given it's drag is actually *lower* than the Bactrian's, I figured the best option to get this PR started was to also set the mass to slightly lower than the Bactrian's, so this PR cuts the Modified Dromedary's mass in half, from `4732` to `2366`.

This would still have the Modified Dromedary as a slow ship.

## Screenshots

The following screenshots illustrate how the disparity in mass makes it so that a Modified Dromedary and Bactrian, with the same # of outfit space left, and with the same engines, makes the Modified Dromedary be much slower in accelerating and turning:

![image](https://github.com/user-attachments/assets/950b51f5-c30e-48d8-891a-6b8a234c71ba)

![image](https://github.com/user-attachments/assets/261c1317-a0c2-4e93-99c2-420bb240c402)



