### PR TITLE
Specify Venta gun hardpoints to be symmetric

### DIFF
--- a/data/incipias/incipias ships.txt
+++ b/data/incipias/incipias ships.txt
@@ -61,7 +61,7 @@ ship "Venta"
 	gun 29 -76.5 "Star Tail"
 	gun -28 -76.5 "Star Tail"
 	gun -28 -76.5 "Star Tail"
-	gun -57 -76 "Plasma Discharger"
+	gun -57.5 -76.5 "Plasma Discharger"
 	explode "medium explosion" 50
 	explode "large explosion" 40
 	explode "huge explosion" 10

--- a/data/incipias/incipias ships.txt
+++ b/data/incipias/incipias ships.txt
@@ -56,12 +56,12 @@ ship "Venta"
 	engine 0 42
 		"over"
 	engine 90 42
-	gun 58.5 -76.5
-	gun 29 -76.5
-	gun 29 -76.5
-	gun -28 -76.5
-	gun -28 -76.5
-	gun -57 -76
+	gun 58.5 -76.5 "Plasma Discharger"
+	gun 29 -76.5 "Star Tail"
+	gun 29 -76.5 "Star Tail"
+	gun -28 -76.5 "Star Tail"
+	gun -28 -76.5 "Star Tail"
+	gun -57 -76 "Plasma Discharger"
 	explode "medium explosion" 50
 	explode "large explosion" 40
 	explode "huge explosion" 10


### PR DESCRIPTION
**Content (I think?)**

This PR addresses ~~my OCD~~ the fact that the Venta's weapon hardpoints aren't defining which gun goes where, leading to an asymmetric layout.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Just defines where each gun goes on the Venta's gun hardpoints, making it so the 2 Plasma Dischargers are on the 2 isolated, further out hardpoints, whereas the 4 Star Tails are clustered together in 2 groups of 2, on the 2 sets of justapositioned hardpoints, as shown in the pics below.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/f3e47327-23d1-4ebc-b3b1-4ca553415895)
![image](https://github.com/user-attachments/assets/9b545d27-0c8e-4b7d-bf99-a2a604defaed)

After:
![image](https://github.com/user-attachments/assets/d745aa25-bbc2-4f5d-b49e-257e4687bfa7)
![image](https://github.com/user-attachments/assets/3c3c9ca5-a98d-4489-ba94-fea559f7383b)

