### PR TITLE
fix(ui): More specific reasons for being unable to land

### DIFF
--- a/data/_ui/landing messages.txt
+++ b/data/_ui/landing messages.txt
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-"landing message" "You cannot land on a gas giant."
+"landing message" "You cannot land on this gas giant."
 	"planet/gas0"
 	"planet/gas0-b"
 	"planet/gas1"
@@ -88,7 +88,7 @@
 	"planet/wormhole"
 	"planet/wormhole-red"
 
-"landing message" "You cannot land on a black hole!"
+"landing message" "You cannot land on this black hole!"
 	"star/black-hole"
 	"star/black-hole-core"
 	"star/small-black-hole"
@@ -99,7 +99,7 @@
 	"planet/dyson2"
 	"planet/dyson3"
 
-"landing message" "You cannot land on a brown dwarf."
+"landing message" "You cannot land on this brown dwarf."
 	"planet/browndwarf-l"
 	"planet/browndwarf-l-rogue"
 	"planet/browndwarf-t"

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -450,7 +450,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 		while(root->parent >= 0)
 			root = &objects[root->parent];
 
-		static const string STAR = "You cannot land on a star!";
+		static const string STAR = "You cannot land on this star!";
 		static const string HOTPLANET = "This planet is too hot to land on.";
 		static const string COLDPLANET = "This planet is too cold to land on.";
 		static const string UNINHABITEDPLANET = "This planet doesn't have anywhere you can land.";


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11412

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR makes the textual change discussed in #11412 to state for a single planet why you cannot land on it, without specifying for other similar planets if you would be able to land on those other planets.
Fixes: #11412

## Testing Done
Attempted to land on a gas giant in Kappa Centauri, and got the updated error-message.

## Save File
See #11412 for a savefile that could be used.

## Wiki Update
N/A

## Performance Impact
None expected.