### PR TITLE
Refactor load functions to use `key` and `hasValue` variables

### DIFF
--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -48,9 +48,12 @@ void Account::Load(const DataNode &node, bool clearFirst)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "credits" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "credits" && hasValue)
 			credits = child.Value(1);
-		else if(child.Token(0) == "salaries income")
+		else if(key == "salaries income")
+		{
 			for(const DataNode &grand : child)
 			{
 				if(grand.Size() < 2)
@@ -58,15 +61,16 @@ void Account::Load(const DataNode &node, bool clearFirst)
 				else
 					salariesIncome[grand.Token(0)] = grand.Value(1);
 			}
-		else if(child.Token(0) == "salaries" && child.Size() >= 2)
+		}
+		else if(key == "salaries" && hasValue)
 			crewSalariesOwed = child.Value(1);
-		else if(child.Token(0) == "maintenance" && child.Size() >= 2)
+		else if(key == "maintenance" && hasValue)
 			maintenanceDue = child.Value(1);
-		else if(child.Token(0) == "score" && child.Size() >= 2)
+		else if(key == "score" && hasValue)
 			creditScore = child.Value(1);
-		else if(child.Token(0) == "mortgage")
+		else if(key == "mortgage")
 			mortgages.emplace_back(child);
-		else if(child.Token(0) == "history")
+		else if(key == "history")
 			for(const DataNode &grand : child)
 				history.push_back(grand.Value(0));
 		else

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -220,32 +220,34 @@ void Body::LoadSprite(const DataNode &node)
 	// to do that unless it is repeating endlessly.
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "frame rate" && child.Size() >= 2 && child.Value(1) >= 0.)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "frame rate" && hasValue && child.Value(1) >= 0.)
 			frameRate = child.Value(1) / 60.;
-		else if(child.Token(0) == "frame time" && child.Size() >= 2 && child.Value(1) > 0.)
+		else if(key == "frame time" && hasValue && child.Value(1) > 0.)
 			frameRate = 1. / child.Value(1);
-		else if(child.Token(0) == "delay" && child.Size() >= 2 && child.Value(1) > 0.)
+		else if(key == "delay" && hasValue && child.Value(1) > 0.)
 			delay = child.Value(1);
-		else if(child.Token(0) == "scale" && child.Size() >= 2 && child.Value(1) > 0.)
+		else if(key == "scale" && hasValue && child.Value(1) > 0.)
 		{
 			double scaleY = (child.Size() >= 3 && child.Value(2) > 0.) ? child.Value(2) : child.Value(1);
 			scale = Point(child.Value(1), scaleY);
 		}
-		else if(child.Token(0) == "start frame" && child.Size() >= 2)
+		else if(key == "start frame" && hasValue)
 		{
 			frameOffset += static_cast<float>(child.Value(1));
 			startAtZero = true;
 		}
-		else if(child.Token(0) == "random start frame")
+		else if(key == "random start frame")
 			randomize = true;
-		else if(child.Token(0) == "no repeat")
+		else if(key == "no repeat")
 		{
 			repeat = false;
 			startAtZero = true;
 		}
-		else if(child.Token(0) == "rewind")
+		else if(key == "rewind")
 			rewind = true;
-		else if(child.Token(0) == "center" && child.Size() >= 3)
+		else if(key == "center" && child.Size() >= 3)
 			center = Point(child.Value(1), child.Value(2));
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/CargoHold.cpp
+++ b/source/CargoHold.cpp
@@ -71,7 +71,8 @@ void CargoHold::Load(const DataNode &node)
 	// Cargo is stored as name / amount pairs in two lists: commodities and outfits.
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "commodities")
+		const string &key = child.Token(0);
+		if(key == "commodities")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
@@ -80,7 +81,7 @@ void CargoHold::Load(const DataNode &node)
 					commodities[grand.Token(0)] += tons;
 				}
 		}
-		else if(child.Token(0) == "outfits")
+		else if(key == "outfits")
 		{
 			for(const DataNode &grand : child)
 			{

--- a/source/ConditionAssignments.cpp
+++ b/source/ConditionAssignments.cpp
@@ -155,24 +155,25 @@ void ConditionAssignments::AddSetCondition(const std::string &name, const Condit
 void ConditionAssignments::Add(const DataNode &node, const ConditionsStore *conditions)
 {
 	this->conditions = conditions;
-	if(node.Token(0) == "set" || node.Token(0) == "clear")
+	const string &key = node.Token(0);
+	if(key == "set" || key == "clear")
 	{
 		if(node.Size() != 2 || !DataNode::IsConditionName(node.Token(1)))
 		{
-			node.PrintTrace("Parse error; " + node.Token(0) + " keyword requires a single valid condition:");
+			node.PrintTrace("Parse error; " + key + " keyword requires a single valid condition:");
 			return;
 		}
 		assignments.emplace_back(node.Token(1), AssignOp::ASSIGN,
-			ConditionSet(node.Token(0) == "set" ? 1 : 0, conditions));
+			ConditionSet(key == "set" ? 1 : 0, conditions));
 	}
 	else if(node.Size() == 2 && (node.Token(1) == "++" || node.Token(1) == "--"))
 	{
-		if(!DataNode::IsConditionName(node.Token(0)))
+		if(!DataNode::IsConditionName(key))
 		{
 			node.PrintTrace("Parse error; " + node.Token(1) + " operator requires a single valid condition:");
 			return;
 		}
-		assignments.emplace_back(node.Token(0), node.Token(1) == "++" ? AssignOp::ADD : AssignOp::SUB,
+		assignments.emplace_back(key, node.Token(1) == "++" ? AssignOp::ADD : AssignOp::SUB,
 			ConditionSet(1, conditions));
 	}
 	else if(node.Size() >= 3)
@@ -202,7 +203,7 @@ void ConditionAssignments::Add(const DataNode &node, const ConditionsStore *cond
 		expr.Optimize(node);
 
 		// Add the assignment when all parsing succeeded.
-		assignments.emplace_back(node.Token(0), ao, expr);
+		assignments.emplace_back(key, ao, expr);
 	}
 	else
 	{

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -430,15 +430,16 @@ bool ConditionSet::ParseNode(const DataNode &node)
 	if(!conditions)
 		throw runtime_error("Unable to ParseNode(full) for a ConditionSet without a pointer to a ConditionsStore!");
 
+	const string &key = node.Token(0);
 	// Special handling for 'and' and 'or' nodes.
 	if(node.Size() == 1)
 	{
-		if(node.Token(0) == "and")
+		if(key == "and")
 		{
 			expressionOperator = ExpressionOp::AND;
 			return ParseBooleanChildren(node);
 		}
-		if(node.Token(0) == "or")
+		if(key == "or")
 		{
 			expressionOperator = ExpressionOp::OR;
 			return ParseBooleanChildren(node);
@@ -450,7 +451,7 @@ bool ConditionSet::ParseNode(const DataNode &node)
 		return FailParse(node, "unexpected child-nodes under toplevel");
 
 	// Special handling for 'never', 'has' and 'not' nodes.
-	if(node.Token(0) == "never")
+	if(key == "never")
 	{
 		if(node.Size() > 1)
 			return FailParse(node, "tokens found after never keyword");
@@ -459,7 +460,7 @@ bool ConditionSet::ParseNode(const DataNode &node)
 		literal = 0;
 		return true;
 	}
-	if(node.Token(0) == "has")
+	if(key == "has")
 	{
 		if(node.Size() != 2 || !DataNode::IsConditionName(node.Token(1)))
 			return FailParse(node, "has keyword requires a single condition");
@@ -469,7 +470,7 @@ bool ConditionSet::ParseNode(const DataNode &node)
 		conditionName = node.Token(1);
 		return true;
 	}
-	if(node.Token(0) == "not")
+	if(key == "not")
 	{
 		if(node.Size() != 2 || !DataNode::IsConditionName(node.Token(1)))
 			return FailParse(node, "not keyword requires a single condition");

--- a/source/ConditionsStore.cpp
+++ b/source/ConditionsStore.cpp
@@ -56,9 +56,10 @@ void ConditionsStore::Load(const DataNode &node)
 {
 	for(const DataNode &child : node)
 	{
-		if(!DataNode::IsConditionName(child.Token(0)))
+		const string &key = child.Token(0);
+		if(!DataNode::IsConditionName(key))
 			child.PrintTrace("Invalid condition during savegame-load:");
-		Set(child.Token(0), (child.Size() >= 2) ? child.Value(1) : 1);
+		Set(key, (child.Size() >= 2) ? child.Value(1) : 1);
 	}
 }
 

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -109,20 +109,22 @@ void Conversation::Load(const DataNode &node, const ConditionsStore *playerCondi
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "scene" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "scene" && hasValue)
 		{
 			// A scene always starts a new text node.
 			AddNode();
 			nodes.back().scene = SpriteSet::Get(child.Token(1));
 		}
-		else if(child.Token(0) == "label" && child.Size() >= 2)
+		else if(key == "label" && hasValue)
 		{
 			// You cannot merge text above a label with text below it.
 			if(!nodes.empty())
 				nodes.back().canMergeOnto = false;
 			AddLabel(child.Token(1), child);
 		}
-		else if(child.Token(0) == "choice")
+		else if(key == "choice")
 		{
 			// Create a new node with one or more choices in it.
 			nodes.emplace_back(true);
@@ -150,12 +152,12 @@ void Conversation::Load(const DataNode &node, const ConditionsStore *playerCondi
 				nodes.pop_back();
 			}
 		}
-		else if(child.Token(0) == "name")
+		else if(key == "name")
 		{
 			// A name entry field is just represented as an empty choice node.
 			nodes.emplace_back(true);
 		}
-		else if(child.Token(0) == "branch")
+		else if(key == "branch")
 		{
 			// Don't merge "branch" nodes with any other nodes.
 			nodes.emplace_back();
@@ -180,9 +182,9 @@ void Conversation::Load(const DataNode &node, const ConditionsStore *playerCondi
 				}
 			}
 		}
-		else if(child.Token(0) == "action" || child.Token(0) == "apply")
+		else if(key == "action" || key == "apply")
 		{
-			if(child.Token(0) == "apply")
+			if(key == "apply")
 				child.PrintTrace("Warning: `apply` is deprecated syntax. Use `action` instead to ensure future compatibility.");
 			// Don't merge "action" nodes with any other nodes. Allow the legacy keyword "apply," too.
 			AddNode();
@@ -190,7 +192,7 @@ void Conversation::Load(const DataNode &node, const ConditionsStore *playerCondi
 			nodes.back().actions.Load(child, playerConditions);
 		}
 		// Check for common errors such as indenting a goto incorrectly:
-		else if(child.Size() > 1)
+		else if(hasValue)
 			child.PrintTrace("Error: Conversation text should be a single token:");
 		else
 		{
@@ -203,7 +205,7 @@ void Conversation::Load(const DataNode &node, const ConditionsStore *playerCondi
 				AddNode();
 
 			// Always append a newline to the end of the text.
-			nodes.back().elements.back().text += child.Token(0) + '\n';
+			nodes.back().elements.back().text += key + '\n';
 
 			// Check whether there is a goto attached to this block of text. If
 			// so, future nodes can't merge onto this one.
@@ -566,21 +568,21 @@ bool Conversation::LoadDestinations(const DataNode &node, const ConditionsStore 
 	bool hasCondition = false;
 	for(const DataNode &child : node)
 	{
-		if(child.Size() == 2 && child.Token(0) == "goto" && hasGoto)
+		if(child.Size() == 2 && key == "goto" && hasGoto)
 		{
 			child.PrintTrace("Warning: Ignoring extra endpoint in conversation choice:");
 		}
-		else if(child.Size() == 2 && child.Token(0) == "goto")
+		else if(child.Size() == 2 && key == "goto")
 		{
 			Goto(child.Token(1), nodes.size() - 1, nodes.back().elements.size() - 1);
 			hasGoto = true;
 		}
-		else if(child.Size() == 2 && child.Token(0) == "to" && child.Token(1) == "display" && hasCondition)
+		else if(child.Size() == 2 && key == "to" && child.Token(1) == "display" && hasCondition)
 		{
 			// Each choice can only have one condition
 			child.PrintTrace("Warning: Ignoring extra condition in conversation choice:");
 		}
-		else if(child.Size() == 2 && child.Token(0) == "to" && child.Token(1) == "display")
+		else if(child.Size() == 2 && key == "to" && child.Token(1) == "display")
 		{
 			nodes.back().elements.back().conditions.Load(child, playerConditions);
 			hasCondition = true;
@@ -588,7 +590,7 @@ bool Conversation::LoadDestinations(const DataNode &node, const ConditionsStore 
 		else
 		{
 			// Check if this is a recognized endpoint name.
-			int index = TokenIndex(child.Token(0));
+			int index = TokenIndex(key);
 			if(child.Size() == 1 && index < 0)
 			{
 				if(hasGoto)
@@ -611,7 +613,7 @@ bool Conversation::LoadDestinations(const DataNode &node, const ConditionsStore 
 bool Conversation::HasDisplayRestriction(const DataNode &node)
 {
 	for(const DataNode &child : node)
-		if(child.Size() == 2 && child.Token(0) == "to" && child.Token(1) == "display")
+		if(child.Size() == 2 && key == "to" && child.Token(1) == "display")
 			return true;
 
 	return false;

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -568,30 +568,32 @@ bool Conversation::LoadDestinations(const DataNode &node, const ConditionsStore 
 	bool hasCondition = false;
 	for(const DataNode &child : node)
 	{
-		if(child.Size() == 2 && key == "goto" && hasGoto)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "goto" && hasValue && hasGoto)
 		{
 			child.PrintTrace("Warning: Ignoring extra endpoint in conversation choice:");
 		}
-		else if(child.Size() == 2 && key == "goto")
+		else if(key == "goto" && hasValue)
 		{
 			Goto(child.Token(1), nodes.size() - 1, nodes.back().elements.size() - 1);
 			hasGoto = true;
 		}
-		else if(child.Size() == 2 && key == "to" && child.Token(1) == "display" && hasCondition)
+		else if(key == "to" && hasValue && child.Token(1) == "display")
 		{
-			// Each choice can only have one condition
-			child.PrintTrace("Warning: Ignoring extra condition in conversation choice:");
-		}
-		else if(child.Size() == 2 && key == "to" && child.Token(1) == "display")
-		{
-			nodes.back().elements.back().conditions.Load(child, playerConditions);
-			hasCondition = true;
+			if(hasCondition)
+				child.PrintTrace("Warning: Ignoring extra condition in conversation choice:");
+			else
+			{
+				nodes.back().elements.back().conditions.Load(child, playerConditions);
+				hasCondition = true;
+			}
 		}
 		else
 		{
 			// Check if this is a recognized endpoint name.
 			int index = TokenIndex(key);
-			if(child.Size() == 1 && index < 0)
+			if(!hasValue && index < 0)
 			{
 				if(hasGoto)
 					child.PrintTrace("Warning: Ignoring extra endpoint in conversation choice:");
@@ -613,7 +615,7 @@ bool Conversation::LoadDestinations(const DataNode &node, const ConditionsStore 
 bool Conversation::HasDisplayRestriction(const DataNode &node)
 {
 	for(const DataNode &child : node)
-		if(child.Size() == 2 && key == "to" && child.Token(1) == "display")
+		if(child.Token(0) == "to" && child.Size() >= 2 && child.Token(1) == "display")
 			return true;
 
 	return false;

--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -570,14 +570,15 @@ bool Conversation::LoadDestinations(const DataNode &node, const ConditionsStore 
 	{
 		const string &key = child.Token(0);
 		bool hasValue = child.Size() >= 2;
-		if(key == "goto" && hasValue && hasGoto)
+		if(key == "goto" && hasValue)
 		{
-			child.PrintTrace("Warning: Ignoring extra endpoint in conversation choice:");
-		}
-		else if(key == "goto" && hasValue)
-		{
-			Goto(child.Token(1), nodes.size() - 1, nodes.back().elements.size() - 1);
-			hasGoto = true;
+			if(hasGoto)
+				child.PrintTrace("Warning: Ignoring extra endpoint in conversation choice:");
+			else
+			{
+				Goto(child.Token(1), nodes.size() - 1, nodes.back().elements.size() - 1);
+				hasGoto = true;
+			}
 		}
 		else if(key == "to" && hasValue && child.Token(1) == "display")
 		{

--- a/source/Effect.cpp
+++ b/source/Effect.cpp
@@ -60,39 +60,41 @@ void Effect::Load(const DataNode &node)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "sprite")
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "sprite")
 			LoadSprite(child);
-		else if(child.Token(0) == "zooms")
+		else if(key == "zooms")
 			inheritsZoom = true;
-		else if(child.Token(0) == "sound" && child.Size() >= 2)
+		else if(key == "sound" && hasValue)
 			sound = Audio::Get(child.Token(1));
-		else if(child.Token(0) == "sound category" && child.Size() >= 2)
+		else if(key == "sound category" && hasValue)
 		{
 			if(categoryNames.contains(child.Token(1)))
 				soundCategory = categoryNames.at(child.Token(1));
 			else
 				child.PrintTrace("Unknown sound category \"" + child.Token(1) + "\"");
 		}
-		else if(child.Token(0) == "lifetime" && child.Size() >= 2)
+		else if(key == "lifetime" && hasValue)
 			lifetime = child.Value(1);
-		else if(child.Token(0) == "random lifetime" && child.Size() >= 2)
+		else if(key == "random lifetime" && hasValue)
 			randomLifetime = child.Value(1);
-		else if(child.Token(0) == "velocity scale" && child.Size() >= 2)
+		else if(key == "velocity scale" && hasValue)
 			velocityScale = child.Value(1);
-		else if(child.Token(0) == "random velocity" && child.Size() >= 2)
+		else if(key == "random velocity" && hasValue)
 			randomVelocity = child.Value(1);
-		else if(child.Token(0) == "random angle" && child.Size() >= 2)
+		else if(key == "random angle" && hasValue)
 			randomAngle = child.Value(1);
-		else if(child.Token(0) == "random spin" && child.Size() >= 2)
+		else if(key == "random spin" && hasValue)
 			randomSpin = child.Value(1);
-		else if(child.Token(0) == "random frame rate" && child.Size() >= 2)
+		else if(key == "random frame rate" && hasValue)
 			randomFrameRate = child.Value(1);
-		else if(child.Token(0) == "absolute angle" && child.Size() >= 2)
+		else if(key == "absolute angle" && hasValue)
 		{
 			absoluteAngle = Angle(child.Value(1));
 			hasAbsoluteAngle = true;
 		}
-		else if(child.Token(0) == "absolute velocity" && child.Size() >= 2)
+		else if(key == "absolute velocity" && hasValue)
 		{
 			absoluteVelocity = child.Value(1);
 			hasAbsoluteVelocity = true;

--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -73,7 +73,7 @@ void Fleet::Load(const DataNode &node)
 		// are only valid with "variant" or "personality" definitions.
 		bool add = (child.Token(0) == "add");
 		bool remove = (child.Token(0) == "remove");
-		bool hasValue = (child.Size() >= 2);
+		bool hasValue = child.Size() >= 2;
 		if((add || remove) && (!hasValue || (child.Token(1) != "variant" && child.Token(1) != "personality")))
 		{
 			child.PrintTrace("Warning: Skipping invalid \"" + child.Token(0) + "\" tag:");

--- a/source/FleetCargo.cpp
+++ b/source/FleetCargo.cpp
@@ -141,17 +141,18 @@ void FleetCargo::Load(const DataNode &node)
 
 void FleetCargo::LoadSingle(const DataNode &node)
 {
+	const string &key = node.Token(0);
 	if(node.Size() < 2)
 		node.PrintTrace("Error: Expected key to have a value:");
-	else if(node.Token(0) == "cargo")
+	else if(key == "cargo")
 			cargo = static_cast<int>(node.Value(1));
-	else if(node.Token(0) == "commodities")
+	else if(key == "commodities")
 	{
 		commodities.clear();
 		for(int i = 1; i < node.Size(); ++i)
 			commodities.push_back(node.Token(i));
 	}
-	else if(node.Token(0) == "outfitters")
+	else if(key == "outfitters")
 	{
 		outfitters.clear();
 		for(int i = 1; i < node.Size(); ++i)

--- a/source/FormationPattern.cpp
+++ b/source/FormationPattern.cpp
@@ -150,19 +150,25 @@ void FormationPattern::Load(const DataNode &node)
 	}
 
 	for(const DataNode &child : node)
-		if(child.Token(0) == "flippable" && child.Size() >= 2)
+	{
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "flippable" && hasValue)
+		{
 			for(int i = 1; i < child.Size(); ++i)
 			{
-				if(child.Token(i) == "x")
+				const string &value = child.Token(i);
+				if(value == "x")
 					flippableX = true;
-				else if(child.Token(i) == "y")
+				else if(value == "y")
 					flippableY = true;
 				else
 					child.PrintTrace("Skipping unrecognized attribute:");
 			}
-		else if(child.Token(0) == "rotatable" && child.Size() >= 2)
+		}
+		else if(key == "rotatable" && hasValue)
 			rotatable = child.Value(1);
-		else if(child.Token(0) == "position" && child.Size() >= 3)
+		else if(key == "position" && child.Size() >= 3)
 		{
 			Line &line = lines.emplace_back();
 			// A point is a line with just 1 position on it.
@@ -172,6 +178,7 @@ void FormationPattern::Load(const DataNode &node)
 			line.endOrAnchor = line.start;
 			// Also allow positions to have a repeat section, for single points only
 			for(const DataNode &grand : child)
+			{
 				if(grand.Token(0) == "repeat" && grand.Size() >= 3)
 				{
 					LineRepeat &repeat = line.repeats.emplace_back();
@@ -179,27 +186,31 @@ void FormationPattern::Load(const DataNode &node)
 				}
 				else
 					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
 		}
-		else if(child.Token(0) == "line" || child.Token(0) == "arc")
+		else if(key == "line" || key == "arc")
 		{
 			Line &line = lines.emplace_back();
 
-			if(child.Token(0) == "arc")
+			if(key == "arc")
 				line.isArc = true;
 
 			for(const DataNode &grand : child)
 			{
-				if(grand.Token(0) == "start" && grand.Size() >= 3)
+				const string &grandKey = grand.Token(0);
+				bool grandHasValue = grand.Size() >= 2;
+				if(grandKey == "start" && grand.Size() >= 3)
 					line.start.Set(grand.Value(1), grand.Value(2));
-				else if(grand.Token(0) == "end" && grand.Size() >= 3 && !line.isArc)
+				else if(grandKey == "end" && grand.Size() >= 3 && !line.isArc)
 					line.endOrAnchor.Set(grand.Value(1), grand.Value(2));
-				else if(grand.Token(0) == "anchor" && grand.Size() >= 3 && line.isArc)
+				else if(grandKey == "anchor" && grand.Size() >= 3 && line.isArc)
 					line.endOrAnchor.Set(grand.Value(1), grand.Value(2));
-				else if(grand.Token(0) == "angle" && grand.Size() >= 2 && line.isArc)
+				else if(grandKey == "angle" && grandHasValue && line.isArc)
 					line.angle = grand.Value(1);
-				else if(grand.Token(0) == "positions" && grand.Size() >= 2)
+				else if(grandKey == "positions" && grandHasValue)
 					line.positions = static_cast<int>(grand.Value(1) + 0.5);
-				else if(grand.Token(0) == "skip")
+				else if(grandKey == "skip")
+				{
 					for(int i = 1; i < grand.Size(); ++i)
 					{
 						if(grand.Token(i) == "first")
@@ -209,22 +220,27 @@ void FormationPattern::Load(const DataNode &node)
 						else
 							grand.PrintTrace("Skipping unrecognized attribute:");
 					}
-				else if(grand.Token(0) == "repeat")
+				}
+				else if(grandKey == "repeat")
 				{
 					LineRepeat &repeat = line.repeats.emplace_back();
-					for(const DataNode &grandGrand : grand)
-						if(grandGrand.Token(0) == "start" && grandGrand.Size() >= 3)
-							repeat.repeatStart.Set(grandGrand.Value(1), grandGrand.Value(2));
-						else if(grandGrand.Token(0) == "end" && grandGrand.Size() >= 3 && !line.isArc)
-							repeat.repeatEndOrAnchor.Set(grandGrand.Value(1), grandGrand.Value(2));
-						else if(grandGrand.Token(0) == "anchor" && grandGrand.Size() >= 3 && line.isArc)
-							repeat.repeatEndOrAnchor.Set(grandGrand.Value(1), grandGrand.Value(2));
-						else if(grandGrand.Token(0) == "angle" && grandGrand.Size() >= 2 && line.isArc)
-							repeat.repeatAngle = grandGrand.Value(1);
-						else if(grandGrand.Token(0) == "positions" && grandGrand.Size() >= 2)
-							repeat.repeatPositions = static_cast<int>(grandGrand.Value(1) + 0.5);
+					for(const DataNode &great : grand)
+					{
+						const string &greatKey = great.Token(0);
+						bool greatHasValue = great.Size() >= 2;
+						if(greatKey == "start" && great.Size() >= 3)
+							repeat.repeatStart.Set(great.Value(1), great.Value(2));
+						else if(greatKey == "end" && great.Size() >= 3 && !line.isArc)
+							repeat.repeatEndOrAnchor.Set(great.Value(1), great.Value(2));
+						else if(greatKey == "anchor" && great.Size() >= 3 && line.isArc)
+							repeat.repeatEndOrAnchor.Set(great.Value(1), great.Value(2));
+						else if(greatKey == "angle" && greatHasValue && line.isArc)
+							repeat.repeatAngle = great.Value(1);
+						else if(greatKey == "positions" && greatHasValue)
+							repeat.repeatPositions = static_cast<int>(great.Value(1) + 0.5);
 						else
-							grandGrand.PrintTrace("Skipping unrecognized attribute:");
+							great.PrintTrace("Skipping unrecognized attribute:");
+					}
 				}
 				else
 					grand.PrintTrace("Skipping unrecognized attribute:");
@@ -232,6 +248,7 @@ void FormationPattern::Load(const DataNode &node)
 		}
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
+	}
 }
 
 

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -147,7 +147,7 @@ void GameAction::LoadSingle(const DataNode &child, const ConditionsStore *player
 	isEmpty = false;
 
 	const string &key = child.Token(0);
-	bool hasValue = (child.Size() >= 2);
+	bool hasValue = child.Size() >= 2;
 
 	if(key == "remove" && child.Size() >= 3 && child.Token(1) == "log")
 	{
@@ -198,7 +198,7 @@ void GameAction::LoadSingle(const DataNode &child, const ConditionsStore *player
 		for(const DataNode &grand : child)
 		{
 			const string &grandKey = grand.Token(0);
-			bool grandHasValue = (grand.Size() > 1);
+			bool grandHasValue = grand.Size() >= 2;
 			if(grandKey == "term" && grandHasValue)
 				debtEntry.term = max<int>(1, grand.Value(1));
 			else if(grandKey == "interest" && grandHasValue)

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -457,13 +457,14 @@ void GameData::ReadEconomy(const DataNode &node)
 	vector<string> headings;
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "purchases")
+		const string &key = child.Token(0);
+		if(key == "purchases")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 3 && grand.Value(2))
 					purchases[Systems().Get(grand.Token(0))][grand.Token(1)] += grand.Value(2);
 		}
-		else if(child.Token(0) == "system")
+		else if(key == "system")
 		{
 			headings.clear();
 			for(int index = 1; index < child.Size(); ++index)
@@ -471,7 +472,7 @@ void GameData::ReadEconomy(const DataNode &node)
 		}
 		else
 		{
-			System &system = *objects.systems.Get(child.Token(0));
+			System &system = *objects.systems.Get(key);
 
 			int index = 0;
 			for(const string &commodity : headings)

--- a/source/GameEvent.cpp
+++ b/source/GameEvent.cpp
@@ -109,15 +109,16 @@ void GameEvent::Load(const DataNode &node, const ConditionsStore *playerConditio
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
 		if(key == "date" && child.Size() >= 4)
 			date = Date(child.Value(1), child.Value(2), child.Value(3));
-		else if(key == "unvisit" && child.Size() >= 2)
+		else if(key == "unvisit" && hasValue)
 			systemsToUnvisit.push_back(GameData::Systems().Get(child.Token(1)));
-		else if(key == "visit" && child.Size() >= 2)
+		else if(key == "visit" && hasValue)
 			systemsToVisit.push_back(GameData::Systems().Get(child.Token(1)));
-		else if(key == "unvisit planet" && child.Size() >= 2)
+		else if(key == "unvisit planet" && hasValue)
 			planetsToUnvisit.push_back(GameData::Planets().Get(child.Token(1)));
-		else if(key == "visit planet" && child.Size() >= 2)
+		else if(key == "visit planet" && hasValue)
 			planetsToVisit.push_back(GameData::Planets().Get(child.Token(1)));
 		else if(allowedChanges.contains(key))
 			changes.push_back(child);

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -266,11 +266,12 @@ void Government::Load(const DataNode &node)
 		else if(key == "custom penalties for")
 			for(const DataNode &grand : child)
 			{
-				if(grand.Token(0) == "remove" && grand.Size() >= 2)
+				const string &grandKey = grand.Token(0);
+				if(grandKey == "remove" && grand.Size() >= 2)
 					customPenalties[GameData::Governments().Get(grand.Token(1))->id].clear();
 				else
 				{
-					auto &pens = customPenalties[GameData::Governments().Get(grand.Token(0))->id];
+					auto &pens = customPenalties[GameData::Governments().Get(grandKey)->id];
 					PenaltyHelper(grand, pens);
 				}
 			}
@@ -282,30 +283,35 @@ void Government::Load(const DataNode &node)
 				illegalShips.clear();
 			}
 			for(const DataNode &grand : child)
-				if(grand.Size() >= 2)
+			{
+				if(grand.Size() < 2)
 				{
-					if(grand.Token(0) == "remove")
-					{
-						if(grand.Size() >= 3 && grand.Token(1) == "ship")
-						{
-							if(!illegalShips.erase(grand.Token(2)))
-								grand.PrintTrace("Invalid remove, ship not found in existing illegals:");
-						}
-						else if(!illegalOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
-							grand.PrintTrace("Invalid remove, outfit not found in existing illegals:");
-					}
-					else if(grand.Token(0) == "ignore")
-					{
-						if(grand.Size() >= 3 && grand.Token(1) == "ship")
-							illegalShips[grand.Token(2)] = 0;
-						else
-							illegalOutfits[GameData::Outfits().Get(grand.Token(1))] = 0;
-					}
-					else if(grand.Size() >= 3 && grand.Token(0) == "ship")
-						illegalShips[grand.Token(1)] = grand.Value(2);
-					else
-						illegalOutfits[GameData::Outfits().Get(grand.Token(0))] = grand.Value(1);
+					grand.PrintTrace("Skipping unrecognized attribute:");
+					continue;
 				}
+				const string &grandKey = grand.Token(0);
+				if(grandKey == "remove")
+				{
+					if(grand.Token(1) == "ship" && grand.Size() >= 3)
+					{
+						if(!illegalShips.erase(grand.Token(2)))
+							grand.PrintTrace("Invalid remove, ship not found in existing illegals:");
+					}
+					else if(!illegalOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
+						grand.PrintTrace("Invalid remove, outfit not found in existing illegals:");
+				}
+				else if(grandKey == "ignore")
+				{
+					if(grand.Token(1) == "ship" && grand.Size() >= 3)
+						illegalShips[grand.Token(2)] = 0;
+					else
+						illegalOutfits[GameData::Outfits().Get(grand.Token(1))] = 0;
+				}
+				else if(grandKey == "ship" && grand.Size() >= 3)
+					illegalShips[grand.Token(1)] = grand.Value(2);
+				else
+					illegalOutfits[GameData::Outfits().Get(grandKey)] = grand.Value(1);
+			}
 		}
 		else if(key == "atrocities")
 		{
@@ -315,30 +321,30 @@ void Government::Load(const DataNode &node)
 				atrocityShips.clear();
 			}
 			for(const DataNode &grand : child)
-				if(grand.Size() >= 2)
+			{
+				const string &grandKey = grand.Token(0);
+				if(grand.Size() == 1)
+					atrocityOutfits[GameData::Outfits().Get(grandKey)] = true;
+				else if(grandKey == "remove")
 				{
-					if(grand.Token(0) == "remove")
+					if(grand.Token(1) == "ship" && grand.Size() >= 3)
 					{
-						if(grand.Size() >= 3 && grand.Token(1) == "ship")
-						{
-							if(!atrocityShips.erase(grand.Token(2)))
-								grand.PrintTrace("Invalid remove, ship not found in existing atrocities:");
-						}
-						else if(!atrocityOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
-							grand.PrintTrace("Invalid remove, outfit not found in existing atrocities:");
+						if(!atrocityShips.erase(grand.Token(2)))
+							grand.PrintTrace("Invalid remove, ship not found in existing atrocities:");
 					}
-					else if(grand.Token(0) == "ignore")
-					{
-						if(grand.Size() >= 3 && grand.Token(1) == "ship")
-							atrocityShips[grand.Token(2)] = false;
-						else
-							atrocityOutfits[GameData::Outfits().Get(grand.Token(1))] = false;
-					}
-					else if(grand.Token(0) == "ship")
-						atrocityShips[grand.Token(1)] = true;
+					else if(!atrocityOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
+						grand.PrintTrace("Invalid remove, outfit not found in existing atrocities:");
 				}
-				else
-					atrocityOutfits[GameData::Outfits().Get(grand.Token(0))] = true;
+				else if(grandKey == "ignore")
+				{
+					if(grand.Token(1) == "ship" && grand.Size() >= 3)
+						atrocityShips[grand.Token(2)] = false;
+					else
+						atrocityOutfits[GameData::Outfits().Get(grand.Token(1))] = false;
+				}
+				else if(grandKey == "ship")
+					atrocityShips[grand.Token(1)] = true;
+			}
 		}
 		else if(key == "enforces" && child.HasChildren())
 			enforcementZones.emplace_back(child);

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -126,12 +126,10 @@ void Interface::Load(const DataNode &node)
 			// Check if this node specifies a known element type.
 			if(key == "sprite" || key == "image" || key == "outline")
 				elements.push_back(new ImageElement(child, anchor));
-			else if(key == "label" || key == "string" || key == "button"
-					|| key == "dynamic button")
+			else if(key == "label" || key == "string" || key == "button" || key == "dynamic button")
 				elements.push_back(new BasicTextElement(child, anchor));
 			else if(key == "wrapped label" || key == "wrapped string"
-					|| key == "wrapped button"
-					|| key == "wrapped dynamic button")
+					|| key == "wrapped button" || key == "wrapped dynamic button")
 				elements.push_back(new WrappedTextElement(child, anchor));
 			else if(key == "bar" || key == "ring")
 				elements.push_back(new BarElement(child, anchor));

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -461,7 +461,7 @@ bool Interface::ImageElement::ParseLine(const DataNode &node)
 {
 	// The "inactive" and "hover" sprite only applies to non-dynamic images.
 	// The "colored" tag only applies to outlines.
-	const string &key = key;
+	const string &key = node.Token(0);
 	bool hasValue = node.Size() >= 2;
 	if(key == "inactive" && hasValue && name.empty())
 		sprite[Element::INACTIVE] = SpriteSet::Get(node.Token(1));
@@ -536,7 +536,7 @@ Interface::TextElement::TextElement(const DataNode &node, const Point &globalAnc
 	if(node.Size() < 2)
 		return;
 
-	const string &key = key;
+	const string &key = node.Token(0);
 	isDynamic = (key.ends_with("string") || key.ends_with("dynamic button"));
 	if(key.ends_with("button") || key.ends_with("dynamic button"))
 	{

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -95,25 +95,27 @@ void Interface::Load(const DataNode &node)
 	string activeIf;
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "anchor")
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "anchor")
 			anchor = ParseAlignment(child);
-		else if(child.Token(0) == "value" && child.Size() >= 3)
+		else if(key == "value" && child.Size() >= 3)
 			values[child.Token(1)] = child.Value(2);
-		else if((child.Token(0) == "point" || child.Token(0) == "box") && child.Size() >= 2)
+		else if((key == "point" || key == "box") && hasValue)
 		{
 			// This node specifies a named point where custom drawing is done.
 			points[child.Token(1)].Load(child, anchor);
 		}
-		else if(child.Token(0) == "list" && child.Size() >= 2)
+		else if(key == "list" && hasValue)
 		{
 			auto &list = lists[child.Token(1)];
 			for(const auto &grand : child)
 				list.emplace_back(grand.Value(0));
 		}
-		else if(child.Token(0) == "visible" || child.Token(0) == "active")
+		else if(key == "visible" || key == "active")
 		{
 			// This node alters the visibility or activation of future nodes.
-			string &str = (child.Token(0) == "visible" ? visibleIf : activeIf);
+			string &str = (key == "visible" ? visibleIf : activeIf);
 			if(child.Size() >= 3 && child.Token(1) == "if")
 				str = child.Token(2);
 			else
@@ -122,20 +124,20 @@ void Interface::Load(const DataNode &node)
 		else
 		{
 			// Check if this node specifies a known element type.
-			if(child.Token(0) == "sprite" || child.Token(0) == "image" || child.Token(0) == "outline")
+			if(key == "sprite" || key == "image" || key == "outline")
 				elements.push_back(new ImageElement(child, anchor));
-			else if(child.Token(0) == "label" || child.Token(0) == "string" || child.Token(0) == "button"
-					|| child.Token(0) == "dynamic button")
+			else if(key == "label" || key == "string" || key == "button"
+					|| key == "dynamic button")
 				elements.push_back(new BasicTextElement(child, anchor));
-			else if(child.Token(0) == "wrapped label" || child.Token(0) == "wrapped string"
-					|| child.Token(0) == "wrapped button"
-					|| child.Token(0) == "wrapped dynamic button")
+			else if(key == "wrapped label" || key == "wrapped string"
+					|| key == "wrapped button"
+					|| key == "wrapped dynamic button")
 				elements.push_back(new WrappedTextElement(child, anchor));
-			else if(child.Token(0) == "bar" || child.Token(0) == "ring")
+			else if(key == "bar" || key == "ring")
 				elements.push_back(new BarElement(child, anchor));
-			else if(child.Token(0) == "pointer")
+			else if(key == "pointer")
 				elements.push_back(new PointerElement(child, anchor));
-			else if(child.Token(0) == "line")
+			else if(key == "line")
 				elements.push_back(new LineElement(child, anchor));
 			else
 			{
@@ -260,13 +262,14 @@ void Interface::Element::Load(const DataNode &node, const Point &globalAnchor)
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
-		if(key == "align" && child.Size() > 1)
+		bool hasValue = child.Size() >= 2;
+		if(key == "align" && hasValue)
 			alignment = ParseAlignment(child);
 		else if(key == "dimensions" && child.Size() >= 3)
 			dimensions = Point(child.Value(1), child.Value(2));
-		else if(key == "width" && child.Size() >= 2)
+		else if(key == "width" && hasValue)
 			dimensions.X() = child.Value(1);
-		else if(key == "height" && child.Size() >= 2)
+		else if(key == "height" && hasValue)
 			dimensions.Y() = child.Value(1);
 		else if(key == "center" && child.Size() >= 3)
 		{
@@ -427,11 +430,12 @@ Interface::ImageElement::ImageElement(const DataNode &node, const Point &globalA
 	if(node.Size() < 2)
 		return;
 
+	const string &key = node.Token(0);
 	// Remember whether this is an outline element.
-	isOutline = (node.Token(0) == "outline");
+	isOutline = (key == "outline");
 	// If this is a "sprite," look up the sprite with the given name. Otherwise,
 	// the sprite path will be dynamically supplied by the Information object.
-	if(node.Token(0) == "sprite")
+	if(key == "sprite")
 		sprite[Element::ACTIVE] = SpriteSet::Get(node.Token(1));
 	else
 		name = node.Token(1);
@@ -457,11 +461,13 @@ bool Interface::ImageElement::ParseLine(const DataNode &node)
 {
 	// The "inactive" and "hover" sprite only applies to non-dynamic images.
 	// The "colored" tag only applies to outlines.
-	if(node.Token(0) == "inactive" && node.Size() >= 2 && name.empty())
+	const string &key = key;
+	bool hasValue = node.Size() >= 2;
+	if(key == "inactive" && hasValue && name.empty())
 		sprite[Element::INACTIVE] = SpriteSet::Get(node.Token(1));
-	else if(node.Token(0) == "hover" && node.Size() >= 2 && name.empty())
+	else if(key == "hover" && hasValue && name.empty())
 		sprite[Element::HOVER] = SpriteSet::Get(node.Token(1));
-	else if(isOutline && node.Token(0) == "colored")
+	else if(isOutline && key == "colored")
 		isColored = true;
 	else
 		return false;
@@ -530,8 +536,9 @@ Interface::TextElement::TextElement(const DataNode &node, const Point &globalAnc
 	if(node.Size() < 2)
 		return;
 
-	isDynamic = (node.Token(0).ends_with("string") || node.Token(0).ends_with("dynamic button"));
-	if(node.Token(0).ends_with("button") || node.Token(0).ends_with("dynamic button"))
+	const string &key = key;
+	isDynamic = (key.ends_with("string") || key.ends_with("dynamic button"));
+	if(key.ends_with("button") || key.ends_with("dynamic button"))
 	{
 		buttonKey = node.Token(1).front();
 		if(node.Size() >= 3)
@@ -547,15 +554,17 @@ Interface::TextElement::TextElement(const DataNode &node, const Point &globalAnc
 // itself. This returns false if it does not recognize the line, either.
 bool Interface::TextElement::ParseLine(const DataNode &node)
 {
-	if(node.Token(0) == "size" && node.Size() >= 2)
+	const string &key = node.Token(0);
+	bool hasValue = node.Size() >= 2;
+	if(key == "size" && hasValue)
 		fontSize = node.Value(1);
-	else if(node.Token(0) == "color" && node.Size() >= 2)
+	else if(key == "color" && hasValue)
 		color[Element::ACTIVE] = GameData::Colors().Get(node.Token(1));
-	else if(node.Token(0) == "inactive" && node.Size() >= 2)
+	else if(key == "inactive" && hasValue)
 		color[Element::INACTIVE] = GameData::Colors().Get(node.Token(1));
-	else if(node.Token(0) == "hover" && node.Size() >= 2)
+	else if(key == "hover" && hasValue)
 		color[Element::HOVER] = GameData::Colors().Get(node.Token(1));
-	else if(node.Token(0) == "truncate" && node.Size() >= 2)
+	else if(key == "truncate" && hasValue)
 	{
 		if(node.Token(1) == "none")
 			truncate = Truncate::NONE;
@@ -685,15 +694,16 @@ bool Interface::WrappedTextElement::ParseLine(const DataNode &node)
 {
 	if(TextElement::ParseLine(node))
 		return true;
-	else if(node.Token(0) == "alignment")
+	if(node.Token(0) == "alignment")
 	{
-		if(node.Token(1) == "left")
+		const string &value = node.Token(1);
+		if(value == "left")
 			textAlignment = Alignment::LEFT;
-		else if(node.Token(1) == "center")
+		else if(value == "center")
 			textAlignment = Alignment::CENTER;
-		else if(node.Token(1) == "right")
+		else if(value == "right")
 			textAlignment = Alignment::RIGHT;
-		else if(node.Token(1) == "justified")
+		else if(value == "justified")
 			textAlignment = Alignment::JUSTIFIED;
 		else
 			return false;
@@ -751,18 +761,20 @@ Interface::BarElement::BarElement(const DataNode &node, const Point &globalAncho
 // itself. This returns false if it does not recognize the line, either.
 bool Interface::BarElement::ParseLine(const DataNode &node)
 {
-	if(node.Token(0) == "color" && node.Size() >= 2)
+	const string &key = node.Token(0);
+	bool hasValue = node.Size() >= 2;
+	if(key == "color" && hasValue)
 	{
 		fromColor = GameData::Colors().Get(node.Token(1));
 		toColor = node.Size() >= 3 ? GameData::Colors().Get(node.Token(2)) : fromColor;
 	}
-	else if(node.Token(0) == "size" && node.Size() >= 2)
+	else if(key == "size" && hasValue)
 		width = node.Value(1);
-	else if(node.Token(0) == "span angle" && node.Size() >= 2)
+	else if(key == "span angle" && hasValue)
 		spanAngle = max(0., min(360., node.Value(1)));
-	else if(node.Token(0) == "start angle" && node.Size() >= 2)
+	else if(key == "start angle" && hasValue)
 		startAngle = max(0., min(360., node.Value(1)));
-	else if(node.Token(0) == "reversed")
+	else if(key == "reversed")
 		reversed = true;
 	else
 		return false;
@@ -796,7 +808,7 @@ void Interface::BarElement::Draw(const Rectangle &rect, const Information &info,
 	}
 	else
 	{
-		// Figue out where the line should be drawn from and to.
+		// Figure out where the line should be drawn from and to.
 		// Note: the default start position is the bottom right.
 		// If "reversed" was specified, the top left will be used instead.
 		Point start = reversed ? rect.TopLeft() : rect.BottomRight();
@@ -857,14 +869,16 @@ Interface::PointerElement::PointerElement(const DataNode &node, const Point &glo
 // itself. This returns false if it does not recognize the line, either.
 bool Interface::PointerElement::ParseLine(const DataNode &node)
 {
-	if(node.Token(0) == "color" && node.Size() >= 2)
+	const string &key = node.Token(0);
+	bool hasValue = node.Size() >= 2;
+	if(key == "color" && hasValue)
 		color = GameData::Colors().Get(node.Token(1));
-	else if(node.Token(0) == "orientation angle" && node.Size() >= 2)
+	else if(key == "orientation angle" && hasValue)
 	{
 		const Angle direction(node.Value(1));
 		orientation = direction.Unit();
 	}
-	else if(node.Token(0) == "orientation vector" && node.Size() >= 3)
+	else if(key == "orientation vector" && node.Size() >= 3)
 	{
 		orientation.X() = node.Value(1);
 		orientation.Y() = node.Value(2);

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -177,9 +177,10 @@ void LocationFilter::Load(const DataNode &node)
 		// neighboring system. If the token is alone on a line, it
 		// introduces many lines of this type of filter. Otherwise, this
 		// child is a normal LocationFilter line.
-		if(child.Token(0) == "not" || child.Token(0) == "neighbor")
+		const string &key = child.Token(0);
+		if(key == "not" || key == "neighbor")
 		{
-			list<LocationFilter> &filters = ((child.Token(0) == "not") ? notFilters : neighborFilters);
+			list<LocationFilter> &filters = ((key == "not") ? notFilters : neighborFilters);
 			filters.emplace_back();
 			if(child.Size() == 1)
 				filters.back().Load(child);

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1753,14 +1753,15 @@ bool Mission::Enter(const System *system, PlayerInfo &player, UI *ui)
 // locations, so move that parsing out to a helper function.
 bool Mission::ParseContraband(const DataNode &node)
 {
-	if(node.Token(0) == "illegal" && node.Size() == 2)
+	const string &key = node.Token(0);
+	if(key == "illegal" && node.Size() == 2)
 		fine = node.Value(1);
-	else if(node.Token(0) == "illegal" && node.Size() == 3)
+	else if(key == "illegal" && node.Size() == 3)
 	{
 		fine = node.Value(1);
 		fineMessage = node.Token(2);
 	}
-	else if(node.Token(0) == "stealth")
+	else if(key == "stealth")
 		failIfDiscovered = true;
 	else
 		return false;

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -73,10 +73,11 @@ MissionAction::MissionDialog::MissionDialog(const string &text):
 
 MissionAction::MissionDialog::MissionDialog(const DataNode &node, const ConditionsStore *playerConditions)
 {
+	const string &key = node.Token(0);
 	// Handle anonymous phrases
 	//    phrase
 	//       ...
-	if(node.Size() == 1 && node.Token(0) == "phrase")
+	if(node.Size() == 1 && key == "phrase")
 	{
 		dialogPhrase = ExclusiveItem<Phrase>(Phrase(node));
 		// Anonymous phrases do not support "to display"
@@ -85,7 +86,7 @@ MissionAction::MissionDialog::MissionDialog(const DataNode &node, const Conditio
 
 	// Handle named phrases
 	//    phrase "A Phrase Name"
-	if(node.Size() == 2 && node.Token(0) == "phrase")
+	if(node.Size() == 2 && key == "phrase")
 		dialogPhrase = ExclusiveItem<Phrase>(GameData::Phrases().Get(node.Token(1)));
 
 	// Handle regular dialog text
@@ -94,7 +95,7 @@ MissionAction::MissionDialog::MissionDialog(const DataNode &node, const Conditio
 	{
 		if(node.Size() > 1)
 			node.PrintTrace("Ignoring extra tokens.");
-		dialogText = node.Token(0);
+		dialogText = key;
 
 		// Prevent a corner case that breaks assumptions. Dialog text cannot be empty (that indicates a phrase).
 		if(dialogText.empty())
@@ -143,7 +144,7 @@ void MissionAction::Load(const DataNode &node, const ConditionsStore *playerCond
 void MissionAction::LoadSingle(const DataNode &child, const ConditionsStore *playerConditions)
 {
 	const string &key = child.Token(0);
-	bool hasValue = (child.Size() >= 2);
+	bool hasValue = child.Size() >= 2;
 
 	if(key == "dialog")
 	{

--- a/source/Mortgage.cpp
+++ b/source/Mortgage.cpp
@@ -89,15 +89,17 @@ void Mortgage::Load(const DataNode &node)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "principal" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "principal" && hasValue)
 			principal = child.Value(1);
-		else if(child.Token(0) == "interest" && child.Size() >= 2)
+		else if(key == "interest" && hasValue)
 		{
 			interest = child.Value(1);
 			int f = 100000. * interest;
 			interestString = "0." + to_string(f) + "%";
 		}
-		else if(child.Token(0) == "term" && child.Size() >= 2)
+		else if(key == "term" && hasValue)
 			term = max(1., child.Value(1));
 	}
 }

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -179,7 +179,7 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions)
 		}
 		else if(key == "conversation" && child.HasChildren())
 			conversation = ExclusiveItem<Conversation>(Conversation(child, playerConditions));
-		else if(key == "conversation" && child.Size() > 1)
+		else if(key == "conversation" && hasValue)
 			conversation = ExclusiveItem<Conversation>(GameData::Conversations().Get(child.Token(1)));
 		else if(key == "to" && hasValue)
 		{

--- a/source/Phrase.cpp
+++ b/source/Phrase.cpp
@@ -212,13 +212,14 @@ void Phrase::Sentence::Load(const DataNode &node, const Phrase *parent)
 		emplace_back();
 		auto &part = back();
 
-		if(child.Token(0) == "word")
+		const string &key = child.Token(0);
+		if(key == "word")
 			for(const DataNode &grand : child)
 				part.choices.emplace_back((grand.Size() >= 2) ? max<int>(1, grand.Value(1)) : 1, grand);
-		else if(child.Token(0) == "phrase")
+		else if(key == "phrase")
 			for(const DataNode &grand : child)
 				part.choices.emplace_back((grand.Size() >= 2) ? max<int>(1, grand.Value(1)) : 1, grand, true);
-		else if(child.Token(0) == "replace")
+		else if(key == "replace")
 			for(const DataNode &grand : child)
 				part.replacements.emplace_back(grand.Token(0), (grand.Size() >= 2) ? grand.Token(1) : string{});
 		else

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -211,9 +211,10 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 			bool resetFleets = !defenseFleets.empty();
 			for(const DataNode &grand : child)
 			{
-				if(grand.Token(0) == "threshold" && grand.Size() >= 2)
+				const string &grandKey = grand.Token(0);
+				if(grandKey == "threshold" && grand.Size() >= 2)
 					defenseThreshold = grand.Value(1);
-				else if(grand.Token(0) == "fleet")
+				else if(grandKey == "fleet")
 				{
 					if(grand.Size() >= 2 && !grand.HasChildren())
 					{

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -212,11 +212,12 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 			for(const DataNode &grand : child)
 			{
 				const string &grandKey = grand.Token(0);
-				if(grandKey == "threshold" && grand.Size() >= 2)
+				bool grandHasValue = grand.Size() >= 2;
+				if(grandKey == "threshold" && grandHasValue)
 					defenseThreshold = grand.Value(1);
 				else if(grandKey == "fleet")
 				{
-					if(grand.Size() >= 2 && !grand.HasChildren())
+					if(grandHasValue && !grand.HasChildren())
 					{
 						// Allow only one "tribute" node to define the tribute fleets.
 						if(resetFleets)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -216,56 +216,58 @@ void PlayerInfo::Load(const filesystem::path &path)
 	DataFile file(path);
 	for(const DataNode &child : file)
 	{
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
 		// Basic player information and persistent UI settings:
-		if(child.Token(0) == "pilot" && child.Size() >= 3)
+		if(key == "pilot" && child.Size() >= 3)
 		{
 			firstName = child.Token(1);
 			lastName = child.Token(2);
 		}
-		else if(child.Token(0) == "date" && child.Size() >= 4)
+		else if(key == "date" && child.Size() >= 4)
 			date = Date(child.Value(1), child.Value(2), child.Value(3));
-		else if(child.Token(0) == "system entry method" && child.Size() >= 2)
+		else if(key == "system entry method" && hasValue)
 			entry = StringToEntry(child.Token(1));
-		else if(child.Token(0) == "previous system" && child.Size() >= 2)
+		else if(key == "previous system" && hasValue)
 			previousSystem = GameData::Systems().Get(child.Token(1));
-		else if(child.Token(0) == "system" && child.Size() >= 2)
+		else if(key == "system" && hasValue)
 			system = GameData::Systems().Get(child.Token(1));
-		else if(child.Token(0) == "planet" && child.Size() >= 2)
+		else if(key == "planet" && hasValue)
 			planet = GameData::Planets().Get(child.Token(1));
-		else if(child.Token(0) == "clearance")
+		else if(key == "clearance")
 			hasFullClearance = true;
-		else if(child.Token(0) == "launching")
+		else if(key == "launching")
 			shouldLaunch = true;
-		else if(child.Token(0) == "playtime" && child.Size() >= 2)
+		else if(key == "playtime" && hasValue)
 			playTime = child.Value(1);
-		else if(child.Token(0) == "travel" && child.Size() >= 2)
+		else if(key == "travel" && hasValue)
 			travelPlan.push_back(GameData::Systems().Get(child.Token(1)));
-		else if(child.Token(0) == "travel destination" && child.Size() >= 2)
+		else if(key == "travel destination" && hasValue)
 			travelDestination = GameData::Planets().Get(child.Token(1));
-		else if(child.Token(0) == "map coloring" && child.Size() >= 2)
+		else if(key == "map coloring" && hasValue)
 			mapColoring = child.Value(1);
-		else if(child.Token(0) == "map zoom" && child.Size() >= 2)
+		else if(key == "map zoom" && hasValue)
 			mapZoom = child.Value(1);
-		else if(child.Token(0) == "collapsed" && child.Size() >= 2)
+		else if(key == "collapsed" && hasValue)
 		{
 			for(const DataNode &grand : child)
 				collapsed[child.Token(1)].insert(grand.Token(0));
 		}
-		else if(child.Token(0) == "reputation with")
+		else if(key == "reputation with")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
 					reputationChanges.emplace_back(
 						GameData::Governments().Get(grand.Token(0)), grand.Value(1));
 		}
-		else if(child.Token(0) == "tribute received")
+		else if(key == "tribute received")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
 					tributeReceived[GameData::Planets().Get(grand.Token(0))] = grand.Value(1);
 		}
 		// Records of things you own:
-		else if(child.Token(0) == "ship")
+		else if(key == "ship")
 		{
 			// Ships owned by the player have various special characteristics:
 			ships.push_back(make_shared<Ship>(child, &conditions));
@@ -273,54 +275,59 @@ void PlayerInfo::Load(const filesystem::path &path)
 			ships.back()->SetIsYours();
 			// Defer finalizing this ship until we have processed all changes to game state.
 		}
-		else if(child.Token(0) == "groups" && child.Size() >= 2 && !ships.empty())
+		else if(key == "groups" && hasValue && !ships.empty())
 			groups[ships.back().get()] = child.Value(1);
-		else if(child.Token(0) == "storage")
+		else if(key == "storage")
 		{
 			for(const DataNode &grand : child)
-				if(grand.Size() >= 2 && grand.Token(0) == "planet")
-					for(const DataNode &grandGrand : grand)
-						if(grandGrand.Token(0) == "cargo")
+				if(grand.Token(0) == "planet" && grand.Size() >= 2)
+				{
+					const Planet *planet = GameData::Planets().Get(grand.Token(1));
+					for(const DataNode &great : grand)
+					{
+						if(great.Token(0) == "cargo")
 						{
-							CargoHold &storage = planetaryStorage[GameData::Planets().Get(grand.Token(1))];
-							storage.Load(grandGrand);
+							CargoHold &storage = planetaryStorage[planet];
+							storage.Load(great);
 						}
+					}
+				}
 		}
-		else if(child.Token(0) == "licenses")
+		else if(key == "licenses")
 		{
 			for(const DataNode &grand : child)
 				AddLicense(grand.Token(0));
 		}
-		else if(child.Token(0) == "account")
+		else if(key == "account")
 			accounts.Load(child, true);
-		else if(child.Token(0) == "cargo")
+		else if(key == "cargo")
 			cargo.Load(child);
-		else if(child.Token(0) == "basis")
+		else if(key == "basis")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
 					costBasis[grand.Token(0)] += grand.Value(1);
 		}
-		else if(child.Token(0) == "stock")
+		else if(key == "stock")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
 					stock[GameData::Outfits().Get(grand.Token(0))] += grand.Value(1);
 		}
-		else if(child.Token(0) == "fleet depreciation")
+		else if(key == "fleet depreciation")
 			depreciation.Load(child);
-		else if(child.Token(0) == "stock depreciation")
+		else if(key == "stock depreciation")
 			stockDepreciation.Load(child);
 
 		// Records of things you have done or are doing, or have happened to you:
-		else if(child.Token(0) == "mission")
+		else if(key == "mission")
 		{
 			missions.emplace_back(child, &conditions);
 			cargo.AddMissionCargo(&missions.back());
 		}
-		else if((child.Token(0) == "mission cargo" || child.Token(0) == "mission passengers") && child.HasChildren())
+		else if((key == "mission cargo" || key == "mission passengers") && child.HasChildren())
 		{
-			map<string, map<string, int>> &toDistribute = (child.Token(0) == "mission cargo")
+			map<string, map<string, int>> &toDistribute = (key == "mission cargo")
 					? missionCargoToDistribute : missionPassengersToDistribute;
 			for(const DataNode &grand : child)
 				if(grand.Token(0) == "player ships" && grand.HasChildren())
@@ -331,43 +338,43 @@ void PlayerInfo::Load(const filesystem::path &path)
 						toDistribute[great.Token(0)][great.Token(1)] = great.Value(2);
 					}
 		}
-		else if(child.Token(0) == "available job")
+		else if(key == "available job")
 			availableJobs.emplace_back(child, &conditions);
-		else if(child.Token(0) == "sort type")
+		else if(key == "sort type")
 			availableSortType = static_cast<SortType>(child.Value(1));
-		else if(child.Token(0) == "sort descending")
+		else if(key == "sort descending")
 			availableSortAsc = false;
-		else if(child.Token(0) == "separate deadline")
+		else if(key == "separate deadline")
 			sortSeparateDeadline = true;
-		else if(child.Token(0) == "separate possible")
+		else if(key == "separate possible")
 			sortSeparatePossible = true;
-		else if(child.Token(0) == "available mission")
+		else if(key == "available mission")
 			availableMissions.emplace_back(child, &conditions);
-		else if(child.Token(0) == "conditions")
+		else if(key == "conditions")
 			conditions.Load(child);
-		else if(child.Token(0) == "gifted ships" && child.HasChildren())
+		else if(key == "gifted ships" && child.HasChildren())
 		{
 			for(const DataNode &grand : child)
 				giftedShips[grand.Token(0)] = EsUuid::FromString(grand.Token(1));
 		}
-		else if(child.Token(0) == "event")
+		else if(key == "event")
 			gameEvents.emplace(GameEvent(child, &conditions));
-		else if(child.Token(0) == "changes")
+		else if(key == "changes")
 		{
 			for(const DataNode &grand : child)
 				dataChanges.push_back(grand);
 		}
-		else if(child.Token(0) == "economy")
+		else if(key == "economy")
 			economy = child;
-		else if(child.Token(0) == "destroyed" && child.Size() >= 2)
+		else if(key == "destroyed" && hasValue)
 			destroyedPersons.push_back(child.Token(1));
 
 		// Records of things you have discovered:
-		else if(child.Token(0) == "visited" && child.Size() >= 2)
+		else if(key == "visited" && hasValue)
 			Visit(*GameData::Systems().Get(child.Token(1)));
-		else if(child.Token(0) == "visited planet" && child.Size() >= 2)
+		else if(key == "visited planet" && hasValue)
 			Visit(*GameData::Planets().Get(child.Token(1)));
-		else if(child.Token(0) == "harvested")
+		else if(key == "harvested")
 		{
 			for(const DataNode &grand : child)
 				if(grand.Size() >= 2)
@@ -375,7 +382,7 @@ void PlayerInfo::Load(const filesystem::path &path)
 						GameData::Systems().Get(grand.Token(0)),
 						GameData::Outfits().Get(grand.Token(1)));
 		}
-		else if(child.Token(0) == "logbook")
+		else if(key == "logbook")
 		{
 			for(const DataNode &grand : child)
 			{
@@ -403,7 +410,7 @@ void PlayerInfo::Load(const filesystem::path &path)
 				}
 			}
 		}
-		else if(child.Token(0) == "start")
+		else if(key == "start")
 			startData.Load(child);
 	}
 	// Modify the game data with any changes that were loaded from this file.
@@ -555,9 +562,10 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 	bool changedSystems = false;
 	for(const DataNode &change : changes)
 	{
-		changedSystems |= (change.Token(0) == "system");
-		changedSystems |= (change.Token(0) == "link");
-		changedSystems |= (change.Token(0) == "unlink");
+		const string &key = change.Token(0);
+		changedSystems |= (key == "system");
+		changedSystems |= (key == "link");
+		changedSystems |= (key == "unlink");
 		GameData::Change(change, &conditions);
 	}
 	if(changedSystems)

--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -210,34 +210,37 @@ const Plugin *Plugins::Load(const filesystem::path &path)
 	bool hasName = false;
 	for(const DataNode &child : DataFile(pluginFile))
 	{
-		if(child.Token(0) == "name" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		bool hasValue = child.Size() >= 2;
+		if(key == "name" && hasValue)
 		{
 			name = child.Token(1);
 			hasName = true;
 		}
-		else if(child.Token(0) == "about" && child.Size() >= 2)
+		else if(key == "about" && hasValue)
 			aboutText += child.Token(1) + '\n';
-		else if(child.Token(0) == "version" && child.Size() >= 2)
+		else if(key == "version" && hasValue)
 			version = child.Token(1);
-		else if(child.Token(0) == "authors" && child.HasChildren())
+		else if(key == "authors" && child.HasChildren())
 			for(const DataNode &grand : child)
 				authors.insert(grand.Token(0));
-		else if(child.Token(0) == "tags" && child.HasChildren())
+		else if(key == "tags" && child.HasChildren())
 			for(const DataNode &grand : child)
 				tags.insert(grand.Token(0));
-		else if(child.Token(0) == "dependencies" && child.HasChildren())
+		else if(key == "dependencies" && child.HasChildren())
 		{
 			for(const DataNode &grand : child)
 			{
-				if(grand.Token(0) == "game version")
+				const string &grandKey = grand.Token(0);
+				if(grandKey == "game version")
 					dependencies.gameVersion = grand.Token(1);
-				else if(grand.Token(0) == "requires" && grand.HasChildren())
+				else if(grandKey == "requires" && grand.HasChildren())
 					for(const DataNode &great : grand)
 						dependencies.required.insert(great.Token(0));
-				else if(grand.Token(0) == "optional" && grand.HasChildren())
+				else if(grandKey == "optional" && grand.HasChildren())
 					for(const DataNode &great : grand)
 						dependencies.optional.insert(great.Token(0));
-				else if(grand.Token(0) == "conflicts" && grand.HasChildren())
+				else if(grandKey == "conflicts" && grand.HasChildren())
 					for(const DataNode &great : grand)
 						dependencies.conflicted.insert(great.Token(0));
 				else

--- a/source/Port.cpp
+++ b/source/Port.cpp
@@ -52,8 +52,8 @@ void Port::Load(const DataNode &node, const ConditionsStore *playerConditions)
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
-
-		if(key == "recharges" && (child.HasChildren() || child.Size() >= 2))
+		bool hasValue = child.Size() >= 2;
+		if(key == "recharges" && (child.HasChildren() || hasValue))
 		{
 			auto setRecharge = [&](const DataNode &valueNode, const string &value) noexcept -> void {
 				if(value == "all")
@@ -74,7 +74,7 @@ void Port::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			for(const DataNode &grand : child)
 				setRecharge(grand, grand.Token(0));
 		}
-		else if(key == "services" && (child.HasChildren() || child.Size() >= 2))
+		else if(key == "services" && (child.HasChildren() || hasValue))
 		{
 			auto setServices = [&](const DataNode &valueNode, const string &value) noexcept -> void {
 				if(value == "all")
@@ -99,7 +99,7 @@ void Port::Load(const DataNode &node, const ConditionsStore *playerConditions)
 		}
 		else if(key == "news")
 			hasNews = true;
-		else if(key == "description" && child.Size() >= 2)
+		else if(key == "description" && hasValue)
 		{
 			description.Load(child, playerConditions);
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -198,58 +198,60 @@ void Preferences::Load()
 	DataFile prefs(Files::Config() / "preferences.txt");
 	for(const DataNode &node : prefs)
 	{
-		if(node.Token(0) == "window size" && node.Size() >= 3)
+		const string &key = node.Token(0);
+		bool hasValue = node.Size() >= 2;
+		if(key == "window size" && node.Size() >= 3)
 			Screen::SetRaw(node.Value(1), node.Value(2));
-		else if(node.Token(0) == "zoom" && node.Size() >= 2)
+		else if(key == "zoom" && hasValue)
 			Screen::SetZoom(node.Value(1));
-		else if(VOLUME_SETTINGS.contains(node.Token(0)) && node.Size() >= 2)
-			Audio::SetVolume(node.Value(1) * VOLUME_SCALE, VOLUME_SETTINGS.at(node.Token(0)));
-		else if(node.Token(0) == "scroll speed" && node.Size() >= 2)
+		else if(VOLUME_SETTINGS.contains(key) && hasValue)
+			Audio::SetVolume(node.Value(1) * VOLUME_SCALE, VOLUME_SETTINGS.at(key));
+		else if(key == "scroll speed" && hasValue)
 			scrollSpeed = node.Value(1);
-		else if(node.Token(0) == "boarding target")
+		else if(key == "boarding target")
 			boardingIndex = max<int>(0, min<int>(node.Value(1), BOARDING_SETTINGS.size() - 1));
-		else if(node.Token(0) == "Flotsam collection")
+		else if(key == "Flotsam collection")
 			flotsamIndex = max<int>(0, min<int>(node.Value(1), FLOTSAM_SETTINGS.size() - 1));
-		else if(node.Token(0) == "view zoom")
+		else if(key == "view zoom")
 			zoomIndex = max(0., node.Value(1));
-		else if(node.Token(0) == "vsync")
+		else if(key == "vsync")
 			vsyncIndex = max<int>(0, min<int>(node.Value(1), VSYNC_SETTINGS.size() - 1));
-		else if(node.Token(0) == "camera acceleration")
+		else if(key == "camera acceleration")
 			cameraAccelerationIndex = max<int>(0, min<int>(node.Value(1), CAMERA_ACCELERATION_SETTINGS.size() - 1));
-		else if(node.Token(0) == "Show all status overlays")
+		else if(key == "Show all status overlays")
 			statusOverlaySettings[OverlayType::ALL].SetState(node.Value(1));
-		else if(node.Token(0) == "Show flagship overlay")
+		else if(key == "Show flagship overlay")
 			statusOverlaySettings[OverlayType::FLAGSHIP].SetState(node.Value(1));
-		else if(node.Token(0) == "Show escort overlays")
+		else if(key == "Show escort overlays")
 			statusOverlaySettings[OverlayType::ESCORT].SetState(node.Value(1));
-		else if(node.Token(0) == "Show enemy overlays")
+		else if(key == "Show enemy overlays")
 			statusOverlaySettings[OverlayType::ENEMY].SetState(node.Value(1));
-		else if(node.Token(0) == "Show neutral overlays")
+		else if(key == "Show neutral overlays")
 			statusOverlaySettings[OverlayType::NEUTRAL].SetState(node.Value(1));
-		else if(node.Token(0) == "Turret overlays")
+		else if(key == "Turret overlays")
 			turretOverlaysIndex = clamp<int>(node.Value(1), 0, TURRET_OVERLAYS_SETTINGS.size() - 1);
-		else if(node.Token(0) == "Automatic aiming")
+		else if(key == "Automatic aiming")
 			autoAimIndex = max<int>(0, min<int>(node.Value(1), AUTO_AIM_SETTINGS.size() - 1));
-		else if(node.Token(0) == "Automatic firing")
+		else if(key == "Automatic firing")
 			autoFireIndex = max<int>(0, min<int>(node.Value(1), AUTO_FIRE_SETTINGS.size() - 1));
-		else if(node.Token(0) == "Parallax background")
+		else if(key == "Parallax background")
 			parallaxIndex = max<int>(0, min<int>(node.Value(1), PARALLAX_SETTINGS.size() - 1));
-		else if(node.Token(0) == "Extended jump effects")
+		else if(key == "Extended jump effects")
 			extendedJumpEffectIndex = max<int>(0, min<int>(node.Value(1), EXTENDED_JUMP_EFFECT_SETTINGS.size() - 1));
-		else if(node.Token(0) == "fullscreen")
+		else if(key == "fullscreen")
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
-		else if(node.Token(0) == "date format")
+		else if(key == "date format")
 			dateFormatIndex = max<int>(0, min<int>(node.Value(1), DATEFMT_OPTIONS.size() - 1));
-		else if(node.Token(0) == "alert indicator")
+		else if(key == "alert indicator")
 			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size() - 1));
-		else if(node.Token(0) == "previous saves" && node.Size() >= 2)
+		else if(key == "previous saves" && hasValue)
 			previousSaveCount = max<int>(3, node.Value(1));
-		else if(node.Token(0) == "alt-mouse turning")
-			settings["Control ship with mouse"] = (node.Size() == 1 || node.Value(1));
-		else if(node.Token(0) == "notification settings")
+		else if(key == "alt-mouse turning")
+			settings["Control ship with mouse"] = (!hasValue || node.Value(1));
+		else if(key == "notification settings")
 			notifOptionsIndex = max<int>(0, min<int>(node.Value(1), NOTIF_OPTIONS.size() - 1));
 		else
-			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
+			settings[key] = (node.Size() == 1 || node.Value(1));
 	}
 
 	// For people updating from a version before the visual red alert indicator,

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -662,16 +662,17 @@ namespace {
 		LocationFilter filter;
 		for(const DataNode &node : file)
 		{
-			if(node.Token(0) == "changes" || (node.Token(0) == "event" && node.Size() == 1))
+			const string &key = node.Token(0);
+			if(key == "changes" || (key == "event" && node.Size() == 1))
 				for(const DataNode &child : node)
 					GameData::Change(child, nullptr);
-			else if(node.Token(0) == "event")
+			else if(key == "event")
 			{
 				const auto *event = GameData::Events().Get(node.Token(1));
 				for(const auto &change : event->Changes())
 					GameData::Change(change, nullptr);
 			}
-			else if(node.Token(0) == "location")
+			else if(key == "location")
 			{
 				filter.Load(node);
 				break;

--- a/source/Sale.h
+++ b/source/Sale.h
@@ -58,11 +58,12 @@ void Sale<Item>::LoadSingle(const DataNode &child, const Set<Item> &items, bool 
 		child.PrintTrace("Error: Cannot \"add\" or \"remove\" inside a \"stock\" node:");
 		return;
 	}
-	if(remove && child.Size() == 1)
+	bool hasValue = child.Size() >= 2;
+	if(remove && !hasValue)
 		this->clear();
-	else if(remove && child.Size() >= 2)
+	else if(remove && hasValue)
 		this->erase(items.Get(child.Token(1)));
-	else if(add && child.Size() >= 2)
+	else if(add && hasValue)
 		this->insert(items.Get(child.Token(1)));
 	else
 		this->insert(items.Get(token));

--- a/source/SavedGame.cpp
+++ b/source/SavedGame.cpp
@@ -47,29 +47,31 @@ void SavedGame::Load(const filesystem::path &path)
 
 	for(const DataNode &node : file)
 	{
-		if(node.Token(0) == "pilot" && node.Size() >= 3)
+		const string &key = node.Token(0);
+		bool hasValue = node.Size() >= 2;
+		if(key == "pilot" && node.Size() >= 3)
 			name = node.Token(1) + " " + node.Token(2);
-		else if(node.Token(0) == "date" && node.Size() >= 4)
+		else if(key == "date" && node.Size() >= 4)
 			date = Date(node.Value(1), node.Value(2), node.Value(3)).ToString();
-		else if(node.Token(0) == "system" && node.Size() >= 2)
+		else if(key == "system" && hasValue)
 		{
 			system = node.Token(1);
 			const System *savedSystem = GameData::Systems().Find(system);
 			if(savedSystem && savedSystem->IsValid())
 				system = savedSystem->DisplayName();
 		}
-		else if(node.Token(0) == "planet" && node.Size() >= 2)
+		else if(key == "planet" && hasValue)
 		{
 			planet = node.Token(1);
 			const Planet *savedPlanet = GameData::Planets().Find(planet);
 			if(savedPlanet && savedPlanet->IsValid())
 				planet = savedPlanet->DisplayName();
 		}
-		else if(node.Token(0) == "playtime" && node.Size() >= 2)
+		else if(key == "playtime" && hasValue)
 			playTime = Format::PlayTime(node.Value(1));
-		else if(node.Token(0) == "flagship index" && node.Size() >= 2)
+		else if(key == "flagship index" && hasValue)
 			flagshipTarget = node.Value(1);
-		else if(node.Token(0) == "account")
+		else if(key == "account")
 		{
 			for(const DataNode &child : node)
 				if(child.Token(0) == "credits" && child.Size() >= 2)
@@ -78,13 +80,15 @@ void SavedGame::Load(const filesystem::path &path)
 					break;
 				}
 		}
-		else if(node.Token(0) == "ship" && ++flagshipIterator == flagshipTarget)
+		else if(key == "ship" && ++flagshipIterator == flagshipTarget)
 		{
 			for(const DataNode &child : node)
 			{
-				if(child.Token(0) == "name" && child.Size() >= 2)
+				const string &childKey = child.Token(0);
+				bool childHasValue = child.Size() >= 2;
+				if(childKey == "name" && childHasValue)
 					shipName = child.Token(1);
-				else if(child.Token(0) == "sprite" && child.Size() >= 2)
+				else if(childKey == "sprite" && childHasValue)
 					shipSprite = SpriteSet::Get(child.Token(1));
 			}
 		}

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -316,11 +316,12 @@ void Ship::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			for(const DataNode &grand : child)
 			{
 				const string &grandKey = grand.Token(0);
-				if(grandKey == "zoom" && grand.Size() >= 2)
+				bool grandHasValue = grand.Size() >= 2;
+				if(grandKey == "zoom" && grandHasValue)
 					engine.zoom = grand.Value(1);
-				else if(grandKey == "angle" && grand.Size() >= 2)
+				else if(grandKey == "angle" && grandHasValue)
 					engine.facing += Angle(grand.Value(1));
-				else if(grandKey == "gimbal" && grand.Size() >= 2)
+				else if(grandKey == "gimbal" && grandHasValue)
 					engine.gimbal += Angle(grand.Value(1));
 				else
 				{
@@ -366,15 +367,16 @@ void Ship::Load(const DataNode &node, const ConditionsStore *playerConditions)
 				for(const DataNode &grand : child)
 				{
 					bool needToCheckAngles = false;
-					if(grand.Token(0) == "angle" && grand.Size() >= 2)
+					const string &grandKey = grand.Token(0);
+					if(grandKey == "angle" && grand.Size() >= 2)
 					{
 						attributes.baseAngle = grand.Value(1);
 						needToCheckAngles = true;
 						defaultBaseAngle = false;
 					}
-					else if(grand.Token(0) == "parallel")
+					else if(grandKey == "parallel")
 						attributes.isParallel = true;
-					else if(grand.Token(0) == "arc" && grand.Size() >= 3)
+					else if(grandKey == "arc" && grand.Size() >= 3)
 					{
 						attributes.isOmnidirectional = false;
 						attributes.minArc = Angle(grand.Value(1));
@@ -383,13 +385,13 @@ void Ship::Load(const DataNode &node, const ConditionsStore *playerConditions)
 						if(!Angle(0.).IsInRange(attributes.minArc, attributes.maxArc))
 							grand.PrintTrace("Warning: Minimum arc is higher than maximum arc. Might not work as expected.");
 					}
-					else if(grand.Token(0) == "blindspot" && grand.Size() >= 3)
+					else if(grandKey == "blindspot" && grand.Size() >= 3)
 						attributes.blindspots.emplace_back(grand.Value(1), grand.Value(2));
-					else if(grand.Token(0) == "turret turn multiplier")
+					else if(grandKey == "turret turn multiplier")
 						attributes.turnMultiplier = grand.Value(1);
-					else if(grand.Token(0) == "under")
+					else if(grandKey == "under")
 						drawUnder = true;
-					else if(grand.Token(0) == "over")
+					else if(grandKey == "over")
 						drawUnder = false;
 					else
 						grand.PrintTrace("Warning: Child nodes of \"" + key
@@ -451,26 +453,28 @@ void Ship::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			if(child.HasChildren())
 				for(const DataNode &grand : child)
 				{
+					const string &grandKey = grand.Token(0);
+					bool grandHasValue = grand.Size() >= 2;
 					// Load in the effect(s) to be displayed when the ship launches.
-					if(grand.Token(0) == "launch effect" && grand.Size() >= 2)
+					if(grandKey == "launch effect" && grandHasValue)
 					{
 						int count = grand.Size() >= 3 ? static_cast<int>(grand.Value(2)) : 1;
 						const Effect *e = GameData::Effects().Get(grand.Token(1));
 						bay.launchEffects.insert(bay.launchEffects.end(), count, e);
 					}
-					else if(grand.Token(0) == "angle" && grand.Size() >= 2)
+					else if(grandKey == "angle" && grandHasValue)
 						bay.facing = Angle(grand.Value(1));
 					else
 					{
 						bool handled = false;
 						for(unsigned i = 1; i < BAY_SIDE.size(); ++i)
-							if(grand.Token(0) == BAY_SIDE[i])
+							if(grandKey == BAY_SIDE[i])
 							{
 								bay.side = i;
 								handled = true;
 							}
 						for(unsigned i = 1; i < BAY_FACING.size(); ++i)
-							if(grand.Token(0) == BAY_FACING[i])
+							if(grandKey == BAY_FACING[i])
 							{
 								bay.facing = BAY_ANGLE[i];
 								handled = true;

--- a/source/ShipManager.cpp
+++ b/source/ShipManager.cpp
@@ -45,7 +45,7 @@ void ShipManager::Load(const DataNode &node)
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
-		bool hasValue = child.Size() > 1;
+		bool hasValue = child.Size() >= 2;
 
 		if(key == "id" && hasValue)
 			id = child.Token(1);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -400,7 +400,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 			trade[value].SetBase(child.Value(valueIndex + 1));
 		else if(key == "arrival")
 		{
-			if(child.Size() >= 2)
+			if(hasValue)
 			{
 				extraHyperArrivalDistance = child.Value(1);
 				extraJumpArrivalDistance = fabs(child.Value(1));
@@ -408,9 +408,10 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 			for(const DataNode &grand : child)
 			{
 				const string &type = grand.Token(0);
-				if(type == "link" && grand.Size() >= 2)
+				bool grandHasValue = grand.Size() >= 2;
+				if(type == "link" && grandHasValue)
 					extraHyperArrivalDistance = grand.Value(1);
-				else if(type == "jump" && grand.Size() >= 2)
+				else if(type == "jump" && grandHasValue)
 					extraJumpArrivalDistance = fabs(grand.Value(1));
 				else
 					grand.PrintTrace("Warning: Skipping unsupported arrival distance limitation:");
@@ -418,7 +419,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 		}
 		else if(key == "departure")
 		{
-			if(child.Size() >= 2)
+			if(hasValue)
 			{
 				jumpDepartureDistance = child.Value(1);
 				hyperDepartureDistance = fabs(child.Value(1));
@@ -426,15 +427,16 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 			for(const DataNode &grand : child)
 			{
 				const string &type = grand.Token(0);
-				if(type == "link" && grand.Size() >= 2)
+				bool grandHasValue = grand.Size() >= 2;
+				if(type == "link" && grandHasValue)
 					hyperDepartureDistance = grand.Value(1);
-				else if(type == "jump" && grand.Size() >= 2)
+				else if(type == "jump" && grandHasValue)
 					jumpDepartureDistance = fabs(grand.Value(1));
 				else
 					grand.PrintTrace("Warning: Skipping unsupported departure distance limitation:");
 			}
 		}
-		else if(key == "invisible fence" && child.Size() >= 2)
+		else if(key == "invisible fence" && hasValue)
 			invisibleFenceRadius = max(0., child.Value(1));
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
@@ -1069,10 +1071,11 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets,
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "hazard" && child.Size() >= 3)
+		const string &key = child.Token(0);
+		if(key == "hazard" && child.Size() >= 3)
 			object.hazards.emplace_back(GameData::Hazards().Get(child.Token(1)), child.Value(2),
 				child, playerConditions);
-		else if(child.Token(0) == "object")
+		else if(key == "object")
 			LoadObject(child, planets, playerConditions, index);
 		else
 			LoadObjectHelper(child, object);
@@ -1084,7 +1087,7 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets,
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing) const
 {
 	const string &key = node.Token(0);
-	bool hasValue = (node.Size() >= 2);
+	bool hasValue = node.Size() >= 2;
 	if(key == "sprite" && hasValue)
 	{
 		object.LoadSprite(node);

--- a/source/Trade.cpp
+++ b/source/Trade.cpp
@@ -27,7 +27,8 @@ void Trade::Load(const DataNode &node)
 {
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "commodity" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		if(key == "commodity" && child.Size() >= 2)
 		{
 			bool isSpecial = (child.Size() < 4);
 			vector<Commodity> &list = (isSpecial ? specialCommodities : commodities);
@@ -47,7 +48,7 @@ void Trade::Load(const DataNode &node)
 			for(const DataNode &grand : child)
 				it->items.push_back(grand.Token(0));
 		}
-		else if(child.Token(0) == "clear")
+		else if(key == "clear")
 			commodities.clear();
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -424,11 +424,13 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 			const Sprite *sprite = SpriteSet::Get(node.Token(1));
 			for(const DataNode &child : node)
 			{
-				if(child.Token(0) == "power" && child.Size() >= 2)
+				const string &childKey = child.Token(0);
+				bool childHasValue = child.Size() >= 2;
+				if(childKey == "power" && childHasValue)
 					solarPower[sprite] = child.Value(1);
-				else if(child.Token(0) == "wind" && child.Size() >= 2)
+				else if(childKey == "wind" && childHasValue)
 					solarWind[sprite] = child.Value(1);
-				else if(child.Token(0) == "icon" && child.Size() >= 2)
+				else if(childKey == "icon" && childHasValue)
 					starIcons[sprite] = SpriteSet::Get(child.Token(1));
 				else
 					child.PrintTrace("Skipping unrecognized attribute:");

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -121,11 +121,13 @@ void Weapon::LoadWeapon(const DataNode &node)
 				(child.Size() >= 3) ? child.Value(2) : 1);
 			for(const DataNode &grand : child)
 			{
-				if((grand.Size() >= 2) && (grand.Token(0) == "facing"))
+				const string &grandKey = grand.Token(0);
+				bool granndHasValue = grand.Size() >= 2;
+				if(grandKey == "facing" && granndHasValue)
 					submunitions.back().facing = Angle(grand.Value(1));
-				else if((grand.Size() >= 3) && (grand.Token(0) == "offset"))
+				else if(grandKey == "offset" && grand.Size() >= 3)
 					submunitions.back().offset = Point(grand.Value(1), grand.Value(2));
-				else if(grand.Size() >= 2 && grand.Token(0) == "spawn on")
+				else if(grandKey == "spawn on" && granndHasValue)
 				{
 					submunitions.back().spawnOnNaturalDeath = false;
 					for(int j = 1; j < grand.Size(); ++j)

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -122,12 +122,12 @@ void Weapon::LoadWeapon(const DataNode &node)
 			for(const DataNode &grand : child)
 			{
 				const string &grandKey = grand.Token(0);
-				bool granndHasValue = grand.Size() >= 2;
-				if(grandKey == "facing" && granndHasValue)
+				bool grandHasValue = grand.Size() >= 2;
+				if(grandKey == "facing" && grandHasValue)
 					submunitions.back().facing = Angle(grand.Value(1));
 				else if(grandKey == "offset" && grand.Size() >= 3)
 					submunitions.back().offset = Point(grand.Value(1), grand.Value(2));
-				else if(grandKey == "spawn on" && granndHasValue)
+				else if(grandKey == "spawn on" && grandHasValue)
 				{
 					submunitions.back().spawnOnNaturalDeath = false;
 					for(int j = 1; j < grand.Size(); ++j)

--- a/source/test/Test.cpp
+++ b/source/test/Test.cpp
@@ -129,43 +129,46 @@ void Test::TestStep::LoadInput(const DataNode &node)
 {
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "key")
+		const string &key = child.Token(0);
+		if(key == "key")
 		{
 			for(int i = 1; i < child.Size(); ++i)
 				inputKeys.insert(child.Token(i));
 
 			for(const DataNode &grand : child)
 			{
-				if(grand.Token(0) == "shift")
+				const string &grandKey = grand.Token(0);
+				if(grandKey == "shift")
 					modKeys |= KMOD_SHIFT;
-				else if(grand.Token(0) == "alt")
+				else if(grandKey == "alt")
 					modKeys |= KMOD_ALT;
-				else if(grand.Token(0) == "control")
+				else if(grandKey == "control")
 					modKeys |= KMOD_CTRL;
 				else
 					grand.PrintTrace("Skipping unrecognized attribute:");
 			}
 		}
-		else if(child.Token(0) == "pointer")
+		else if(key == "pointer")
 		{
 			for(const DataNode &grand : child)
 			{
+				const string &grandKey = grand.Token(0);
 				static const string BAD_AXIS_INPUT = "Error: Pointer axis input without coordinate:";
-				if(grand.Token(0) == "X")
+				if(grandKey == "X")
 				{
 					if(grand.Size() < 2)
 						grand.PrintTrace(BAD_AXIS_INPUT);
 					else
 						XValue = grand.Value(1);
 				}
-				else if(grand.Token(0) == "Y")
+				else if(grandKey == "Y")
 				{
 					if(grand.Size() < 2)
 						grand.PrintTrace(BAD_AXIS_INPUT);
 					else
 						YValue = grand.Value(1);
 				}
-				else if(grand.Token(0) == "click")
+				else if(grandKey == "click")
 					for(int i = 1; i < grand.Size(); ++i)
 					{
 						if(grand.Token(i) == "left")
@@ -181,7 +184,7 @@ void Test::TestStep::LoadInput(const DataNode &node)
 					grand.PrintTrace("Skipping unrecognized attribute:");
 			}
 		}
-		else if(child.Token(0) == "command")
+		else if(key == "command")
 			command.Load(child);
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
@@ -288,9 +291,11 @@ void Test::LoadSequence(const DataNode &node, const ConditionsStore *playerCondi
 			case TestStep::Type::NAVIGATE:
 				for(const DataNode &grand : child)
 				{
-					if(grand.Token(0) == "travel" && grand.Size() >= 2)
+					const string &grandKey = grand.Token(0);
+					bool grandHasValue = grand.Size() >= 2;
+					if(grandKey == "travel" && grandHasValue)
 						step.travelPlan.push_back(GameData::Systems().Get(grand.Token(1)));
-					else if(grand.Token(0) == "travel destination" && grand.Size() >= 2)
+					else if(grandKey == "travel destination" && grandHasValue)
 						step.travelDestination = GameData::Planets().Get(grand.Token(1));
 					else
 					{
@@ -352,7 +357,8 @@ void Test::Load(const DataNode &node, const ConditionsStore *playerConditions)
 
 	for(const DataNode &child : node)
 	{
-		if(child.Token(0) == "status" && child.Size() >= 2)
+		const string &key = child.Token(0);
+		if(key == "status" && child.Size() >= 2)
 		{
 			const string &statusText = child.Token(1);
 			auto it = find_if(STATUS_TO_TEXT.begin(), STATUS_TO_TEXT.end(),
@@ -373,9 +379,9 @@ void Test::Load(const DataNode &node, const ConditionsStore *playerConditions)
 				child.PrintTrace("Error: Unsupported status (" + ExpectedOptions(STATUS_TO_TEXT) + "):");
 			}
 		}
-		else if(child.Token(0) == "sequence")
+		else if(key == "sequence")
 			LoadSequence(child, playerConditions);
-		else if(child.Token(0) == "description")
+		else if(key == "description")
 		{
 			// Provides a human friendly description of the test, but it is not used internally.
 		}

--- a/source/test/TestData.cpp
+++ b/source/test/TestData.cpp
@@ -53,7 +53,7 @@ void TestData::Load(const DataNode &node, const filesystem::path &sourceDataFile
 	for(const DataNode &child : node)
 		// Only need to parse the category for now. The contents will be
 		// scanned for at write-out of the test-data.
-		if(child.Size() > 1 && child.Token(0) == "category")
+		if(child.Token(0) == "category" && child.Size() >= 2)
 		{
 			if(child.Token(1) == "savegame")
 				dataSetType = Type::SAVEGAME;


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Many early Load functions will call `child.Token(0)` or `child.Size() >= 2` every time they compare against the key of a node or determine if it has a value. Later Load functions started to instead create `key` and `hasValue` variables that get these values once and then compare against the variables instead of continually calling the DataNode functions. This PR goes through every location I could find in the game that needs updated to the newer format.

## Testing Done

The game runs without any logged errors or apparent issues.

