### PR TITLE
fix(ui): Restore landing messages for stars and black holes

### DIFF
--- a/data/_ui/landing messages.txt
+++ b/data/_ui/landing messages.txt
@@ -88,7 +88,7 @@
 	"planet/wormhole"
 	"planet/wormhole-red"
 
-"landing message" "You cannot land on this black hole!"
+"landing message" "You cannot land on a black hole!"
 	"star/black-hole"
 	"star/black-hole-core"
 	"star/small-black-hole"

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -452,7 +452,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 		while(root->parent >= 0)
 			root = &objects[root->parent];
 
-		static const string STAR = "You cannot land on this star!";
+		static const string STAR = "You cannot land on a star!";
 		static const string HOTPLANET = "This planet is too hot to land on.";
 		static const string COLDPLANET = "This planet is too cold to land on.";
 		static const string UNINHABITEDPLANET = "This planet doesn't have anywhere you can land.";


### PR DESCRIPTION
**Feature**

This PR addresses stars and black holes from the bug described in issue #11412

## Acknowledgement

- [X ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Nobody is currently expected to land on stars and black holes.

## Testing Done
Will be checked in CI, and those are the original messages from before #11427

## Save File
N/A

## Wiki Update
N/A

## Performance Impact
None expected
