### PR TITLE
fix(ui): Stop starfield movement when the engine is inactive

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -617,10 +617,10 @@ void Engine::Step(bool isActive)
 			// Update the current zoom modifier if the flagship is landing or taking off.
 			nextZoom.modifier = Preferences::Has("Landing zoom") ? 1. + pow(1. - flagship->Zoom(), 2) : 1.;
 		}
-	}
 
-	// Step the background to account for the current velocity and zoom.
-	GameData::StepBackground(centerVelocity, zoom);
+		// Step the background to account for the current velocity and zoom.
+		GameData::StepBackground(centerVelocity, zoom);
+	}
 
 	outlines.clear();
 	const Color &cloakColor = *GameData::Colors().Get("cloak highlight");

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -619,7 +619,8 @@ void Engine::Step(bool isActive)
 		}
 
 		// Step the background to account for the current velocity and zoom.
-		GameData::StepBackground(centerVelocity, zoom);
+		if(!timePaused)
+			GameData::StepBackground(centerVelocity, zoom);
 	}
 
 	outlines.clear();


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The starfield should not move when the engine is out of focus or paused.

## Testing Done
Departed and started moving, then opened the player info panel.

## Performance Impact
N/A
