### PR TITLE
fix: remove extraneous word

### DIFF
--- a/data/human/paradise world jobs.txt
+++ b/data/human/paradise world jobs.txt
@@ -529,7 +529,7 @@ mission "Paradise Job: Pirate Retirees (Illegal)"
 	description `This coterie of <bunks> wealthy "retirees" is willing to pay <payment> for stylish, no-questions-asked transport to <destination>, along with <tons> of their most treasured possessions.`
 	passengers 4 10 .6
 	cargo "treasured possessions" 4 10 .2
-	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After taking boarding your ship, they arrest the so-called retirees and search through their "treasured possessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the possessions and take away the criminals, leaving you with a small fine.`
+	illegal 15000 `After scanning your ship, law enforcement notifies you. Apparently the "retirees" you've been carting around are secretly wanted individuals. After boarding your ship, they arrest the so-called retirees and search through their "treasured possessions," which are innocent enough, besides being obtained illegally. In the end, they confiscate the possessions and take away the criminals, leaving you with a small fine.`
 	stealth
 	to offer
 		random < 5


### PR DESCRIPTION
**Typo fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removed an extra word from the fine paragraph in `Paradise Job: Pirate Retirees (Illegal)`.