### PR TITLE
feat(ui): Animate the main menu background stars and haze

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -259,6 +259,11 @@ interface "menu background"
 
 
 interface "main menu"
+	# Background animation:
+	value "x speed" -.5
+	value "y speed" .1
+	value "y amplitude" 2.
+
 	# Credits:
 	sprite "_menu/side panel"
 		center -360 0

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1412,6 +1412,9 @@ tip "Fixed starfield zoom"
 tip "Parallax background"
 	`Add parallax to objects in the background (haze and starfield). If set to fancy, create three layers of parallax. If set to fast, create one layer of parallax.`
 
+tip "Animate main menu background"
+	`Animate the background stars and haze in the main menu.`
+
 tip "Show hyperspace flash"
 	`Create a white flash when hyperspacing between systems.`
 

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "LoadPanel.h"
 #include "Logger.h"
 #include "MainPanel.h"
+#include "pi.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Point.h"
@@ -43,6 +44,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
+#include <cmath>
 
 using namespace std;
 
@@ -110,6 +112,11 @@ MenuPanel::~MenuPanel()
 
 void MenuPanel::Step()
 {
+	if(Preferences::Has("Animate main menu background"))
+	{
+		GameData::StepBackground(Point(-1., 3. * sin(animation * TO_RAD)));
+		animation += 0.3;
+	}
 	if(GetUI()->IsTop(this) && !scrollingPaused)
 	{
 		scroll += scrollSpeed;

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -101,7 +101,7 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 	ySpeed = mainMenuUi->GetValue("y speed");
 	yAmplitude = mainMenuUi->GetValue("y amplitude");
 	// Start the animation wave at a random point.
-	animation += Random::Real() * 360.;
+	animation = Random::Real() * 360.;
 
 	// When the player is in the menu, pause the game sounds.
 	Audio::Pause();

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -97,6 +97,12 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 	if(!scrollSpeed)
 		scrollSpeed = 1;
 
+	xSpeed = mainMenuUi->GetValue("x speed");
+	ySpeed = mainMenuUi->GetValue("y speed");
+	yAmplitude = mainMenuUi->GetValue("y amplitude");
+	// Start the animation wave at a random point.
+	animation += Random::Real() * 360.;
+
 	// When the player is in the menu, pause the game sounds.
 	Audio::Pause();
 }
@@ -114,8 +120,8 @@ void MenuPanel::Step()
 {
 	if(Preferences::Has("Animate main menu background"))
 	{
-		GameData::StepBackground(Point(-1., 3. * sin(animation * TO_RAD)));
-		animation += 0.3;
+		GameData::StepBackground(Point(xSpeed, yAmplitude * sin(animation * TO_RAD)));
+		animation += ySpeed;
 	}
 	if(GetUI()->IsTop(this) && !scrollingPaused)
 	{

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -43,8 +43,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cassert>
-#include <stdexcept>
 #include <cmath>
+#include <stdexcept>
 
 using namespace std;
 

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -51,9 +51,13 @@ private:
 private:
 	PlayerInfo &player;
 	UI &gamePanels;
-	double animation = 0.;
 
 	const Interface *mainMenuUi;
+
+	double animation = 0.;
+	double xSpeed = 0.;
+	double ySpeed = 0.;
+	double yAmplitude = 0.;
 
 	std::vector<std::string> credits;
 	long long int scroll = 0;

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -51,6 +51,7 @@ private:
 private:
 	PlayerInfo &player;
 	UI &gamePanels;
+	double animation = 0.;
 
 	const Interface *mainMenuUi;
 

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -187,6 +187,7 @@ void Preferences::Load()
 	settings["Show hyperspace flash"] = true;
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
+	settings["Animate main menu background"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -717,6 +717,7 @@ void PreferencesPanel::DrawSettings()
 		"Draw starfield",
 		"Fixed starfield zoom",
 		BACKGROUND_PARALLAX,
+		"Animate main menu background",
 		"Show hyperspace flash",
 		EXTENDED_JUMP_EFFECTS,
 		SHIP_OUTLINES,


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR adds a new preference that is on by default to animate the stars and haze in the background on the menu panels. The background follows a sine curve.

## Testing Done

https://github.com/user-attachments/assets/609c2ae8-a011-45a4-ac91-e236d638d920


