### PR TITLE
fix(content): Add missing "distance 4 8" to Hai job

### DIFF
--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -1819,6 +1819,7 @@ mission "Superstitious Hai [3]"
 	destination
 		government "Hai"
 		attributes "retirement"
+		distance 4 8
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -1999,6 +1999,7 @@ mission "Superstitious Hai [9]"
 	destination
 		government "Hai"
 		attributes "retirement"
+		distance 4 8
 	on visit
 		dialog phrase "generic passenger on visit"
 	on complete


### PR DESCRIPTION
**Content (Jobs)**
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
While doing jobs in Hai space, a `Superstitious Hai` job auto-failed at takeoff. Looking at the datafile, the job `"Superstitious Hai [3]"` and `"Superstitious Hai [9]"` were missing `distance 4 8`, which is found on the other `Superstitious Hai` jobs (1-12).

This PR adds that same `distance 4 8` to `destination` to the two jobs missing it so that the jobs don't auto-fail in some scenarios.

## Screenshots
![image](https://github.com/user-attachments/assets/6a56b373-3ebc-4ddf-a9bb-ea9fa1ac5f94)

## Testing Done / Save File
Did not test such a minor change, though I can if desired.