### PR TITLE
chore(ci): Update sccache action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cd-sccache-refs/heads/master
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
       - uses: lukka/get-cmake@latest
@@ -74,7 +74,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cd-sccache-refs/heads/master
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
         shell: bash
@@ -114,7 +114,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cd-sccache-refs/heads/master
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libminizip-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libfuse2
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
@@ -53,7 +53,7 @@ jobs:
         with:
           show-progress: false
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - uses: lukka/get-cmake@latest
       - uses: lukka/run-vcpkg@v11
         with:
@@ -91,7 +91,7 @@ jobs:
         with:
           show-progress: false
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - name: Add Mingw to PATH
         run: |
           echo (Join-Path C: mingw32 bin) >> $env:GITHUB_PATH
@@ -132,7 +132,7 @@ jobs:
         with:
           show-progress: false
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - name: Install pkg-config
         run: type -P pkg-config || brew install pkg-config
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.os }}-${{ matrix.opengl }}-ci-sccache-refs/heads/master
     - name: Setup sccache
-      uses: Mozilla-Actions/sccache-action@v0.0.5
+      uses: Mozilla-Actions/sccache-action@v0.0.8
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
@@ -108,7 +108,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-steam-ci-sccache-refs/heads/master
       - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+        uses: Mozilla-Actions/sccache-action@v0.0.8
       - name: Build Endless Sky
         run: |
           cd steam
@@ -138,7 +138,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-ci-sccache-refs/heads/master
     - name: Setup sccache
-      uses: Mozilla-Actions/sccache-action@v0.0.5
+      uses: Mozilla-Actions/sccache-action@v0.0.8
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
@@ -181,7 +181,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-clang-${{ runner.arch }}-ci-sccache-refs/heads/master
     - name: Setup sccache
-      uses: Mozilla-Actions/sccache-action@v0.0.5
+      uses: Mozilla-Actions/sccache-action@v0.0.8
     - uses: lukka/get-cmake@latest
     - uses: lukka/run-vcpkg@v11
       with:
@@ -214,7 +214,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-ci-sccache-refs/heads/master
     - name: Setup sccache
-      uses: Mozilla-Actions/sccache-action@v0.0.5
+      uses: Mozilla-Actions/sccache-action@v0.0.8
     - name: Install pkg-config
       run: type -P pkg-config || brew install pkg-config
     - uses: lukka/get-cmake@latest
@@ -250,7 +250,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-ci-sccache-refs/heads/master
     - name: Setup sccache
-      uses: Mozilla-Actions/sccache-action@v0.0.5
+      uses: Mozilla-Actions/sccache-action@v0.0.8
     - name: Install pkg-config
       run: type -P pkg-config || brew install pkg-config
     - uses: lukka/get-cmake@latest


### PR DESCRIPTION
**CI/CD/Testing**

This PR updates the sccache action, fixing compatibility with the new github cache service.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
https://github.com/Mozilla-Actions/sccache-action/releases/tag/v0.0.8 makes the build cache work properly with github. The older version broke a while ago, causing our builds to be slower.

## Testing Done
Workflows here.