### PR TITLE
Corrected wrong comment

### DIFF
--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -358,7 +358,7 @@ void StarField::MakeStars(int stars, int width)
 	tileIndex.pop_back();
 	partial_sum(tileIndex.begin(), tileIndex.end(), tileIndex.begin());
 
-	// Each star consists of five vertices, each with four data elements.
+	// Each star consists of six vertices, each with four data elements.
 	vector<GLfloat> data(6 * 4 * stars, 0.f);
 	for(auto it = temp.begin(); it != temp.end(); )
 	{


### PR DESCRIPTION
**Typo fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
I’ve been trying to understand the star field generation approach. Unless I am totally mistaken the comment here is wrong and it is six vertices per star, not five.