### PR TITLE
fix(typo): Add missing period to outfitter warning

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -404,13 +404,13 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 
 		if(cost > credits)
 			errors.push_back("You do not have enough money to buy this outfit. You need a further " +
-				Format::CreditString(cost - credits));
+				Format::CreditString(cost - credits) + ".");
 
 		// Add the cost to buy the required license.
 		else if(cost + licenseCost > credits)
 			errors.push_back("You do not have enough money to buy this outfit because you also need "
 				"to buy a license for it. You need a further " +
-				Format::CreditString(cost + licenseCost - credits));
+				Format::CreditString(cost + licenseCost - credits) + ".");
 	}
 
 	bool anyShipCanInstall = true;


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Add a missing period to the end of the "You do not have enough money" outfitter dialog.

## Testing Done
Yes.
