### PR TITLE
Fix wrong parameter passed to glUniformMatrix2fv

### DIFF
--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -200,7 +200,7 @@ void StarField::Draw(const Point &blur, const System *system) const
 			GLfloat rotate[4] = {
 				static_cast<float>(unit.Y()), static_cast<float>(-unit.X()),
 				static_cast<float>(unit.X()), static_cast<float>(unit.Y())};
-			glUniformMatrix2fv(rotateI, pass, false, rotate);
+			glUniformMatrix2fv(rotateI, 1, false, rotate);
 
 			glUniform1f(elongationI, length * zoom);
 			glUniform1f(brightnessI, min(1., pow(zoom, .5)));


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Method `StarField::Draw()` currently passes `pass` (a value between 1 and 3) as `count` parameter to `glUniformMatrix2fv`. Documentation for this parameter says:

> For the matrix (glUniformMatrix*) commands, specifies the number of matrices that are to be modified. This should be 1 if the targeted uniform variable is not an array of matrices, and 1 or more if it is an array of matrices.

The targeted uniform variable in this scenario is not an array, so this value should be 1.

It seems that this bug doesn’t currently have an impact, thanks to the parameter value being ignored (?) by the implementation.

For reference: this issue has been introduced in #7765, specifically in the commit labeled “Quality improvements.” I cannot see any discussion for this change, so I’m suspecting that this was a left-over from some attempt that actually turned `rotate` into an array.