### PR TITLE
Lock Finishers behind Heliarch License

### DIFF
--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -190,6 +190,8 @@ outfit "Finisher Storage Tube"
 	category "Ammunition"
 	series "Ammunition"
 	index 08011
+	licenses
+		Heliarch
 	cost 58800
 	thumbnail "outfit/finisher storage"
 	"mass" 4
@@ -204,6 +206,8 @@ outfit "Finisher Torpedo"
 	category "Ammunition"
 	series "Ammunition"
 	index 08010
+	licenses
+		Heliarch
 	cost 32000
 	thumbnail "outfit/finisher"
 	"mass" .5


### PR DESCRIPTION
**Balance (?)**

Locks the Finisher Torpedo and the Finisher Storage Tube behind the Heliarch License

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Despite both Finisher launchers being License-locked, the ammo and storage outfits weren't.

Now that we have the universal ammo restocking going on, this should prevent those without the Heliarch License from infinitely restocking Finishers.