### PR TITLE
Don’t draw the same stars in different parallax layers

### DIFF
--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -209,11 +209,10 @@ void StarField::Draw(const Point &blur, const System *system) const
 			double borderX = fabs(blur.X()) + 1.;
 			double borderY = fabs(blur.Y()) + 1.;
 			// Find the absolute bounds of the star field we must draw.
-			float shove = pow(-5., pass);
-			int minX = pos.X() + (Screen::Left() - borderX) / zoom - shove;
-			int minY = pos.Y() + (Screen::Top() - borderY) / zoom - shove;
-			int maxX = pos.X() + (Screen::Right() + borderX) / zoom - shove;
-			int maxY = pos.Y() + (Screen::Bottom() + borderY) / zoom - shove;
+			int minX = pos.X() + (Screen::Left() - borderX) / zoom;
+			int minY = pos.Y() + (Screen::Top() - borderY) / zoom;
+			int maxX = pos.X() + (Screen::Right() + borderX) / zoom;
+			int maxY = pos.Y() + (Screen::Bottom() + borderY) / zoom;
 			// Round down to the start of the nearest tile.
 			minX &= ~(TILE_SIZE - 1l);
 			minY &= ~(TILE_SIZE - 1l);
@@ -222,7 +221,7 @@ void StarField::Draw(const Point &blur, const System *system) const
 			{
 				for(int gx = minX; gx < maxX; gx += TILE_SIZE)
 				{
-					Point off = Point(gx + shove, gy + shove) - pos;
+					Point off = Point(gx, gy) - pos;
 					GLfloat translate[2] = {
 						static_cast<float>(off.X()),
 						static_cast<float>(off.Y())

--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -230,9 +230,9 @@ void StarField::Draw(const Point &blur, const System *system) const
 					glUniform2fv(translateI, 1, translate);
 
 					int index = (gx & widthMod) / TILE_SIZE + ((gy & widthMod) / TILE_SIZE) * tileCols;
-					int first = 6 * tileIndex[index];
-					int count = 6 * tileIndex[index + 1] - first;
-					glDrawArrays(GL_TRIANGLES, first, density * count / (pass * layers));
+					int first = tileIndex[index];
+					int count = (tileIndex[index + 1] - first) * density / layers;
+					glDrawArrays(GL_TRIANGLES, 6 * (first + (pass - 1) * count), 6 * (count / pass));
 				}
 			}
 		}


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The parallax layers currently draw the same stars at slightly different zoom levels. If you look closely, this actually shows – you have the same constellations moving in the foreground and background. This is unnecessary given that the number of stars displayed is divided by the number of layers anyway.

This change makes sure that the starting offset for each layer is different, so there are no overlaps between the stars drawn in each parallax layer. It also moves multiplication with the vertex count towards the end, so that the vertex count passed to `glDrawArrays` is guaranteed to be a multiple of 6. I think this code has been drawing partial stars before, and my screenshot actually shows something that seems to be one half of a star.

## Screenshots
Duplicate constellations currently showing up with “fancy” parallax background (gets even more obvious when moving):
![Screenshot of the stars displayed in the game, with each star duplicated nearby](https://github.com/user-attachments/assets/35fad399-9090-4c12-a55c-d8435a346920)

## Testing Done
In my testing the visuals didn’t really change, other than not being able to find duplicate constellations any more.

## Performance Impact
None, it’s essentially the same operations as before, merely moved around.