### PR TITLE
fix(mechanics): Make the starfield update when zooming while paused

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -620,8 +620,7 @@ void Engine::Step(bool isActive)
 		}
 
 		// Step the background to account for the current velocity and zoom.
-		if(!timePaused)
-			GameData::StepBackground(centerVelocity, zoom);
+		GameData::StepBackground(timePaused ? Point() : centerVelocity, zoom);
 	}
 
 	outlines.clear();


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When the game is paused, all starfield updates are paused as well. This includes updates for when the zoom level is changed, even though it's possible to change zoom while paused. This PR instead zeroes out the velocity of the background, letting zoom updates occur.

## Screenshots
With the bug:
![image](https://github.com/user-attachments/assets/a02a4d67-e8b4-4b4b-94f5-0b3be381b022)
![image](https://github.com/user-attachments/assets/7d7d4ea1-f153-404f-b381-61ef955973db)
How it's meant to look:
![image](https://github.com/user-attachments/assets/5f48dd40-ed16-4a50-a5f4-2945b3ac74a9)
![image](https://github.com/user-attachments/assets/e1dc06a3-3af4-46c8-9f7e-34631bcff2bb)

## Testing Done
Flew around, then paused. Saw the background get bigger and smaller when zooming as expected.

## Performance Impact
Nada.
