### PR TITLE
fix(mechanics): Correct field bounds calculation for fancy parallax

### DIFF
--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -209,7 +209,7 @@ void StarField::Draw(const Point &blur, const System *system) const
 			double borderX = fabs(blur.X()) + 1.;
 			double borderY = fabs(blur.Y()) + 1.;
 			// Find the absolute bounds of the star field we must draw.
-			float shove = pow(-5., pass);
+			float shove = static_cast<int>(pow(-5., pass));
 			int minX = pos.X() + (Screen::Left() - borderX) / zoom - shove;
 			int minY = pos.Y() + (Screen::Top() - borderY) / zoom - shove;
 			int maxX = pos.X() + (Screen::Right() + borderX) / zoom - shove;

--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -209,7 +209,7 @@ void StarField::Draw(const Point &blur, const System *system) const
 			double borderX = fabs(blur.X()) + 1.;
 			double borderY = fabs(blur.Y()) + 1.;
 			// Find the absolute bounds of the star field we must draw.
-			float shove = static_cast<int>(pow(-5., pass));
+			int shove = static_cast<int>(pow(-5., pass));
 			int minX = pos.X() + (Screen::Left() - borderX) / zoom - shove;
 			int minY = pos.Y() + (Screen::Top() - borderY) / zoom - shove;
 			int maxX = pos.X() + (Screen::Right() + borderX) / zoom - shove;

--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -209,17 +209,17 @@ void StarField::Draw(const Point &blur, const System *system) const
 			double borderX = fabs(blur.X()) + 1.;
 			double borderY = fabs(blur.Y()) + 1.;
 			// Find the absolute bounds of the star field we must draw.
-			int minX = pos.X() + (Screen::Left() - borderX) / zoom;
-			int minY = pos.Y() + (Screen::Top() - borderY) / zoom;
-			int maxX = pos.X() + (Screen::Right() + borderX) / zoom;
-			int maxY = pos.Y() + (Screen::Bottom() + borderY) / zoom;
+			float shove = pow(-5., pass);
+			int minX = pos.X() + (Screen::Left() - borderX) / zoom - shove;
+			int minY = pos.Y() + (Screen::Top() - borderY) / zoom - shove;
+			int maxX = pos.X() + (Screen::Right() + borderX) / zoom - shove;
+			int maxY = pos.Y() + (Screen::Bottom() + borderY) / zoom - shove;
 			// Round down to the start of the nearest tile.
 			minX &= ~(TILE_SIZE - 1l);
 			minY &= ~(TILE_SIZE - 1l);
 
 			for(int gy = minY; gy < maxY; gy += TILE_SIZE)
 			{
-				float shove = pow(-5., pass);
 				for(int gx = minX; gx < maxX; gx += TILE_SIZE)
 				{
 					Point off = Point(gx + shove, gy + shove) - pos;

--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -209,7 +209,7 @@ void StarField::Draw(const Point &blur, const System *system) const
 			double borderX = fabs(blur.X()) + 1.;
 			double borderY = fabs(blur.Y()) + 1.;
 			// Find the absolute bounds of the star field we must draw.
-			int shove = static_cast<int>(pow(-5., pass));
+			float shove = pow(-5., pass);
 			int minX = pos.X() + (Screen::Left() - borderX) / zoom - shove;
 			int minY = pos.Y() + (Screen::Top() - borderY) / zoom - shove;
 			int maxX = pos.X() + (Screen::Right() + borderX) / zoom - shove;


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Enable “fancy” parallax background and start moving down. Observe the lower edge of the screen. You will notice groups of stars suddenly jumping into existence there. This mostly affects the third parallax layer (foreground stars), the effect is far less noticeable with the second layer. The issue is the field bounds calculation failing to consider the `shove` value.

*Note*: I made `shove` an integer given that it is only used in integer operations. Calculating it as an integer would add only minimal complexity but still not worth it here.

## Testing Done
With this change the effect is gone.

## Performance Impact
None