### PR TITLE
fix(ui): Fix camera acceleration/starfield movement/motion blur breaking under certain circumstances

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -37,6 +37,8 @@ target_sources(EndlessSkyLib PRIVATE
 	BoardingPanel.h
 	Body.cpp
 	Body.h
+	Camera.cpp
+	Camera.h
 	CaptureOdds.cpp
 	CaptureOdds.h
 	CargoHold.cpp

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -28,10 +28,14 @@ namespace {
 
 
 
-void Camera::SnapTo(const Point &target)
+void Camera::SnapTo(const Point &target, bool keepVelocity)
 {
+	// If a player is jumping to a new system, preserve their velocity by offsetting oldTarget and center by the
+	// current velocity.
+	Point newTarget = keepVelocity ? target - velocity : target;
 	oldTarget = target;
 	center = target;
+	// Velocity is zeroed here, but it will be re-calculated when MoveTo is called later in this frame.
 	velocity = Point();
 	accel = Point();
 }

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -30,12 +30,13 @@ namespace {
 
 void Camera::SnapTo(const Point &target, bool keepVelocity)
 {
-	// If a player is jumping to a new system, preserve their velocity by offsetting oldTarget and center by the
-	// current velocity.
+	// If a player is jumping to a new system, preserve their velocity by offsetting oldTarget
+	// and center by the current velocity.
 	Point newTarget = keepVelocity ? target - velocity : target;
-	oldTarget = target;
-	center = target;
-	// Velocity is zeroed here, but it will be re-calculated when MoveTo is called later in this frame.
+	oldTarget = newTarget;
+	center = newTarget;
+	// Velocity is zeroed here even when keepVelocity is true, but it will be re-calculated
+	// when MoveTo is called later in this frame.
 	velocity = Point();
 	accel = Point();
 }

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -15,7 +15,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Camera.h"
 
-#include "Logger.h"
 #include "Preferences.h"
 
 #include <cmath>

--- a/source/Camera.cpp
+++ b/source/Camera.cpp
@@ -1,0 +1,81 @@
+/* Camera.cpp
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Camera.h"
+
+#include "Logger.h"
+#include "Preferences.h"
+
+#include <cmath>
+
+using namespace std;
+
+namespace {
+	const double CAMERA_VELOCITY_TRACKING = 0.1;
+	const double CAMERA_POSITION_CENTERING = 0.01;
+}
+
+
+
+void Camera::SnapTo(const Point &target)
+{
+	oldTarget = target;
+	center = target;
+	velocity = Point();
+}
+
+
+
+void Camera::MoveTo(const Point &target, double influence, bool killVelocity)
+{
+	// The new base velocity is the change in position of the target between frames.
+	Point baseVelocity = target - oldTarget;
+	oldTarget = target;
+	if(Preferences::CameraAcceleration() == Preferences::CameraAccel::OFF)
+	{
+		center = target;
+		velocity = baseVelocity;
+		return;
+	}
+
+	double cameraAccelMultiplier = Preferences::CameraAcceleration() == Preferences::CameraAccel::REVERSED ? -1. : 1.;
+
+	// Flip the velocity offset if cameraAccelMultiplier is negative to simplify logic.
+	const Point absoluteOldCenterVelocity = baseVelocity.Lerp(velocity, cameraAccelMultiplier);
+
+	const Point newAbsVelocity = absoluteOldCenterVelocity.Lerp(baseVelocity, CAMERA_VELOCITY_TRACKING);
+
+	Point newCenter = (center + newAbsVelocity).Lerp(target, CAMERA_POSITION_CENTERING);
+
+	// Flip the velocity back over the baseVelocity.
+	Point newVelocity = baseVelocity.Lerp(newAbsVelocity, cameraAccelMultiplier);
+
+	center = newCenter.Lerp(target, pow(influence, .5));
+	velocity = killVelocity ? baseVelocity : newVelocity.Lerp(baseVelocity, pow(influence, .5));
+}
+
+
+
+const Point &Camera::Center() const
+{
+	return center;
+}
+
+
+
+const Point &Camera::Velocity() const
+{
+	return velocity;
+}

--- a/source/Camera.h
+++ b/source/Camera.h
@@ -27,7 +27,7 @@ public:
 	// Instantly snap the camera to the given target.
 	void SnapTo(const Point &target);
 	// Move the camera toward the given target.
-	void MoveTo(const Point &target, double influence, bool killVelocity);
+	void MoveTo(const Point &target, double hyperspaceInfluence);
 
 	// The position of the camera's center.
 	const Point &Center() const;
@@ -38,5 +38,7 @@ public:
 private:
 	Point center;
 	Point velocity;
+
+	Point accel;
 	Point oldTarget;
 };

--- a/source/Camera.h
+++ b/source/Camera.h
@@ -1,0 +1,42 @@
+/* Camera.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Point.h"
+
+#include <utility>
+
+
+
+// A class that represents the viewport while in space.
+class Camera {
+public:
+	// Instantly snap the camera to the given target.
+	void SnapTo(const Point &target);
+	// Move the camera toward the given target.
+	void MoveTo(const Point &target, double influence, bool killVelocity);
+
+	// The position of the camera's center.
+	const Point &Center() const;
+	// The velocity that the camera is moving at. Used for motion blur and starfield movement.
+	const Point &Velocity() const;
+
+
+private:
+	Point center;
+	Point velocity;
+	Point oldTarget;
+};

--- a/source/Camera.h
+++ b/source/Camera.h
@@ -17,8 +17,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Point.h"
 
-#include <utility>
-
 
 
 // A class that represents the viewport while in space.

--- a/source/Camera.h
+++ b/source/Camera.h
@@ -23,7 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class Camera {
 public:
 	// Instantly snap the camera to the given target.
-	void SnapTo(const Point &target);
+	void SnapTo(const Point &target, bool keepVelocity = false);
 	// Move the camera toward the given target.
 	void MoveTo(const Point &target, double hyperspaceInfluence);
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1543,7 +1543,7 @@ void Engine::EnterSystem()
 
 	emptySoundsTimer.clear();
 
-	camera.SnapTo(flagship->Center());
+	camera.SnapTo(flagship->Center(), true);
 
 	// Help message for new players. Show this message for the first four days,
 	// since the new player ships can make at most four jumps before landing.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -244,9 +244,6 @@ namespace {
 
 	const double RADAR_SCALE = .025;
 	const double MAX_FUEL_DISPLAY = 3000.;
-
-	const double CAMERA_VELOCITY_TRACKING = 0.1;
-	const double CAMERA_POSITION_CENTERING = 0.01;
 }
 
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1600,6 +1600,8 @@ void Engine::CalculateStep()
 			bool isHyperspacing = flagship->IsHyperspacing();
 			if(isHyperspacing)
 				hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
+			else
+				hyperspacePercentage = 0.;
 			Camera newCamera = camera;
 			newCamera.MoveTo(flagship->Center(), hyperspacePercentage, isHyperspacing);
 			newCenter = newCamera.Center();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1591,27 +1591,18 @@ void Engine::CalculateStep()
 		CalculateUnpaused(flagship, playerSystem);
 
 	// Draw the objects. Start by figuring out where the view should be centered:
-	Point newCenter = camera.Center();
-	Point newCenterVelocity;
-	if(flagship)
+	Camera newCamera = camera;
+	if(flagship && !timePaused)
 	{
-		if(!timePaused)
-		{
-			if(flagship->IsHyperspacing())
-				hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
-			else
-				hyperspacePercentage = 0.;
-			Camera newCamera = camera;
-			newCamera.MoveTo(flagship->Center(), hyperspacePercentage);
-			newCenter = newCamera.Center();
-			newCenterVelocity = newCamera.Velocity();
-		}
+		if(flagship->IsHyperspacing())
+			hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
 		else
-			newCenterVelocity = flagship->Velocity();
+			hyperspacePercentage = 0.;
+		newCamera.MoveTo(flagship->Center(), hyperspacePercentage);
 	}
-	draw[currentCalcBuffer].SetCenter(newCenter, newCenterVelocity);
-	batchDraw[currentCalcBuffer].SetCenter(newCenter);
-	radar[currentCalcBuffer].SetCenter(newCenter);
+	draw[currentCalcBuffer].SetCenter(newCamera.Center(), newCamera.Velocity());
+	batchDraw[currentCalcBuffer].SetCenter(newCamera.Center());
+	radar[currentCalcBuffer].SetCenter(newCamera.Center());
 
 	// Populate the radar.
 	FillRadar();
@@ -1627,7 +1618,7 @@ void Engine::CalculateStep()
 				draw[currentCalcBuffer].Add(object);
 		}
 	// Draw the asteroids and minables.
-	asteroids.Draw(draw[currentCalcBuffer], newCenter, zoom);
+	asteroids.Draw(draw[currentCalcBuffer], newCamera.Center(), zoom);
 	// Draw the flotsam.
 	for(const shared_ptr<Flotsam> &it : flotsam)
 		draw[currentCalcBuffer].Add(*it);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -247,30 +247,6 @@ namespace {
 
 	const double CAMERA_VELOCITY_TRACKING = 0.1;
 	const double CAMERA_POSITION_CENTERING = 0.01;
-
-	pair<Point, Point> NewCenter(const Point &oldCenter, const Point &oldCenterVelocity,
-		const Point &baseCenter, const Point &baseVelocity, const double influence, const bool killVelocity)
-	{
-		if(Preferences::CameraAcceleration() == Preferences::CameraAccel::OFF)
-			return make_pair(baseCenter, baseVelocity);
-
-		double cameraAccelMultiplier = Preferences::CameraAcceleration() == Preferences::CameraAccel::REVERSED ? -1. : 1.;
-
-		// Flip the velocity offset if cameraAccelMultiplier is negative to simplify logic.
-		const Point absoluteOldCenterVelocity = baseVelocity.Lerp(oldCenterVelocity, cameraAccelMultiplier);
-
-		const Point newAbsVelocity = absoluteOldCenterVelocity.Lerp(baseVelocity, CAMERA_VELOCITY_TRACKING);
-
-		Point newCenter = (oldCenter + newAbsVelocity).Lerp(baseCenter, CAMERA_POSITION_CENTERING);
-
-		// Flip the velocity back over the baseVelocity
-		Point newVelocity = baseVelocity.Lerp(newAbsVelocity, cameraAccelMultiplier);
-
-		newCenter = newCenter.Lerp(baseCenter, pow(influence, .5));
-		newVelocity = killVelocity ? baseVelocity : newVelocity.Lerp(baseVelocity, pow(influence, .5));
-
-		return make_pair(newCenter, newVelocity);
-	}
 }
 
 
@@ -294,12 +270,12 @@ Engine::Engine(PlayerInfo &player)
 	// Figure out what planet the player is landed on, if any.
 	const StellarObject *object = player.GetStellarObject();
 	if(object)
-		center = object->Position();
+		camera.SnapTo(object->Position());
 
 	// Now we know the player's current position. Draw the planets.
 	draw[currentCalcBuffer].Clear(step, zoom);
-	draw[currentCalcBuffer].SetCenter(center);
-	radar[currentCalcBuffer].SetCenter(center);
+	draw[currentCalcBuffer].SetCenter(camera.Center());
+	radar[currentCalcBuffer].SetCenter(camera.Center());
 	const Ship *flagship = player.Flagship();
 	for(const StellarObject &object : player.GetSystem()->Objects())
 		if(object.HasSprite())
@@ -421,8 +397,7 @@ void Engine::Place()
 	// that all special ships have been repositioned.
 	ships.splice(ships.end(), newShips);
 
-	center = flagship->Center();
-	centerVelocity = flagship->Velocity();
+	camera.SnapTo(flagship->Center());
 
 	player.SetPlanet(nullptr);
 }
@@ -530,21 +505,11 @@ void Engine::Step(bool isActive)
 	const shared_ptr<Ship> flagship = player.FlagshipPtr();
 	const StellarObject *object = player.GetStellarObject();
 	if(object)
-	{
-		center = object->Position();
-		centerVelocity = Point();
-	}
+		camera.SnapTo(object->Position());
 	else if(flagship)
 	{
 		if(isActive && !timePaused)
-		{
-			const auto [newCenter, newCenterVelocity] = NewCenter(center, centerVelocity,
-				flagship->Center(), flagship->Velocity(), hyperspacePercentage,
-				flagship->IsHyperspacing());
-
-			center = newCenter;
-			centerVelocity = newCenterVelocity;
-		}
+			camera.MoveTo(flagship->Center(), hyperspacePercentage, flagship->IsHyperspacing());
 
 		if(doEnterLabels)
 		{
@@ -588,7 +553,7 @@ void Engine::Step(bool isActive)
 	}
 
 	wasActive = isActive;
-	Audio::Update(center);
+	Audio::Update(camera.Center());
 
 	// Update the zoom value now that the calculation thread is paused.
 	if(nextZoom)
@@ -620,7 +585,7 @@ void Engine::Step(bool isActive)
 		}
 
 		// Step the background to account for the current velocity and zoom.
-		GameData::StepBackground(timePaused ? Point() : centerVelocity, zoom);
+		GameData::StepBackground(timePaused ? Point() : camera.Velocity(), zoom);
 	}
 
 	outlines.clear();
@@ -631,7 +596,7 @@ void Engine::Step(bool isActive)
 			if(ship->IsParked() || ship->GetSystem() != player.GetSystem() || ship->Cloaking() == 0.)
 				continue;
 
-			outlines.emplace_back(ship->GetSprite(), (ship->Position() - center) * zoom, ship->Unit() * zoom,
+			outlines.emplace_back(ship->GetSprite(), (ship->Position() - camera.Center()) * zoom, ship->Unit() * zoom,
 				ship->GetFrame(), Color::Multiply(ship->Cloaking(), cloakColor));
 		}
 
@@ -639,7 +604,7 @@ void Engine::Step(bool isActive)
 	if(flagship && !flagship->IsDestroyed() && Preferences::Has("Highlight player's flagship"))
 	{
 		outlines.emplace_back(flagship->GetSprite(),
-			(flagship->Center() - center) * zoom,
+			(flagship->Center() - camera.Center()) * zoom,
 			flagship->Unit() * zoom * flagship->Scale(),
 			flagship->GetFrame(),
 			*GameData::Colors().Get("flagship highlight"));
@@ -739,7 +704,7 @@ void Engine::Step(bool isActive)
 		if(Preferences::Has("Show missile overlays"))
 			for(const Projectile &projectile : projectiles)
 			{
-				Point pos = projectile.Position() - center;
+				Point pos = projectile.Position() - camera.Center();
 				if(projectile.MissileStrength() && projectile.GetGovernment()->IsEnemy()
 						&& (pos.Length() < max(Screen::Width(), Screen::Height()) * .5 / zoom))
 					missileLabels.emplace_back(AlertLabel(pos, projectile, flagship, zoom));
@@ -759,7 +724,7 @@ void Engine::Step(bool isActive)
 #else
 					turretOverlays.emplace_back(
 #endif
-						(flagship->Position() - center
+						(flagship->Position() - camera.Center()
 							+ flagship->Zoom() * flagship->Facing().Rotate(hardpoint.GetPoint()))
 							* static_cast<double>(zoom),
 						(flagship->Facing() + hardpoint.GetAngle()).Unit(),
@@ -772,7 +737,7 @@ void Engine::Step(bool isActive)
 				}
 		// Update the planet label positions.
 		for(PlanetLabel &label : labels)
-			label.Update(center, zoom, labels, *player.GetSystem());
+			label.Update(camera.Center(), zoom, labels, *player.GetSystem());
 	}
 
 	if(flagship && flagship->IsOverheated())
@@ -831,7 +796,7 @@ void Engine::Step(bool isActive)
 		info.SetString("destination", name);
 
 		targets.push_back({
-			object->Position() - center,
+			object->Position() - camera.Center(),
 			object->Facing(),
 			object->Radius(),
 			GetPlanetTargetPointerColor(*object->GetPlanet()),
@@ -877,7 +842,7 @@ void Engine::Step(bool isActive)
 			0);
 		info.SetString("target name", targetAsteroid->DisplayName() + " " + targetAsteroid->Noun());
 
-		targetVector = targetAsteroid->Position() - center;
+		targetVector = targetAsteroid->Position() - camera.Center();
 
 		if(flagship->Attributes().Get("tactical scan power") || flagship->Attributes().Get("strategic scan power"))
 		{
@@ -922,13 +887,13 @@ void Engine::Step(bool isActive)
 			// of the width and the height of the sprite.
 			double size = (target->Width() + target->Height()) * .35;
 			targets.push_back({
-				target->Position() - center,
+				target->Position() - camera.Center(),
 				Angle(45.) + target->Facing(),
 				size,
 				GetShipTargetPointerColor(targetType),
 				4});
 
-			targetVector = target->Position() - center;
+			targetVector = target->Position() - camera.Center();
 
 			double targetRange = target->Position().Distance(flagship->Position());
 			// Finds the range of the scan collections.
@@ -1032,7 +997,7 @@ void Engine::Step(bool isActive)
 		&& (flagship->CargoScanFraction() || flagship->OutfitScanFraction()))
 	{
 		double width = max(target->Width(), target->Height());
-		Point pos = target->Position() - center;
+		Point pos = target->Position() - camera.Center();
 		const bool outfitInRange = pos.LengthSquared() <= (flagship->Attributes().Get("outfit scan power") * 10000);
 		const Status::Type outfitOverlayType = outfitInRange ? Status::Type::SCAN : Status::Type::SCAN_OUT_OF_RANGE;
 		statuses.emplace_back(pos, flagship->OutfitScanFraction(), 0.,
@@ -1088,7 +1053,7 @@ void Engine::Step(bool isActive)
 		{
 			double size = (ship->Width() + ship->Height()) * .35;
 			targets.push_back({
-				ship->Position() - center,
+				ship->Position() - camera.Center(),
 				Angle(45.) + ship->Facing(),
 				size,
 				*GameData::Colors().Get("ship target pointer player"),
@@ -1109,7 +1074,7 @@ void Engine::Step(bool isActive)
 			bool scanComplete = true;
 			for(const shared_ptr<Minable> &minable : asteroids.Minables())
 			{
-				Point offset = minable->Position() - center;
+				Point offset = minable->Position() - camera.Center();
 				// Use the squared length, as we used the squared scan range.
 				bool inRange = offset.LengthSquared() <= scanRangeMetric;
 
@@ -1143,7 +1108,7 @@ void Engine::Step(bool isActive)
 	const auto targetAsteroidPtr = flagship ? flagship->GetTargetAsteroid() : nullptr;
 	if(targetAsteroidPtr && !flagship->IsHyperspacing())
 		targets.push_back({
-			targetAsteroidPtr->Position() - center,
+			targetAsteroidPtr->Position() - camera.Center(),
 			targetAsteroidPtr->Facing(),
 			.8 * targetAsteroidPtr->Radius(),
 			GetMinablePointerColor(true),
@@ -1192,7 +1157,7 @@ list<ShipEvent> &Engine::Events()
 // Draw a frame.
 void Engine::Draw() const
 {
-	Point motionBlur = Preferences::Has("Render motion blur") ? centerVelocity : Point();
+	Point motionBlur = Preferences::Has("Render motion blur") ? camera.Velocity() : Point();
 
 	Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetExtendedJumpEffects();
 	if(jumpEffectState != Preferences::ExtendedJumpEffects::OFF)
@@ -1396,10 +1361,10 @@ void Engine::Click(const Point &from, const Point &to, bool hasShift, bool hasCo
 	uiClickBox = Rectangle::WithCorners(from, to);
 	if(isRadarClick)
 		clickBox = Rectangle::WithCorners(
-			(from - radarCenter) / RADAR_SCALE + center,
-			(to - radarCenter) / RADAR_SCALE + center);
+			(from - radarCenter) / RADAR_SCALE + camera.Center(),
+			(to - radarCenter) / RADAR_SCALE + camera.Center());
 	else
-		clickBox = Rectangle::WithCorners(from / zoom + center, to / zoom + center);
+		clickBox = Rectangle::WithCorners(from / zoom + camera.Center(), to / zoom + camera.Center());
 }
 
 
@@ -1581,7 +1546,7 @@ void Engine::EnterSystem()
 
 	emptySoundsTimer.clear();
 
-	center = flagship->Center();
+	camera.SnapTo(flagship->Center());
 
 	// Help message for new players. Show this message for the first four days,
 	// since the new player ships can make at most four jumps before landing.
@@ -1629,7 +1594,7 @@ void Engine::CalculateStep()
 		CalculateUnpaused(flagship, playerSystem);
 
 	// Draw the objects. Start by figuring out where the view should be centered:
-	Point newCenter = center;
+	Point newCenter = camera.Center();
 	Point newCenterVelocity;
 	if(flagship)
 	{
@@ -1638,11 +1603,10 @@ void Engine::CalculateStep()
 			bool isHyperspacing = flagship->IsHyperspacing();
 			if(isHyperspacing)
 				hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
-			const auto [newCameraCenter, newCameraVelocity] = NewCenter(center, centerVelocity,
-				flagship->Center(), flagship->Velocity(), hyperspacePercentage,
-				isHyperspacing);
-			newCenter = newCameraCenter;
-			newCenterVelocity = newCameraVelocity;
+			Camera newCamera = camera;
+			newCamera.MoveTo(flagship->Center(), hyperspacePercentage, isHyperspacing);
+			newCenter = newCamera.Center();
+			newCenterVelocity = newCamera.Velocity();
 		}
 		else
 			newCenterVelocity = flagship->Velocity();
@@ -1841,7 +1805,7 @@ void Engine::CalculateUnpaused(const Ship *flagship, const System *playerSystem)
 
 	// Step the weather.
 	for(Weather &weather : activeWeather)
-		weather.Step(newVisuals, flagship ? flagship->Position() : center);
+		weather.Step(newVisuals, flagship ? flagship->Position() : camera.Center());
 	Prune(activeWeather);
 
 	// Move the visuals.
@@ -2270,7 +2234,7 @@ void Engine::HandleMouseClicks()
 			{
 				// If the player clicked to land on a planet,
 				// do so unless already landing elsewhere.
-				Point position = object.Position() - center;
+				Point position = object.Position() - camera.Center();
 				const Planet *planet = object.GetPlanet();
 				if(planet->IsAccessible(flagship) && (clickPoint - position).Length() < object.Radius())
 				{
@@ -2359,7 +2323,7 @@ void Engine::HandleMouseClicks()
 	if(isRightClick && !clickTarget && !clickedAsteroid && !isMouseTurningEnabled)
 	{
 		UI::PlaySound(UI::UISound::TARGET);
-		ai.IssueMoveTarget(clickPoint + center, playerSystem);
+		ai.IssueMoveTarget(clickPoint + camera.Center(), playerSystem);
 	}
 
 	// Treat an "empty" click as a request to clear targets.
@@ -3055,6 +3019,6 @@ void Engine::EmplaceStatusOverlay(const shared_ptr<Ship> &it, Preferences::Overl
 	if(it->IsYours())
 		cloak *= 0.6;
 
-	statuses.emplace_back(it->Position() - center, it->Shields(), it->Hull(),
+	statuses.emplace_back(it->Position() - camera.Center(), it->Shields(), it->Hull(),
 		min(it->Hull(), it->DisabledHull()), max(20., width * .5), type, alpha * (1. - cloak));
 }

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -506,7 +506,7 @@ void Engine::Step(bool isActive)
 	else if(flagship)
 	{
 		if(isActive && !timePaused)
-			camera.MoveTo(flagship->Center(), hyperspacePercentage, flagship->IsHyperspacing());
+			camera.MoveTo(flagship->Center(), hyperspacePercentage);
 
 		if(doEnterLabels)
 		{
@@ -1597,13 +1597,12 @@ void Engine::CalculateStep()
 	{
 		if(!timePaused)
 		{
-			bool isHyperspacing = flagship->IsHyperspacing();
-			if(isHyperspacing)
+			if(flagship->IsHyperspacing())
 				hyperspacePercentage = flagship->GetHyperspacePercentage() / 100.;
 			else
 				hyperspacePercentage = 0.;
 			Camera newCamera = camera;
-			newCamera.MoveTo(flagship->Center(), hyperspacePercentage, isHyperspacing);
+			newCamera.MoveTo(flagship->Center(), hyperspacePercentage);
 			newCenter = newCamera.Center();
 			newCenterVelocity = newCamera.Velocity();
 		}

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "AmmoDisplay.h"
 #include "AsteroidField.h"
 #include "shader/BatchDrawList.h"
+#include "Camera.h"
 #include "CollisionSet.h"
 #include "Color.h"
 #include "Command.h"
@@ -249,9 +250,8 @@ private:
 	bool isMouseHoldEnabled = false;
 	bool isMouseTurningEnabled = false;
 
-	// Viewport position and velocity.
-	Point center;
-	Point centerVelocity;
+	// Viewport camera.
+	Camera camera;
 	// Other information to display.
 	Information info;
 	std::vector<Target> targets;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bugs described in issues #11455 and #11457.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR fixes both bugs described in #11455. This is achieved by turning the camera into its own class.

The Camera class has a MoveTo function that is mostly the same as the NewCenter function from Engine. Instead of accepting a target position and velocity, this function now only accepts a target position. The target's velocity is then calculated by subtracting the target's previous position with its newest position to get the true amount of movement that the target made between frames. This is the second approach that I described in the issue:
> Or the camera velocity can ignore the flagship velocity all together, and instead use the difference in position between two frames to determine the velocity.

By calculating the velocity in this way, the camera uses the true movement of the player's ship at all times, even during events like landing, taking off, or boarding where we're cheating the flagship's location without using the true Body velocity of the ship.

In addition to this, the way that the camera's velocity is calculated has been changed. The old "velocity" has been renamed to "accel", as it was really only being used to calculate the camera's acceleration and wasn't really the camera's true velocity. The camera's velocity is now calculated by using the difference in the camera's position between frames. This fixes the reverse acceleration issue described in #11455.

This PR also fixes #11457 by setting hyperspacePercentage to 0 when your flagship is not in hyperspace. Previously, this variable would get stuck at 1 after the first time you jumped, effectively causing camera acceleration to always behave as if it were off.

## Testing Done

Took off and landed my ship with camera accel off and on. Observed that the starfield movement looked normal. Set camera accel to reverse and didn't see any odd behavior in the starfield movement. Jumped between systems and camera acceleration was still present.
