### PR TITLE
Lower Patir 2 gravities across the board

### DIFF
--- a/data/map beyond patir.txt
+++ b/data/map beyond patir.txt
@@ -25,7 +25,7 @@ system Athiri
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Athiri Black Hole Event Horizon" 1
 	hazard "Athiri Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/black hole corona core"
 		period 1
@@ -52,7 +52,7 @@ system Balnii
 	fleet "Magic Asteroid" 900
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Balnii Black Hole Event Horizon" 1
-	hazard "Black Hole Gravity" 2
+	hazard "Small Black Hole Gravity" 2
 	object
 		sprite "star/big black hole core"
 		period 1
@@ -70,7 +70,7 @@ system Chanai
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Chanai Black Hole Event Horizon" 1
 	hazard "Chanai Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/black hole 3 core"
 		period 1
@@ -93,7 +93,7 @@ system Ghila
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Ghila Black Hole Event Horizon" 1
 	hazard "Thepa and Ghila Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/black-hole-still-core"
 		period 1
@@ -142,7 +142,7 @@ system Maithi
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Beyond Patir Black Hole Event Horizon" 1
 	hazard "Beyond Patir Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/black hole 5 core"
 		period 1
@@ -165,7 +165,7 @@ system Mitera
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Beyond Patir Black Hole Event Horizon" 1
 	hazard "Beyond Patir Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/black hole 4 core"
 		period 1
@@ -188,7 +188,7 @@ system Sarifa
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Beyond Patir Black Hole Event Horizon" 1
 	hazard "Sarifa Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/f8"
 		distance 549
@@ -210,7 +210,7 @@ system Thepa
 	hazard "Beyond Patir Shield Eraser" 1
 	hazard "Beyond Patir Black Hole Event Horizon" 1
 	hazard "Thepa and Ghila Black Hole Accretion Disk" 1
-	hazard "Black Hole Gravity" 1
+	hazard "Small Black Hole Gravity" 1
 	object
 		sprite "star/black hole 6 core"
 		period 1


### PR DESCRIPTION
**Balance**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Based on Arachi's comments and my testing, the current black hole gravity in Patir 2 requires around 300 units of max speed in order to be reasonably completed. It also messes with the landing autopilot, making it difficult to land on the Chanai structure. The PR changes the systems to use the small black hole gravity instead of the standard one; not particularly accurate lore wise, but much less frustrating overall by reducting acceleration and the effect radius by a third. Chanai is still not out of the effect, but right at the edge, where even low thrust ships should be able to land without too much effort as long as they can get to that point. Another possibility would be to add an arrival distance, butI'd leave that maybe for after the unstable is out

## Testing Done
Verified that it lowers the engine requirements to around 200 units of max speed and increases enjoyment. I did it with a Pelican with Crucibles.
