### PR TITLE
feat(ui): Adjust the starfield behavior and menu animation

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -261,9 +261,9 @@ interface "menu background"
 
 interface "main menu"
 	# Background animation:
-	value "x speed" -.5
-	value "y speed" .1
-	value "y amplitude" 2.
+	value "x speed" -.4
+	value "y speed" .02
+	value "y amplitude" .6
 
 	# Credits:
 	sprite "_menu/side panel"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -294,7 +294,7 @@ Engine::Engine(PlayerInfo &player)
 				system->Position() - player.GetSystem()->Position());
 
 	GameData::SetHaze(player.GetSystem()->Haze(), true);
-	GameData::SetBackgroundPosition(center);
+	GameData::SetBackgroundPosition(camera.Center());
 }
 
 
@@ -1556,7 +1556,7 @@ void Engine::EnterSystem()
 	// different position relative to what it was when the player landed.
 	SystemEntry entry = player.GetSystemEntry();
 	if(entry == SystemEntry::WORMHOLE || entry == SystemEntry::JUMP)
-		GameData::SetBackgroundPosition(center);
+		GameData::SetBackgroundPosition(camera.Center());
 
 	// Help message for new players. Show this message for the first four days,
 	// since the new player ships can make at most four jumps before landing.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -321,6 +321,7 @@ Engine::Engine(PlayerInfo &player)
 				system->Position() - player.GetSystem()->Position());
 
 	GameData::SetHaze(player.GetSystem()->Haze(), true);
+	GameData::SetBackgroundPosition(center);
 }
 
 
@@ -1465,6 +1466,7 @@ void Engine::EnterSystem()
 	const System *system = flagship->GetSystem();
 	Audio::PlayMusic(system->MusicName());
 	GameData::SetHaze(system->Haze(), false);
+	GameData::SetBackgroundPosition(center);
 
 	Messages::Add("Entering the " + system->DisplayName() + " system on "
 		+ today.ToString() + (system->IsInhabited(flagship) ?

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1466,7 +1466,6 @@ void Engine::EnterSystem()
 	const System *system = flagship->GetSystem();
 	Audio::PlayMusic(system->MusicName());
 	GameData::SetHaze(system->Haze(), false);
-	GameData::SetBackgroundPosition(center);
 
 	Messages::Add("Entering the " + system->DisplayName() + " system on "
 		+ today.ToString() + (system->IsInhabited(flagship) ?
@@ -1584,6 +1583,15 @@ void Engine::EnterSystem()
 	emptySoundsTimer.clear();
 
 	center = flagship->Center();
+
+	// If the player entered a system by wormhole or jump drive, center the background
+	// on the player's position. This is not done when entering a system by hyperdrive
+	// so that there is a seamless transition between systems, and entry by taking off
+	// from a planet is also excluded as to prevent the background from snapping to a
+	// different position relative to what it was when the player landed.
+	SystemEntry entry = player.GetSystemEntry();
+	if(entry == SystemEntry::WORMHOLE || entry == SystemEntry::JUMP)
+		GameData::SetBackgroundPosition(center);
 
 	// Help message for new players. Show this message for the first four days,
 	// since the new player ships can make at most four jumps before landing.

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -922,6 +922,20 @@ void GameData::StepBackground(const Point &vel, double zoom)
 
 
 
+const Point &GameData::GetBackgroundPosition()
+{
+	return background.Position();
+}
+
+
+
+void GameData::SetBackgroundPosition(const Point &position)
+{
+	background.SetPosition(position);
+}
+
+
+
 void GameData::SetHaze(const Sprite *sprite, bool allowAnimation)
 {
 	background.SetHaze(sprite, allowAnimation);

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -172,6 +172,8 @@ public:
 
 	static const StarField &Background();
 	static void StepBackground(const Point &vel, double zoom = 1.);
+	static const Point &GetBackgroundPosition();
+	static void SetBackgroundPosition(const Point &position);
 	static void SetHaze(const Sprite *sprite, bool allowAnimation);
 
 	static const std::string &Tooltip(const std::string &label);

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -100,8 +100,6 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 	xSpeed = mainMenuUi->GetValue("x speed");
 	ySpeed = mainMenuUi->GetValue("y speed");
 	yAmplitude = mainMenuUi->GetValue("y amplitude");
-	// Start the animation wave at a random point.
-	animation = Random::Real() * 360.;
 
 	// When the player is in the menu, pause the game sounds.
 	Audio::Pause();

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -100,6 +100,8 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 	xSpeed = mainMenuUi->GetValue("x speed");
 	ySpeed = mainMenuUi->GetValue("y speed");
 	yAmplitude = mainMenuUi->GetValue("y amplitude");
+	returnPos = GameData::GetBackgroundPosition();
+	GameData::SetBackgroundPosition(Point());
 
 	// When the player is in the menu, pause the game sounds.
 	Audio::Pause();
@@ -110,6 +112,7 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 MenuPanel::~MenuPanel()
 {
 	Audio::Resume();
+	GameData::SetBackgroundPosition(returnPos);
 }
 
 

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -54,6 +54,8 @@ private:
 
 	const Interface *mainMenuUi;
 
+	// When the menu panel is closed, return the starfield to this position.
+	Point returnPos;
 	double animation = 0.;
 	double xSpeed = 0.;
 	double ySpeed = 0.;

--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -115,6 +115,20 @@ void StarField::FinishLoading()
 
 
 
+const Point &StarField::Position() const
+{
+	return pos;
+}
+
+
+
+void StarField::SetPosition(const Point &position)
+{
+	pos = position;
+}
+
+
+
 void StarField::SetHaze(const Sprite *sprite, bool allowAnimation)
 {
 	// If no sprite is given, set the default one.

--- a/source/shader/StarField.h
+++ b/source/shader/StarField.h
@@ -39,6 +39,8 @@ class StarField {
 public:
 	void Init(int stars, int width);
 	void FinishLoading();
+	const Point &Position() const;
+	void SetPosition(const Point &position);
 	void SetHaze(const Sprite *sprite, bool allowAnimation);
 
 	void Step(Point vel, double zoom = 1.);


### PR DESCRIPTION
**UI**

This PR addresses #11444 and a few other starfield tweaks mentioned on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR makes the following changes:
* Removes the random starting point from the main menu animation.
* Tones down the animation speed, matching the values that @Anarchist2 provided in the linked issue.
* Makes it so that the menu animation doesn't impact the starfield position when you return to the game.
* Jumping between systems and traveling through wormholes now sets the starfield position to the camera's position, which matches the behavior of the starfield prior to #11345.

## Testing Done
I played the game.
