### PR TITLE
feat(mechanics): Allow extended jump effects to function independent of motion blur

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1193,10 +1193,9 @@ list<ShipEvent> &Engine::Events()
 void Engine::Draw() const
 {
 	Point motionBlur = centerVelocity;
-	int baseBlur = Preferences::Has("Render motion blur") ? 1 : 0;
+	double baseBlur = Preferences::Has("Render motion blur") ? 1. : 0.;
 
 	Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetExtendedJumpEffects();
-
 	if(jumpEffectState != Preferences::ExtendedJumpEffects::OFF)
 		motionBlur *= baseBlur + pow(hyperspacePercentage *
 			(jumpEffectState == Preferences::ExtendedJumpEffects::MEDIUM ? 2.5 : 5.), 2);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1201,7 +1201,7 @@ void Engine::Draw() const
 		motionBlur *= baseBlur + pow(hyperspacePercentage *
 			(jumpEffectState == Preferences::ExtendedJumpEffects::MEDIUM ? 2.5 : 5.), 2);
 	else
-			motionBlur *= baseBlur;
+		motionBlur *= baseBlur;
 
 	GameData::Background().Draw(motionBlur,
 		(player.Flagship() ? player.Flagship()->GetSystem() : player.GetSystem()));

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1192,12 +1192,16 @@ list<ShipEvent> &Engine::Events()
 // Draw a frame.
 void Engine::Draw() const
 {
-	Point motionBlur = Preferences::Has("Render motion blur") ? centerVelocity : Point();
+	Point motionBlur = centerVelocity;
+	int baseBlur = Preferences::Has("Render motion blur") ? 1 : 0;
 
 	Preferences::ExtendedJumpEffects jumpEffectState = Preferences::GetExtendedJumpEffects();
+
 	if(jumpEffectState != Preferences::ExtendedJumpEffects::OFF)
-		motionBlur *= 1. + pow(hyperspacePercentage *
+		motionBlur *= baseBlur + pow(hyperspacePercentage *
 			(jumpEffectState == Preferences::ExtendedJumpEffects::MEDIUM ? 2.5 : 5.), 2);
+	else
+			motionBlur *= baseBlur;
 
 	GameData::Background().Draw(motionBlur,
 		(player.Flagship() ? player.Flagship()->GetSystem() : player.GetSystem()));


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Even though motion blur and extended jump effects can be toggled separately, the motion blur added by extended jump effects won't apply unless motion blur is on. This PR decouples the two preferences, allowing for motion blur to apply only when jumping.

## Testing Done
Tested every combination of motion blur and extended jump effects.

## Performance Impact
A single new variable.
