### PR TITLE
fix(mechanics): Consider sprite size correctly when drawing haze (#5711)

### DIFF
--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -257,14 +257,11 @@ void StarField::Draw(const Point &blur, const System *system) const
 	else
 		transparency = 0.;
 
-	// Set zoom to a higher level than stars to avoid premature culling.
-	zoom = min(.25, zoom / 1.4);
-
 	// Any object within this range must be drawn. Some haze sprites may repeat
 	// more than once if the view covers a very large area.
 	Point size = Point(1., 1.) * haze[0].front().Radius();
-	Point topLeft = pos + (Screen::TopLeft() - size) / zoom;
-	Point bottomRight = pos + (Screen::BottomRight() + size) / zoom;
+	Point topLeft = pos + Screen::TopLeft() / zoom - size;
+	Point bottomRight = pos + Screen::BottomRight() / zoom + size;
 	if(transparency > 0.)
 		AddHaze(drawList, haze[1], topLeft, bottomRight, 1 - transparency);
 	AddHaze(drawList, haze[0], topLeft, bottomRight, transparency);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #5711

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The bug has been previously addressed by introducing excessive off-screen painting. My fix removes this work-around and fixes the calculation to correctly consider sprite size instead. `size` here is the sprite “radius” in world coordinates, it should only be added to `Screen::TopLeft()` after the latter has been translated from screen coordinates to world coordinates.

## Testing Done
I’ve reproduced the original issue and verified that it no longer occurs with this fix.

## Performance Impact
This should improve performance somewhat.