### PR TITLE
fix(mechanics): Skip invalid systems when calculating system neighbors

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -514,13 +514,13 @@ void System::UpdateSystem(const Set<System> &systems, const set<double> &neighbo
 
 	// Some systems in the game may be considered inaccessible. If this system is inaccessible,
 	// then it shouldn't have accessible links or jump neighbors.
-	if(inaccessible)
+	if(!IsValid() || inaccessible)
 		return;
 
 	// If linked systems are inaccessible, then they shouldn't be a part of the accessible links
 	// set that gets used for navigation and other purposes.
 	for(const System *link : links)
-		if(!link->Inaccessible())
+		if(link->IsValid() && !link->Inaccessible())
 			accessibleLinks.insert(link);
 
 	// Neighbors are cached for each system for the purpose of quicker
@@ -1140,7 +1140,7 @@ void System::UpdateNeighbors(const Set<System> &systems, double distance)
 	{
 		const System &other = it.second;
 		// Skip systems that have no name or that are inaccessible.
-		if(it.first.empty() || other.TrueName().empty() || other.Inaccessible())
+		if(!link->IsValid() || it.first.empty() || other.TrueName().empty() || other.Inaccessible())
 			continue;
 
 		if(&other != this && other.Position().Distance(position) <= distance)

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -1139,8 +1139,8 @@ void System::UpdateNeighbors(const Set<System> &systems, double distance)
 	for(const auto &it : systems)
 	{
 		const System &other = it.second;
-		// Skip systems that have no name or that are inaccessible.
-		if(!link->IsValid() || it.first.empty() || other.TrueName().empty() || other.Inaccessible())
+		// Skip systems that are invalid or inaccessible.
+		if(!other.IsValid() || other.Inaccessible())
 			continue;
 
 		if(&other != this && other.Position().Distance(position) <= distance)


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #2369.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

If an invalid system is encountered (one that is referenced but not defined), it creates an invisible system at 0, 0. We've made a few changes in the past to prevent players from entering this 0, 0 system, but as noted by Hurl's comment a couple years ago, there's still one case where players can enter this invalid system.

Now it could be possible that the relatively recent DistanceMap refactor unknowingly caught the case of routing to invalid systems, but I think it'd be safe to make this change as well. This PR makes it so that invalid systems cannot be hyperdrive or jump drive neighbors to any systems, therefore completely eliminating the possibility of the player jumping into an invalid system, as no other system in the game will have it as a valid destination.

## Testing Done

I didn't, but this will definitely work if the bug still exists in any way.
