### PR TITLE
feat(ui): Warn the player if their ship is too cold to use their engines

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1225,6 +1225,9 @@ tip "no steering!"
 tip "insufficient bunks?"
 	`This ship does not have enough bunks for its crew. It could become unresponsive at random times.`
 
+tip "insufficient heat?"
+	`This ship is too cold to use some of its engines while idle. Its movement may be hindered if it does not have another way of generating heat.`
+
 tip "afterburner only?"
 	`This ship's only thruster is an afterburner. It may be unable to move if the afterburner runs out of fuel.`
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1323,8 +1323,10 @@ vector<string> Ship::FlightCheck() const
 	double reverseThrust = attributes.Get("reverse thrust");
 	double afterburner = attributes.Get("afterburner thrust");
 	double thrustEnergy = attributes.Get("thrusting energy");
+	double thrustHeat = attributes.Get("thrusting heat");
 	double turn = attributes.Get("turn");
 	double turnEnergy = attributes.Get("turning energy");
+	double turnHeat = attributes.Get("turning heat");
 	double hyperDrive = navigation.HasHyperdrive();
 	double jumpDrive = navigation.HasJumpDrive();
 
@@ -1345,6 +1347,8 @@ vector<string> Ship::FlightCheck() const
 	{
 		if(RequiredCrew() > attributes.Get("bunks"))
 			checks.emplace_back("insufficient bunks?");
+		if(IdleHeat() <= 0. && (thrustHeat < 0. || turnHeat < 0.))
+			checks.emplace_back("insufficient heat?");
 		if(!thrust && !reverseThrust)
 			checks.emplace_back("afterburner only?");
 		if(!thrust && !afterburner)


### PR DESCRIPTION
This PR addresses the bug described in issue #11473 and other places.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds a warning if a ship's idle heat is zero or negative while its thrusting heat or turning heat is negative, as their engines may not be able to produce enough heat to power their engines.

## Screenshots
![can you believe it? pride month, just a day away](https://github.com/user-attachments/assets/4e2ffb3c-96fb-43c4-a58b-591fcdbaff56)

## Testing Done
Installed heat-consuming engines on a ship whose idle heat was negative and saw the warning. Took off and couldn't move as expected.

## Performance Impact
Zilch.
