### PR TITLE
Remove run-cmake action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
       - run: |
-          echo 'connect-timeout = 10' > ~/.curlrc
+          echo 'connect-timeout = 5' > ~/.curlrc
           cmake --preset linux-release
           cmake --build build --preset linux-ci-release
       - name: Package Application
@@ -83,7 +83,6 @@ jobs:
         with:
           vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
       - run: |
-          echo 'connect-timeout = 10' > %APPDATA%\\.curlrc
           cmake --preset mingw-release
           cmake --build build --preset mingw-ci-release
       - name: Package Application
@@ -122,7 +121,7 @@ jobs:
         with:
           vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
       - run: |
-          echo 'connect-timeout = 10' > ~/.curlrc
+          echo 'connect-timeout = 5' > ~/.curlrc
           cmake --preset macos-release
           cmake --build build --preset macos-ci-release
       - name: Package Application

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
       - run: |
-          echo 'connect-timeout = 10' > ~/.curlrc
+          echo 'connect-timeout = 5' > ~/.curlrc
           cmake --preset linux-release
           cmake --build build --preset linux-ci-release
       - name: Package Application
@@ -59,7 +59,6 @@ jobs:
         with:
           vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
       - run: |
-          echo 'connect-timeout = 10' > %APPDATA%\\.curlrc
           cmake --preset mingw-release
           cmake --build build --preset mingw-ci-release
       - name: Package Application
@@ -100,7 +99,6 @@ jobs:
         with:
           vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
       - run: |
-          echo 'connect-timeout = 10' > %APPDATA%\\.curlrc
           cmake --preset mingw32-release
           cmake --build build --preset mingw32-ci-release
       - name: Package Application
@@ -147,7 +145,7 @@ jobs:
           mv "build/release/Endless Sky.app" "Endless Sky.app.arm"
           rm -rf build/release
       - run: |
-          echo 'connect-timeout = 10' > ~/.curlrc
+          echo 'connect-timeout = 5' > ~/.curlrc
           cmake --preset macos-release
           cmake --build build --preset macos-ci-release
       - name: Create universal binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
     - run: |
-        echo 'connect-timeout = 10' > ~/.curlrc
+        echo 'connect-timeout = 5' > ~/.curlrc
         cmake --preset ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
         cmake --build build --preset ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
         ctest --preset ${{ matrix.opengl == 'GL' && 'linux-ci' || 'linux-gles-ci' }}
@@ -144,7 +144,6 @@ jobs:
       with:
         vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
     - run: |
-        echo 'connect-timeout = 10' > %APPDATA%\\.curlrc
         cmake --preset mingw-ci
         cmake --build build --preset mingw-ci
         ctest --preset mingw-ci
@@ -187,7 +186,6 @@ jobs:
       with:
         vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
     - run: |
-        echo 'connect-timeout = 10' > %APPDATA%\\.curlrc
         cmake --preset clang-cl-ci
         cmake --build build --preset clang-cl-ci
         ctest --preset clang-cl-ci
@@ -222,7 +220,7 @@ jobs:
       with:
         vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
     - run: |
-        echo 'connect-timeout = 10' > ~/.curlrc
+        echo 'connect-timeout = 5' > ~/.curlrc
         cmake --preset macos-ci
         cmake --build build --preset macos-ci
         ctest --preset macos-ci
@@ -258,7 +256,7 @@ jobs:
       with:
         vcpkgGitCommitId: '2cf957350da28ad032178a974607f59f961217d9'
     - run: |
-        echo 'connect-timeout = 10' > ~/.curlrc
+        echo 'connect-timeout = 5' > ~/.curlrc
         cmake --preset macos-arm-ci
         cmake --build build --preset macos-arm-ci
         ctest --preset macos-arm-ci


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug causing 3-hour build times in the CI.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Replaces the action with the commands it runs.

## Testing Done
See the workflows.