### PR TITLE
Give Patir an event horizon

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -39,6 +39,16 @@ effect "ion hazard"
 	"random velocity" 2
 
 
+hazard "Patir Black Hole Event Horizon"
+	"constant strength"
+	"range" 20
+	weapon
+		"target effect" "nano spark"
+		"damage dropoff" 0 90
+		"dropoff modifier" 0
+		"relative hull damage" .0001
+		"piercing" 10
+
 
 hazard "Beyond Patir Shield Eraser"
 	"constant strength"

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -30710,6 +30710,7 @@ system Patir
 	trade Metal 354
 	trade Plastic 426
 	fleet Ka'sei 300
+	hazard "Patir Black Hole Event Horizon" 1
 	hazard "Ember Waste Base Heat" 100
 		to spawn
 			not "ka'het: beyond Patir"


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a weak event horizon to Patir, damaging any ship that comes too close

## Testing Done
Took a shuttle to Patir and verified the damage, as well as that the Ka'sei rarely come close enough to get damaged at all, let alone significantly
