### PR TITLE
Fixed the bug that was causing a crash.

### DIFF
--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -492,6 +492,9 @@ string Font::TruncateFront(const string &str, int &width) const
 		bool prevWorks = (prevWidth <= width);
 		nextChars += (prevWorks ? isSame : -isSame);
 
+		// Don't exceed the length of the string.
+		nextChars = nextChars > static_cast<int>(str.length()) ? str.length() : nextChars;
+
 		int nextWidth = WidthRawString(str.substr(str.size() - nextChars).c_str());
 		bool nextWorks = (nextWidth <= width);
 		if(prevWorks != nextWorks && abs(nextChars - prevChars) == 1)


### PR DESCRIPTION
This PR addresses the bug/feature described in issue #11286

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Implemented check to ensure that substr call does not go beyond the limits of the string.

## Screenshots
N/A

## Testing Done
Tested with various input.

## Performance Impact
None.