### PR TITLE
fix(content): Remove no longer used Cutthroat variant from FW event

### DIFF
--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1676,11 +1676,11 @@ event "pirate use jousting cutthroat"
 	fleet "Large Southern Pirate"
 		add variant 2
 			"Cutthroat" 2
-			"Cutthroat (Jousting)"
+			"Cutthroat"
 		add variant 1
 			"Modified Argosy (Blaster)"
 			"Fury (Gatling)"
-			"Cutthroat (Jousting)"
+			"Cutthroat"
 
 
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
After recent changes to pirate variant stats, the Cutthroat "Jousting" variant was removed as the stats no longer worked/matched for the ship's adjusted role. However, the variant was still being used in a FW event that added the Cutthroat.

This PR removes the variant. If we wish to remove the event entirely, or on the other side, rename it from "jousting" and possibly have a patch of some sort, I could do that too.