### PR TITLE
feat(content): Add markers to systems in Wanderers: Alpha Surveillance D

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1279,20 +1279,30 @@ mission "Wanderers: Alpha Surveillance D"
 			`	You thank the Quarg for being willing to help you, and you and Elias return to your ship.`
 				accept
 	
+	mark "Hi Yahr"
 	on enter "Hi Yahr"
 		dialog `As you enter the system, Elias checks his tracker device. "Yup, I'm picking up signs of a jump-enabled Carrier," he says. "The path goes east, beyond the edge of Hai space."`
+		unmark "Hi Yahr"
+		mark "Celeborim"
 	on enter "Celeborim"
 		dialog `Elias checks the tracker again. "Southeast, from here," he says. Meanwhile, your ship's warning sirens begin going off; there are alien ships here, and they don't seem friendly.`
+		unmark "Celeborim"
+		mark "Asikafarnut"
 	on enter "Asikafarnut"
 		dialog `Elias checks the tracker. "Still due southeast," he says. "And I hope those Korath ships aren't on the same side as the Alphas."`
+		unmark "Asikafarnut"
+		mark "Ferukistek"
 	on enter "Sobarati"
 		dialog `Elias fiddles with his tracking device for a while, and then gives up. "Sorry, I'm not reading any signals here. Maybe they jumped right over this system?"`
 	on enter "Ferukistek"
 		dialog `Elias says, "Found their trail. They've turned and headed east again, and maybe a little bit north."`
+		unmark "Ferukistek"
+		mark "Host"
 	on enter "Makferuti"
 		dialog `Elias frowns as he looks at the tracker's readout. "I think we've taken a wrong turn. No sign of jump drives being used in this system," he says.`
 	on enter "Host"
 		dialog `When you enter this system, your sensors pick up a Navy Carrier in orbit around an Earth-like planet. It appears that you have found the Alpha base. "That's them," says Hanover. "I hope you're strong enough to destroy them." The Carrier starts to launch fighters: Korath ones, not human ships. This might be a difficult fight...`
+		unmark "Host"
 	
 	npc
 		government "Kor Sestor"

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1291,12 +1291,15 @@ mission "Wanderers: Alpha Surveillance D"
 	on enter "Asikafarnut"
 		dialog `Elias checks the tracker. "Still due southeast," he says. "And I hope those Korath ships aren't on the same side as the Alphas."`
 		unmark "Asikafarnut"
+		mark "Sobarati"
 		mark "Ferukistek"
 	on enter "Sobarati"
 		dialog `Elias fiddles with his tracking device for a while, and then gives up. "Sorry, I'm not reading any signals here. Maybe they jumped right over this system?"`
+		unmark "Sobarati"
 	on enter "Ferukistek"
 		dialog `Elias says, "Found their trail. They've turned and headed east again, and maybe a little bit north."`
 		unmark "Ferukistek"
+		unmark "Sobarati"
 		mark "Host"
 	on enter "Makferuti"
 		dialog `Elias frowns as he looks at the tracker's readout. "I think we've taken a wrong turn. No sign of jump drives being used in this system," he says.`


### PR DESCRIPTION
This PR addresses the bug/feature described in issue #9182

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds markers to the systems that you fly through in Wanderers: Alpha Surveillance D, addressing some of the concerns that it's too difficult to figure out where you're supposed to go while you're being shot at.

## Testing Done
Did the mission.

## Save File
This save file can be used to test these changes:
[combat testless~autosave.txt](https://github.com/user-attachments/files/20537725/combat.testless.autosave.txt)
