### PR TITLE
refactor(ci): Rework build caching to rely only on actions/cache

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,25 +29,30 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libxmu-dev libxi-dev libgl-dev libglu1-mesa-dev libgles2-mesa-dev libminizip-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libfuse2
-      - name: Setup cached directories
-        uses: actions/cache@v4
+      - name: Find cache keys
+        run: echo "RESTORE_KEYS=$(git log --pretty=format:'${{ runner.os }}-cd-sccache-%H' -n 50 | tr '\n' '\n')" >> $GITHUB_ENV
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
-          path: /home/runner/.cache/sccache
-          key: ${{ runner.os }}-cd-sccache-${{ github.ref }}
-          restore-keys: |
-            ${{ runner.os }}-cd-sccache-refs/heads/master
-      - name: Setup sccache
-        uses: Mozilla-Actions/sccache-action@v0.0.5
+          key: ${{ runner.os }}-cd-sccache-${{ github.sha }}
+          restore-keys: ${{ env.RESTORE_KEYS }}
+          evict-old-files: '2d'
+          create-symlink: 'true'
+          append-timestamp: 'false'
       - name: Adjust version strings
         run: ./utils/cd_update_versions.sh
       - uses: lukka/get-cmake@latest
+      - uses: TAServers/vcpkg-cache@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
+          vcpkgGitCommitId: '89dc8be6dbcf18482a5a1bf86a2f4615c939b0fb'
       - run: |
-          echo 'connect-timeout = 5' > ~/.curlrc
           cmake --preset linux-release
           cmake --build build --preset linux-ci-release
+        env:
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Package Application
         run: ./utils/build_appimage.sh build/release
       - name: Upload artifact


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses various issues with third-party build caching systems.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
With github's recent api changes, most third-party caching tools broke, including vcpkg and sccache, causing build times of over three hours in some cases. This was worked around in #11478 and #11446, but the situation is worse than we first thought, as vcpkg is outright removing their caching feature.

This PR reworks build caching to not rely on third-party caching services (though third-party actions using actions/cache are still present):
 - Replacing sccache with ccache
   - This allows for cleaning old cache entries without having to wait for the cache to fill up
   - Caches are also stored per-commit now, so we don't need to manually update them
 - Per-package vcpkg binary caches
   - The build caches should also be stored by ccache, and deleted after two days. This should allow for fast package rebuilds when experimenting with new libraries.

## Testing Done
See the workflows.

## Performance Impact
Hopefully faster builds than ever before.