### PR TITLE
ui: Disable TextArea scrollshifting and optimize area resetting

### DIFF
--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -170,54 +170,9 @@ void Dialog::Draw()
 	const Sprite *bottom = SpriteSet::Get(isWide ? "ui/dialog bottom wide" : "ui/dialog bottom");
 	const Sprite *cancel = SpriteSet::Get("ui/dialog cancel");
 
-	// If the dialog is too tall, then switch to wide mode.
-	Point textRectSize(Width() - HORIZONTAL_PADDING, 0);
-	int maxHeight = Screen::Height() * 3 / 4;
-	if(text->GetTextHeight(false) > maxHeight)
-	{
-		textRectSize.Y() = maxHeight;
-		isWide = true;
-		// Re-wrap with the new width.
-		textRectSize.X() = Width() - HORIZONTAL_PADDING;
-		text->SetRect(Rectangle(Point{}, textRectSize));
-
-		if(text->GetLongestLineWidth() <= top->Width() - HORIZONTAL_MARGIN - HORIZONTAL_PADDING)
-		{
-			// Formatted text is long and skinny (e.g. scan result dialog). Go back
-			// to using the default width, since the wide width doesn't help.
-			isWide = false;
-			textRectSize.X() = Width() - HORIZONTAL_PADDING;
-			text->SetRect(Rectangle(Point{}, textRectSize));
-		}
-	}
-	else
-		textRectSize.Y() = text->GetTextHeight(false);
-
-	// The height of the bottom sprite without the included button's height.
-	const int realBottomHeight = bottom->Height() - cancel->Height();
-
-	int height = TOP_PADDING + textRectSize.Y() + BOTTOM_PADDING +
-			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
-	// Determine how many extension panels we need.
-	if(height <= realBottomHeight + top->Height())
-		extensionCount = 0;
-	else
-		extensionCount = (height - middle->Height()) / middle->Height();
-
-	// Now that we know how big we want to render the text, position the text area.
-
 	// Get the position of the top of this dialog, and of the input.
-	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5f);
+	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5);
 	Point inputPos = Point(0., -(cancel->Height() + INPUT_HEIGHT)) - pos;
-	// Resize textRectSize to match the visual height of the dialog, which will
-	// be rounded up from the actual text height by the number of panels that
-	// were added. This helps correctly position the TextArea scroll buttons.
-	textRectSize.Y() = (top->Height() + realBottomHeight - VERTICAL_PADDING) + extensionCount * middle->Height() -
-			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
-
-	Point textPos(Width() * -.5 + LEFT_PADDING, pos.Y() + VERTICAL_PADDING);
-	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
-	text->SetRect(textRect);
 
 	// Draw the top section of the dialog box.
 	pos.Y() += top->Height() * .5;
@@ -430,6 +385,59 @@ void Dialog::Init(const string &message, Truncate truncate, bool canCancel, bool
 	text->SetTruncate(truncate);
 	text->SetText(message);
 	AddChild(text);
+
+	const Sprite *top = SpriteSet::Get("ui/dialog top");
+	// If the dialog is too tall, then switch to wide mode.
+	int maxHeight = Screen::Height() * 3 / 4;
+	if(text->GetTextHeight(false) > maxHeight)
+	{
+		textRectSize.Y() = maxHeight;
+		isWide = true;
+		// Re-wrap with the new width
+		textRectSize.X() = Width() - HORIZONTAL_PADDING;
+		text->SetRect(Rectangle(Point{}, textRectSize));
+
+		if(text->GetLongestLineWidth() <= top->Width() - HORIZONTAL_MARGIN - HORIZONTAL_PADDING)
+		{
+			// Formatted text is long and skinny (e.g. scan result dialog). Go back
+			// to using the default width, since the wide width doesn't help.
+			isWide = false;
+			textRectSize.X() = Width() - HORIZONTAL_PADDING;
+			text->SetRect(Rectangle(Point{}, textRectSize));
+		}
+	}
+	else
+		textRectSize.Y() = text->GetTextHeight(false);
+
+	top = SpriteSet::Get(isWide ? "ui/dialog top wide" : "ui/dialog top");
+	const Sprite *middle = SpriteSet::Get(isWide ? "ui/dialog middle wide" : "ui/dialog middle");
+	const Sprite *bottom = SpriteSet::Get(isWide ? "ui/dialog bottom wide" : "ui/dialog bottom");
+	const Sprite *cancel = SpriteSet::Get("ui/dialog cancel");
+	// The height of the bottom sprite without the included button's height.
+	const int realBottomHeight = bottom->Height() - cancel->Height();
+
+	int height = TOP_PADDING + textRectSize.Y() + BOTTOM_PADDING +
+			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
+	// Determine how many extension panels we need.
+	if(height <= realBottomHeight + top->Height())
+		extensionCount = 0;
+	else
+		extensionCount = (height - middle->Height()) / middle->Height();
+
+	// Now that we know how big we want to render the text, position the text
+	// area and add it to the UI.
+
+	// Get the position of the top of this dialog, and of the text and input.
+	Point pos(0., (top->Height() + extensionCount * middle->Height() + bottom->Height()) * -.5f);
+	Point textPos(Width() * -.5 + LEFT_PADDING, pos.Y() + VERTICAL_PADDING);
+	// Resize textRectSize to match the visual height of the dialog, which will
+	// be rounded up from the actual text height by the number of panels that
+	// were added. This helps correctly position the TextArea scroll buttons.
+	textRectSize.Y() = (top->Height() + realBottomHeight - VERTICAL_PADDING) + extensionCount * middle->Height() -
+			(realBottomHeight - BOTTOM_PADDING) * (!isMission && (intFun || stringFun));
+
+	Rectangle textRect = Rectangle::FromCorner(textPos, textRectSize);
+	text->SetRect(textRect);
 }
 
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -127,6 +127,7 @@ namespace {
 // Open the missions panel directly.
 MissionPanel::MissionPanel(PlayerInfo &player)
 	: MapPanel(player),
+	missionInterface(GameData::Interfaces().Get("mission")),
 	available(player.AvailableJobs()),
 	accepted(player.Missions()),
 	availableIt(player.AvailableJobs().begin()),
@@ -142,6 +143,7 @@ MissionPanel::MissionPanel(PlayerInfo &player)
 	description->SetFont(FontSet::Get(14));
 	description->SetAlignment(Alignment::JUSTIFIED);
 	description->SetColor(*GameData::Colors().Get("bright"));
+	description->SetRect(missionInterface->GetBox("description"));
 
 	// Select the first available or accepted mission in the currently selected
 	// system, or along the travel plan.
@@ -161,6 +163,7 @@ MissionPanel::MissionPanel(PlayerInfo &player)
 // Switch to the missions panel from another map panel.
 MissionPanel::MissionPanel(const MapPanel &panel)
 	: MapPanel(panel),
+	missionInterface(GameData::Interfaces().Get("mission")),
 	available(player.AvailableJobs()),
 	accepted(player.Missions()),
 	availableIt(player.AvailableJobs().begin()),
@@ -182,6 +185,7 @@ MissionPanel::MissionPanel(const MapPanel &panel)
 	description->SetFont(FontSet::Get(14));
 	description->SetAlignment(Alignment::JUSTIFIED);
 	description->SetColor(*GameData::Colors().Get("bright"));
+	description->SetRect(missionInterface->GetBox("description"));
 
 	// Select the first available or accepted mission in the currently selected
 	// system, or along the travel plan.
@@ -919,9 +923,7 @@ void MissionPanel::DrawMissionInfo()
 
 	info.SetString("today", player.GetDate().ToString());
 
-	const Interface *missionInterface = GameData::Interfaces().Get("mission");
 	missionInterface->Draw(info, this);
-	description->SetRect(missionInterface->GetBox("description"));
 
 	// If a mission is selected, draw its descriptive text.
 	if(availableIt != available.end())

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <list>
 
 class Color;
+class Interface;
 class Mission;
 class PlayerInfo;
 class TextArea;
@@ -81,6 +82,8 @@ private:
 	void CycleInvolvedSystems(const Mission &mission);
 
 private:
+	const Interface *missionInterface;
+
 	const std::list<Mission> &available;
 	const std::list<Mission> &accepted;
 	int cycleInvolvedIndex = 0;

--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -235,7 +235,6 @@ void TextArea::Invalidate()
 {
 	bufferIsValid = false;
 	textIsValid = false;
-	scrollable = false;
 }
 
 

--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -126,10 +126,10 @@ int TextArea::GetLongestLineWidth()
 
 void TextArea::Draw()
 {
-	Validate(scrollHeightIncludesTrailingBreak);
 	if(!buffer)
 		buffer = std::make_unique<RenderBuffer>(size);
 
+	Validate(scrollHeightIncludesTrailingBreak);
 	if(!bufferIsValid || !scroll.IsAnimationDone())
 	{
 		scroll.Step();
@@ -241,16 +241,6 @@ void TextArea::Invalidate()
 
 void TextArea::Validate(bool trailingBreak)
 {
-	if(scrollable != scroll.Scrollable())
-	{
-		const Point offset{4, 0};
-		scrollable = scroll.Scrollable();
-		if(scrollable)
-			SetRect({position - offset, size - 2 * offset});
-		else
-			SetRect({position + offset, size + 2 * offset});
-	}
-
 	if(!textIsValid || trailingBreak != scrollHeightIncludesTrailingBreak)
 	{
 		wrappedText.Wrap(text);

--- a/source/TextArea.h
+++ b/source/TextArea.h
@@ -72,7 +72,6 @@ private:
 	Color color;
 	Point position;
 	Point size;
-	bool scrollable = false;
 
 	ScrollVar<double> scroll;
 	bool dragging = false;


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Reverted shrinking of TextAreas if the text is scrollable, because it seems that it creates more problems than it fixes (until we have an appropriate refactor).
Also standardized all panels that use them to set the area rectangle only once on initialization (opposite of what #11488 did, while still fixing the same bug).
Finally, dialogs no longer auto resize, because doing it every frame isn't an ideal solution, and with the above reverts, it's not needed for any bug fix anymore.

## Screenshots
Same as in #10612, but the other way around.

## Testing Done
Tested dialogs, mission descriptions, and planet descriptions in both the planet and map panels.

## Performance Impact
N/A to slightly better.
