### PR TITLE
Officially acknowledge XGA as the required minimal screen resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Endless Sky has very minimal system requirements, meaning most systems should be
 |---|----:|----:|
 |RAM | 750 MB | 2 GB |
 |Graphics | OpenGL 3.0 | OpenGL 3.3 |
+|Screen Resolution | 1024x768 | 1920x1080 |
 |Storage Free | 350 MB | 1.5 GB |
 
 ## Building from source

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -31,6 +31,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
+	// The minimal screen resolution requirements.
+	constexpr int minWidth = 1024;
+	constexpr int minHeight = 768;
+
 	SDL_Window *mainWindow = nullptr;
 	SDL_GLContext context = nullptr;
 	int width = 0;
@@ -110,15 +114,12 @@ bool GameWindow::Init(bool headless)
 			" The game will run more slowly.");
 
 	// Make the window just slightly smaller than the monitor resolution.
-	int minWidth = 640;
-	int minHeight = 480;
 	int maxWidth = mode.w;
 	int maxHeight = mode.h;
 	if(maxWidth < minWidth || maxHeight < minHeight)
-	{
-		ExitWithError("Monitor resolution is too small!");
-		return false;
-	}
+		Logger::LogError("Monitor resolution is too small! Minimal requirement is "
+			+ to_string(minWidth) + 'x' + to_string(minHeight)
+			+ ", while your resolution is " + to_string(maxWidth) + 'x' + to_string(maxHeight) + '.');
 
 	int windowWidth = maxWidth - 100;
 	int windowHeight = maxHeight - 100;


### PR DESCRIPTION
**Refactor**/**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
As per https://github.com/endless-sky/endless-sky/issues/1778#issuecomment-256499849, XGA is the expected minimal resolution for the game to be playable.
Additionally, for testing purposes, it is now possible to launch the game with resolution lower than required, still leaving a note about the problem in the error log.

## Testing Done
Changed my monitor's resolution to 640x480, and saw the logged error.

## Performance Impact
N/A