### PR TITLE
fix(ui): Allow the fixed starfield zoom preference to immediately update the menu background when the menu animation is disabled

### DIFF
--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -124,6 +124,8 @@ void MenuPanel::Step()
 		GameData::StepBackground(Point(xSpeed, yAmplitude * sin(animation * TO_RAD)));
 		animation += ySpeed;
 	}
+	else
+		GameData::StepBackground(Point());
 	if(GetUI()->IsTop(this) && !scrollingPaused)
 	{
 		scroll += scrollSpeed;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11493.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The reason for the bug is because the zoom of the starfield is updated by the StepBackground call, but StepBackground isn't called if the background animation is disabled. This PR makes it so that the StepBackground call is made even when the animation is disabled.

## Testing Done

Maybe.
