### PR TITLE
fix(ui): Use the small screen map buttons sooner to avoid overlapping UI elements

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1945,6 +1945,7 @@ interface "map buttons (small screen)" bottom right
 interface "map"
 	value "max zoom" 2
 	value "min zoom" -2
+	value "small screen width" 1300
 
 	anchor top
 	string "route error"

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1945,7 +1945,6 @@ interface "map buttons (small screen)" bottom right
 interface "map"
 	value "max zoom" 2
 	value "min zoom" -2
-	value "small screen width" 1300
 
 	anchor top
 	string "route error"

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -378,7 +378,8 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 		info.SetCondition("max zoom");
 	if(player.MapZoom() <= static_cast<int>(mapInterface->GetValue("min zoom")))
 		info.SetCondition("min zoom");
-	const Interface *mapButtonUi = GameData::Interfaces().Get(Screen::Width() < 1280
+	bool isSmallScreen = Screen::Width() < mapInterface->GetValue("small screen width");
+	const Interface *mapButtonUi = GameData::Interfaces().Get(isSmallScreen
 		? "map buttons (small screen)" : "map buttons");
 	mapButtonUi->Draw(info, this);
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -378,8 +378,7 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 		info.SetCondition("max zoom");
 	if(player.MapZoom() <= static_cast<int>(mapInterface->GetValue("min zoom")))
 		info.SetCondition("min zoom");
-	bool isSmallScreen = Screen::Width() < mapInterface->GetValue("small screen width");
-	const Interface *mapButtonUi = GameData::Interfaces().Get(isSmallScreen
+	const Interface *mapButtonUi = GameData::Interfaces().Get(Screen::Width() < 1300
 		? "map buttons (small screen)" : "map buttons");
 	mapButtonUi->Draw(info, this);
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11483.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Updated the screen width at which the small map buttons interface kicks in to <1300 pixels instead of <1280 pixels.

## Testing Done + Screenshots

This is the narrowest I can get my window without the small screen buttons kicking in. Note that there is no overlap between the shipyard button and the abort button, as can be see in the linked issue.
![image](https://github.com/user-attachments/assets/a8c7fc68-5668-48e9-97a2-93d27a394bbb)
Any narrower and it swaps over to the small buttons interface.
![image](https://github.com/user-attachments/assets/83b8ed6c-ea60-453d-90b3-0472d33212ea)
