### PR TITLE
fix(ui): Cache the days remaining for completing deadline missions

### DIFF
--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -191,7 +191,7 @@ bool MenuPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		return true;
 	}
 	else if(key == 'p')
-		GetUI()->Push(new PreferencesPanel());
+		GetUI()->Push(new PreferencesPanel(player));
 	else if(key == 'l' || key == 'm')
 		GetUI()->Push(new LoadPanel(player, gamePanels));
 	else if(key == 'n' && (!player.IsLoaded() || player.IsDead()))

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4245,7 +4245,7 @@ void PlayerInfo::CalculateRemainingDeadline(const Mission &mission, DistanceMap 
 	// If at any point a location can't be reached, it is ignored instead of treating
 	// it as if it has an infinite distance.
 	if(daysLeft > 0 && Preferences::Has("Deadline blink by distance")
-			&& here.HasRoute(*mission.Destination()->GetSystem()))
+		&& here.HasRoute(*mission.Destination()->GetSystem()))
 	{
 		set<const System *> toVisit;
 		for(const Planet *stopover : mission.Stopovers())

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -460,6 +460,8 @@ void PlayerInfo::Load(const filesystem::path &path)
 	ApplyChanges();
 	// Ensure the player is in a valid state after loading & applying changes.
 	ValidateLoad();
+	// Cache the remaining number of days for all deadline missions.
+	CalculateRemainingDeadlines();
 
 	// Restore access to services, if it was granted previously.
 	if(planet && hasFullClearance)
@@ -600,7 +602,7 @@ void PlayerInfo::FinishTransaction()
 
 
 // Apply the given set of changes to the game data.
-void PlayerInfo::AddChanges(list<DataNode> &changes)
+void PlayerInfo::AddChanges(list<DataNode> &changes, bool instantChanges)
 {
 	bool changedSystems = false;
 	for(const DataNode &change : changes)
@@ -623,6 +625,10 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 				if(!neighbor->Hidden() || system->Links().contains(neighbor))
 					seen.insert(neighbor);
 		}
+		// Update the deadline calculations for missions in case the system
+		// changes resulted in a change in DistanceMap calculations.
+		if(instantChanges)
+			CalculateRemainingDeadlines();
 	}
 
 	// Only move the changes into my list if they are not already there.
@@ -635,13 +641,13 @@ void PlayerInfo::AddChanges(list<DataNode> &changes)
 // Add an event that will happen at the given date.
 void PlayerInfo::AddEvent(GameEvent event, const Date &date)
 {
-	// Check if the event should be applied directly.
+	// Check if the event should be applied right now or scheduled for later.
 	if(date <= this->date)
 	{
 		GameEvent eventCopy = event;
 		list<DataNode> eventChanges = {eventCopy.Apply(*this)};
 		if(!eventChanges.empty())
-			AddChanges(eventChanges);
+			AddChanges(eventChanges, true);
 	}
 	else
 	{
@@ -797,6 +803,12 @@ void PlayerInfo::AdvanceDate(int amount)
 	// Reset the reload counters for all your ships.
 	for(const shared_ptr<Ship> &ship : ships)
 		ship->GetArmament().ReloadAll();
+
+	// Recalculate how many days you have left for deadline missions.
+	// We need to fully recalculate the number of days remaining instead of
+	// just reducing the cached values by 1 because the player may have
+	// explored new systems that change the DistanceMap calculations.
+	CalculateRemainingDeadlines();
 }
 
 
@@ -2088,6 +2100,24 @@ bool PlayerInfo::HasAvailableEnteringMissions() const
 
 
 
+void PlayerInfo::CalculateRemainingDeadlines()
+{
+	remainingDeadlines.clear();
+	DistanceMap here(*this, system);
+	for(const Mission &mission : missions)
+		CalculateRemainingDeadline(mission, here);
+}
+
+
+
+int PlayerInfo::RemainingDeadline(const Mission &mission) const
+{
+	auto it = remainingDeadlines.find(&mission);
+	return it == remainingDeadlines.end() ? 0 : it->second;
+}
+
+
+
 const PlayerInfo::SortType PlayerInfo::GetAvailableSortType() const
 {
 	return availableSortType;
@@ -2373,6 +2403,11 @@ void PlayerInfo::MissionCallback(int response)
 	if(response == Conversation::ACCEPT || response == Conversation::LAUNCH)
 	{
 		bool shouldAutosave = mission.RecommendsAutosave();
+		if(mission.Deadline())
+		{
+			DistanceMap here(*this, system);
+			CalculateRemainingDeadline(mission, here);
+		}
 		if(planet)
 		{
 			cargo.AddMissionCargo(&mission);
@@ -4197,6 +4232,55 @@ void PlayerInfo::SortAvailable()
 
 	if(!availableSortAsc)
 		availableJobs.reverse();
+}
+
+
+
+void PlayerInfo::CalculateRemainingDeadline(const Mission &mission, DistanceMap &here)
+{
+	if(!mission.Deadline())
+		return;
+
+	int daysLeft = mission.Deadline() - GetDate() + 1;
+	// If at any point a location can't be reached, it is ignored instead of treating
+	// it as if it has an infinite distance.
+	if(daysLeft > 0 && Preferences::Has("Deadline blink by distance")
+			&& here.HasRoute(*mission.Destination()->GetSystem()))
+	{
+		set<const System *> toVisit;
+		for(const Planet *stopover : mission.Stopovers())
+		{
+			if(here.HasRoute(*stopover->GetSystem()))
+				toVisit.insert(stopover->GetSystem());
+			// Stopovers require you to land on a planet, which takes an extra day.
+			--daysLeft;
+		}
+		for(const System *waypoint : mission.Waypoints())
+			if(here.HasRoute(*waypoint))
+				toVisit.insert(waypoint);
+
+		// This is a traveling salesman problem. Estimate the minimum number
+		// of days that it would take to reach every point of interest by
+		// traveling to the next closest location after each step.
+		DistanceMap distance = here;
+		int systemCount = toVisit.size();
+		for(int i = 0; i < systemCount; ++i)
+		{
+			const System *closest;
+			int minimalDist = numeric_limits<int>::max();
+			for(const System *sys : toVisit)
+				if(distance.Days(*sys) < minimalDist)
+				{
+					closest = sys;
+					minimalDist = distance.Days(*sys);
+				}
+			daysLeft -= distance.Days(*closest);
+			distance = DistanceMap(*this, closest);
+			toVisit.erase(closest);
+		}
+		daysLeft -= distance.Days(*mission.Destination()->GetSystem());
+	}
+	remainingDeadlines[&mission] = daysLeft;
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -37,6 +37,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 #include <vector>
 
+class DistanceMap;
 class Outfit;
 class Planet;
 class RaidFleet;
@@ -98,7 +99,7 @@ public:
 	void FinishTransaction();
 
 	// Apply the given changes and store them in the player's saved game file.
-	void AddChanges(std::list<DataNode> &changes);
+	void AddChanges(std::list<DataNode> &changes, bool instantChanges = false);
 	// Add an event that will happen at the given date.
 	void AddEvent(GameEvent event, const Date &date);
 
@@ -218,6 +219,16 @@ public:
 	const std::list<Mission> &Missions() const;
 	const std::list<Mission> &AvailableJobs() const;
 	bool HasAvailableEnteringMissions() const;
+
+	// Determine how many days left the player has for each mission with a deadline, for
+	// the purpose of determining how frequently the MapPanel should blink the mission
+	// marker.
+	void CalculateRemainingDeadlines();
+	// The number of days left before this mission's deadline has elapsed, or,
+	// if the "Deadline blink by distance" preference is true, before the player
+	// doesn't have enough days left to complete the mission before the deadline
+	// will elapse. Returns 0 if the give mission doesn't have a deadline.
+	int RemainingDeadline(const Mission &mission) const;
 
 	enum SortType {ABC, PAY, SPEED, CONVENIENT};
 	const SortType GetAvailableSortType() const;
@@ -362,6 +373,8 @@ private:
 
 	// New missions are generated each time you land on a planet.
 	void CreateMissions();
+	// Add a mission that was just accepted to the cached remaining deadlines.
+	void CalculateRemainingDeadline(const Mission &mission, DistanceMap &here);
 	void StepMissions(UI *ui);
 	void Autosave() const;
 	void Save(const std::string &path) const;
@@ -444,6 +457,11 @@ private:
 	// This pointer to the most recently accepted boarding/assisting/entering mission
 	// enables its NPCs to be placed before the player lands, and is then cleared.
 	Mission *activeInFlightMission = nullptr;
+	// For each active mission with a deadline, calculate how many days the player
+	// has left to compelete the mission. The number of days remaining is reduced
+	// by the number of days of travel it will take to complete the mission if the
+	// "Deadline blink by distance" preference is true.
+	std::map<const Mission *, int> remainingDeadlines;
 	// How to sort availableJobs
 	bool availableSortAsc = true;
 	SortType availableSortType;

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -77,7 +77,7 @@ private:
 
 private:
 	PlayerInfo &player;
-	// Determine if the player's mission deadlines need recached when
+	// Determine if the player's mission deadlines need to be recached when
 	// this panel is closed due to the deadline blink preference changing.
 	bool recacheDeadlines = false;
 

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+class PlayerInfo;
 class RenderBuffer;
 struct Plugin;
 
@@ -35,7 +36,7 @@ struct Plugin;
 // UI panel for editing preferences, especially the key mappings.
 class PreferencesPanel : public Panel {
 public:
-	PreferencesPanel();
+	PreferencesPanel(PlayerInfo &player);
 	virtual ~PreferencesPanel();
 
 	// Draw this panel.
@@ -75,6 +76,11 @@ private:
 
 
 private:
+	PlayerInfo &player;
+	// Determine if the player's mission deadlines need recached when
+	// this panel is closed due to the deadline blink preference changing.
+	bool recacheDeadlines = false;
+
 	int editing;
 	int selected;
 	int hover;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11351

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

As noted in the linked issue, a DistanceMap calculation was being made every frame when the "Deadline blink by distance" preference was set to true and you were looking at the map, or the minimap when jumping had a deadline mission nearby. When using a plugin jump drive with a large jump range, this calculation becomes extremely expensive.

This PR changes it so that this calculation is cached whenever a new deadline mission is accepted, and it is recalculated for all current deadline missions whenever...
1. the day changes,
2. the map is opened while you're landed on a planet (since you could have changed your flagship's jump capabilities),
3. whenever the preference is changed in the preferences panel, or
4. a zero-day event causes all system neighbors to be recalculated.

## Testing Done

Used the dev drive from World Forge and accepted an escort mission with a deadline. Observed that on the master branch, opening the map results in intense lag. Using this PR, the lag is gone. Observed that toggling the preference, removing the dev drive from my ship, and jumping between systems all properly update the blink rate of the mission destination marker.
