### PR TITLE
fix(ui): New, robust truncation functions used in DisplayText

### DIFF
--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -414,6 +414,40 @@ string Font::TruncateText(const DisplayText &text, int &width) const
 }
 
 
+
+string Font::TruncateBack(const string &str, int &width) const
+{
+	return TruncateEndsOrMiddle(str, width,
+		[](const string &str, int charCount)
+		{
+			return str.substr(0, charCount) + "...";
+		});
+}
+
+
+
+string Font::TruncateFront(const string &str, int &width) const
+{
+	return TruncateEndsOrMiddle(str, width,
+		[](const string &str, int charCount)
+		{
+			return "..." + str.substr(str.size() - charCount);
+		});
+}
+
+
+
+string Font::TruncateMiddle(const string &str, int &width) const
+{
+	return TruncateEndsOrMiddle(str, width,
+		[](const string &str, int charCount)
+		{
+			return str.substr(0, (charCount + 1) / 2) + "..." + str.substr(str.size() - charCount / 2);
+		});
+}
+
+
+
 string Font::TruncateEndsOrMiddle(const string &str, int &width,
 	function<string(const string &, int)> getResultString) const
 {
@@ -447,37 +481,4 @@ string Font::TruncateEndsOrMiddle(const string &str, int &width,
 	}
 	width = workingWidth;
 	return getResultString(str, workingChars);
-}
-
-
-
-string Font::TruncateBack(const string &str, int &width) const
-{
-	return TruncateEndsOrMiddle(str, width,
-		[](const string &str, int charCount)
-		{
-			return str.substr(0, charCount) + "...";
-		});
-}
-
-
-
-string Font::TruncateFront(const string &str, int &width) const
-{
-	return TruncateEndsOrMiddle(str, width,
-		[](const string &str, int charCount)
-		{
-			return "..." + str.substr(str.size() - charCount);
-		});
-}
-
-
-
-string Font::TruncateMiddle(const string &str, int &width) const
-{
-	return TruncateEndsOrMiddle(str, width,
-		[](const string &str, int charCount)
-		{
-			return str.substr(0, (charCount + 1) / 2) + "..." + str.substr(str.size() - charCount / 2);
-		});
 }

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -454,7 +454,8 @@ string Font::TruncateEndsOrMiddle(const string &str, int &width,
 string Font::TruncateBack(const string &str, int &width) const
 {
 	return TruncateEndsOrMiddle(str, width,
-		[](const string &str, int charCount) {
+		[](const string &str, int charCount)
+		{
 			return str.substr(0, charCount) + "...";
 		});
 }

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -443,9 +443,7 @@ string Font::TruncateEndsOrMiddle(const string &str, int &width,
 			low = nextChars + (nextChars == low);
 		}
 		else
-		{
 			high = nextChars - 1;
-		}
 	}
 	width = workingWidth;
 	return getResultString(str, workingChars);

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -414,9 +414,8 @@ string Font::TruncateText(const DisplayText &text, int &width) const
 }
 
 
-string Font::TruncateEndsOrMiddle(
-	const string &str, int &width,
-	std::function<std::string(const std::string&, int)> getResultString) const
+string Font::TruncateEndsOrMiddle(const string &str, int &width,
+	function<string(const string &, int)> getResultString) const
 {
 	int firstWidth = WidthRawString(str.c_str());
 	if(firstWidth <= width)

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -430,7 +430,8 @@ string Font::TruncateEndsOrMiddle(const string &str, int &width,
 	int low = 0, high = str.size() - 1;
 	while(low <= high)
 	{
-		int nextChars = (low + high) / 2; // Think "how many chars to take from both ends, omitting in the middle"
+		// Think "how many chars to take from both ends, omitting in the middle".
+		int nextChars = (low + high) / 2;
 		int nextWidth = WidthRawString(getResultString(str, nextChars).c_str());
 		if(nextWidth <= width)
 		{

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -476,7 +476,8 @@ string Font::TruncateFront(const string &str, int &width) const
 string Font::TruncateMiddle(const string &str, int &width) const
 {
 	return TruncateEndsOrMiddle(str, width,
-		[](const string &str, int charCount) {
+		[](const string &str, int charCount)
+		{
 			return str.substr(0, (charCount + 1) / 2) + "..." + str.substr(str.size() - charCount / 2);
 		});
 }

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -440,7 +440,7 @@ string Font::TruncateEndsOrMiddle(
 				workingChars = nextChars;
 				workingWidth = nextWidth;
 			}
-			low = nextChars + (nextChars == low ? 1 : 0);
+			low = nextChars + (nextChars == low);
 		}
 		else
 		{

--- a/source/text/Font.cpp
+++ b/source/text/Font.cpp
@@ -465,7 +465,8 @@ string Font::TruncateBack(const string &str, int &width) const
 string Font::TruncateFront(const string &str, int &width) const
 {
 	return TruncateEndsOrMiddle(str, width,
-		[](const string &str, int charCount) {
+		[](const string &str, int charCount)
+		{
 			return "..." + str.substr(str.size() - charCount);
 		});
 }

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -73,9 +73,8 @@ private:
 	std::string TruncateFront(const std::string &str, int &width) const;
 	std::string TruncateMiddle(const std::string &str, int &width) const;
 
-	std::string TruncateEndsOrMiddle(
-		const std::string &str, int &width,
-		std::function<std::string(const std::string&, int)> getResultString) const;
+	std::string TruncateEndsOrMiddle(const std::string &str, int &width,
+		std::function<std::string(const std::string &, int)> getResultString) const;
 
 private:
 	const Shader *shader;

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "../opengl.h"
 
 #include <filesystem>
+#include <functional>
 #include <string>
 
 class Color;
@@ -72,6 +73,20 @@ private:
 	std::string TruncateFront(const std::string &str, int &width) const;
 	std::string TruncateMiddle(const std::string &str, int &width) const;
 
+	/**
+	 *  Private common implementation for:
+	 *  	@ref Font::TruncateBack, @ref Font::TruncateFront, @ref Font::TruncateMiddle
+	 *  @param str the string to fit in a given layout space
+	 *  @param width (input/output) the available layout width, returns actual truncated string width
+	 *  @param getResultString a lambda taking the original string and a desired character count
+	 *  		(not including the ellipsis), returning the truncation result
+	 *  		(differentiating the Back/Middle/Front functions)
+	 *  @return A truncated string using ellipsis replacing parts of the original that best-fits in the original width
+	 *  		(if the input string already fits, it's returned unchanged)
+	 */
+	std::string TruncateEndsOrMiddle(
+		const std::string &str, int &width,
+		std::function<std::string(const std::string&, int)> getResultString) const;
 
 private:
 	const Shader *shader;

--- a/source/text/Font.h
+++ b/source/text/Font.h
@@ -73,17 +73,6 @@ private:
 	std::string TruncateFront(const std::string &str, int &width) const;
 	std::string TruncateMiddle(const std::string &str, int &width) const;
 
-	/**
-	 *  Private common implementation for:
-	 *  	@ref Font::TruncateBack, @ref Font::TruncateFront, @ref Font::TruncateMiddle
-	 *  @param str the string to fit in a given layout space
-	 *  @param width (input/output) the available layout width, returns actual truncated string width
-	 *  @param getResultString a lambda taking the original string and a desired character count
-	 *  		(not including the ellipsis), returning the truncation result
-	 *  		(differentiating the Back/Middle/Front functions)
-	 *  @return A truncated string using ellipsis replacing parts of the original that best-fits in the original width
-	 *  		(if the input string already fits, it's returned unchanged)
-	 */
 	std::string TruncateEndsOrMiddle(
 		const std::string &str, int &width,
 		std::function<std::string(const std::string&, int)> getResultString) const;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11286
Redo of #11308
Replaces #11484 

## Acknowledgement
- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Reimplements the three `Font::TruncateSomewhere` functions using a binary search approach. Prevents issues with border cases.
(See discussions in previous issues/PRs).

## Screenshots
<details>

Input in the snapshot name dialog:
```
3017-04-29ajksololdJOIDJoasidjoAIJSDOIajdpoiAJDPOIJaosdijAPOIDJOaijdoAIJDOaijsdopiAJDPOiajdoijASODIJaopisdjAPOIJSDPOaijsdpoAIJSDPOiajsdopiAJDSMMMMMMMMMMMMMMMMMMMM........................
```
Using `zoom 150` on a 2560x1440 display on Mint 22.1 cinnamon.

Before (lazy, running a compile from end of April):
![image](https://github.com/user-attachments/assets/fab46bd3-3827-48f3-b3be-5eef544291ae)

After:
![image](https://github.com/user-attachments/assets/8a869058-9edc-4aaf-8ed9-360e404fcbf4)

Video from #11484 showcasing that dialog hacked to `Truncate::MIDDLE`:
https://github.com/user-attachments/assets/73875762-18f9-4d04-86c8-63ddf27ed1fb

</details>

## Testing Done
- Tried to fill new-game pilot name fields to the brim with varying inputs - no crash, looks fine.
- See screenshots

## Performance Impact
N/A - I don't think text display is perf-crit anywhere

## Notes
- There's a half-hidden thingy to notice: When the functions were discrete copies, the loop wasn't measuring the ellipses assuming their contribution to be constant, and handling kerning using the `after` parameter of the measurement function. That holds up OK until you get to TruncateMiddle - that one did the same, but kerning can't be properly/precisely predicted that way when the ellipses are in the middle. So I dropped that mini-optimization, and afterwards the entire "binary search" part can be identical for all three Truncate settings. The perf loss is negligible and probably more than balanced by the lower binary search loop count - though I didn't measure any of that. Readability suffers a bit thanks to the clear and obvious C++ lambda notation, but it's worth it imo.
- ~The doc on that function is maybe over the top~ Nope - `check_code_style.py` hates it, will have to go. Insisting on a trailing blank on a source line? Not on my turf.
- The function _name_ is likewise open for suggestions - be glad I _didn't_ actually name it `TruncateSomewhere`.
- The diff here is not really readable, try the raw file view instead. It's all at the end of the file.