### PR TITLE
feat(balance): Decouple the effects of scrambling from energy

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -212,9 +212,11 @@ namespace {
 	// The scale is such that a weapon with a scrambling damage of 6 and a reload
 	// of 60 (i.e. the ion cannon) will approximately have an 9.5% of jamming its
 	// target, while seven of those same weapons will have a 50% chance of jamming.
+	// Very small amounts of scrambling are ignored, to prevent weapons from jamming
+	// well after combat has ended.
 	double CalculateJamChance(double scrambling)
 	{
-		return scrambling ? 1. - pow(2., -1. * (scrambling / 70.)) : 1.;
+		return scrambling > .1 ? 1. - pow(2., -1. * (scrambling / 70.)) : 0.;
 	}
 }
 


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Scrambling damage was first introduced as an additional effect of ion damage; the higher the ionisation and lower the victim's energy reserves, the higher the chance of jamming. This behaviour was eventually split off into its own attribute, but the old formula was retained, making scrambling damage still somewhat dependent on ion damage in a lot of cases.

This PR makes the following changes:
- **Completely remove energy from the jamming equation.** This should make scrambling damage easier to work with, 
- **Have jamming chance scale non-linearly.** This prevents scrambling damage from being too oppressive when used en mass without making it useless at smaller scales.
- **Remove the 50% jamming cap.** Existing scrambling weaponry don't deal enough scrambling damage to reach this threshold anyway (unless you're also crippling their energy and/or health at the same time), and I don't see a good reason to cap it when we have absolute control over how much scrambling damage a weapon can deal.

Overall, against a target with full energy reserves, scrambling damage is roughly twice as effective than before (or, to put it in another perspective, it's as effective as if the target was permanently at half energy capacity).

## Testing Done
Tested fights against different ships with different amounts of scramble damage on weaponry. Saw the expected DPS reduction in all cases.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/151

## Performance Impact
Ships that have taken scramble damage run `pow(...)` every frame that they attempt to fire their weapons.
