### PR TITLE
Graveyard gas giants

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -247,7 +247,7 @@ planet Anitlos
 
 planet Antamesa
 	attributes "gas giant" "requires: gaslining" uninhabited
-	landscape land/nasa31
+	landscape land/nasa24
 	description `The planet’s tempest winds thrum beneath vibrant emerald and velvet auroras that flare like curtains aflame. Derelict stations sprawl across its skies, a single flank of each bristling with empty missile tubes. A handful remain semi-intact, casting warm, rosy halos against the swirling clouds, launchers still baring skyward at forgotten foes.`
 	government Uninhabited
 	security 0
@@ -474,7 +474,7 @@ planet Bailey
 
 planet Baliesa
 	attributes "gas giant" "requires: gaslining" uninhabited
-	landscape land/nasa26
+	landscape land/nasa33
 	description `One of the smallest "Hot Jupiters" known, Baliesa is a calm, undemanding gas giant. Occasional storms form near the terminator line between the night and day side, but soon split in smaller and smaller vortexes until they disappear. The violet-tinted skies of the upper atmosphere leave space to a bright pink-colored haze below, hampering visual navigation but otherwise not causing any trouble.`
 	government Uninhabited
 	security 0
@@ -1708,7 +1708,7 @@ planet "Factory of Eblumab"
 
 planet Faliete
 	attributes "gas giant" "requires: gaslining" uninhabited
-	landscape land/nasa14
+	landscape land/nasa36
 	description `Veiled behind roiling storms, the silhouette of an enormous structure is suspended within the planet’s upper clouds. Automated drones swarm the complex like moths to a flame, carrying raw components to mysterious ends. Occasionally, the factory disgorges vast slabs of smoky glass and metallic alloy. They glint in the dim light as they flutter downwards, fracturing into ever-smaller mosaics of scrap as they descend.`
 	description `	By the time these expansive sheets reach the lower atmosphere, they are little more than incandescent fragments, casting a constant, shimmering glow across the sky.`
 	government Uninhabited
@@ -4393,7 +4393,7 @@ planet Passaritus
 
 planet Pathera
 	attributes "gas giant" "requires: gaslining" uninhabited
-	landscape land/nasa24
+	landscape land/nasa14
 	description `The planet’s upper bands contain an unusually high concentration of rainbow-hued micrometeoroids, leaving ghostly trails in their wake. Rising thermal columns glow in a delicate pink as they carry some of the debris upwards.`
 	government Uninhabited
 	security 0

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -3405,7 +3405,7 @@ planet Melenci
 
 planet Meligara
 	attributes "gas giant" "requires: gaslining" uninhabited
-	landscape land/nasa22
+	landscape land/nasa41
 	description `Of the three gas giants that orbit around Ritilas, Meligara is by far the closest to the lavender wormholes. The small distance made it inevitable for the two to influence each other: the gas giant has no major moon, and even its ring visibly tend to incline and become elliptical when the wormhole is at its closest.`
 	description `	Its thick clouds make it nearly impossible to navigate through the lower atmosphere, echoing strange readings in every direction.`
 	government Uninhabited

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -245,6 +245,13 @@ planet Anitlos
 	description `	The other moons of Oura, while not quite as rich as Anitlos, are nonetheless a bounty of rare materials. Notably, rare elements like boron and beryllium, only produced by cosmic ray spallation of elements like oxygen, are produced at elevated rates in the ice of certain moons due to the trapping of charged particles by Oura's magnetic field.`
 	government Uninhabited
 
+planet Antamesa
+	attributes "gas giant" "requires: gaslining" uninhabited
+	landscape land/nasa31
+	description `The planet’s tempest winds thrum beneath vibrant emerald and velvet auroras that flare like curtains aflame. Derelict stations sprawl across its skies, a single flank of each bristling with empty missile tubes. A handful remain semi-intact, casting warm, rosy halos against the swirling clouds, launchers still baring skyward at forgotten foes.`
+	government Uninhabited
+	security 0
+
 planet Antipode
 	attributes core frontier frozen mining
 	landscape land/snow17
@@ -464,6 +471,13 @@ planet Bailey
 	tribute 300
 		threshold 1500
 		fleet "Small CCOR" 11
+
+planet Baliesa
+	attributes "gas giant" "requires: gaslining" uninhabited
+	landscape land/nasa26
+	description `One of the smallest "Hot Jupiters" known, Baliesa is a calm, undemanding gas giant. Occasional storms form near the terminator line between the night and day side, but soon split in smaller and smaller vortexes until they disappear. The violet-tinted skies of the upper atmosphere leave space to a bright pink-colored haze below, hampering visual navigation but otherwise not causing any trouble.`
+	government Uninhabited
+	security 0
 
 planet "Bank of Blugtad"
 	attributes arach urban wealthy
@@ -1691,6 +1705,14 @@ planet "Factory of Eblumab"
 	"required reputation" 15
 	bribe 0
 	security 0.2
+
+planet Faliete
+	attributes "gas giant" "requires: gaslining" uninhabited
+	landscape land/nasa14
+	description `Veiled behind roiling storms, the silhouette of an enormous structure is suspended within the planet’s upper clouds. Automated drones swarm the complex like moths to a flame, carrying raw components to mysterious ends. Occasionally, the factory disgorges vast slabs of smoky glass and metallic alloy. They glint in the dim light as they flutter downwards, fracturing into ever-smaller mosaics of scrap as they descend.`
+	description `	By the time these expansive sheets reach the lower atmosphere, they are little more than incandescent fragments, casting a constant, shimmering glow across the sky.`
+	government Uninhabited
+	security 0
 
 planet "Far Garden"
 	attributes farming saryd tourism urban
@@ -3381,6 +3403,14 @@ planet Melenci
 	bribe 0
 	security 0
 
+planet Meligara
+	attributes "gas giant" "requires: gaslining" uninhabited
+	landscape land/nasa22
+	description `Of the three gas giants that orbit around Ritilas, Meligara is by far the closest to the lavender wormholes. The small distance made it inevitable for the two to influence each other: the gas giant has no major moon, and even its ring visibly tend to incline and become elliptical when the wormhole is at its closest.`
+	description `	Its thick clouds make it nearly impossible to navigate through the lower atmosphere, echoing strange readings in every direction.`
+	government Uninhabited
+	security 0
+
 planet Memory
 	attributes deep factory medical research
 	landscape land/badlands9-harro
@@ -4360,6 +4390,13 @@ planet Passaritus
 	description `Decades ago, Passaritus was the subject of an ambitious project by the Deep to mine metallic hydrogen from its mantle. Being barely large enough to form metallic hydrogen in the first place, the gas giant's gravity was thought to be low enough to make extraction feasible. Unfortunately, the Deep had overestimated their ability to build an extraction device that was not only functional, but economical, and the project has since been moved to the backburner.`
 	description `	Passaritus still happens to be an interesting locale to visit, at least if you have a gaslined ship. Its small size and relatively rapid rotation gives it sweeping bands of color, each corresponding to a different layer or wind speed, and the lower gravity allows updrafts to carry your ship upwards for kilometers.`
 	government Uninhabited
+
+planet Pathera
+	attributes "gas giant" "requires: gaslining" uninhabited
+	landscape land/nasa24
+	description `The planet’s upper bands contain an unusually high concentration of rainbow-hued micrometeoroids, leaving ghostly trails in their wake. Rising thermal columns glow in a delicate pink as they carry some of the debris upwards.`
+	government Uninhabited
+	security 0
 
 planet Pearl
 	attributes forest medical paradise tourism

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -248,7 +248,7 @@ planet Anitlos
 planet Antamesa
 	attributes "gas giant" "requires: gaslining" uninhabited
 	landscape land/nasa24
-	description `The planet’s tempest winds thrum beneath vibrant emerald and velvet auroras that flare like curtains aflame. Derelict stations sprawl across its skies, a single flank of each bristling with empty missile tubes. A handful remain semi-intact, casting warm, rosy halos against the swirling clouds, launchers still baring skyward at forgotten foes.`
+	description `The planet's tempest winds thrum beneath vibrant emerald and velvet auroras that flare like curtains aflame. Derelict stations sprawl across its skies, a single flank of each bristling with empty missile tubes. A handful remain semi-intact, casting warm, rosy halos against the swirling clouds, launchers still baring skyward at forgotten foes.`
 	government Uninhabited
 	security 0
 
@@ -1709,7 +1709,7 @@ planet "Factory of Eblumab"
 planet Faliete
 	attributes "gas giant" "requires: gaslining" uninhabited
 	landscape land/nasa36
-	description `Veiled behind roiling storms, the silhouette of an enormous structure is suspended within the planet’s upper clouds. Automated drones swarm the complex like moths to a flame, carrying raw components to mysterious ends. Occasionally, the factory disgorges vast slabs of smoky glass and metallic alloy. They glint in the dim light as they flutter downwards, fracturing into ever-smaller mosaics of scrap as they descend.`
+	description `Veiled behind roiling storms, the silhouette of an enormous structure is suspended within the planet's upper clouds. Automated drones swarm the complex like moths to a flame, carrying raw components to mysterious ends. Occasionally, the factory disgorges vast slabs of smoky glass and metallic alloy. They glint in the dim light as they flutter downwards, fracturing into ever-smaller mosaics of scrap as they descend.`
 	description `	By the time these expansive sheets reach the lower atmosphere, they are little more than incandescent fragments, casting a constant, shimmering glow across the sky.`
 	government Uninhabited
 	security 0
@@ -4394,7 +4394,7 @@ planet Passaritus
 planet Pathera
 	attributes "gas giant" "requires: gaslining" uninhabited
 	landscape land/nasa14
-	description `The planet’s upper bands contain an unusually high concentration of rainbow-hued micrometeoroids, leaving ghostly trails in their wake. Rising thermal columns glow in a delicate pink as they carry some of the debris upwards.`
+	description `The planet's upper bands contain an unusually high concentration of rainbow-hued micrometeoroids, leaving ghostly trails in their wake. Rising thermal columns glow in a delicate pink as they carry some of the debris upwards.`
 	government Uninhabited
 	security 0
 

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -475,7 +475,7 @@ planet Bailey
 planet Baliesa
 	attributes "gas giant" "requires: gaslining" uninhabited
 	landscape land/nasa33
-	description `One of the smallest "Hot Jupiters" known, Baliesa is a calm, undemanding gas giant. Occasional storms form near the terminator line between the night and day side, but soon split in smaller and smaller vortexes until they disappear. The violet-tinted skies of the upper atmosphere leave space to a bright pink-colored haze below, hampering visual navigation but otherwise not causing any trouble.`
+	description `One of the smallest "Hot Jupiters" known, Baliesa is a calm, undemanding gas giant. Occasional storms form near the terminator line between the night and day side, but soon split into smaller and smaller vortexes until they disappear. The violet-tinted skies of the upper atmosphere leave space to a bright pink-colored haze below, hampering visual navigation but otherwise not causing any trouble.`
 	government Uninhabited
 	security 0
 
@@ -3406,7 +3406,7 @@ planet Melenci
 planet Meligara
 	attributes "gas giant" "requires: gaslining" uninhabited
 	landscape land/nasa41
-	description `Of the three gas giants that orbit around Ritilas, Meligara is by far the closest to the lavender wormholes. The small distance made it inevitable for the two to influence each other: the gas giant has no major moon, and even its ring visibly tend to incline and become elliptical when the wormhole is at its closest.`
+	description `Of the three gas giants that orbit around Ritilas, Meligara is by far the closest to the lavender wormholes. The small distance made it inevitable for the two to influence each other: the gas giant has no major moon, and even its ring visibly tends to incline and become elliptical when the wormhole is at its closest.`
 	description `	Its thick clouds make it nearly impossible to navigate through the lower atmosphere, echoing strange readings in every direction.`
 	government Uninhabited
 	security 0

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -12464,7 +12464,7 @@ system Delia
 		distance 748.5
 		period 370.040
 	object Faliete
-		sprite planet/gas12-b
+		sprite planet/gas10-b
 		distance 2258.66
 		period 1939.71
 		object

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -12464,7 +12464,7 @@ system Delia
 		distance 748.5
 		period 370.040
 	object Faliete
-		sprite planet/gas11
+		sprite planet/gas12-b
 		distance 2258.66
 		period 1939.71
 		object

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -12463,7 +12463,7 @@ system Delia
 		sprite planet/desert9-b
 		distance 748.5
 		period 370.040
-	object
+	object Faliete
 		sprite planet/gas11
 		distance 2258.66
 		period 1939.71
@@ -16742,7 +16742,7 @@ system Fereti
 			scale 0.5
 		distance 1687.04
 		period 489.974
-	object
+	object Pathera
 		sprite planet/gas2
 		distance 2166.29
 		period 712.951
@@ -18192,7 +18192,7 @@ system Gerenus
 	object
 		sprite star/k-giant
 		period 10
-	object
+	object Baliesa
 		sprite planet/gas4-hot
 		distance 390.558
 		period 56.3673
@@ -32063,7 +32063,7 @@ system Polerius
 		sprite planet/wormhole-red
 		distance 1824.15
 		period 691.676
-	object
+	object Antamesa
 		sprite planet/gas14-b
 		distance 2448.24
 		period 1075.45
@@ -34207,7 +34207,7 @@ system Ritilas
 		sprite planet/wormhole
 		distance 1666
 		period 868.879
-	object
+	object Meligara
 		sprite planet/gas6
 		distance 2320
 		period 1427.83


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR makes gas giants landable in the Graveyard: Antamesa, Baliesa, Faliete, Meligara and Pathera. This makes it somewhat more dense than most of the galaxy in that, but the same can be said about the Ember Wastes and they are planned to be used by the Remnant in a number of missions - especially the north, which is why I tried to put three there. The only change to the systems themselves was swapping the sprite of the gas giant in Delia, as it was yet another blue gas giant (like the other 4) and I wanted some more variety. No major lore implications, but they elaborate a bit on other plot points relevant to the area they are in. Huge thanks to reticent-rem for writing three of these descriptions!

Note: some of the landscapes used are from https://github.com/endless-sky/endless-sky/pull/11490 , which means it cannot be merged until that PR is in or until they are switched to other pictures

## Screenshots
Distribution:
![image](https://github.com/user-attachments/assets/d11261c3-3a50-4b17-885b-e0e4c07700e6)
