### PR TITLE
Disallow Project Hawking during Deep: TMBR

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1045,6 +1045,8 @@ mission "Deep: Project Hawking"
 	to offer
 		random < 40
 		has "Deep: Mystery Cubes 4: done"
+		not "Deep: TMBR 0: active"
+		not "Deep: TMBR 1: active"
 		or
 			not "chosen sides"
 			has "main plot completed"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11504

## Acknowledgement

- [ X ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Diallows Project Hawking, where you transport Garrison, Pierre, Laura and Hannah around to gather materials, from offering while you have the TMBR mission active, which has you take There Might Be Riots to the same scientists on Midgard.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Landed a couple times on Valhalla and checked spaceport. No Project Hawking.

## Save File
This save file can be used to test these changes:
[Lerantsta Fish~hawkingtesting.txt](https://github.com/user-attachments/files/20594994/Lerantsta.Fish.hawkingtesting.txt)

## Artwork Checklist
(If any artwork was added or changed by this PR, the following must be provided.)
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}

## Wiki Update
(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)

## Performance Impact
None
