### PR TITLE
feat(content): Let the TMBR missions be completed without requiring Deep Archaeology

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -1150,7 +1150,7 @@ mission "There Might Be Riots part 3B"
 		personality heroic nemesis
 		fleet
 			variant
-				"Combat Drone" 15
+				"Combat Drone" 5
 	npc
 		government "Team Red"
 		personality waiting heroic
@@ -1162,7 +1162,7 @@ mission "There Might Be Riots part 3B"
 		personality waiting heroic
 		fleet
 			variant
-				"Combat Drone" 35
+				"Combat Drone" 25
 	
 	on visit
 		dialog `You arrive on <planet>, but realize that your escort carrying the band and their supplies has not arrived yet. Better depart and wait for your escorts to enter the system.`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -974,7 +974,6 @@ mission "There Might Be Riots part 2"
 	passengers 8
 	to offer
 		has "There Might Be Riots 1: done"
-		has "Deep Archaeology 5: done"
 		random < 30
 	
 	on offer

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -364,6 +364,24 @@ mission "Sad Archie"
 
 
 
+mission "Rim Archaeology Reminder"
+	landing
+	non-blocking
+	name "Foster's Assistance?"
+	description "Head to <destination> and see if Albert Foster can help uncover Zug's mystery."
+	source
+		not planet "Vinci"
+	destination "Vinci"
+	to offer
+		not "archaeology before TMBR"
+		has "Deep Archaeology 5: done"
+	on offer
+		conversation
+			`As your ship settles down on <origin>, you recall the visions of an alien civilization you experienced while in Ildaria, and how the terrain you saw resembled the landscape of Zug. Perhaps Foster can help you investigate further.` 
+				accept
+
+
+
 mission "Rim Archaeology 1"
 	landing
 	name "Archaeology on <planet>"
@@ -371,8 +389,13 @@ mission "Rim Archaeology 1"
 	source "Vinci"
 	destination "Zug"
 	passengers 1
+	blocked `You consider telling Albert Foster about your findings on Zug, but realize that you don't have a bunk free to take him there! Return when you have free space.`
 	to offer
 		has "Sad Archie: done"
+		has "Deep Archaeology 5: done"
+		or
+			has "archaeology before TMBR"
+			has "Rim Archaeology Reminder: offered"
 	
 	on offer
 		conversation
@@ -383,10 +406,10 @@ mission "Rim Archaeology 1"
 					defer
 			branch recent
 				not "archaeology before TMBR"
-			`	Foster seems glad to see you. "It's been a while, <first>. Has something caught your eye recently?"`
+			`	Foster seems glad to see you. "It's been a while, <first>. Something catch your eye recently?"`
 				goto interest
 			label recent
-			`	Foster is slightly surprised by your arrival. "Sorry to say, but I haven't made any progress with the Deep since we last talked. Unless you have something else you want to tell me about?"`
+			`	Foster is slightly surprised by your arrival. "My apologies, but I haven't made any progress in the Deep since we last talked. Unless you have something else for me?"`
 			label interest
 			`	You do your best to pique his interest without saying anything that will make him think you're crazy, but he's clearly not buying it. "I'm sorry," he says, "but I'm not mounting an expedition just because you have a 'hunch.' So unless you're willing to tell me the source of your information, I'm not interested." He turns his attention back to the data pad that he was reading before you walked into his office.`
 			choice

--- a/data/sheragi/archaeology missions.txt
+++ b/data/sheragi/archaeology missions.txt
@@ -355,6 +355,11 @@ mission "Sad Archie"
 	on complete
 		log `Experienced a strange vision while drifting in the Ildaria system that looked like the fall of a civilization of dragon-people. The terrain on the planet of Zug looks strikingly similar to this vision.`
 		conversation
+			branch tmbr
+				has "Deep Archaeology 5: done"
+			action
+				set "archaeology before TMBR"
+			label tmbr
 			`On a whim, as you're landing on Zug you pull up a geological map of the planet and find that the geography you dreamt of while drifting in the Ildaria system was surprisingly close to the real thing. There's even a massive basalt outcropping right where you saw a lava flow burying a city. There's no way your ship's sensors can tell what's underneath it, though.`
 
 
@@ -376,7 +381,14 @@ mission "Rim Archaeology 1"
 				`	(Of course!)`
 				`	(Not right now.)`
 					defer
-			`Foster seems glad to see you. You do your best to pique his interest without saying anything that will make him think you're crazy, but he's clearly not buying it. "I'm sorry," he says, "but I'm not mounting an expedition just because you have a 'hunch.' So unless you're willing to tell me the source of your information, I'm not interested." He turns his attention back to the data pad that he was reading before you walked into his office.`
+			branch recent
+				not "archaeology before TMBR"
+			`	Foster seems glad to see you. "It's been a while, <first>. Has something caught your eye recently?"`
+				goto interest
+			label recent
+			`	Foster is slightly surprised by your arrival. "Sorry to say, but I haven't made any progress with the Deep since we last talked. Unless you have something else you want to tell me about?"`
+			label interest
+			`	You do your best to pique his interest without saying anything that will make him think you're crazy, but he's clearly not buying it. "I'm sorry," he says, "but I'm not mounting an expedition just because you have a 'hunch.' So unless you're willing to tell me the source of your information, I'm not interested." He turns his attention back to the data pad that he was reading before you walked into his office.`
 			choice
 				`	"I'd rather not say."`
 				`	"I had this dream about dragon-people on Zug."`


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
It's been frequently commented that the Emerald Sword mission line is one of the most unintuitive segments of the game. For the most part, this is by design; we want there to be secrets that reward a player who picks up on smaller details like Ulrich's vision. However, the second part of TMBR requiring Deep Archaeology is obtuse to a point beyond what I feel makes sense, especially since they aren't linked in a way where it would make sense to force Deep Archaeology before it.

This PR lets the entirety of TMBR be completed before Deep Archaeology and adds a mission telling them to go back to Foster if they've already seen the vision in Ildaria before doing Deep Archaeology. It also reduces the number of drones present in TMBR 3B, since the combat rating requirement inherited from Deep Archaeology is no longer present.

## Testing Done
Not yet.

## Save File
This save file can be used to test these changes:
[First Last~TMBR Test.txt](https://github.com/user-attachments/files/20620743/First.Last.TMBR.Test.txt)
(The file already has TMBR 1 completed. You should be able to choose either completing the rest of TMBR or Deep Archaeology from there.)
