### PR TITLE
feat(ui): Added a "Show mini-map" preference option for having the system mini-map always on

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1472,8 +1472,8 @@ tip "Rotate flagship in HUD"
 tip "Show planet labels"
 	`Display an overlay on nearby landable planets and stations.`
 
-tip "Show mini-map"
-	`Display a mini-map of nearby systems when initiating a hyperspace jump.`
+tip "Mini-map display"
+	`Control the display of a mini-map of nearby systems. If set to "when jumping", the mini-map only appears when initiating a hyperspace jump. If set to "always on", then it is always present when in flight.`
 
 tip "Clickable radar display"
 	`Activate the ability to send commands to your escorts using the in-system radar mini-map.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1472,7 +1472,7 @@ tip "Rotate flagship in HUD"
 tip "Show planet labels"
 	`Display an overlay on nearby landable planets and stations.`
 
-tip "Mini-map display"
+tip "Show mini-map"
 	`Control the display of a mini-map of nearby systems. If set to "when jumping", the mini-map only appears when initiating a hyperspace jump. If set to "always on", then it is always present when in flight.`
 
 tip "Clickable radar display"

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -545,7 +545,7 @@ void Engine::Step(bool isActive)
 			// If the jump has completed, draw the next system in the player's jump
 			// plan, or set the minimapSystems to nullptr to only display the current
 			// system if the travel plan is empty.
-			vector<const System *> &plan = player.TravelPlan();
+			const vector<const System *> &plan = player.TravelPlan();
 			if(plan.empty())
 			{
 				minimapSystems[0] = nullptr;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -522,21 +522,50 @@ void Engine::Step(bool isActive)
 		{
 			doEnter = false;
 			events.emplace_back(flagship, flagship, ShipEvent::JUMP);
+			// Only let the minimap linger for 1.5 seconds after a jump has completed.
+			displayMinimap = min(displayMinimap, 90);
 		}
 		if(flagship->IsEnteringHyperspace() || flagship->Commands().Has(Command::JUMP))
 		{
-			if(jumpCount < 100)
-				++jumpCount;
+			// Let the minimap linger for 3 seconds after the player hit the jump key.
+			displayMinimap = 180;
+			// Draw the systems that the player is jumping between on the minimap.
 			const System *from = flagship->GetSystem();
 			const System *to = flagship->GetTargetSystem();
 			if(from && to && from != to)
 			{
-				jumpInProgress[0] = from;
-				jumpInProgress[1] = to;
+				minimapSystems[0] = from;
+				minimapSystems[1] = to;
 			}
 		}
-		else if(jumpCount > 0)
-			--jumpCount;
+		else if(displayMinimap > 0)
+			--displayMinimap;
+		else
+		{
+			// If the jump has completed, draw the next system in the player's jump
+			// plan, or set the minimapSystems to nullptr to only display the current
+			// system if the travel plan is empty.
+			vector<const System *> &plan = player.TravelPlan();
+			if(plan.empty())
+			{
+				minimapSystems[0] = nullptr;
+				minimapSystems[1] = nullptr;
+			}
+			else
+			{
+				minimapSystems[0] = flagship->GetSystem();
+				minimapSystems[1] = plan.front();
+			}
+		}
+		if(displayMinimap)
+		{
+			if(displayMinimap < 30 && fadeMinimap)
+				--fadeMinimap;
+			else if(fadeMinimap < 30)
+				++fadeMinimap;
+		}
+		else
+			fadeMinimap = 0;
 	}
 	ai.UpdateEvents(events);
 	if(isActive)
@@ -1318,8 +1347,13 @@ void Engine::Draw() const
 		for(int i = 0; i < 2; ++i)
 			SpriteShader::Draw(mark[i], center + Point(dx[i], 0.), 1., targetSwizzle);
 	}
-	if(jumpCount && Preferences::Has("Show mini-map"))
-		MapPanel::DrawMiniMap(player, .5f * min(1.f, jumpCount / 30.f), jumpInProgress, step);
+
+	// Draw the systems mini-map.
+	Preferences::MinimapDisplay minimap = Preferences::GetMinimapDisplay();
+	if(minimap == Preferences::MinimapDisplay::ALWAYS_ON)
+		MapPanel::DrawMiniMap(player, 1.f, minimapSystems, step);
+	else if(displayMinimap && minimap == Preferences::MinimapDisplay::WHEN_JUMPING)
+		MapPanel::DrawMiniMap(player, .5f * min(1.f, fadeMinimap / 30.f), minimapSystems, step);
 
 	// Draw ammo status.
 	double ammoIconWidth = hud->GetValue("ammo icon width");

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -269,8 +269,15 @@ private:
 	std::vector<AlertLabel> missileLabels;
 	std::vector<TurretOverlay> turretOverlays;
 	std::vector<std::pair<const Outfit *, int>> ammo;
-	int jumpCount = 0;
-	const System *jumpInProgress[2] = {nullptr, nullptr};
+	// How many frames the mini-map should be displayed for when it is set to only appear
+	// when jumping.
+	int displayMinimap = 0;
+	// Controls the fading in and out of the minimap. The minimap should fade in and out over
+	// the course of 30 frames (0.5 seconds).
+	int fadeMinimap = 0;
+	// The two primary systems to display in the minimap, along with all their linked neighbors.
+	// If either are null, then only the player's current system is drawn.
+	const System *minimapSystems[2] = {nullptr, nullptr};
 	// Flagship's hyperspace percentage converted to a [0, 1] double.
 	double hyperspacePercentage = 0.;
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -341,6 +341,7 @@ void MapPanel::Draw()
 		RingShader::Draw(Zoom() * (playerSystem.Position() + center),
 			(playerJumpDistance + .5) * Zoom(), (playerJumpDistance - .5) * Zoom(), jumpRangeColor);
 
+	// Draw a circle around the selected system.
 	Color brightColor(.4f, 0.f);
 	RingShader::Draw(Zoom() * (selectedSystem->Position() + center),
 		11.f, 9.f, brightColor);
@@ -458,25 +459,37 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 
 
 
-void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *const jump[2], int step)
+void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *const draw[2], int step)
 {
+	bool hasDestination = false;
+	Point center;
+	set<const System *> drawnSystems;
+	const System *currentSystem = player.GetSystem();
+	if(draw[0] && draw[1])
+	{
+		hasDestination = true;
+		center = .5 * (draw[0]->Position() + draw[1]->Position());
+		drawnSystems = { draw[0], draw[1] };
+	}
+	else
+	{
+		drawnSystems.insert(currentSystem);
+		center = currentSystem->Position();
+	}
+
 	const Font &font = FontSet::Get(14);
 	Color lineColor(alpha, 0.f);
-	Point center = .5 * (jump[0]->Position() + jump[1]->Position());
-	const Point &drawPos = GameData::Interfaces().Get("hud")->GetPoint("mini-map");
-	set<const System *> drawnSystems = { jump[0], jump[1] };
-	bool isLink = jump[0]->Links().contains(jump[1]);
+	Color brightColor(.4f * alpha, 0.f);
 
+	const Point &drawPos = GameData::Interfaces().Get("hud")->GetPoint("mini-map");
 	const Set<Color> &colors = GameData::Colors();
 	const Color &currentColor = colors.Get("active mission")->Additive(alpha * 2.f);
 	const Color &blockedColor = colors.Get("blocked mission")->Additive(alpha * 2.f);
 	const Color &waypointColor = colors.Get("waypoint")->Additive(alpha * 2.f);
 
 	const Ship *flagship = player.Flagship();
-	for(int i = 0; i < 2; ++i)
-	{
+	auto drawSystemLinks = [&](const System &system) -> void {
 		static const string UNKNOWN_SYSTEM = "Unexplored System";
-		const System &system = *jump[i];
 		const Government *gov = system.GetGovernment();
 		Point from = system.Position() - center + drawPos;
 		const string &name = player.KnowsName(system) ? system.DisplayName() : UNKNOWN_SYSTEM;
@@ -488,6 +501,10 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 		if(player.CanView(system) && system.IsInhabited(flagship) && gov)
 			color = gov->GetColor().Additive(alpha);
 		RingShader::Draw(from, OUTER, INNER, color);
+
+		// Add a circle around the system that the player is currently in.
+		if(&system == currentSystem)
+			RingShader::Draw(from, 11.f, 9.f, brightColor);
 
 		for(const System *link : system.Links())
 		{
@@ -556,21 +573,29 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 					DrawPointer(from, missionCounter, waypointColor, false);
 			}
 		}
-	}
+	};
 
-	// Draw the rest of the directional arrow. If this is a normal jump,
-	// the stem was already drawn above.
-	Point from = jump[0]->Position() - center + drawPos;
-	Point to = jump[1]->Position() - center + drawPos;
-	Point unit = (to - from).Unit();
-	from += LINK_OFFSET * unit;
-	to -= LINK_OFFSET * unit;
-	Color bright(2.f * alpha, 0.f);
-	// Non-hyperspace jumps are drawn with a dashed directional arrow.
-	if(!isLink)
-		LineShader::DrawDashed(from, to, unit, LINK_WIDTH, bright, 11., 4.);
-	LineShader::Draw(to, to + Angle(-30.).Rotate(unit) * -10., LINK_WIDTH, bright);
-	LineShader::Draw(to, to + Angle(30.).Rotate(unit) * -10., LINK_WIDTH, bright);
+	if(hasDestination)
+	{
+		for(int i = 0; i < 2; ++i)
+			drawSystemLinks(*draw[i]);
+
+		// Draw the rest of the directional arrow. If this is a normal jump,
+		// the stem was already drawn above.
+		Point from = draw[0]->Position() - center + drawPos;
+		Point to = draw[1]->Position() - center + drawPos;
+		Point unit = (to - from).Unit();
+		from += LINK_OFFSET * unit;
+		to -= LINK_OFFSET * unit;
+		Color bright(2.f * alpha, 0.f);
+		// Non-hyperspace jumps are drawn with a dashed directional arrow.
+		if(!draw[0]->Links().contains(draw[1]))
+			LineShader::DrawDashed(from, to, unit, LINK_WIDTH, bright, 11., 4.);
+		LineShader::Draw(to, to + Angle(-30.).Rotate(unit) * -10., LINK_WIDTH, bright);
+		LineShader::Draw(to, to + Angle(30.).Rotate(unit) * -10., LINK_WIDTH, bright);
+	}
+	else
+		drawSystemLinks(*currentSystem);
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -469,7 +469,7 @@ void MapPanel::DrawMiniMap(const PlayerInfo &player, float alpha, const System *
 	{
 		hasDestination = true;
 		center = .5 * (draw[0]->Position() + draw[1]->Position());
-		drawnSystems = { draw[0], draw[1] };
+		drawnSystems = {draw[0], draw[1]};
 	}
 	else
 	{

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -82,7 +82,7 @@ public:
 	// escort/storage tooltips, and the non-routable system warning.
 	void FinishDrawing(const std::string &buttonCondition);
 
-	static void DrawMiniMap(const PlayerInfo &player, float alpha, const System *const jump[2], int step);
+	static void DrawMiniMap(const PlayerInfo &player, float alpha, const System *const draw[2], int step);
 
 	// Map panels allow fast-forward to stay active.
 	bool AllowsFastForward() const noexcept final;

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -164,6 +164,9 @@ namespace {
 	const vector<string> ALERT_INDICATOR_SETTING = {"off", "audio", "visual", "both"};
 	int alertIndicatorIndex = 3;
 
+	const vector<string> MINIMAP_DISPLAY_SETTING = {"off", "when jumping", "always on"};
+	int minimapDisplayIndex = 1;
+
 	int previousSaveCount = 3;
 }
 
@@ -245,6 +248,8 @@ void Preferences::Load()
 			dateFormatIndex = max<int>(0, min<int>(node.Value(1), DATEFMT_OPTIONS.size() - 1));
 		else if(key == "alert indicator")
 			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size() - 1));
+		else if(key == "minimap display")
+			minimapDisplayIndex = max<int>(0, min<int>(node.Value(1), MINIMAP_DISPLAY_SETTING.size() - 1));
 		else if(key == "previous saves" && hasValue)
 			previousSaveCount = max<int>(3, node.Value(1));
 		else if(key == "alt-mouse turning")
@@ -315,6 +320,7 @@ void Preferences::Save()
 	out.Write("Parallax background", parallaxIndex);
 	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
+	out.Write("minimap display", minimapDisplayIndex);
 	out.Write("previous saves", previousSaveCount);
 
 	for(const auto &it : settings)
@@ -806,4 +812,26 @@ bool Preferences::DoAlertHelper(Preferences::AlertIndicator toDo)
 int Preferences::GetPreviousSaveCount()
 {
 	return previousSaveCount;
+}
+
+
+
+void Preferences::ToggleMinimapDisplay()
+{
+	if(++minimapDisplayIndex >= static_cast<int>(MINIMAP_DISPLAY_SETTING.size()))
+		minimapDisplayIndex = 0;
+}
+
+
+
+Preferences::MinimapDisplay Preferences::GetMinimapDisplay()
+{
+	return static_cast<MinimapDisplay>(minimapDisplayIndex);
+}
+
+
+
+const std::string &Preferences::MinimapSetting()
+{
+	return MINIMAP_DISPLAY_SETTING[minimapDisplayIndex];
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -247,7 +247,7 @@ void Preferences::Load()
 			dateFormatIndex = max<int>(0, min<int>(node.Value(1), DATEFMT_OPTIONS.size() - 1));
 		else if(key == "alert indicator")
 			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size() - 1));
-		else if(key == "minimap display")
+		else if(key == "Show mini-map")
 			minimapDisplayIndex = max<int>(0, min<int>(node.Value(1), MINIMAP_DISPLAY_SETTING.size() - 1));
 		else if(key == "previous saves" && hasValue)
 			previousSaveCount = max<int>(3, node.Value(1));
@@ -319,7 +319,7 @@ void Preferences::Save()
 	out.Write("Parallax background", parallaxIndex);
 	out.Write("Extended jump effects", extendedJumpEffectIndex);
 	out.Write("alert indicator", alertIndicatorIndex);
-	out.Write("minimap display", minimapDisplayIndex);
+	out.Write("Show mini-map", minimapDisplayIndex);
 	out.Write("previous saves", previousSaveCount);
 
 	for(const auto &it : settings)

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -184,7 +184,6 @@ void Preferences::Load()
 	settings["Damaged fighters retreat"] = true;
 	settings["Show escort systems on map"] = true;
 	settings["Show stored outfits on map"] = true;
-	settings["Show mini-map"] = true;
 	settings["Show planet labels"] = true;
 	settings["Show asteroid scanner overlay"] = true;
 	settings["Show hyperspace flash"] = true;

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -114,6 +114,12 @@ public:
 		BOTH
 	};
 
+	enum class MinimapDisplay : int_fast8_t {
+		OFF = 0,
+		WHEN_JUMPING,
+		ALWAYS_ON
+	};
+
 
 public:
 	static void Load();
@@ -198,13 +204,18 @@ public:
 	static FlotsamCollection GetFlotsamCollection();
 	static const std::string &FlotsamSetting();
 
-	/// Red alert siren and symbol
+	/// Red alert siren and symbol.
 	static void ToggleAlert();
 	static AlertIndicator GetAlertIndicator();
 	static const std::string &AlertSetting();
 	static bool PlayAudioAlert();
 	static bool DisplayVisualAlert();
 	static bool DoAlertHelper(AlertIndicator toDo);
+
+	/// Minimap display settings.
+	static void ToggleMinimapDisplay();
+	static MinimapDisplay GetMinimapDisplay();
+	static const std::string &MinimapSetting();
 
 	static int GetPreviousSaveCount();
 };

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -81,7 +81,7 @@ namespace {
 	const string BACKGROUND_PARALLAX = "Parallax background";
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
-	const string MINIMAP_DISPLAY = "Mini-map display";
+	const string MINIMAP_DISPLAY = "Show mini-map";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
 
 	// How many pages of controls and settings there are.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -81,6 +81,7 @@ namespace {
 	const string BACKGROUND_PARALLAX = "Parallax background";
 	const string EXTENDED_JUMP_EFFECTS = "Extended jump effects";
 	const string ALERT_INDICATOR = "Alert indicator";
+	const string MINIMAP_DISPLAY = "Mini-map display";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
 
 	// How many pages of controls and settings there are.
@@ -736,7 +737,7 @@ void PreferencesPanel::DrawSettings()
 		"Highlight player's flagship",
 		"Rotate flagship in HUD",
 		"Show planet labels",
-		"Show mini-map",
+		MINIMAP_DISPLAY,
 		"Clickable radar display",
 		ALERT_INDICATOR,
 		"Extra fleet status messages",
@@ -989,6 +990,11 @@ void PreferencesPanel::DrawSettings()
 		{
 			isOn = Preferences::GetAlertIndicator() != Preferences::AlertIndicator::NONE;
 			text = Preferences::AlertSetting();
+		}
+		else if(setting == MINIMAP_DISPLAY)
+		{
+			isOn = Preferences::GetMinimapDisplay() != Preferences::MinimapDisplay::OFF;
+			text = Preferences::MinimapSetting();
 		}
 		else
 			text = isOn ? "on" : "off";
@@ -1340,6 +1346,8 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleNotificationSetting();
 	else if(str == ALERT_INDICATOR)
 		Preferences::ToggleAlert();
+	else if(str == MINIMAP_DISPLAY)
+		Preferences::ToggleMinimapDisplay();
 	// All other options are handled by just toggling the boolean state.
 	else
 		Preferences::Set(str, !Preferences::Has(str));


### PR DESCRIPTION
**UI**

This PR addresses the feature described by https://github.com/endless-sky/endless-sky/issues/10949#issuecomment-2944677259.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Updates the "Show mini-map" from a boolean setting to instead have three options: "off", "when jumping" (which is the current "on" behavior) and "always on".

I've also slightly changed the behavior of the "when jumping" option. Currently, if you send a jump command to your flagship and then immediately cancel it, the minimap will fade in slightly and the start fading out when the command is cancelled. Now, the minimap will remain visible for 3 seconds after the jump command is canceled.

## Screenshots

![image](https://github.com/user-attachments/assets/292c58aa-d827-4286-8ee2-61af233dd608)

When the mini-map display is set to always on, then it will display the next jump in your travel plan.

![image](https://github.com/user-attachments/assets/718d23f7-6faa-44ce-b1a0-7dbb18053e2d)

If you have no travel plan, it will only display the current system.

![image](https://github.com/user-attachments/assets/3730ccb4-a8e4-4e94-9b31-972884678f03)

## Testing Done

Confirmed that toggling the preference works and saved. Jumped around while changing the setting and observed the expected behavior with each value.

## Performance Impact

I noticed that the minimap doesn't do any sort of caching, but it's not making any particularly expensive calculations. Performance was fine when playing with the minimap always on.
