### PR TITLE
feat: Add version metadata for Windows

### DIFF
--- a/source/WinApp.rc
+++ b/source/WinApp.rc
@@ -1,1 +1,26 @@
+#include <winver.h>
+
 AppIcon ICON "../icons/WinApp.ico"
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION 0,10,14,0
+	PRODUCTVERSION 0,10,14,0
+{
+	BLOCK "StringFileInfo"
+	{
+		BLOCK "040904B0"
+		{
+			VALUE "CompanyName", "\0"
+			VALUE "FileDescription", "Space exploration and combat game\0"
+			VALUE "FileVersion", "0.10.14-alpha\0"
+			VALUE "InternalName", "Endless Sky\0"
+			VALUE "OriginalFilename", "Endless Sky.exe\0"
+			VALUE "ProductName", "Endless Sky\0"
+			VALUE "ProductVersion", "0.10.14-alpha\0"
+		}
+	}
+	BLOCK "VarFileInfo"
+	{
+		VALUE "Translation", 0x409, 1200
+	}
+}

--- a/source/WinApp.rc
+++ b/source/WinApp.rc
@@ -8,6 +8,7 @@ VS_VERSION_INFO VERSIONINFO
 {
 	BLOCK "StringFileInfo"
 	{
+		// U.S. English
 		BLOCK "040904B0"
 		{
 			VALUE "CompanyName", "\0"
@@ -21,6 +22,7 @@ VS_VERSION_INFO VERSIONINFO
 	}
 	BLOCK "VarFileInfo"
 	{
+		// U.S. English
 		VALUE "Translation", 0x409, 1200
 	}
 }


### PR DESCRIPTION
**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added some version metadata so that Windows doesn't show version 0.0.0.0

## Testing Done
Compiled locally with mingw, and made sure the metadata shows up in the main exe's properties.

## Performance Impact
N/A