### PR TITLE
Fix MacOS Release CD

### DIFF
--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -211,14 +211,12 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Zip artifact
-        run: |
-          cd build/release
-          7z a macos-artifact-x64.zip "Endless Sky.app"
+        run: 7z a macos-artifact-x64.zip "./build/release/*"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-x64
-          path: build/release/macos-artifact-x64.zip
+          path: macos-artifact-x64.zip
 
 
   release_macos_arm:
@@ -261,14 +259,12 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Zip artiface
-        run: |
-          cd build/release
-          7z a macos-artifact-arm.zip "Endless Sky.app"
+        run: 7z a macos-artifact-arm.zip "./build/release/*"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-arm
-          path: build/release/macos-artifact-arm.zip
+          path: macos-artifact-arm.zip
 
 
   release_macos:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -260,7 +260,7 @@ jobs:
           cmake --build build --preset macos-arm-ci-release
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
-      - name: Zip artiface
+      - name: Zip artifact
         run: |
           cd build/release
           7z a macos-artifact-arm.zip "Endless Sky.app"
@@ -283,10 +283,10 @@ jobs:
         with:
           name: macos-artifact-x64
           path: x64/macos-artifact-x64.zip
-      - name: Extract x64 artiface
+      - name: Extract x64 artifact
         run: |
           cd x64
-          7z x macos-artiface-x64.zip
+          7z x macos-artifact-x64.zip
       - uses: actions/download-artifact@v4
         with:
           name: macos-artifact-arm

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -211,12 +211,14 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Zip artifact
-        run: 7z a macos-artifact-x64.zip "build/release/Endless Sky.app"
+        run: |
+          cd build/release
+          7z a macos-artifact-x64.zip "Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-x64
-          path: macos-artifact-x64.zip
+          path: build/release/macos-artifact-x64.zip
 
 
   release_macos_arm:
@@ -259,12 +261,14 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Zip artiface
-        run: 7z a macos-artifact-arm "build/release/Endless Sky.app"
+        run: |
+          cd build/release
+          7z a macos-artifact-arm "Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-arm
-          path: macos-artifact-arm.zip
+          path: build/release/macos-artifact-arm.zip
 
 
   release_macos:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -211,12 +211,14 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Zip artifact
-        run: 7z a macos-artifact-x64.zip "./build/release/*"
+        run: |
+          cd build/release
+          7z a macos-artifact-x64.zip "Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-x64
-          path: macos-artifact-x64.zip
+          path: build/release/macos-artifact-x64.zip
 
 
   release_macos_arm:
@@ -259,12 +261,14 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
       - name: Zip artiface
-        run: 7z a macos-artifact-arm.zip "./build/release/*"
+        run: |
+          cd build/release
+          7z a macos-artifact-arm.zip "Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-arm
-          path: macos-artifact-arm.zip
+          path: build/release/macos-artifact-arm.zip
 
 
   release_macos:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -210,11 +210,13 @@ jobs:
           cmake --build build --preset macos-ci-release
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
+      - name: Zip artifact
+        run: 7z a macos-artifact-x64.zip "build/release/Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-x64
-          path: build/release/Endless Sky.app
+          path: macos-artifact-x64.zip
 
 
   release_macos_arm:
@@ -256,11 +258,13 @@ jobs:
           cmake --build build --preset macos-arm-ci-release
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
+      - name: Zip artiface
+        run: 7z a macos-artifact-arm "build/release/Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-artifact-arm
-          path: build/release/Endless Sky.app
+          path: macos-artifact-arm.zip
 
 
   release_macos:
@@ -274,11 +278,19 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: macos-artifact-x64
-          path: x64/Endless Sky.app
+          path: x64/macos-artifact-x64.zip
+      - name: Extract x64 artiface
+        run: |
+          cd x64
+          7z x macos-artiface-x64.zip
       - uses: actions/download-artifact@v4
         with:
           name: macos-artifact-arm
           path: arm/Endless Sky.app
+      - name: Extract arm artifact
+        run: |
+          cd arm
+          7z x macos-artifact-arm.zip
       - name: Create universal binary
         run: |
           cp -r "arm/Endless Sky.app" "Endless Sky.app"

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -263,7 +263,7 @@ jobs:
       - name: Zip artiface
         run: |
           cd build/release
-          7z a macos-artifact-arm "Endless Sky.app"
+          7z a macos-artifact-arm.zip "Endless Sky.app"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -290,7 +290,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: macos-artifact-arm
-          path: arm/Endless Sky.app
+          path: arm/macos-artifact-arm.zip
       - name: Extract arm artifact
         run: |
           cd arm


### PR DESCRIPTION
**CI/CD/Testing**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Apparently, uploading and then downloading artifacts in GitHub Actions jobs with actions/upload-artifact and actions/download-artifact doesn't preserve the executable bits.
We recently started doing this as part of our MacOS release CD workflow in order to parallelise the compilation of the x64 and arm binaries.
This results in the final dmg containing executables without the executable flags set, so MacOS won't run it.
This PR fixes this by zipping the things we are uploading via actions/upload-artifact and then downloading via actions/download-artifact. This means that these Actions never see the individual executable files, and so cannot mess up the executable bits.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Ran the Release CD. Checked the files inside the resulting dmg and the executable and libraries have the executable bit set. Also test ran on MacOS 13.something and it works.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Release CD might take a couple of minutes longer for the MacOS build.
