### PR TITLE
docs: Add an "Acceptable licenses" section to the contributing file

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you are not comfortable with losing complete creative freedom over your work,
 
 By contributing code or written content to the game, you accept that your works are being published under the [GPLv3.0 license](https://www.gnu.org/licenses/).
 
-All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file.
+All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and the work must be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file along with the license it is published under.
 
 Common artwork licenses that are allowed include:
 * Anything in the public domain. (e.g. works published by NASA or other government agencies, or licensed under the CC0 public domain license.)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -72,3 +72,23 @@ If you have opened a new feature pull request during a stable release developmen
 ### Reviewing a pull request
 
 Reviewing pull requests is an important part of maintaining Endless Sky and the main way that new content is added to the game. Your feedback helps contributors improve their work and ensures that new content is the best it can be. For more information, see the [wiki page](https://github.com/endless-sky/endless-sky/wiki/ReviewingPRs).
+
+### Acceptable licenses
+
+By contributing code or written content to the game, you accept that your works are being published under the [GPLv3.0 license](https://www.gnu.org/licenses/).
+
+All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file .
+
+Common artwork licenses that are allowed include:
+* Anything in the public domain. (e.g. works published by NASA or other government agencies, or licensed under the CC0 public domain license.)
+* Any attribution (BY) Creative Commons license version 3.0 and later, which may also be share-alike (SA). (e.g. CC-BY-3.0, CC-BY-SA-4.0)
+
+Common artwork licenses that are disallowed include:
+* Creative Commons licenses older than version 3.0. (e.g. CC-BY-2.0)
+* Any non-commerical (NC) or no derivative works (ND) creative commons licenses. (e.g. CC-BY-NC-3.0)
+* Most proprietary licenses, including licenses used by many image hosting websites such as Pexels, Pixabay, and Unsplash.
+	* Note that many image hosting websites used to license images under the CC0 Public Domain license, but have since moved to using non-free proprietary licenses which limit derivative and/or commerical uses. For such websites, using older images may be acceptable. Confirm that the page that you sourced the image from clearly lists the license that the image was published under.
+
+For more reading on free licenses, see the following pages:
+* [The DFSG and Software Licenses](https://wiki.debian.org/DFSGLicenses)
+* [Debian License Information](https://www.debian.org/legal/licenses/)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,6 +29,26 @@ If you believe your issue has been resolved, you can close the issue yourself. I
 
 If you are not comfortable with losing complete creative freedom over your work, please consider publishing it as a plugin instead. Plugins can be advertised on our [Discord server](https://discord.gg/ZeuASSx) or the [official plugins repository](https://github.com/endless-sky/endless-sky-plugins). For more information on when to consider publishing your content as a plugin or opening a pull request to add it to the game, please read the [Creation Guide - Plugin or Pull Request?](https://github.com/endless-sky/endless-sky/wiki/Creation-Guide---Plug-in-or-Pull-Request) article.
 
+### Acceptable licenses
+
+By contributing code or written content to the game, you accept that your works are being published under the [GPLv3.0 license](https://www.gnu.org/licenses/).
+
+All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file .
+
+Common artwork licenses that are allowed include:
+* Anything in the public domain. (e.g. works published by NASA or other government agencies, or licensed under the CC0 public domain license.)
+* Any attribution (BY) Creative Commons license version 3.0 and later, which may also be share-alike (SA). (e.g. CC-BY-3.0, CC-BY-SA-4.0)
+
+Common artwork licenses that are disallowed include:
+* Creative Commons licenses older than version 3.0. (e.g. CC-BY-2.0)
+* Any non-commerical (NC) or no derivative works (ND) creative commons licenses. (e.g. CC-BY-NC-3.0)
+* Most proprietary licenses, including licenses used by many image hosting websites such as Pexels, Pixabay, and Unsplash.
+	* Note that many image hosting websites used to license images under the CC0 Public Domain license, but have since moved to using non-free proprietary licenses which limit derivative and/or commerical uses. For such websites, using older images may be acceptable. Confirm that the page that you sourced the image from clearly lists the license that the image was published under.
+
+For more reading on free licenses, see the following pages:
+* [The DFSG and Software Licenses](https://wiki.debian.org/DFSGLicenses)
+* [Debian License Information](https://www.debian.org/legal/licenses/)
+
 ### Posting pull requests
 
 If you are posting a pull request, please:
@@ -72,23 +92,3 @@ If you have opened a new feature pull request during a stable release developmen
 ### Reviewing a pull request
 
 Reviewing pull requests is an important part of maintaining Endless Sky and the main way that new content is added to the game. Your feedback helps contributors improve their work and ensures that new content is the best it can be. For more information, see the [wiki page](https://github.com/endless-sky/endless-sky/wiki/ReviewingPRs).
-
-### Acceptable licenses
-
-By contributing code or written content to the game, you accept that your works are being published under the [GPLv3.0 license](https://www.gnu.org/licenses/).
-
-All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file .
-
-Common artwork licenses that are allowed include:
-* Anything in the public domain. (e.g. works published by NASA or other government agencies, or licensed under the CC0 public domain license.)
-* Any attribution (BY) Creative Commons license version 3.0 and later, which may also be share-alike (SA). (e.g. CC-BY-3.0, CC-BY-SA-4.0)
-
-Common artwork licenses that are disallowed include:
-* Creative Commons licenses older than version 3.0. (e.g. CC-BY-2.0)
-* Any non-commerical (NC) or no derivative works (ND) creative commons licenses. (e.g. CC-BY-NC-3.0)
-* Most proprietary licenses, including licenses used by many image hosting websites such as Pexels, Pixabay, and Unsplash.
-	* Note that many image hosting websites used to license images under the CC0 Public Domain license, but have since moved to using non-free proprietary licenses which limit derivative and/or commerical uses. For such websites, using older images may be acceptable. Confirm that the page that you sourced the image from clearly lists the license that the image was published under.
-
-For more reading on free licenses, see the following pages:
-* [The DFSG and Software Licenses](https://wiki.debian.org/DFSGLicenses)
-* [Debian License Information](https://www.debian.org/legal/licenses/)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you are not comfortable with losing complete creative freedom over your work,
 
 By contributing code or written content to the game, you accept that your works are being published under the [GPLv3.0 license](https://www.gnu.org/licenses/).
 
-All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file .
+All artwork, sounds, and other non-written assets contributed to the game must fall under a copyright license that follows the [Debian Free Software Guidelines](https://www.debian.org/social_contract#guidelines) and be listed in the [copyright](https://github.com/endless-sky/endless-sky/blob/master/copyright) file.
 
 Common artwork licenses that are allowed include:
 * Anything in the public domain. (e.g. works published by NASA or other government agencies, or licensed under the CC0 public domain license.)


### PR DESCRIPTION
**Documentation**

This PR addresses #9413.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds a new "Acceptable license" section to the contributing file, documenting what copyright licenses are allowed to be used for contributed assets.