### PR TITLE
fix(typo): Avalet description typo

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -398,7 +398,7 @@ planet Asterus
 planet Avalet
 	attributes "gas giant" "requires: gaslining" uninhabited
 	landscape land/clouds_01
-	description `Avalet is a hot ice giant, similar in size to Neptune but orbiting far closer to Anax. Tidally locked, one face of the gas plant is heated to incandescence while the other experiences temperatures cold enough to freeze the water and ammonia out of its mostly hydrogen atmosphere. This drives a cycle of winds that ring the entire planet, producing immense cyclones capable of throwing clouds to the edge of space.`
+	description `Avalet is a hot ice giant, similar in size to Neptune but orbiting far closer to Anax. Tidally locked, one face of the gas planet is heated to incandescence while the other experiences temperatures cold enough to freeze the water and ammonia out of its mostly hydrogen atmosphere. This drives a cycle of winds that ring the entire planet, producing immense cyclones capable of throwing clouds to the edge of space.`
 	description `	The erosion of the solar wind against Avalet produces a bright cometary tail visible from Aviskir, and in multiple Avgi mythologies the planet occupied a role of preeminence: a messenger, or a king, or even a creator. In more modern times, the antimatter trapped by Avalet's magnetic field fueled Avgi starships until Antivli Station was built, a fading reflection of its mythological significance.`
 	government Uninhabited
 


### PR DESCRIPTION
**Typo fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Reported by Zugidor on discord. Thanks!

Fixes a typo in Avalet's description - "gas plant" to "gas planet".