### PR TITLE
Fix(typo): Reword no-fly warning for ships in another system

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -350,7 +350,7 @@ void PlanetPanel::TakeOffIfReady()
 			shipNames.pop_back();
 			shipNames.pop_back();
 			GetUI()->Push(new Dialog(this, &PlanetPanel::CheckWarningsAndTakeOff,
-				"Some of your ships in other systems are not be able to fly:\n" + shipNames +
+				"Some of your ships in other systems are not able to fly:\n" + shipNames +
 				"\nDo you want to park those ships and depart?", Truncate::MIDDLE));
 			return;
 		}


### PR DESCRIPTION
**Typo fix**
This time around things should actually work...

This PR addresses a bug/feature that I noticed on a Discord screenshot.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removed the word "be" from `Some of your ships in other systems are not be able to fly`

## Testing Done
N/A

## Save File
Loot vital outfits off a ship and test if you get this message properly, I guess.
