### PR TITLE
Fix(typo): Agree with plural "words" in Successors: Trusted

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -999,7 +999,7 @@ mission "Successors: Trusted"
 			branch "no kaatrij"
 				has "successors kaatrij patron"
 			`	This sparks some murmuring among the gathered Successors, both the representatives themselves and the other, quieter members who continue to stand around the periphery of the pool. There is no direct reply for some time until, after what seems like several minutes, the representative from House Kaatrij returns to the center and speaks.`
-			`	"Guest. House Kaatrij shall recognize thy noble words, even if we hold no reason for belief in them. We will permit the others to let thee buy our trinkets, and we shall watch thee closely to see if thy words is matched in action."`
+			`	"Guest. House Kaatrij shall recognize thy noble words, even if we hold no reason for belief in them. We will permit the others to let thee buy our trinkets, and we shall watch thee closely to see if thy words are matched in action."`
 			`	With no further comments from any of the Successors, the representative from House Sioeora calls for a vote from among the gathered representatives. Sioeora and Chydiyi vote for the proposition and Kaatrij abstains from the vote, remaining at the rim of the pool, inspecting your behavior closely. The representative from Sioeora then promptly produces another small box from within their outfit and presents it to you. You open it to reveal one of the pin insignias that you have seen throughout this meeting.`
 				goto license
 			label "no kaatrij"


### PR DESCRIPTION
**Typo fix**

This PR addresses a bug described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1381595315395629130).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Changed is->are to match the plural form "thy words"

## Testing Done
N/A

## Save File
I don't have a save for this... and honestly it probably doesn't need one?