### PR TITLE
feat(UI): add ability to collapse ship list in Outfitter (Fixes #11204)

### DIFF
--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -24,6 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ScrollBar.h"
 #include "ScrollVar.h"
 #include "ShipInfoDisplay.h"
+#include "Rectangle.h"
 
 #include <map>
 #include <set>
@@ -185,6 +186,7 @@ protected:
 	std::map<std::string, std::vector<std::string>> catalog;
 	const CategoryList &categories;
 	std::set<std::string> &collapsed;
+	bool fleetCollapsed = false;
 
 	ShipInfoDisplay shipInfo;
 	OutfitInfoDisplay outfitInfo;
@@ -217,6 +219,8 @@ private:
 
 private:
 	bool delayedAutoScroll = false;
+
+	Rectangle fleetArrowZone;
 
 	Point hoverPoint;
 	std::string shipName;


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #11204

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a collapse / expand toggle to the ship list shown in the Outfitter panel.

Motivation: When an outfitter stocks many ships, the list can push the outfits grid off‑screen and force extra scrolling.

Implementation highlights:

New showShips boolean in ShopPanel tracks visibility of the ship list.

Chevron icon + mouse hotspot in the ship‑list header toggles the state.

Preference saved via Preferences::UI() so the choice persists across sessions.

Layout maths updated to reclaim vertical space when the list is collapsed.

Fixes #11204.


## Testing Done
Local build: Unable to complete a build on macOS. CMake configure fails with
`Could not find a package configuration file provided by "unofficial‑minizip"`.
As a result I could not perform in‑game smoke testing.


## Wiki Update
If merged, add a short note to Game Manual → Interface → Outfitter about the new collapse toggle.

## Performance Impact
Negligible: one extra boolean check in each ShopPanel::Draw() call and a small preference read/write on click.
