### PR TITLE
feat(condition): Add separate conditions for fleet/flagship cargo/passenger space total and free

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3680,25 +3680,47 @@ void PlayerInfo::RegisterDerivedConditions()
 		return round((1. - safeChance) * 1000.); });
 
 	// Special conditions for cargo and passenger space.
-	// If boarding a ship, missions should not consider the space available
-	// in the player's entire fleet. The only fleet parameter offered to a
-	// boarding mission is the fleet composition (e.g. 4 Heavy Warships).
 	conditions["cargo space"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
-		if(flagship && !availableBoardingMissions.empty())
-			return flagship->Cargo().Free();
 		int64_t retVal = 0;
 		for(const shared_ptr<Ship> &ship : ships)
 			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system)
 				retVal += ship->Attributes().Get("cargo space");
 		return retVal; });
 	conditions["passenger space"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
-		if(flagship && !availableBoardingMissions.empty())
-			return flagship->Cargo().BunksFree();
 		int64_t retVal = 0;
 		for(const shared_ptr<Ship> &ship : ships)
 			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system)
 				retVal += ship->Attributes().Get("bunks") - ship->RequiredCrew();
 		return retVal; });
+	conditions["cargo space free"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
+		int64_t retVal = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system)
+				retVal += ship->Cargo().Free();
+		return retVal; });
+	conditions["passenger space free"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
+		int64_t retVal = 0;
+		for(const shared_ptr<Ship> &ship : ships)
+			if(!ship->IsParked() && !ship->IsDisabled() && ship->GetActualSystem() == system)
+				retVal += ship->Cargo().BunksFree();
+		return retVal; });
+
+	conditions["flagship: cargo space"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
+		if(!flagship)
+			return 0;
+		return flagship->Attributes().Get("cargo space"); });
+	conditions["flagship: passenger space"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
+		if(!flagship)
+			return 0;
+		return flagship->Attributes().Get("bunks") - flagship->RequiredCrew(); });
+	conditions["flagship: cargo space free"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
+		if(!flagship)
+			return 0;
+		return flagship->Cargo().Free(); });
+	conditions["flagship: passenger space free"].ProvideNamed([this](const ConditionEntry &ce) -> int64_t {
+		if(!flagship)
+			return 0;
+		return flagship->Cargo().BunksFree(); });
 
 	// The number of active, present ships the player has of the given category
 	// (e.g. Heavy Warships).


### PR DESCRIPTION
**Feature**

This PR addresses the bug described in issue #11387.
Closes #11387.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Right now, we have "cargo space" and "passenger space" conditions that change their behavior depending on the context. If they're used in most cases, then they return the total cargo and passenger space of your local fleet. But if you're used during a boarding mission, they return the free cargo and passenger space of your flagship. As noted in #11387, this contextual behavior isn't working as was likely intended.

This PR creates multiple conditions for each case that a mission might want to check.
* `"cargo space"`: The total cargo space of your local fleet.
* `"cargo space free"`: The free cargo space of your local fleet.
* `"flagship: cargo space"`: The total cargo space of your flagship.
* `"flagship: cargo space free"`: The free cargo space of your flagship.
* Swap "cargo" for "passenger" and you get the analogous conditions for passenger space.

## Usage examples

They're conditions. You use them the same as any other condition.

## Testing Done

Maybe.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/154
