### PR TITLE
feat(content): Remove crew, bank, job, and trading services from automata planets

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -1239,11 +1239,14 @@ wormhole "Devil-Run Wormhole"
 	link Devil-Run "Deep Space 7C"
 
 planet "Devru Kaska"
-	attributes korath station
+	attributes korath sestor station
 	landscape land/station27
 	music ambient/machinery
 	description `The Kor Sestor prefer to develop planets rather than planting stations in space, but this is a necessary exception: a deuterium refinery that harvests hydrogen both from the gas giant it orbits, and from the strong solar wind from this system's primary star.`
-	spaceport `As the station's orbit carries it in and out of the gas giant's shadow, the station cools by a considerable amount, and the metal of the hull creaks and groans in protest. When the station is not in shadow, the temperatures here are almost too hot for human survival.`
+	port
+		recharges all
+		services "offers missions"
+		description `As the station's orbit carries it in and out of the gas giant's shadow, the station cools by a considerable amount, and the metal of the hull creaks and groans in protest. When the station is not in shadow, the temperatures here are almost too hot for human survival.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -1293,10 +1296,13 @@ planet "Double Haze"
 	security 0.3
 
 planet "Drekag Firask"
-	attributes korath
+	attributes korath sestor
 	landscape land/sea5
 	description `Much of the surface of this world is covered in water. Ships the size of small cities float in the oceans, carried by the tides. The ships are designed to incubate algae and other microorganisms that once provided the Korath both with food and with a source of mixed hydrocarbons similar to petroleum. With the Korath gone and the food no longer needed, many of the ships have fallen into disrepair, or have drifted into the polar regions and been crushed against icebergs.`
-	spaceport `This is one of the few city-ships still in operation, probably because it was designed to produce oils and petroleum rather than raw food stuff. But even this ship is in poor repair, drifting low enough in the water that when storms arise, the waves break over the outer walls of the city and flood the streets where the Korath inhabitants once lived.`
+	port
+		recharges all
+		services "offers missions"
+		description `This is one of the few city-ships still in operation, probably because it was designed to produce oils and petroleum rather than raw food stuff. But even this ship is in poor repair, drifting low enough in the water that when storms arise, the waves break over the outer walls of the city and flood the streets where the Korath inhabitants once lived.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -1628,10 +1634,13 @@ planet "Esayaku Fen"
 	security 0
 
 planet "Esek Stovar"
-	attributes korath station
+	attributes korath mereti station
 	landscape land/station28
 	description `This Kor Mereti outpost is far enough from the front in their war with the Kor Sestor that it has fallen somewhat into disuse. The largest docking bays are still kept open for refueling and repairs, but the sections of the station that used to be living quarters have been sealed off.`
-	spaceport `Because this station is only in use now by autonomous vehicles, there is no atmosphere, and no need for airlocks or containment fields. The hangar bay doors have all been left wide open, so ships can come and go as they please.`
+	port
+		recharges all
+		services "offers missions"
+		description `Because this station is only in use now by autonomous vehicles, there is no atmosphere, and no need for airlocks or containment fields. The hangar bay doors have all been left wide open, so ships can come and go as they please.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -1729,11 +1738,14 @@ planet "Far'en Lai"
 	government Uninhabited
 
 planet "Fara Skaeruti"
-	attributes korath station
+	attributes korath mereti station
 	landscape land/station24
 	music ambient/machinery
 	description `This station serves both as a deuterium refinery and as a factory. A large number of small spires protrude from the hull of the station, each carrying fuel pipes, so that ships can simply dock with one of the spires to refuel instead of having to navigate inside a hangar.`
-	spaceport `A swarm of robotic spacecraft flows around this station. The traffic pattern is chaotic, yet efficient, adapting from moment to moment depending on which ships are coming or going. The robots never crash into each other, even though they sometimes pass each other with less than a meter in between, while traveling at high speeds.`
+	port
+		recharges all
+		services "offers missions"
+		description `A swarm of robotic spacecraft flows around this station. The traffic pattern is chaotic, yet efficient, adapting from moment to moment depending on which ships are coming or going. The robots never crash into each other, even though they sometimes pass each other with less than a meter in between, while traveling at high speeds.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -2898,10 +2910,13 @@ planet Kella-Uuoru-Sossa
 				has "trusted by the successors"
 
 planet "Keneska Fek"
-	attributes korath
+	attributes korath sestor
 	landscape land/desert10-harro
 	description `The Kor Sestor apparently use this as a mining world, but rather than digging for minerals they have been intentionally crashing metal-rich asteroids into undeveloped sections of the desert where the robots can then break them apart and extract the ore. Predictably, the ecological effects of this sort of mining are devastating.`
-	spaceport `The Kor Sestor refineries are laid out in a grid pattern. Each square of the grid is a few kilometers on each side, and is laid out in exactly the same way: a central power station, surrounded by smelters and repair bays and factories and storehouses laid out like spokes of a wheel. Each square produces and maintains a fleet of worker robots that occasionally collaborate to construct a new square, extending the city farther outward. Lines of harvester robots snake out from the refineries to the downed asteroids like trails of ants.`
+	port
+		recharges all
+		services "offers missions"
+		description `The Kor Sestor refineries are laid out in a grid pattern. Each square of the grid is a few kilometers on each side, and is laid out in exactly the same way: a central power station, surrounded by smelters and repair bays and factories and storehouses laid out like spokes of a wheel. Each square produces and maintains a fleet of worker robots that occasionally collaborate to construct a new square, extending the city farther outward. Lines of harvester robots snake out from the refineries to the downed asteroids like trails of ants.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -3406,11 +3421,14 @@ planet "Mendez Station"
 	security 0
 
 planet "Merask Fortuno"
-	attributes korath station
+	attributes korath mereti station
 	landscape land/station25
 	music ambient/machinery
 	description `This station was built primarily for harvesting hyperspace fuel. Even when the Korath were still here, the harvesting was almost entirely automated, so the station only has living quarters for a handful of people.`
-	spaceport `Despite their masters being gone, the machines and robots of this station carry out their work just as diligently as before, harvesting fuel that will now be used only by other automata.`
+	port
+		recharges all
+		services "offers missions"
+		description `Despite their masters being gone, the machines and robots of this station carry out their work just as diligently as before, harvesting fuel that will now be used only by other automata.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -3427,11 +3445,14 @@ planet Mere
 		fleet "Large Militia" 14
 
 planet "Mereti Station"
-	attributes korath station
+	attributes korath mereti station
 	landscape land/station16
 	music ambient/machinery
 	description `This large station serves as the "mission control" for the robotic ships of the Kor Mereti faction. Warships of every shape and design are clustered in its docking bays or flying patrol outside.`
-	spaceport `The central core of this station is entirely sealed off, running on its own power generators serviced by self-maintaining repair robots. Inside the core are the advanced computers that direct the Kor Mereti war effort.`
+	port
+		recharges all
+		services "offers missions"
+		description `The central core of this station is entirely sealed off, running on its own power generators serviced by self-maintaining repair robots. Inside the core are the advanced computers that direct the Kor Mereti war effort.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -4703,11 +4724,14 @@ planet "Refuge of Belugt"
 	security 0.2
 
 planet "Rekat Moraski"
-	attributes korath station
+	attributes korath mereti station
 	landscape land/station26
 	music ambient/machinery
 	description `This station is a refinery where ore from asteroids is processed into metal. Larger asteroids are processed where they are; smaller ones are brought into the refinery itself to be mined.`
-	spaceport `This station has several bays large enough that a small asteroid can be steered inside. Harvester microbots then work their way into seams of metal in the asteroid, digging deeper and deeper until the asteroid is honeycombed with small tunnels and all the metal-rich veins have been extracted.`
+	port
+		recharges all
+		services "offers missions"
+		description `This station has several bays large enough that a small asteroid can be steered inside. Harvester microbots then work their way into seams of metal in the asteroid, digging deeper and deeper until the asteroid is honeycombed with small tunnels and all the metal-rich veins have been extracted.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -4910,10 +4934,13 @@ planet "Sandy Two"
 	security 0.4
 
 planet "Sapira Mereti"
-	attributes korath
+	attributes korath mereti
 	landscape land/lava11
 	description `This was the seat of government and last military stronghold of the Kor Mereti faction during the Korath civil war. Here they built the factories and shipyards that churned out autonomous warships to prosecute their war against the Kor Sestor. The machines now rule this world alone, and have made it entirely uninhabitable for living creatures as they delve ever deeper into the planet's crust to harvest metal and fuel, and construct more and more factories to build new generations of robotic warships.`
-	spaceport `With no living creatures in sight, the only noises in this refueling depot are the roaring engines as robot ships land and take off, communicating silently with each other via radio. The autonomous ships land and take off with perfect precision in a steady, unbroken stream. Many of them have been damaged by weapons fire, and as soon as they land they are covered by a swarm of welding and repair microbots that lay down new layers of hull armor and rebuild weapons and engines that have been destroyed.`
+	port
+		recharges all
+		services "offers missions"
+		description `With no living creatures in sight, the only noises in this refueling depot are the roaring engines as robot ships land and take off, communicating silently with each other via radio. The autonomous ships land and take off with perfect precision in a steady, unbroken stream. Many of them have been damaged by weapons fire, and as soon as they land they are covered by a swarm of welding and repair microbots that lay down new layers of hull armor and rebuild weapons and engines that have been destroyed.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -4968,10 +4995,13 @@ planet "Sebarep Atarkis"
 	description `	While you know it is extraordinarily unlikely due to the sheer size of the planet, you can't help but wonder what would happen if a ringroid were to fall directly upon your ship as you lurk under the clouds.`
 
 planet "Sebra Skira"
-	attributes korath station
+	attributes korath sestor station
 	landscape land/space4
 	description `This is one of the primary war platforms for the Kor Sestor. Some sections of the station are much newer than others, and the scars are still visible in places where weapons fire has annihilated part of the station. The robots have rebuilt the damaged parts in a seemingly random pattern, like burls of bark growing over damaged parts of a tree.`
-	spaceport `There is no atmosphere inside this station, and indeed it is unlikely the station could hold air even if it were ever recaptured by living beings. In places, the stars shine through small cracks in the hull.`
+	port
+		recharges all
+		services "offers missions"
+		description `There is no atmosphere inside this station, and indeed it is unlikely the station could hold air even if it were ever recaptured by living beings. In places, the stars shine through small cracks in the hull.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -5100,10 +5130,13 @@ planet "Sessiliki Far"
 	security 0
 
 planet "Sestor Ikfar"
-	attributes korath
+	attributes korath sestor
 	landscape land/hills1
 	description `This dry, hot world is home to almost no native life, but is ideal for the Korath automata because of its abundant solar energy. In the places where the Korath cities once were, the Kor Sestor have built massive factories with buildings sometimes close to a kilometer in height. In other places the land remains undeveloped, but the factories are constantly expanding outward.`
-	spaceport `In place of streets, massive tunnels and shafts run through the factory cities, wide enough for two capital ships to pass each other traveling in opposite directions without the risk of collision. The tunnels branch out into smaller and smaller passageways like capillaries branching out from an artery.`
+	port
+		recharges all
+		services "offers missions"
+		description `In place of streets, massive tunnels and shafts run through the factory cities, wide enough for two capital ships to pass each other traveling in opposite directions without the risk of collision. The tunnels branch out into smaller and smaller passageways like capillaries branching out from an artery.`
 	"required reputation" 1
 	bribe 0
 	security 0
@@ -5376,10 +5409,13 @@ planet "Solima Skarati"
 	description `The Korath were endlessly creative in devising new weapons of war during the twilight years of their empire, but what destroyed this planet in the end was not a military disaster but an ecological one. Small villages along the ocean shores and rusting fleets of boats bear witness to the fact that this ocean world was once a fruitful fishery. But now the ocean carries high levels of industrial toxins, and in place of large fish only small invertebrates remain.`
 
 planet "Sopi Lefarkata"
-	attributes frozen korath
+	attributes frozen korath sestor
 	landscape land/mountain24-spfld
 	description `This is a cold and mountainous world, and most of its oceans are covered in ice. A handful of giant craters gouged out from the sides of mountains are the only sign that there were once Korath settlements here. But, the Kor Sestor robots have begun building settlements of their own, in caverns deep under the mountains where they are safe from orbital bombardment. Where recent Kor Mereti attacks have collapsed one of the access tunnels, swarms of robots have gathered to dig them out like ants when their hill has been stepped on.`
-	spaceport `The caverns of the Kor Sestor are hidden deep under the mountains, but there are also a handful of refueling stations on the surface. Each one is guarded by towering weapon platforms and swarms of autonomous fighter drones.`
+	port
+		recharges all
+		services "offers missions"
+		description `The caverns of the Kor Sestor are hidden deep under the mountains, but there are also a handful of refueling stations on the surface. Each one is guarded by towering weapon platforms and swarms of autonomous fighter drones.`
 	"required reputation" 1
 	bribe 0
 	security 0

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3479,23 +3479,29 @@ mission "Wanderers: Sestor: Combined Patch 1"
 event "wanderers: sestor planets unrestricted"
 	planet "Drekag Firask"
 		"required reputation" 0
-		spaceport clear
+		remove spaceport
+		remove attributes sestor
 	planet "Sestor Ikfar"
 		"required reputation" 0
-		spaceport clear
+		remove spaceport
+		remove attributes sestor
 		description `This dry, hot world is home to almost no native life, but is ideal for the Korath automata because of its abundant solar energy. In the places where the Korath cities once were, the Kor Sestor have built massive factories with buildings sometimes close to a kilometer in height. In other places the land remains undeveloped, and now that the factories have been shut down it seems likely that it will stay that way for a very long time.`
 	planet "Devru Kaska"
 		"required reputation" 0
-		spaceport clear
+		remove spaceport
+		remove attributes sestor
 	planet "Sebra Skira"
 		"required reputation" 0
-		spaceport clear
+		remove spaceport
+		remove attributes sestor
 	planet "Keneska Fek"
 		"required reputation" 0
-		spaceport clear
+		remove spaceport
+		remove attributes sestor
 	planet "Sopi Lefarkata"
 		"required reputation" 0
-		spaceport clear
+		remove spaceport
+		remove attributes sestor
 		description `This is a cold and mountainous world, and most of its oceans are covered in ice. A handful of giant craters gouged out from the sides of mountains are the only sign that there were once Korath settlements here. The Kor Sestor robots began building settlements of their own, in caverns deep under the mountains where they are safe from orbital bombardment, but now these settlements are falling into disrepair. Where the last set of Kor Mereti attacks collapsed one of the access tunnels, a handful of robots have gathered, trying in vain to dig them out.`
 
 event "wanderers taking jobs from kor efreti"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the feature described in issue #1722.
Closes #1722.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Changes all the automata planets to only have "offers missions" as a service, removing crew, bank, job, and trading services. This makes the automata planets effectively behave as uninhabited planets when you land on them.

I've also gone ahead and added `mereti` and `sestor` attributes to the respective automata planets, since they lacked such attributes.

## Testing Done

Well I sure hope it works.
