### PR TITLE
feat(artwork): Scale the flare of the tiny-sized Hai engines to be smaller than the small-sized engines

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -718,6 +718,7 @@ outfit `"Baellie" Atomic Engines`
 	"turning heat" 1.28
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
+		"scale" 0.8
 	"flare sound" "atomic tiny"
 	"steering flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
@@ -877,6 +878,7 @@ outfit `"Basrem" Atomic Steering`
 	"turning heat" 1.5
 	"steering flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
+		"scale" 0.8
 	"steering flare sound" "atomic tiny"
 	description "Hai atomic engines are too expensive to buy for most humans. All but the smallest of the engines are worth more than many of the most common ships flown in human space."
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the feature described in issue #4551.
Closes #4551.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds `"scale" 0.8"` to the tiny Hai thrusters so that their flares are not the exact same size as the small Hai thrusters.

## Screenshots + Testing Done

Can you tell which ship has the tiny thrusters? (Before)
![image](https://github.com/user-attachments/assets/fd39f7c0-f83a-475c-9a30-7a2d763d57f4)

How about now? (After)
![image](https://github.com/user-attachments/assets/3c0d59a2-4d47-47ef-86b4-cbd64eccd5e3)
