### PR TITLE
Fix reference to Hippocrates in Adelita 2

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -7314,7 +7314,7 @@ mission "Adelita 2"
 
 			`	"Great. My name is Alejandra, but call me Ale. Here's the plan: you're going to drop me and a friend off at <planet>, where we'll film the conditions in a secret Syndicate sweatshop.`
 			`	"Thing is, these aren't just poorly paid factory workers. They're slaves. As you can imagine, we can't get in as regular workers, so with a bit of hacking, we got ourselves jobs on-site as private security. We know that one of the Syndicate's 'trusted contractors' is getting the slaves from the pirates on Covert, and we also know where they're doing the transaction.`
-			`	"So while we get the footage we need in the factories, you'll be going with my associate, Bunker, to spy on the Syndicate's rendezvous with the pirates on <planet>."`
+			`	"So while we get the footage we need in the factories, you'll be going with my associate, Bunker, to spy on the Syndicate's rendezvous with the pirates on Hippocrates."`
 			choice
 				`	"Hold on, pirates?"`
 				`	"Won't this get me in trouble with the Syndicate?"`


### PR DESCRIPTION
**Typo fix**

This PR addresses a typo that does not have a reported bug number.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In the mission "Adelita 2", the text is intended to refer to two planets: Maker and Hippocrates. However, the text substitution `<planet>` is used in both cases, so both planets are referred to as "Maker".

This text change replaces the second `<planet>` with "Hippocrates".

## Testing Done
Double-checked the spelling of "Hippocrates". Ran through the edited mission on my local install to verify there were no inadvertent formatting issues breaking it.
