### PR TITLE
fix(mechanics): Correct landing logic for recharging ships

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1622,8 +1622,9 @@ void PlayerInfo::Land(UI *ui)
 				const bool alreadyLanded = ship->GetPlanet() == planet;
 				if(alreadyLanded || planet->CanLand(*ship) || (clearance && planet->IsAccessible(ship.get())))
 				{
-					ship->Recharge(canUseServices ? planet->GetPort().GetRecharges() : Port::RechargeType::None,
-						planet->GetPort().HasService(Port::ServicesType::HireCrew));
+					const Port &port = planet->GetPort();
+					ship->Recharge(canUseServices ? port.GetRecharges() : Port::RechargeType::None,
+						port.HasService(Port::ServicesType::HireCrew));
 					if(!ship->GetPlanet())
 						ship->SetPlanet(planet);
 				}
@@ -1632,12 +1633,18 @@ void PlayerInfo::Land(UI *ui)
 				else
 				{
 					const StellarObject *landingObject = AI::FindLandingLocation(*ship);
-					const bool foundSpaceport = landingObject;
 					if(!landingObject)
 						landingObject = AI::FindLandingLocation(*ship, false);
 					if(landingObject)
-						ship->SetPlanet(landingObject->GetPlanet());
-					ship->Recharge(foundSpaceport);
+					{
+						const Planet *landingPlanet = landingObject->GetPlanet();
+						const Port &port = landingPlanet->GetPort();
+						ship->Recharge(landingPlanet->CanUseServices() ? port.GetRecharges() : Port::RechargeType::None,
+							port.HasService(Port::ServicesType::HireCrew));
+						ship->SetPlanet(planet);
+					}
+					else
+						ship->Recharge(Port::RechargeType::None, false);
 				}
 			}
 			else


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10766.
Closes #10766.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

As noted in the linked issue, there is a call to Ship::Recharge that was not updated to use the new RechargeType enum and was still using a boolean as the input parameter. What this effectively meant is that if your flagship lands on a planet and you have an escort that can't land with you but can land on another planet in the system, that ship will only have its shields recharged (since the boolean implicitly converts to 1, which matches RechargeType::Shields).

Updated this section of the code to match the behavior of the code that runs when the ship is able to land on the same planet as you, just using the alternative landing location instead.

## Save File + Testing Done

1. Load this save file: [Test Pilot~Landing Logic Fix Test.txt](https://github.com/user-attachments/files/20683057/Test.Pilot.Landing.Logic.Fix.Test.txt)
2. Travel to Sol.
3. Land on Jupiter.
4. Observe that your escort Shuttle doesn't refuel in vanilla, but does refuel with this PR.
