### PR TITLE
fix(mechanics): Properly place die effects spawned by projectiles

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -129,7 +129,8 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 			// This projectile didn't die in a collision. Create any death effects.
 			// Place effects ahead of the projectile by 1.5x velocity. 1x comes from
 			// the anticipated movement of the projectile on its frame of death, and
-			// 0.5x comes from the behaivor of BatchDrawList::Add.
+			// 0.5x comes from the behavior of BatchDrawList::Add drawing the projectile sprite
+			// half way between its current position and its next position.
 			Point effectPosition = position + 1.5 * velocity;
 			for(const auto &it : weapon->DieEffects())
 				for(int i = 0; i < it.second; ++i)

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -127,9 +127,13 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 		if(lifetime > -1000)
 		{
 			// This projectile didn't die in a collision. Create any death effects.
+			// Place effects ahead of the projectile by 1.5x velocity. 1x comes from
+			// the anticipated movement of the projectile on its frame of death, and
+			// 0.5x comes from the behaivor of BatchDrawList::Add.
+			Point effectPosition = position + 1.5 * velocity;
 			for(const auto &it : weapon->DieEffects())
 				for(int i = 0; i < it.second; ++i)
-					visuals.emplace_back(*it.first, position, velocity, angle);
+					visuals.emplace_back(*it.first, effectPosition, velocity, angle);
 
 			for(const auto &it : weapon->Submunitions())
 				if(lifetime > -100 ? it.spawnOnNaturalDeath : it.spawnOnAntiMissileDeath)
@@ -144,6 +148,9 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 		MarkForRemoval();
 		return;
 	}
+	// Spawn live effects. By using the current position of the projectile and not
+	// adding any offset from the projectile's velocity, effects will appear to spawn
+	// from the back of the projectile.
 	for(const auto &it : weapon->LiveEffects())
 		if(!Random::Int(it.second))
 			visuals.emplace_back(*it.first, position, velocity, angle);
@@ -275,9 +282,14 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 // marks the projectile as needing deletion if it has run out of hits.
 void Projectile::Explode(vector<Visual> &visuals, double intersection, Point hitVelocity)
 {
+	// Offset the placement position of effects by the projectile's velocity while
+	// also accounting for the intersection clipping. Hit effects should appear from
+	// the front of the projectile, and so are shifted forward by the full velocity
+	// of the projectile.
+	Point effectPosition = position + velocity * intersection;
 	for(const auto &it : weapon->HitEffects())
 		for(int i = 0; i < it.second; ++i)
-			visuals.emplace_back(*it.first, position + velocity * intersection, velocity, angle, hitVelocity);
+			visuals.emplace_back(*it.first, effectPosition, velocity, angle, hitVelocity);
 	// The projectile dies if it has no hits remaining.
 	if(--hitsRemaining == 0)
 	{

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -150,7 +150,8 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 	}
 	// Spawn live effects. By using the current position of the projectile and not
 	// adding any offset from the projectile's velocity, effects will appear to spawn
-	// from the back of the projectile.
+	// from behind the projectile, as by the time the effect is visible, the projectile
+	// will have moved one frame forward from this position.
 	for(const auto &it : weapon->LiveEffects())
 		if(!Random::Int(it.second))
 			visuals.emplace_back(*it.first, position, velocity, angle);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #5479.
Closes #5479.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When die effects are placed, they currently don't account for the velocity of the parent projectile, hence the behavior seen in the linked issue. This PR changes die effects to have 1.5x the velocity of the parent projectile added to the effect's spawn position. This causes the die effect to appear where the projectile would be next frame had it still been alive.

I'll note that I first tried using an offset of 0.5x, and that did cause the die effect to appear on top of where the projectile was the frame that it died, but that only occurred while my flagship was stationary. As soon as I started moving my flagship, the die effect's origin started to move away from where the projectile was on its last frame. By using an offset of 1.5x, the influence of the flagship's movement goes away... somehow. I'm not entirely sure why that is, tbh. But depending on the style of the die effect, this may or may not be the desirable behavior. I did test how some of the die effects in the game look with and without this behavior, and the velocities that projectiles move at actually meant that the change isn't super big, but the updated behavior does appear better to me, or it at least isn't worse than it was before.

One oddity with this is that die effects don't look very good when used with lasers (they appear half the laser's length ahead of it), but they don't look very good with lasers right now anyway (they appear at the hardpoint). Using an offset of 1x the velocity produced the best result with lasers, but made other weapons I tested not appear as good. Data-defined effect offset time?

## Testing Done + Save File

1. Install [this plugin](https://github.com/user-attachments/files/20684752/test-die-effect.zip) and save file linked in the issue (or just start a new save file, since it's on New Boston).
2. Fire the pom pom gun.
3. Observe that the die effect is placed properly ahead of the projectile instead of jumping back.