### PR TITLE
feat(content): Adjust Sea Scorpion engine hardpoints

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1031,11 +1031,11 @@ ship "Sea Scorpion"
 		zoom 0.4
 		left
 	"steering engine" 29.5 61
-		zoom 0.5
+		zoom 0.55
 		angle -90
 		right
 	"steering engine" -29.5 61
-		zoom 0.5
+		zoom 0.55
 		angle 90
 		left
 	gun -13 -77.5

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1022,20 +1022,20 @@ ship "Sea Scorpion"
 		"Tracker Storage Pod" 4
 		"Value Detector" 2
 
-	engine -28.5 68.5
-	engine 28.5 68.5
-	"steering engine" -28.5 68.5
+	engine -23.5 68.5
+	engine 23.5 68.5
+	"steering engine" -23.5 68.5
 		zoom 0.4
 		right
-	"steering engine" 28.5 68.5
+	"steering engine" 23.5 68.5
 		zoom 0.4
 		left
-	"steering engine" 64.5 23.5
-		zoom 0.55
+	"steering engine" 29.5 61
+		zoom 0.5
 		angle -90
 		right
-	"steering engine" -64.5 23.5
-		zoom 0.55
+	"steering engine" -29.5 61
+		zoom 0.5
 		angle 90
 		left
 	gun -13 -77.5


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The Hai Sea Scorpion's steering flares are in a bit of an odd position. Their exit point is pretty close to the ship's center of mass, making the turning look strange. This PR moves them backwards towards the rear engines, making it look like the steering flares are more properly pivoting the ship around its center of mass.

Some alternatives could be moving them up higher, which I find odd as that's close to the guns, or removing the steering flares entirely, as I feel the Sea Scorpion's overall design looks better without them (and steering flares overall aren't great for most ships), but the current method keeps them.

Additionally, I've adjusted the thruster hardpoints slightly as they weren't directly leaving the two engine pods on the model. I don't believe any major model change is necessary either; a lot of ES's steering sprites are added on after the fact for models; some have structure for them, others are slapped on after the fact.

## Screenshots

Before:
![before](https://github.com/user-attachments/assets/c517cbef-8929-45a0-9a9b-ef66cd6b025b)

After:
![after](https://github.com/user-attachments/assets/5735f5af-bdb4-4fcb-ad5d-bb4c42798026)

https://github.com/user-attachments/assets/0028c1dd-a185-434f-ab6a-ba915d9413d1
