### PR TITLE
fix(ui): Report the proper tonnage of commodities sold when departing

### DIFF
--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -101,8 +101,10 @@ void MainPanel::Step()
 	// will call this object's OnCallback() function;
 	if(isActive && player.GetPlanet() && !player.GetPlanet()->IsWormhole())
 	{
-		GetUI()->Push(new PlanetPanel(player, bind(&MainPanel::OnCallback, this)));
+		PlanetPanel *planetPanel = new PlanetPanel(player, bind(&MainPanel::OnCallback, this));
+		GetUI()->Push(planetPanel);
 		player.Land(GetUI());
+		planetPanel->FinishLanding();
 		isActive = false;
 	}
 

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -33,6 +33,7 @@ class Ship;
 class SpaceportPanel;
 class System;
 class TextArea;
+class TradingPanel;
 
 
 
@@ -43,6 +44,11 @@ class PlanetPanel : public Panel {
 public:
 	PlanetPanel(PlayerInfo &player, std::function<void()> callback);
 	virtual ~PlanetPanel() override;
+
+	// This panel is constructed before the player has finished all
+	// of their landing logic. This is called after the landing logic
+	// has concluded to finish initializing this panel.
+	void FinishLanding();
 
 	virtual void Step() override;
 	virtual void Draw() override;
@@ -71,13 +77,12 @@ private:
 
 	// Whether this planet has a shipyard or outfitter
 	// and the items that are for sale in each shop.
-	bool initializedShops = false;
 	bool hasShipyard = false;
 	bool hasOutfitter = false;
 	Sale<Ship> shipyardStock;
 	Sale<Outfit> outfitterStock;
 
-	std::shared_ptr<Panel> trading;
+	std::shared_ptr<TradingPanel> trading;
 	std::shared_ptr<Panel> bank;
 	std::shared_ptr<SpaceportPanel> spaceport;
 	std::shared_ptr<Panel> hiring;

--- a/source/TradingPanel.h
+++ b/source/TradingPanel.h
@@ -17,6 +17,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Panel.h"
 
+#include <map>
+#include <string>
+
 class PlayerInfo;
 class System;
 
@@ -30,6 +33,14 @@ class TradingPanel : public Panel {
 public:
 	explicit TradingPanel(PlayerInfo &player);
 	~TradingPanel();
+
+	// Set the initial commodities that the player has with them. This must be
+	// called after the player has pooled their cargo from their fleet.
+	void SetInitialCommodities(const std::map<std::string, int> &initial);
+	// Determine how many commodities the player sold from their initial cargo.
+	// This must be called before the player's pooled cargo is moved back
+	// onto their fleet.
+	void CalculateCommoditiesSold(const std::map<std::string, int> &current);
 
 	virtual void Step() override;
 	virtual void Draw() override;
@@ -55,6 +66,12 @@ private:
 	bool sellOutfits = false;
 
 	// Keep track of how much we sold and how much profit was made.
-	int tonsSold = 0;
+	int commoditiesSold = 0;
+	int outfitTonsSold = 0;
 	int64_t profit = 0;
+	// The initial number of tons of each commodity that the player had when
+	// they landed. This is compared against how many of each commodity the
+	// player has when they depart to determine how many tons of commodities
+	// were sold for profit/loss.
+	std::map<std::string, int> initial;
 };


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #2172.
Closes #2172.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The trading panel currently increments a "tonsSold" variable any time you sell a commodity. This is then displayed in the "You sold X tons of cargo for Y credits" message when you depart. The problem is that this is incremented for ANY commodity you sell, meaning you could rapidly buy and sell the same commodity over and over again, and as long as you legitimately sold at least one ton of something that you'd brought to the planet (which causes a `profit` variable to become non-zero and display the message), then the displayed number of tons of cargo sold will have no relation to the profit/loss that is displayed.

This PR changes it so that instead of keeping track of every ton of commodity that you sell, it instead keeps track of which commodities you have on you when you land and compares that to which commodities you have as you're departing. If any particular type of commodity that you depart with is less than it was when you landed, then that is what gets used for the displayed tonnage sold.

## Testing Done

Yes.