### PR TITLE
Fix(typo): Fix Greenrock sending northern pirate fleet when demanded …

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2267,7 +2267,9 @@ planet Greenrock
 	security 0
 	tribute 1800
 		threshold 3500
-		fleet "Large Southern Pirates" 13
+		fleet "Large Southern Pirates" 9
+		fleet "Large Northern Pirates" 2
+		fleet "Large Core Pirates" 2
 
 planet Greenview
 	attributes hai "hai tourism" "hai: human presence" "human tourism" station


### PR DESCRIPTION
…tribute instead of southern fleet

(The lines in parentheses (like this one) are instructions for filling out this template. These lines can be deleted.)
(The lines in double curly brackets ({{}}) should be replaced as it describes.)
(You can open a PR to add to or improve this template, if you find it lacking!)

(Choose one heading, or add your own.)
**Content (Artwork / Missions / Jobs)**
**Balance**
**Feature**
**Bug fix**
**Typo fix**
**CI/CD/Testing**
**Refactor**
**Documentation**

This PR addresses the bug/feature described in issue #{{insert number}}

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Greenrock is on the southern human space but sent northern pirate fleet when demanded tribute instead of southern one.

## Screenshots
{{Include before and after screenshots demonstrating your changes, if applicable.}}

## Usage examples
{{If your changes affect how game data can be defined, provide examples demonstrating the changes here.}}

## Testing Done
{{Describe how you tested these changes. Ensure that new issues aren't introduced.}}
{{If this is a new feature, have you added any automated tests using the unit or integration testing framework?}}

## Save File
This save file can be used to test these changes:
{{Attach a save file that allows people to easily test your added mission content or see your new in-game art.}}

## Artwork Checklist
(If any artwork was added or changed by this PR, the following must be provided.)
 - [ ] I updated the copyright attributions, or decline to claim copyright of any assets produced or modified
 - [ ] I created a PR to the [endless-sky-assets repo](https://github.com/endless-sky/endless-sky-assets) with the necessary image, blend, and texture assets: {{insert PR link}}
 - [ ] I created a PR to the [endless-sky-high-dpi repo](https://github.com/endless-sky/endless-sky-high-dpi) with the `@2x` versions of these art assets: {{insert PR link}}

## Wiki Update
(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)

## Performance Impact
{{If this PR changed code, describe any performance impact (positive or negative). "N/A" if no performance-critical code is changed.}}
