### PR TITLE
fix(ui): Properly cache job deadlines on accept

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1220,6 +1220,11 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 		// Any potential on offer conversation has been finished, so update
 		// the active NPCs for the first time.
 		UpdateNPCs(player);
+		if(deadline)
+		{
+			DistanceMap here(player);
+			player.CalculateRemainingDeadline(*this, here);
+		}
 	}
 	else if(trigger == DECLINE)
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2208,11 +2208,6 @@ void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 			it->Do(Mission::ACCEPT, *this, ui);
 			if(it->IsFailed())
 				RemoveMission(Mission::Trigger::FAIL, *it, ui);
-			if(mission.Deadline())
-			{
-				DistanceMap here(*this, system);
-				CalculateRemainingDeadline(mission, here);
-			}
 			// Might not have cargo anymore, so some jobs can be sorted to end.
 			SortAvailable();
 			break;
@@ -2409,11 +2404,6 @@ void PlayerInfo::MissionCallback(int response)
 	if(response == Conversation::ACCEPT || response == Conversation::LAUNCH)
 	{
 		bool shouldAutosave = mission.RecommendsAutosave();
-		if(mission.Deadline())
-		{
-			DistanceMap here(*this, system);
-			CalculateRemainingDeadline(mission, here);
-		}
 		if(planet)
 		{
 			cargo.AddMissionCargo(&mission);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2208,7 +2208,13 @@ void PlayerInfo::AcceptJob(const Mission &mission, UI *ui)
 			it->Do(Mission::ACCEPT, *this, ui);
 			if(it->IsFailed())
 				RemoveMission(Mission::Trigger::FAIL, *it, ui);
-			SortAvailable(); // Might not have cargo anymore, so some jobs can be sorted to end
+			if(mission.Deadline())
+			{
+				DistanceMap here(*this, system);
+				CalculateRemainingDeadline(mission, here);
+			}
+			// Might not have cargo anymore, so some jobs can be sorted to end.
+			SortAvailable();
 			break;
 		}
 }

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -362,6 +362,9 @@ public:
 	// Should help dialogs relating to carriers be displayed?
 	bool DisplayCarrierHelp() const;
 
+	// Add a mission that was just accepted to the cached remaining deadlines.
+	void CalculateRemainingDeadline(const Mission &mission, DistanceMap &here);
+
 
 private:
 	// Apply any "changes" saved in this player info to the global game state.
@@ -373,8 +376,6 @@ private:
 
 	// New missions are generated each time you land on a planet.
 	void CreateMissions();
-	// Add a mission that was just accepted to the cached remaining deadlines.
-	void CalculateRemainingDeadline(const Mission &mission, DistanceMap &here);
 	void StepMissions(UI *ui);
 	void Autosave() const;
 	void Save(const std::string &path) const;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1383485791791087777).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a job is accepted, it should be added immediately to the player's deadline cache. It seems the function that was supposed to do it, isn't called for jobs, so I moved it to another place.

Please don't tell me to move the function in PlayerInfo.cpp, it's already a mess there. I'll do it separately.

## Testing Done
yes™.

## Performance Impact
N/A
