### PR TITLE
fix(ui): Don't play sound when scrolling in the logbook

### DIFF
--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -280,7 +280,6 @@ bool LogbookPanel::Drag(double dx, double dy)
 	else
 		categoryScroll = max(0., min(maxCategoryScroll, categoryScroll - dy));
 
-	UI::PlaySound(UI::UISound::NORMAL);
 	return true;
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported on [discord](https://discord.com/channels/251118043411775489/536900466655887360/1383476645234479244)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removes the sound.