### PR TITLE
feat(ui): Add a visual nuke alert to the HUD

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1078,6 +1078,9 @@ interface "hud"
 	sprite "ui/red alert"
 		from 10 10
 		align top left
+	visible if "nuke alert"
+	sprite "icon/nuke"
+		from 24 24
 	visible
 	sprite "ui/radar"
 		from 0 0

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1662,6 +1662,7 @@ outfit "Nuclear Missile"
 		"hull damage" 7000
 		"hit force" 6000
 		"missile strength" 200
+		"triggers nuke alert"
 	description "It has been centuries since the last nuclear war was fought, and until very recently, most people in the galaxy assumed that that era of chaos and destruction was forever behind us..."
 	description "	[Nuclear missiles are a one-shot weapon: each missile occupies a gun slot, and after it is fired, the slot it was in is left empty.]"
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -757,8 +757,17 @@ void Engine::Step(bool isActive)
 	info.SetString("date", player.GetDate().ToString());
 	if(flagship)
 	{
-		// Have an alarm label flash up when enemy ships are in the system
-		if(alarmTime && step / 20 % 2 && Preferences::DisplayVisualAlert())
+		// Have an alarm label flash up when enemy ships are in the system.
+		bool nukeAlert = any_of(projectiles.begin(), projectiles.end(),
+			[](const Projectile &projectile) -> bool {
+				return projectile.GetWeapon().TriggersNukeAlert() && projectile.GetGovernment()->IsEnemy();
+			});
+		if(nukeAlert)
+		{
+			if(step / 12 % 2)
+				info.SetCondition("nuke alert");
+		}
+		else if(alarmTime && step / 20 % 2 && Preferences::DisplayVisualAlert())
 			info.SetCondition("red alert");
 		double fuelCap = flagship->Attributes().Get("fuel capacity");
 		// If the flagship has a large amount of fuel, display a solid bar.

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -72,6 +72,8 @@ void Weapon::LoadWeapon(const DataNode &node)
 			canCollideAsteroids = false;
 		else if(key == "no minable collisions")
 			canCollideMinables = false;
+		else if(key == "triggers nuke alert")
+			triggersNukeAlert = true;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -222,6 +222,8 @@ public:
 	// Return the ranges at which the weapon's damage dropoff begins and ends.
 	const std::pair<double, double> &DropoffRanges() const;
 
+	bool TriggersNukeAlert() const;
+
 
 protected:
 	// Legacy support: allow turret outfits with no turn rate to specify a
@@ -377,6 +379,8 @@ private:
 	mutable bool calculatedDamage = true;
 	mutable bool doesDamage = false;
 	mutable double totalLifetime = -1.;
+
+	bool triggersNukeAlert = false;
 };
 
 
@@ -488,3 +492,5 @@ inline bool Weapon::ConsumesDisruption() const { return FiringDisruption() < 0.;
 inline bool Weapon::ConsumesSlowing() const { return FiringSlowing() < 0.; }
 
 inline bool Weapon::HasDamageDropoff() const { return hasDamageDropoff; }
+
+inline bool Weapon::TriggersNukeAlert() const { return triggersNukeAlert; }


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
_There is a warning light on your ship's main control panel that has never turned on. It is a relic of the dark age of galactic travel, part of a sensor system that is built into every starship, to detect incoming nuclear warheads. You had almost forgotten it even existed, because you have never seen it flash.
It begins flashing now._

Added a visual alert that appears when there are enemy nuclear missiles in the system. It's independent of the normal enemy alarm setting, and has priority over the red radar icon when both are to be shown.
To be detected, the weapon spawning the missile must have the new `"triggers nuke alert"` attribute. It's not included in the attributes view in the outfitter, as it's more of a lore thing, and has no effect on the player's own nukes anyway. I added it to the human nukes (Azure please help which of the Avgi weapons need it).

## Screenshots
For now it uses the nuke ammo icon, but looks fine as a temporary solution imo.
![{74B475B4-87FD-4966-8A17-DED6D157B2C0}](https://github.com/user-attachments/assets/079ea584-e840-4d2f-9566-897ad71e812d)

## Testing Done
Tested that enemy missiles trigger the warning, and my own don't.

## Wiki Update
Soon.

## Performance Impact
N/A
