### PR TITLE
feat(ui): Display a weapon's velocity and prospecting efficiency in the outfitter

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1207,8 +1207,8 @@ tip "anti-missile:"
 tip "tractor beam:"
 	`The base velocity that this weapon pulls flotsam toward itself. Heavier flotsam is more difficult to pull.`
 
-tip "mining efficiency:"
-	`A measure of how well this weapon prevents damage to valuable materials while mining. Weapons with a higher efficiency will thus result in higher yields. Some minable objects are tougher than others, and are therefore less susceptible to having their yields increased.`
+tip "mining precision:"
+	`A measure of how well this weapon prevents damage to valuable materials while mining. Weapons with a positive precision result in higher yields, while a negative precision results in lower yields. Some minable objects are tougher than others, and are therefore less susceptible to having their yields altered.`
 
 
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -928,6 +928,9 @@ tip "ammo usage:"
 tip "range:"
 	`Total range of this weapon.`
 
+tip "velocity:"
+	`The initial velocity of projectiles fired by this weapon. Some projectiles may accelerate or decelerate from this initial value as they travel.`
+
 tip "dropoff modifier:"
 	`The multiplier applied to the damage of this weapon once its projectile has reached the maximum dropoff range.`
 
@@ -1203,6 +1206,9 @@ tip "anti-missile:"
 
 tip "tractor beam:"
 	`The base velocity that this weapon pulls flotsam toward itself. Heavier flotsam is more difficult to pull.`
+
+tip "prospecting efficiency:"
+	`A measure of this weapon's prospecting capability when mining. Weapons with a higher prospecting efficiency will result in higher yields. Some minable objects are tougher than others, and are therefore less suseptible to having their yields increased.`
 
 
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -929,7 +929,7 @@ tip "range:"
 	`Total range of this weapon.`
 
 tip "velocity:"
-	`The initial velocity of projectiles fired by this weapon. Some projectiles may accelerate or decelerate from this initial value as they travel.`
+	`The initial velocity of projectiles fired by this weapon. Some weapons have projectiles that accelerate or decelerate from this initial value as they travel.`
 
 tip "dropoff modifier:"
 	`The multiplier applied to the damage of this weapon once its projectile has reached the maximum dropoff range.`
@@ -1207,8 +1207,8 @@ tip "anti-missile:"
 tip "tractor beam:"
 	`The base velocity that this weapon pulls flotsam toward itself. Heavier flotsam is more difficult to pull.`
 
-tip "prospecting efficiency:"
-	`A measure of this weapon's prospecting capability when mining. Weapons with a higher prospecting efficiency will result in higher yields. Some minable objects are tougher than others, and are therefore less susceptible to having their yields increased.`
+tip "mining efficiency:"
+	`A measure of how well this weapon prevents damage to valuable materials while mining. Weapons with a higher efficiency will thus result in higher yields. Some minable objects are tougher than others, and are therefore less susceptible to having their yields increased.`
 
 
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1208,7 +1208,7 @@ tip "tractor beam:"
 	`The base velocity that this weapon pulls flotsam toward itself. Heavier flotsam is more difficult to pull.`
 
 tip "prospecting efficiency:"
-	`A measure of this weapon's prospecting capability when mining. Weapons with a higher prospecting efficiency will result in higher yields. Some minable objects are tougher than others, and are therefore less suseptible to having their yields increased.`
+	`A measure of this weapon's prospecting capability when mining. Weapons with a higher prospecting efficiency will result in higher yields. Some minable objects are tougher than others, and are therefore less susceptible to having their yields increased.`
 
 
 

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -497,13 +497,14 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		}
 	}
 
+	double range = outfit.Range();
 	attributeLabels.emplace_back("range:");
-	attributeValues.emplace_back(Format::Number(outfit.Range()));
+	attributeValues.emplace_back(Format::Number(range));
 	attributesHeight += 20;
 
 	attributeLabels.emplace_back("velocity:");
 	double velocity = outfit.WeightedVelocity();
-	if(velocity == outfit.Range())
+	if(velocity == range)
 		attributeValues.emplace_back("instantaneous");
 	else
 		attributeValues.emplace_back(Format::Number(velocity * 60.));
@@ -708,7 +709,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"missile strength:",
 		"anti-missile:",
 		"tractor beam:",
-		"prospecting efficiency:",
+		"mining efficiency:",
 	};
 	vector<double> otherValues = {
 		outfit.Inaccuracy(),

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -709,7 +709,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"missile strength:",
 		"anti-missile:",
 		"tractor beam:",
-		"mining efficiency:",
+		"mining precision:",
 	};
 	vector<double> otherValues = {
 		outfit.Inaccuracy(),

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -501,6 +501,14 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributeValues.emplace_back(Format::Number(outfit.Range()));
 	attributesHeight += 20;
 
+	attributeLabels.emplace_back("velocity:");
+	double velocity = outfit.WeightedVelocity();
+	if(velocity == outfit.Range())
+		attributeValues.emplace_back("instantaneous");
+	else
+		attributeValues.emplace_back(Format::Number(velocity * 60.));
+	attributesHeight += 20;
+
 	// Identify the dropoff at range and inform the player.
 	double fullDropoff = outfit.MaxDropoff();
 	if(fullDropoff != 1.)
@@ -699,14 +707,16 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"blast radius:",
 		"missile strength:",
 		"anti-missile:",
-		"tractor beam:"
+		"tractor beam:",
+		"prospecting efficiency:",
 	};
 	vector<double> otherValues = {
 		outfit.Inaccuracy(),
 		outfit.BlastRadius(),
 		static_cast<double>(outfit.MissileStrength()),
 		static_cast<double>(outfit.AntiMissile()),
-		outfit.TractorBeam() * 60.
+		outfit.TractorBeam() * 60.,
+		outfit.Prospecting() && outfit.MinableDamage() ? outfit.Prospecting() / outfit.MinableDamage() : 0.,
 	};
 
 	for(unsigned i = 0; i < OTHER_NAMES.size(); ++i)


### PR DESCRIPTION
**UI**

This PR addresses the feature described in issue #3771 w.r.t displaying velocity, plus the an observation made on Discord at least once w.r.t. prospecting not being visible.
Closes #3771.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds the following two weapon attributes to the outfitter info display:
* `velocity`: The initial velocity of the projectile, or the velocity override if one is provided. For weapons whose velocity equals their range (i.e. lasers), the display reads "instantaneous".
* `mining precision`: Instead of displaying the prospecting "damage" per shot or DPS, this value is the prospecting per shot divided by the minable damage per shot of a weapon. The reason for displaying this instead of the raw prospecting value is because the manner in which prospecting interacts with minables means that this ratio between prospecting and minable damage per shot is what you want to maximize on a weapon.

## Testing Done + Screenshots

![image](https://github.com/user-attachments/assets/0a2c820f-c1c6-4e51-ac99-bb68968e71cf)
(Imagine that says "mining precision." I'm not bothering with another screenshot.)
![image](https://github.com/user-attachments/assets/150c44fa-c1e6-4160-bf53-21faca029405)

