### PR TITLE
Close message log by clicking empty space

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2362,6 +2362,9 @@ interface "info panel"
 interface "message log"
 	value "width" 570
 
+	button d ""
+		from 570 0 top left
+		to 0 0 bottom right
 	sprite "ui/message log key"
 		center 710 -30 bottom left
 	visible if "!important messages only"

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2365,6 +2365,9 @@ interface "message log"
 	button d ""
 		from 570 0 top left
 		to 0 0 bottom right
+	button "A" ""
+		center 710 -30 bottom left
+		dimensions 200 60
 	sprite "ui/message log key"
 		center 710 -30 bottom left
 	visible if "!important messages only"


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #11557

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR makes it possible to close the message log panel by clicking the darkened background region, similar to how the logbook works.
This is done by adding a button element to the "message log" interface that sends the "d" key, which closes the panel.
The region spanned by this button is similar to the region that closes the logbook panel.
There is also a "dummy" button that sends the "A" key (which is unused by the logbook panel) creating an exclusion zone around the filter toggle click zone.

## Screenshots
![image](https://github.com/user-attachments/assets/d2d276e6-bd9a-4e63-9e53-da5707017697)
Red highlight is the region that closes the panel.
Yellow(?) is the "dummy" region.
Blue-white is the filter toggle zone.

(The colours are not present in this PR.)

## Usage examples
N/A

## Testing Done
Click

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A(?)

## Performance Impact
Minimal
