### PR TITLE
feat(content): Make "Wanderers: Alpha Surveillance H" offer first before any other eligible missions can offer

### DIFF
--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1494,6 +1494,7 @@ mission "Wanderers: Alpha Surveillance H"
 	description "Meet Admiral Danforth in the spaceport on <origin>, and talk about what to do next about the Alphas."
 	landing
 	source "Farpoint"
+	"offer precedence" 100
 	to offer
 		has "Wanderers: Alpha Surveillance G: done"
 	


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

Closes #7964.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds `"offer precedence" 100` to "Wanderers: Alpha Surveillance H". This causes the mission where you wake up after getting knocked out be the first mission to offer, assuming there are any other missions that are able to offer at the same time.

I decided to do this instead of using `priority` because it allows other missions to offer, while `priority` would block other missions from offering.

## Testing Done

Yes.

## Save File

Let me know if you ~don't trust me~ need one.