### PR TITLE
Fix inappropriate dialog appearance in Cognizance 18

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -654,8 +654,8 @@ mission "Remnant: Cognizance 18"
 				"'olofez" 10
 	on enter "Nenia"
 		dialog `As you enter the system, you quickly search for the Archon, but it is nowhere to be seen. A Korath hunting party, however, is clearly waiting for you and moves to attack. As their ships converge on you, the Pelicans immediately set to work collecting void sprites. As the last one closes its hold, the confirmation codes flash across your tactical screen. "Good to go."`
-	on enter "Pantica"
-		dialog `You watch vigilantly as the Pelicans with the void sprites dip low into Esquiline's atmosphere and open their bay doors. The void sprites emerge tentatively, then confidently launch themselves into the clouds. A few minutes later, you receive a message from Esquiline station informing you that the first void sprite just swooped through the bay, grabbed one of the asteroid supplements, and vanished into the clouds again.`
+	on fail
+		fail "Remnant: Cognizance 18B"
 	on complete
 		log "Successfully introduced a flock of void sprites to Esquiline. Time will tell how they fare."
 		"salary: Remnant" = 2500
@@ -665,6 +665,19 @@ mission "Remnant: Cognizance 18"
 		conversation
 			`Moments later a ping comes in on the commlink, and Prefect Chilia appears on screen accompanied by Plume. Plume gestures first. "Thank you for your work, Captain. It is unclear what the results of this effort will be, but for now, we wait and see. Hopefully the void sprites settle in," he concludes.`
 			`	"In the meantime," continues Chilia, "We are allocating you a daily stipend from our resources to cover some of your ongoing crew, maintenance, and upgrading costs. A larger one-time allotment has already been credited to your account with the shipyard facilities to help cover costs incurred during this mission."`
+
+
+
+mission "Remnant: Cognizance 18B"
+	entering
+	invisible
+	source
+		system "Nenia"
+	destination "Aventine"
+	to offer
+		has "Remnant: Cognizance 18: active"
+	on enter "Pantica"
+		dialog `You watch vigilantly as the Pelicans with the void sprites dip low into Esquiline's atmosphere and open their bay doors. The void sprites emerge tentatively, then confidently launch themselves into the clouds. A few minutes later, you receive a message from Esquiline station informing you that the first void sprite just swooped through the bay, grabbed one of the asteroid supplements, and vanished into the clouds again.`
 
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #7442

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The mission "Remnant: Cognizance 18" involves the player travelling from Viminal in the Arculus system to the Nenia system with some escorts and then returning to Aventine in the Pantica system.
The mission contains an "on enter" dialog for the Pantica system. This dialog is intended to appear after you have visisted the Nenia system during this mission, but there is no such limit placed on the "on enter" dialog; it will appear the first time you enter the Pantica system with this mission active.
This PR moves this "on enter" dialog to a new mission, which is offered when entering the Nenia system with the mission "Remnant: Cognizance 18" mission active. This new mission is invisible and has no other content. This should mean that the dialogs appear in the intended order.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Only in my imagination.

## Save File
This save file can be used to test these changes:
[warp core cog 18 test~original.txt](https://github.com/user-attachments/files/20874132/warp.core.cog.18.test.original.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
