### PR TITLE
fix(ui): Correct pluralization on the mission panel

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -918,8 +918,8 @@ void MissionPanel::DrawMissionInfo()
 	if(availableIt != available.end() || acceptedIt != accepted.end())
 		info.SetCondition("has description");
 
-	info.SetString("cargo free", to_string(player.Cargo().Free()) + " tons");
-	info.SetString("bunks free", to_string(player.Cargo().BunksFree()) + " bunks");
+	info.SetString("cargo free", Format::SimplePluralization(player.Cargo().Free(), "ton"));
+	info.SetString("bunks free", Format::SimplePluralization(player.Cargo().BunksFree(), "bunk"));
 
 	info.SetString("today", player.GetDate().ToString());
 

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -352,7 +352,7 @@ string Format::CargoString(double amount, const string &cargo)
 
 
 // Converts the integer to string, and adds the noun, pluralized if needed.
-string SimplePluralization(int amount, const std::string &noun)
+string Format::SimplePluralization(int amount, const string &noun)
 {
 	string result = to_string(amount) + ' ' + noun;
 	if(amount != 1)

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -351,6 +351,17 @@ string Format::CargoString(double amount, const string &cargo)
 
 
 
+// Converts the integer to string, and adds the noun, pluralized if needed.
+string SimplePluralization(int amount, const std::string &noun)
+{
+	string result = to_string(amount) + ' ' + noun;
+	if(amount != 1)
+		result += 's';
+	return result;
+}
+
+
+
 // Convert a time in seconds to years/days/hours/minutes/seconds
 string Format::PlayTime(double timeVal)
 {

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -45,6 +45,8 @@ public:
 	static std::string MassString(double amount);
 	// Creates a string similar to '<amount> tons of <cargo>'.
 	static std::string CargoString(double amount, const std::string &cargo);
+	// Converts the integer to string, and adds the noun, pluralized if needed.
+	static std::string SimplePluralization(int amount, const std::string &noun);
 	// Convert a time in seconds to years/days/hours/minutes/seconds
 	static std::string PlayTime(double timeVal);
 	// Convert an ammo count into a short string for use in the ammo display.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11582 (resolves #11582).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a simple pluralization helper to Format, and used it in MissionPanel.

## Testing Done
![image](https://github.com/user-attachments/assets/82c9aebf-f32a-430c-870a-b3ed8e4e9b27)
![{A23733E0-E5EC-40D3-8F07-C48D3C7AD7EB}](https://github.com/user-attachments/assets/9d46dcf4-196a-483a-a875-dceb00e43ea9)
(ignore the TextArea misaligned due to window resizing)

## Performance Impact
N/A