### PR TITLE
refactor: Move common code for listing items to Format

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "DistanceMap.h"
 #include "FighterHitHelper.h"
 #include "Flotsam.h"
+#include "text/Format.h"
 #include "FormationPattern.h"
 #include "FormationPositioner.h"
 #include "GameData.h"
@@ -4230,17 +4231,11 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 			string message = "Note: you have ";
 			message += (missions == 1 ? "a mission that requires" : "missions that require");
 			message += " landing on ";
-			size_t count = destinations.size();
-			bool oxfordComma = (count > 2);
-			for(const Planet *planet : destinations)
-			{
-				message += planet->DisplayName();
-				--count;
-				if(count > 1)
-					message += ", ";
-				else if(count == 1)
-					message += (oxfordComma ? ", and " : " and ");
-			}
+			message += Format::List<set, const Planet *>(destinations,
+				[](const Planet *const &planet)
+				{
+					return planet->DisplayName();
+				});
 			message += " in the system you are jumping to.";
 			Messages::Add(message, Messages::Importance::Info);
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -275,35 +275,12 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	if(debtPaid)
 		typesPaid["debt"] = debtPaid;
 
-	// If you made payments of three or more types, the punctuation needs to
-	// include commas, so just handle that separately here.
-	if(typesPaid.size() >= 3)
-	{
-		auto it = typesPaid.begin();
-		for(unsigned int i = 0; i < typesPaid.size() - 1; ++i)
+	out << Format::List<map, string, int64_t>(typesPaid,
+		[](const pair<string, int64_t> &it)
 		{
-			out << Format::CreditString(it->second) << " in " << it->first << ", ";
-			++it;
-		}
-		out << "and " << Format::CreditString(it->second) << " in " << it->first + ".";
-	}
-	else
-	{
-		if(salariesPaid)
-			out << Format::CreditString(salariesPaid) << " in crew salaries"
-				<< ((mortgagesPaid || finesPaid || debtPaid || maintenancePaid) ? " and " : ".");
-		if(maintenancePaid)
-			out << Format::CreditString(maintenancePaid) << "  in maintenance"
-				<< ((mortgagesPaid || finesPaid || debtPaid) ? " and " : ".");
-		if(mortgagesPaid)
-			out << Format::CreditString(mortgagesPaid) << " in mortgages"
-				<< ((finesPaid || debtPaid) ? " and " : ".");
-		if(finesPaid)
-			out << Format::CreditString(finesPaid) << " in fines"
-				<< (debtPaid ? " and " : ".");
-		if(debtPaid)
-			out << Format::CreditString(debtPaid) << " in debt.";
-	}
+			return Format::CreditString(it.second) + " in " + it.first;
+		});
+	out << '.';
 	return out.str();
 }
 

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -146,7 +146,10 @@ void ItemInfoDisplay::UpdateDescription(const string &text, const vector<string>
 				bool isVoweled = false;
 				for(const char &c : "aeiou")
 					if(name.starts_with(c) || name.starts_with(toupper(c)))
+					{
 						isVoweled = true;
+						break;
+					}
 				return (isVoweled ? "an " : "a ") + name + " License";
 			});
 		fullText += ".\n";

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -16,10 +16,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ItemInfoDisplay.h"
 
 #include "text/Alignment.h"
-#include "text/Format.h"
 #include "Color.h"
 #include "shader/FillShader.h"
 #include "text/FontSet.h"
+#include "text/Format.h"
 #include "GameData.h"
 #include "Rectangle.h"
 #include "Screen.h"

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ItemInfoDisplay.h"
 
 #include "text/Alignment.h"
+#include "text/Format.h"
 #include "Color.h"
 #include "shader/FillShader.h"
 #include "text/FontSet.h"
@@ -139,23 +140,15 @@ void ItemInfoDisplay::UpdateDescription(const string &text, const vector<string>
 	{
 		static const string NOUN[2] = {"outfit", "ship"};
 		string fullText = text + "\tTo purchase this " + NOUN[isShip] + " you must have ";
-		for(unsigned i = 0; i < licenses.size(); ++i)
-		{
-			bool isVoweled = false;
-			for(const char &c : "aeiou")
-				if(*licenses[i].begin() == c || *licenses[i].begin() == toupper(c))
-					isVoweled = true;
-			if(i)
+		fullText += Format::List<vector, string>(licenses,
+			[](const string &name)
 			{
-				if(licenses.size() > 2)
-					fullText += ", ";
-				else
-					fullText += " ";
-			}
-			if(i && i == licenses.size() - 1)
-				fullText += "and ";
-			fullText += (isVoweled ? "an " : "a ") + licenses[i] + " License";
-		}
+				bool isVoweled = false;
+				for(const char &c : "aeiou")
+					if(name.starts_with(c) || name.starts_with(toupper(c)))
+						isVoweled = true;
+				return (isVoweled ? "an " : "a ") + name + " License";
+			});
 		fullText += ".\n";
 		description.Wrap(fullText);
 	}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1575,7 +1575,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 			[](const Planet *const &planet)
 			{
 				return planet->DisplayName();
-			});;
+			});
 	}
 	// Waypoints and marks: "<system name>" with "," and "and".
 	if(!result.waypoints.empty())

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1565,9 +1565,9 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 		subs["<payment>"] = Format::CreditString(abs(result.paymentApparent));
 	// Stopovers: "<name> in the <system name> system" with "," and "and".
 	auto getDisplayName = [](const auto *const &item)
-		{
-			return item->DisplayName();
-		};
+	{
+		return item->DisplayName();
+	};
 	if(!result.stopovers.empty())
 	{
 		subs["<stopovers>"] = Format::List<set, const Planet *>(result.stopovers,

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1564,6 +1564,10 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	if(result.paymentApparent)
 		subs["<payment>"] = Format::CreditString(abs(result.paymentApparent));
 	// Stopovers: "<name> in the <system name> system" with "," and "and".
+	auto getDisplayName = [](const auto *const &item)
+		{
+			return item->DisplayName();
+		};
 	if(!result.stopovers.empty())
 	{
 		subs["<stopovers>"] = Format::List<set, const Planet *>(result.stopovers,
@@ -1571,25 +1575,13 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 			{
 				return planet->DisplayName() + " in the " + planet->GetSystem()->DisplayName() + " system";
 			});
-		subs["<planet stopovers>"] = Format::List<set, const Planet *>(result.stopovers,
-			[](const Planet *const &planet)
-			{
-				return planet->DisplayName();
-			});
+		subs["<planet stopovers>"] = Format::List<set, const Planet *>(result.stopovers, getDisplayName);
 	}
 	// Waypoints and marks: "<system name>" with "," and "and".
 	if(!result.waypoints.empty())
-		subs["<waypoints>"] = Format::List<set, const System *>(result.waypoints,
-			[](const System *const &system)
-			{
-				return system->DisplayName();
-			});
+		subs["<waypoints>"] = Format::List<set, const System *>(result.waypoints, getDisplayName);
 	if(!result.markedSystems.empty())
-		subs["<marks>"] = Format::List<set, const System *>(result.markedSystems,
-			[](const System *const &system)
-			{
-				return system->DisplayName();
-			});
+		subs["<marks>"] = Format::List<set, const System *>(result.markedSystems, getDisplayName);
 
 	// Done making subs, so expand the phrases and recursively substitute.
 	for(const auto &keyValue : subs)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1563,46 +1563,33 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	subs["<day>"] = result.deadline.LongString();
 	if(result.paymentApparent)
 		subs["<payment>"] = Format::CreditString(abs(result.paymentApparent));
-	// Stopover and waypoint substitutions: iterate by reference to the
-	// pointers so we can check when we're at the very last one in the set.
 	// Stopovers: "<name> in the <system name> system" with "," and "and".
 	if(!result.stopovers.empty())
 	{
-		string stopovers;
-		string planets;
-		const Planet * const *last = &*--result.stopovers.end();
-		int count = 0;
-		for(const Planet * const &planet : result.stopovers)
-		{
-			if(count++)
+		subs["<stopovers>"] = Format::List<set, const Planet *>(result.stopovers,
+			[](const Planet *const &planet)
 			{
-				string result = (&planet != last) ? ", " : (count > 2 ? ", and " : " and ");
-				stopovers += result;
-				planets += result;
-			}
-			stopovers += planet->DisplayName() + " in the " + planet->GetSystem()->DisplayName() + " system";
-			planets += planet->DisplayName();
-		}
-		subs["<stopovers>"] = stopovers;
-		subs["<planet stopovers>"] = planets;
+				return planet->DisplayName() + " in the " + planet->GetSystem()->DisplayName() + " system";
+			});
+		subs["<planet stopovers>"] = Format::List<set, const Planet *>(result.stopovers,
+			[](const Planet *const &planet)
+			{
+				return planet->DisplayName();
+			});;
 	}
 	// Waypoints and marks: "<system name>" with "," and "and".
-	auto systemsReplacement = [](const set<const System *> &systemsSet) -> string {
-		string systems;
-		const System * const *last = &*--systemsSet.end();
-		int count = 0;
-		for(const System * const &system : systemsSet)
-		{
-			if(count++)
-				systems += (&system != last) ? ", " : (count > 2 ? ", and " : " and ");
-			systems += system->DisplayName();
-		}
-		return systems;
-	};
 	if(!result.waypoints.empty())
-		subs["<waypoints>"] = systemsReplacement(result.waypoints);
+		subs["<waypoints>"] = Format::List<set, const System *>(result.waypoints,
+			[](const System *const &system)
+			{
+				return system->DisplayName();
+			});
 	if(!result.markedSystems.empty())
-		subs["<marks>"] = systemsReplacement(result.markedSystems);
+		subs["<marks>"] = Format::List<set, const System *>(result.markedSystems,
+			[](const System *const &system)
+			{
+				return system->DisplayName();
+			});
 
 	// Done making subs, so expand the phrases and recursively substitute.
 	for(const auto &keyValue : subs)

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4854,34 +4854,23 @@ bool PlayerInfo::CanBeSaved() const
 void PlayerInfo::DoAccounting()
 {
 	// Check what salaries and tribute the player receives.
+	map<string, int64_t> income;
 	int64_t salariesIncome = accounts.SalariesIncomeTotal();
+	if(salariesIncome)
+		income["salary"] = salariesIncome;
 	int64_t tributeIncome = GetTributeTotal();
+	if(tributeIncome)
+		income["in tribute"] = tributeIncome;
 	FleetBalance balance = MaintenanceAndReturns();
-	if(salariesIncome || tributeIncome || balance.assetsReturns)
+	if(balance.assetsReturns)
+		income["based on outfits and ships"] = balance.assetsReturns;
+	if(!income.empty())
 	{
-		string message = "You receive ";
-		if(salariesIncome)
-		{
-			message += Format::CreditString(salariesIncome) + " salary";
-			if(tributeIncome)
+		string message = "You receive " + Format::List<map, string, int64_t>(income,
+			[](const pair<string, int64_t> &it)
 			{
-				if(balance.assetsReturns)
-					message += ", ";
-				else
-					message += " and ";
-			}
-		}
-		if(tributeIncome)
-			message += Format::CreditString(tributeIncome) + " in tribute";
-		if(balance.assetsReturns)
-		{
-			if(salariesIncome && tributeIncome)
-				message += ",";
-			if(salariesIncome || tributeIncome)
-				message += " and ";
-			message += Format::CreditString(balance.assetsReturns) + " based on outfits and ships";
-		}
-		message += ".";
+				return to_string(it.second) + ' ' + it.first;
+			}) + '.';
 		Messages::Add(message, Messages::Importance::High, true);
 		accounts.AddCredits(salariesIncome + tributeIncome + balance.assetsReturns);
 	}

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4869,7 +4869,7 @@ void PlayerInfo::DoAccounting()
 		string message = "You receive " + Format::List<map, string, int64_t>(income,
 			[](const pair<string, int64_t> &it)
 			{
-				return to_string(it.second) + ' ' + it.first;
+				return Format::CreditString(it.second) + ' ' + it.first;
 			}) + '.';
 		Messages::Add(message, Messages::Importance::High, true);
 		accounts.AddCredits(salariesIncome + tributeIncome + balance.assetsReturns);

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -86,4 +86,30 @@ public:
 
 	// Function for the "find" dialogs:
 	static int Search(const std::string &str, const std::string &sub);
+
+	// Return a string containing the elements separated with commas and "and" where needed.
+	template<template<class...> class C, class... T>
+	static std::string List(const C<T...> &elements,
+		std::function<std::string(typename C<T...>::const_reference)> toString);
 };
+
+
+
+template<template<class...> class C, class... T>
+std::string Format::List(const C<T...> &elements,
+	std::function<std::string(typename C<T...>::const_reference)> toString)
+{
+	std::string result;
+	if(elements.empty())
+		return result;
+	auto it = elements.begin();
+	result = toString(*it);
+	std::advance(it, 1);
+	if(it == elements.end())
+		return result;
+	if(elements.size() == 2)
+		return result + " and " + toString(*it);
+	for( ; it != std::prev(elements.end()); std::advance(it, 1))
+		result += ", " + toString(*it);
+	return result + ", and " + toString(*it);
+}


### PR DESCRIPTION
**Refactor**

This PR addresses the problem that has always bothered me.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a templated (so it works in various cases) function to Format, responsible for adding `,`, `and`, and `, and` when listing items from the given container.

It's currently used in the four places that I managed to grep out, but if you know of any other code that could benefit from it, post your comments below. I didn't replace the ships listing code in the sale dialog as it puts everything on separate lines, and is more complicated in general.

## Testing Done
- [x] Destination messages
- [x] Income messages
- [x] Payments messages
- [x] License requirements
- [x] Waypoint and stopover replacements

## Performance Impact
N/A
