### PR TITLE
Fix Windows release CD

### DIFF
--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -107,7 +107,7 @@ jobs:
           vcpkgGitCommitId: '89dc8be6dbcf18482a5a1bf86a2f4615c939b0fb'
       - name: Run CMake
         run: |
-          cmake --preset mingw-release -DCPACK_PACKAGE_FILE_NAME=EndlessSky-${{ inputs.release_version }}-win64-setup
+          cmake --preset mingw-release -DCPACK_PACKAGE_FILE_NAME="EndlessSky-${{ inputs.release_version }}-win64-setup"
           cmake --build build --preset mingw-ci-release
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
@@ -163,7 +163,7 @@ jobs:
           vcpkgGitCommitId: '89dc8be6dbcf18482a5a1bf86a2f4615c939b0fb'
       - name: Run CMake
         run: |
-          cmake --preset mingw32-release -DCPACK_PACKAGE_FILE_NAME=EndlessSky-${{ inputs.release_version }}-win32-setup
+          cmake --preset mingw32-release -DCPACK_PACKAGE_FILE_NAME="EndlessSky-${{ inputs.release_version }}-win32-setup"
           cmake --build build --preset mingw32-ci-release
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"


### PR DESCRIPTION
**CI/CD/Testing**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
It seems the `.` character in the cpack parameter name breaks the workflow if not enclosed in quotes.