### PR TITLE
feat(enhancement): Allow weapon hardpoints to be swizzled with the ship

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -103,6 +103,13 @@ const Swizzle *Body::GetSwizzle() const
 
 
 
+bool Body::InheritsParentSwizzle() const
+{
+	return inheritsParentSwizzle;
+}
+
+
+
 // Get the frame index for the given time step. If no time step is given, this
 // will return the frame from the most recently given step.
 float Body::GetFrame(int step) const
@@ -249,6 +256,8 @@ void Body::LoadSprite(const DataNode &node)
 			rewind = true;
 		else if(key == "center" && child.Size() >= 3)
 			center = Point(child.Value(1), child.Value(2));
+		else if(key == "inherits parent swizzle")
+			inheritsParentSwizzle = true;
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
@@ -282,6 +291,8 @@ void Body::SaveSprite(DataWriter &out, const string &tag) const
 			out.Write("rewind");
 		if(center)
 			out.Write("center", center.X(), center.Y());
+		if(inheritsParentSwizzle)
+			out.Write("inherits parent swizzle");
 	}
 	out.EndChild();
 }

--- a/source/Body.h
+++ b/source/Body.h
@@ -51,6 +51,7 @@ public:
 	double Radius() const;
 	// Which color swizzle should be applied to the sprite?
 	const Swizzle *GetSwizzle() const;
+	bool InheritsParentSwizzle() const;
 	// Get the sprite frame and mask for the given time step.
 	float GetFrame(int step = -1) const;
 	const Mask &GetMask(int step = -1) const;
@@ -132,6 +133,7 @@ private:
 	const Sprite *sprite = nullptr;
 	// Allow objects based on this one to adjust their frame rate and swizzle.
 	const Swizzle *swizzle = Swizzle::None();
+	bool inheritsParentSwizzle = false;
 
 	float frameRate = 2.f / 60.f;
 	int delay = 0;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2837,6 +2837,8 @@ void Engine::DrawShipSprites(const Ship &ship)
 				ship.Velocity(),
 				ship.Facing() + hardpoint.GetAngle(),
 				ship.Zoom());
+			if(body.InheritsParentSwizzle())
+				body.SetSwizzle(ship.GetSwizzle());
 			drawObject(body);
 		}
 	};


### PR DESCRIPTION
**Feature**

This PR addresses the feature described on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
You can now make a visible hardpoint swizzle accordingly to the ship (see the syntax below). It can be especially useful for larger sprites that would look weird with a static color.

## Usage examples
```html
outfit <name>
	weapon
		"hardpoint sprite" <name>
			"inherits parent swizzle"
```

## Testing Done
yes.™

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/160

## Performance Impact
I'm not really sure about the additional bool. A possible alternative would be to set the swizzle to null instead, but that could be easily overlooked in future code and lead to problems.
