### PR TITLE
feat(content): Make the Heavy Gust available

### DIFF
--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -315,7 +315,19 @@ ship "Heavy Gust"
 	"final explode" "final explosion medium"
 	description "The Heavy Gust is a further modification of the Strong Wind, adjusted even more heavily for combat purposes at the expense of much of its precursor's peacetime utility. These modifications make the Heavy Gust a fast medium warship, agile enough to keep up with foes too quick to be caught with a Tempest."
 
-
+ship "Heavy Gust" "Heavy Gust (Moonbeam)"
+	outfits
+		"Sunbeam" 4
+		"Moonbeam" 2
+		"Moonbeam Turret"
+		
+		"Blue Sun Reactor"
+		"Dark Storm Shielding"
+		
+		"Type 4 Radiant Thruster"
+		"Type 4 Radiant Steering"
+		"Hyperdrive"
+		
 
 ship "Tempest"
 	sprite "ship/tempest"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -303,7 +303,8 @@ mission "Wanderers: First Mereti Attack"
 			variant
 				"Derecho"
 				"Tempest" 2
-				"Autumn Leaf" 3
+				"Heavy Gust"
+				"Autumn Leaf" 1
 	npc
 		government "Wanderer"
 		system Kaliptari
@@ -313,9 +314,9 @@ mission "Wanderers: First Mereti Attack"
 			variant
 				"Derecho"
 				"Tempest" 2
-				"Strong Wind" 1
-				"Autumn Leaf" 2
-				"Summer Leaf" 3
+				"Heavy Gust" 1
+				"Autumn Leaf" 3
+				"Summer Leaf" 2
 	on complete
 		event "wanderers: kaliptari battle ends"
 
@@ -1006,7 +1007,8 @@ mission "Wanderers: Mind Escorts"
 			variant
 				"Hurricane" 2
 				"Derecho" 3
-				"Tempest" 5
+				"Tempest" 4
+				"Heavy Gust" 2
 
 mission "Wanderers: Mind 4"
 	landing
@@ -1704,6 +1706,7 @@ mission "Wanderers: Sestor Attack"
 			names "wanderer"
 			variant
 				"Tempest (Heavy)"
+				"Heavy Gust"
 				"Strong Wind"
 		fleet
 			names "wanderer"
@@ -3194,6 +3197,7 @@ mission "Wanderers: Sestor: Factory Escorts"
 				"Tempest (Heavy)"
 				"Tempest (Moonbeam)" 2
 				"Tempest"
+				"Heavy Gust (Moonbeam)" 2
 
 
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1618,6 +1618,7 @@ mission "Wanderers: Alpha Surveillance J"
 	
 	on complete
 		"reputation: Wanderer" >?= 30
+		event "wanderers: heavy gust mass production" 30
 		event "wanderers: unfettered invasion starts" 64
 		log "Reported to the Wanderers that the Alphas who had been selling jump drives to the Unfettered have been weakened and driven into hiding. The Wanderers are ramping up production of military ships to try to face the continuing Unfettered onslaught."
 		conversation

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1641,7 +1641,16 @@ mission "Wanderers: Unfettered Invasion Patch"
 		event "wanderers: unfettered invasion starts"
 		fail
 
-
+# Giving Heavy Gust to old saves:
+mission "Wanderers: Heavy Gust Patch"
+	landing
+	invisible
+	to offer
+		has "event: wanderers: unfettered invasion starts"
+		not "event: wanderers: heavy gust mass production"
+	on offer
+		event "wanderers: heavy gust mass production"
+		fail
 
 mission "Wanderers Invaded 0"
 	landing

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -1807,7 +1807,7 @@ mission "Wanderers Invaded 2"
 		fleet
 			names "wanderer"
 			variant
-				"Strong Wind" 1
+				"Heavy Gust" 1
 				"Autumn Leaf" 2
 				"Summer Leaf" 3
 	npc
@@ -2498,8 +2498,7 @@ mission "Wanderers Defend Sich'ka'ara"
 			names "wanderer"
 			variant
 				"Tempest (Heavy)"
-				"Tempest"
-				"Strong Wind" 1
+				"Heavy Gust" 2
 				"Autumn Leaf" 2
 				"Summer Leaf" 3
 	on complete
@@ -2940,7 +2939,7 @@ mission "Wanderers Ap'arak 2"
 			variant
 				"Derecho (Turret)"
 				"Derecho"
-				"Strong Wind" 2
+				"Heavy Gust" 2
 				"Autumn Leaf" 4
 				"Summer Leaf" 3
 	npc

--- a/data/wanderer/wanderers.txt
+++ b/data/wanderer/wanderers.txt
@@ -1065,6 +1065,9 @@ event "wanderers: moonbeam mass production"
 		add variant
 			"Derecho"
 			"Autumn Leaf (Heavy)" 2
+		add variant 2
+			"Heavy Gust"
+			"Heavy Gust (Moonbeam)" 2
 	outfitter "Wanderer Advanced"
 		"Moonbeam"
 		"Moonbeam Turret"

--- a/data/wanderer/wanderers.txt
+++ b/data/wanderer/wanderers.txt
@@ -783,6 +783,30 @@ event "wanderers: unfettered invasion starts"
 	planet "Varu Mer'ek"
 		add attributes "evacuation"
 
+event "wanderers: heavy gust mass production"
+	shipyard "Wanderer Advanced"
+		"Heavy Gust"
+	fleet "Wanderer Defense"
+		add variant 2
+			"Heavy Gust"
+			"Autumn Leaf"
+		add variant 3
+			"Heavy Gust"
+			"Autumn Leaf" 2
+		add variant 2
+			"Heavy Gust" 2
+		add variant 1
+			"Heavy Gust" 3
+		add variant 1
+			"Strong Wind"
+			"Heavy Gust"
+		remove variant
+			"Strong Wind"
+			"Summer Leaf"
+		remove variant
+			"Strong Wind"
+			"Summer Leaf" 3
+
 event "wanderers: riptide mass production"
 	fleet "Wanderer Freight"
 		add variant 3
@@ -806,7 +830,10 @@ event "wanderers: tempest mass production"
 			"Tempest"
 			"Summer Leaf"
 			"Autumn Leaf"
-		add variant 4
+		add variant 3
+			"Tempest (Heavy)"
+			"Heavy Gust"
+		add variant 1
 			"Tempest (Heavy)"
 			"Strong Wind"
 		add variant 1
@@ -819,20 +846,11 @@ event "wanderers: tempest mass production"
 		add variant 1
 			"Tempest (Missile)" 2
 		add variant 2
-			"Strong Wind"
-			"Autumn Leaf"
-		add variant 2
 			"Autumn Leaf" 3
 		add variant 1
 			"Summer Leaf" 4
 		remove variant
 			"Summer Leaf" 5
-		remove variant
-			"Strong Wind"
-			"Summer Leaf"
-		remove variant
-			"Strong Wind"
-			"Summer Leaf" 3
 		remove variant
 			"Autumn Leaf" 2
 		remove variant
@@ -958,7 +976,8 @@ event "wanderers: derecho mass production"
 			"Tempest (Heavy)"
 		add variant 4
 			"Derecho"
-			"Strong Wind" 2
+			"Heavy Gust"
+			"Strong Wind"
 		add variant 3
 			"Derecho (Tough)"
 			"Autumn Leaf"
@@ -1011,6 +1030,9 @@ event "wanderers: hurricane mass production"
 		add variant 2
 			"Hurricane (Tough)"
 			"Tempest (Missile)" 2
+		add variant 2
+			"Hurricane"
+			"Heavy Gust" 2
 	shipyard "Wanderer Advanced"
 		"Hurricane"
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds the Wanderer Heavy Gust to fleets and shipyards, appearing after the Autumn Leaf but before the Tempest. While it's visible before the Tempest enters production, it can't be purchased until the player gains the military license.
Also adds Heavy Gusts in some fleets added later (including adding a moonbeam variant that appears when the moonbeam becomes available), and to some mission fleets.
I was originally planning to have more mention of it, but there really isn't much space at all between those two events, since the Tempest appears almost immediately after the Unfettered attack, and that's the first event after the Autumn Leaf's release.

## Testing Done
none

## Save File
Will be available on any save that's completed Wanderers, I don't currently have one at the relevant point in the campaign.
