### PR TITLE
Ember Waste Node duplicate line removal

### DIFF
--- a/data/drak/indigenous.txt
+++ b/data/drak/indigenous.txt
@@ -179,7 +179,6 @@ ship "Ember Waste Node"
 		"mass" 1500
 		"drag" 12.3
 		"heat dissipation" .67
-		"fuel capacity" 250
 		"cargo space" 39
 		"outfit space" 0
 		"thrust" 120


### PR DESCRIPTION
Cheap contribution -- the Ember Waste Node has the fuel capacity line twice, with 250 (l.182) and with 200 (l.194).

This PR proudly and pompously removes the first one because of consistency with the fuel capacities of all other space creatures which are multiples of 100.

Doesn't change the cargo space from 39 to 40, because there's surely a good reason for the current value.

## Acknowledgement

- [ ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.