### PR TITLE
feat(ui): Smoothly move the system minimap toward the next destination system

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -185,6 +185,8 @@ target_sources(EndlessSkyLib PRIVATE
 	Minable.cpp
 	Minable.h
 	MinableDamageDealt.h
+	MiniMap.cpp
+	MiniMap.h
 	Mission.cpp
 	Mission.h
 	MissionAction.cpp

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -523,7 +523,6 @@ void Engine::Step(bool isActive)
 		{
 			doEnter = false;
 			events.emplace_back(flagship, flagship, ShipEvent::JUMP);
-			minimap.Fade();
 		}
 
 		minimap.Step(flagship);
@@ -1458,6 +1457,7 @@ void Engine::EnterSystem()
 		// its destination system. Player travel causes a date change,
 		// thus the wormhole's new position should be used.
 		flagship->SetPosition(usedWormhole->Position());
+		minimap.SnapToCenter();
 		if(player.HasTravelPlan())
 		{
 			// Wormhole travel generally invalidates travel plans

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -250,7 +250,7 @@ namespace {
 
 Engine::Engine(PlayerInfo &player)
 	: player(player), ai(player, ships, asteroids.Minables(), flotsam),
-	ammoDisplay(player), shipCollisions(256u, 32u, CollisionType::SHIP)
+	ammoDisplay(player), minimap(player), shipCollisions(256u, 32u, CollisionType::SHIP)
 {
 	zoom.base = Preferences::ViewZoom();
 	zoom.modifier = Preferences::Has("Landing zoom") ? 2. : 1.;
@@ -518,54 +518,15 @@ void Engine::Step(bool isActive)
 				if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsAccessible(flagship.get()))
 					labels.emplace_back(labels, *player.GetSystem(), object);
 		}
+
 		if(doEnter && flagship->Zoom() == 1. && !flagship->IsHyperspacing())
 		{
 			doEnter = false;
 			events.emplace_back(flagship, flagship, ShipEvent::JUMP);
-			// Only let the minimap linger for 1.5 seconds after a jump has completed.
-			displayMinimap = min(displayMinimap, 90);
+			minimap.Fade();
 		}
-		if(flagship->IsEnteringHyperspace() || flagship->Commands().Has(Command::JUMP))
-		{
-			// Let the minimap linger for 3 seconds after the player hit the jump key.
-			displayMinimap = 180;
-			// Draw the systems that the player is jumping between on the minimap.
-			const System *from = flagship->GetSystem();
-			const System *to = flagship->GetTargetSystem();
-			if(from && to && from != to)
-			{
-				minimapSystems[0] = from;
-				minimapSystems[1] = to;
-			}
-		}
-		else if(displayMinimap > 0)
-			--displayMinimap;
-		else
-		{
-			// If the jump has completed, draw the next system in the player's jump
-			// plan, or set the minimapSystems to nullptr to only display the current
-			// system if the travel plan is empty.
-			const vector<const System *> &plan = player.TravelPlan();
-			if(plan.empty())
-			{
-				minimapSystems[0] = nullptr;
-				minimapSystems[1] = nullptr;
-			}
-			else
-			{
-				minimapSystems[0] = flagship->GetSystem();
-				minimapSystems[1] = plan.front();
-			}
-		}
-		if(displayMinimap)
-		{
-			if(displayMinimap < 30 && fadeMinimap)
-				--fadeMinimap;
-			else if(fadeMinimap < 30)
-				++fadeMinimap;
-		}
-		else
-			fadeMinimap = 0;
+
+		minimap.Step(flagship);
 	}
 	ai.UpdateEvents(events);
 	if(isActive)
@@ -1349,11 +1310,7 @@ void Engine::Draw() const
 	}
 
 	// Draw the systems mini-map.
-	Preferences::MinimapDisplay minimap = Preferences::GetMinimapDisplay();
-	if(minimap == Preferences::MinimapDisplay::ALWAYS_ON)
-		MapPanel::DrawMiniMap(player, 1.f, minimapSystems, step);
-	else if(displayMinimap && minimap == Preferences::MinimapDisplay::WHEN_JUMPING)
-		MapPanel::DrawMiniMap(player, .5f * min(1.f, fadeMinimap / 30.f), minimapSystems, step);
+	minimap.Draw(step);
 
 	// Draw ammo status.
 	double ammoIconWidth = hud->GetValue("ammo icon width");

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "shader/DrawList.h"
 #include "EscortDisplay.h"
 #include "Information.h"
+#include "MiniMap.h"
 #include "PlanetLabel.h"
 #include "Point.h"
 #include "Preferences.h"
@@ -269,17 +270,10 @@ private:
 	std::vector<AlertLabel> missileLabels;
 	std::vector<TurretOverlay> turretOverlays;
 	std::vector<std::pair<const Outfit *, int>> ammo;
-	// How many frames the mini-map should be displayed for when it is set to only appear
-	// when jumping.
-	int displayMinimap = 0;
-	// Controls the fading in and out of the minimap. The minimap should fade in and out over
-	// the course of 30 frames (0.5 seconds).
-	int fadeMinimap = 0;
-	// The two primary systems to display in the minimap, along with all their linked neighbors.
-	// If either are null, then only the player's current system is drawn.
-	const System *minimapSystems[2] = {nullptr, nullptr};
 	// Flagship's hyperspace percentage converted to a [0, 1] double.
 	double hyperspacePercentage = 0.;
+
+	MiniMap minimap;
 
 	int step = 0;
 	bool timePaused = false;

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -52,6 +52,7 @@ public:
 	static const int SHOW_DANGER = -7;
 	static const int SHOW_STARS = -8;
 
+	static const unsigned MAX_MISSION_POINTERS_DRAWN;
 	static const float OUTER;
 	static const float INNER;
 	static const float LINK_WIDTH;
@@ -68,6 +69,11 @@ public:
 	};
 
 
+public:
+	static void DrawPointer(Point position, unsigned &systemCount, const Color &color,
+		bool drawBack = true, bool bigger = false);
+	static std::pair<bool, bool> BlinkMissionIndicator(const PlayerInfo &player, const Mission &mission, int step);
+
 
 public:
 	explicit MapPanel(PlayerInfo &player, int commodity = SHOW_REPUTATION,
@@ -81,8 +87,6 @@ public:
 	// on top of everything else. This includes distance info, map mode buttons,
 	// escort/storage tooltips, and the non-routable system warning.
 	void FinishDrawing(const std::string &buttonCondition);
-
-	static void DrawMiniMap(const PlayerInfo &player, float alpha, const System *const draw[2], int step);
 
 	// Map panels allow fast-forward to stay active.
 	bool AllowsFastForward() const noexcept final;
@@ -210,8 +214,6 @@ private:
 	void DrawNames();
 	void DrawMissions();
 	void DrawPointer(const System *system, unsigned &systemCount, unsigned max, const Color &color, bool bigger = false);
-	static void DrawPointer(Point position, unsigned &systemCount, const Color &color,
-		bool drawBack = true, bool bigger = false);
 
 
 private:

--- a/source/MiniMap.cpp
+++ b/source/MiniMap.cpp
@@ -1,0 +1,257 @@
+/* MiniMap.cpp
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "MiniMap.h"
+
+#include "Color.h"
+#include "Command.h"
+#include "text/Font.h"
+#include "text/FontSet.h"
+#include "GameData.h"
+#include "Government.h"
+#include "shader/LineShader.h"
+#include "Interface.h"
+#include "MapPanel.h"
+#include "Mission.h"
+#include "Planet.h"
+#include "PlayerInfo.h"
+#include "Preferences.h"
+#include "shader/RingShader.h"
+#include "Set.h"
+#include "Ship.h"
+#include "System.h"
+
+#include <set>
+#include <vector>
+
+using namespace std;
+
+
+
+MiniMap::MiniMap(const PlayerInfo &player)
+	: player(player)
+{
+}
+
+
+
+void MiniMap::Fade()
+{
+	// Only let the minimap linger for 1.5 seconds after a jump has completed.
+	displayMinimap = min(displayMinimap, 90);
+}
+
+
+
+void MiniMap::Step(const shared_ptr<Ship> &flagship)
+{
+	if(!flagship)
+		return;
+
+	// If the flagship is in hyperspace or the player is holding the jump command,
+	// determine what system the player is jumping or about to jump into.
+	if(flagship->IsEnteringHyperspace() || flagship->Commands().Has(Command::JUMP))
+	{
+		// Let the minimap linger for 3 seconds after the player hit the jump key.
+		displayMinimap = 180;
+		// Draw the systems that the player is jumping between on the minimap.
+		const System *from = flagship->GetSystem();
+		const System *to = flagship->GetTargetSystem();
+		if(from && to && from != to)
+		{
+			current = from;
+			target = to;
+		}
+	}
+	// If the player isn't jumping, count down how long the jump 
+	else if(displayMinimap > 0)
+		--displayMinimap;
+	else
+	{
+		// If the jump has completed, draw the next system in the player's jump
+		// plan, or set the minimapSystems to nullptr to only display the current
+		// system if the travel plan is empty.
+		const vector<const System *> &plan = player.TravelPlan();
+		if(plan.empty())
+		{
+			current = flagship->GetSystem();
+			target = nullptr;
+		}
+		else
+		{
+			current = flagship->GetSystem();
+			target = plan.front();
+		}
+	}
+
+	// Control the fading in and out of the minimap.
+	if(displayMinimap)
+	{
+		if(displayMinimap < 30 && fadeMinimap)
+			--fadeMinimap;
+		else if(fadeMinimap < 30)
+			++fadeMinimap;
+	}
+	else
+		fadeMinimap = 0;
+
+	// Determine where the minimap should be centered.
+	if(target)
+		center = .5 * (current->Position() + target->Position());
+	else
+		center = current->Position();
+}
+
+
+
+void MiniMap::Draw(int step) const
+{
+	const Ship *flagship = player.Flagship();
+	if(!flagship || !current)
+		return;
+
+	Preferences::MinimapDisplay pref = Preferences::GetMinimapDisplay();
+	if(pref == Preferences::MinimapDisplay::OFF)
+		return;
+
+	float alpha = 1.f;
+	if(pref == Preferences::MinimapDisplay::WHEN_JUMPING)
+	{
+		if(!displayMinimap)
+			return;
+		alpha = .5f * min(1.f, fadeMinimap / 30.f);
+	}
+
+	set<const System *> drawnSystems;
+	drawnSystems.insert(current);
+	if(target)
+		drawnSystems.insert(target);
+
+	const Font &font = FontSet::Get(14);
+	Color lineColor(alpha, 0.f);
+	Color brightColor(.4f * alpha, 0.f);
+
+	const Point &drawPos = GameData::Interfaces().Get("hud")->GetPoint("mini-map");
+	const Set<Color> &colors = GameData::Colors();
+	const Color &currentColor = colors.Get("active mission")->Additive(alpha * 2.f);
+	const Color &blockedColor = colors.Get("blocked mission")->Additive(alpha * 2.f);
+	const Color &waypointColor = colors.Get("waypoint")->Additive(alpha * 2.f);
+
+	const System *flagshipSystem = flagship->GetSystem();
+	auto drawSystemLinks = [&](const System &system) -> void {
+		static const string UNKNOWN_SYSTEM = "Unexplored System";
+		const Government *gov = system.GetGovernment();
+		Point from = system.Position() - center + drawPos;
+		const string &name = player.KnowsName(system) ? system.DisplayName() : UNKNOWN_SYSTEM;
+		font.Draw(name, from + Point(MapPanel::OUTER, -.5 * font.Height()), lineColor);
+
+		// Draw the origin and destination systems, since they
+		// might not be linked via hyperspace.
+		Color color = Color(.5f * alpha, 0.f);
+		if(player.CanView(system) && system.IsInhabited(flagship) && gov)
+			color = gov->GetColor().Additive(alpha);
+		RingShader::Draw(from, MapPanel::OUTER, MapPanel::INNER, color);
+
+		// Add a circle around the system that the player is currently in.
+		if(&system == flagshipSystem)
+			RingShader::Draw(from, 11.f, 9.f, brightColor);
+
+		for(const System *link : system.Links())
+		{
+			// Only draw systems known to be attached to the jump systems.
+			if(!player.CanView(system) && !player.CanView(*link))
+				continue;
+
+			// Draw the system link. This will double-draw the jump
+			// path if it is via hyperlink, to increase brightness.
+			Point to = link->Position() - center + drawPos;
+			Point unit = (from - to).Unit() * MapPanel::LINK_OFFSET;
+			LineShader::Draw(from - unit, to + unit, MapPanel::LINK_WIDTH, lineColor);
+
+			if(drawnSystems.contains(link))
+				continue;
+			drawnSystems.insert(link);
+
+			gov = link->GetGovernment();
+			Color color = Color(.5f * alpha, 0.f);
+			if(player.CanView(*link) && link->IsInhabited(flagship) && gov)
+				color = gov->GetColor().Additive(alpha);
+			RingShader::Draw(to, MapPanel::OUTER, MapPanel::INNER, color);
+		}
+
+		unsigned missionCounter = 0;
+		for(const Mission &mission : player.Missions())
+		{
+			if(missionCounter >= MapPanel::MAX_MISSION_POINTERS_DRAWN)
+				break;
+
+			if(!mission.IsVisible())
+				continue;
+
+			if(mission.Destination()->IsInSystem(&system))
+			{
+				pair<bool, bool> blink = MapPanel::BlinkMissionIndicator(player, mission, step);
+				if(!blink.first)
+				{
+					bool isSatisfied = mission.IsSatisfied(player) && !mission.IsFailed() && blink.second;
+					MapPanel::DrawPointer(from, missionCounter, isSatisfied ? currentColor : blockedColor, false);
+				}
+				else
+					++missionCounter;
+			}
+
+			for(const System *waypoint : mission.Waypoints())
+			{
+				if(missionCounter >= MapPanel::MAX_MISSION_POINTERS_DRAWN)
+					break;
+				if(waypoint == &system)
+					MapPanel::DrawPointer(from, missionCounter, waypointColor, false);
+			}
+			for(const Planet *stopover : mission.Stopovers())
+			{
+				if(missionCounter >= MapPanel::MAX_MISSION_POINTERS_DRAWN)
+					break;
+				if(stopover->IsInSystem(&system))
+					MapPanel::DrawPointer(from, missionCounter, waypointColor, false);
+			}
+			for(const System *mark : mission.MarkedSystems())
+			{
+				if(missionCounter >= MapPanel::MAX_MISSION_POINTERS_DRAWN)
+					break;
+				if(mark == &system)
+					MapPanel::DrawPointer(from, missionCounter, waypointColor, false);
+			}
+		}
+	};
+
+	drawSystemLinks(*current);
+	if(!target)
+		return;
+	drawSystemLinks(*target);
+
+	// Draw the directional arrow. If this is a normal jump,
+	// the stem was already drawn above.
+	Point from = current->Position() - center + drawPos;
+	Point to = target->Position() - center + drawPos;
+	Point unit = (to - from).Unit();
+	from += MapPanel::LINK_OFFSET * unit;
+	to -= MapPanel::LINK_OFFSET * unit;
+	Color bright(2.f * alpha, 0.f);
+	// Non-hyperspace jumps are drawn with a dashed directional arrow.
+	if(!current->Links().contains(target))
+		LineShader::DrawDashed(from, to, unit, MapPanel::LINK_WIDTH, bright, 11., 4.);
+	LineShader::Draw(to, to + Angle(-30.).Rotate(unit) * -10., MapPanel::LINK_WIDTH, bright);
+	LineShader::Draw(to, to + Angle(30.).Rotate(unit) * -10., MapPanel::LINK_WIDTH, bright);
+}

--- a/source/MiniMap.h
+++ b/source/MiniMap.h
@@ -30,7 +30,7 @@ class MiniMap {
 public:
 	MiniMap(const PlayerInfo &player);
  
-	void Fade();
+	void SnapToCenter();
 	void Step(const std::shared_ptr<Ship> &flagship);
 	void Draw(int step) const;
 
@@ -43,6 +43,11 @@ private:
 	const System *target = nullptr;
 	// Where the minimap is focused.
 	Point center;
+	// Tracks the old target, the next target, and the number of frames that the center
+	// has been interpolating between the two.
+	Point oldCenter;
+	Point targetCenter;
+	int lerpCount = 0;
 
 	// How many frames the mini-map should be displayed for when it is set to only appear
 	// when jumping.

--- a/source/MiniMap.h
+++ b/source/MiniMap.h
@@ -1,0 +1,53 @@
+/* MiniMap.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Point.h"
+
+#include <memory>
+
+class PlayerInfo;
+class Ship;
+class System;
+
+
+
+// A minature map of the nearby systems that displays while on the main panel.
+class MiniMap {
+public:
+	MiniMap(const PlayerInfo &player);
+ 
+	void Fade();
+	void Step(const std::shared_ptr<Ship> &flagship);
+	void Draw(int step) const;
+
+
+private:
+	const PlayerInfo &player;
+	// The system that the player is currently in.
+	const System *current = nullptr;
+	// The system that is next in the player's travel plan.
+	const System *target = nullptr;
+	// Where the minimap is focused.
+	Point center;
+
+	// How many frames the mini-map should be displayed for when it is set to only appear
+	// when jumping.
+	int displayMinimap = 0;
+	// Controls the fading in and out of the minimap. The minimap should fade in and out over
+	// the course of 30 frames (0.5 seconds).
+	int fadeMinimap = 0;
+};


### PR DESCRIPTION
**Refactor** + **UI**

This PR addresses the feature described by https://github.com/endless-sky/endless-sky/pull/11516#issuecomment-3017737560

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR adds smooth movement to the system minimap. Right now, the minimap will snap to the middle point of the target system and the current system, or snap to the current system if there is no target system. This PR changes it so that the minimap smoothly interpolates toward these target points. In addition to this, the minimap will smoothly move while you are in the middle of jumping, centering itself on the target system.

In the course of doing this, I've made the minimap its own class, instead of being a culmination of a static function in MapPanel and a few variables in Engine. I also fixed a couple bugs #11516 while I was at it.
* The opacity of the "when jumping" minimap capped out at 50%, while I set the "always on" minimap to 100% opacity. They're now both 50%.
* I was using the wrong end of the travel plan when you're not actively jumping.
* With no travel plan, you were able to select a destination using the jump command, open the map to select a different system as your travel destination, and return to the main panel to see the minimap still displaying the previous target for a split second.

## ~~Screenshots~~ Videos! + Testing Done

A video of how the smooth minimap movement looks. At the start I don't have any travel plan and I'm using the jump command to select the target system. I then use the map to create a travel plan, showing how the minimap will account for the next system in your travel plan.
https://github.com/user-attachments/assets/51cfdadc-2df3-43a7-bfb9-4b14c0120e0f


