### PR TITLE
fix(code): Pass shared_ptrs as references during sound loading

### DIFF
--- a/source/audio/Sound.cpp
+++ b/source/audio/Sound.cpp
@@ -28,8 +28,8 @@ namespace {
 	// is an unsupported format (anything but little-endian 16-bit PCM at 44100 HZ),
 	// this will return 0.
 	uint32_t ReadHeader(shared_ptr<iostream> in, uint32_t &frequency);
-	uint32_t Read4(const shared_ptr<iostream> in);
-	uint16_t Read2(const shared_ptr<iostream> in);
+	uint32_t Read4(const shared_ptr<iostream> &in);
+	uint16_t Read2(const shared_ptr<iostream> &in);
 }
 
 
@@ -155,7 +155,7 @@ namespace {
 
 
 
-	uint32_t Read4(const shared_ptr<iostream> in)
+	uint32_t Read4(const shared_ptr<iostream> &in)
 	{
 		unsigned char data[4];
 		in->read(reinterpret_cast<char *>(data), 4);
@@ -169,7 +169,7 @@ namespace {
 
 
 
-	uint16_t Read2(const shared_ptr<iostream> in)
+	uint16_t Read2(const shared_ptr<iostream> &in)
 	{
 		unsigned char data[2];
 		in->read(reinterpret_cast<char *>(data), 2);

--- a/source/audio/Sound.cpp
+++ b/source/audio/Sound.cpp
@@ -27,7 +27,7 @@ namespace {
 	// Read a WAV header, and return the size of the data, in bytes. If the file
 	// is an unsupported format (anything but little-endian 16-bit PCM at 44100 HZ),
 	// this will return 0.
-	uint32_t ReadHeader(shared_ptr<iostream> in, uint32_t &frequency);
+	uint32_t ReadHeader(shared_ptr<iostream> &in, uint32_t &frequency);
 	uint32_t Read4(const shared_ptr<iostream> &in);
 	uint16_t Read2(const shared_ptr<iostream> &in);
 }
@@ -96,7 +96,7 @@ namespace {
 	// Read a WAV header, and return the size of the data, in bytes. If the file
 	// is an unsupported format (anything but little-endian 16-bit PCM at 44100 HZ),
 	// this will return 0.
-	uint32_t ReadHeader(shared_ptr<iostream> in, uint32_t &frequency)
+	uint32_t ReadHeader(shared_ptr<iostream> &in, uint32_t &frequency)
 	{
 		uint32_t chunkID = Read4(in);
 		if(chunkID != 0x46464952) // "RIFF" in big endian.


### PR DESCRIPTION
**Typo fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
We can pass the shared_ptrs as references if we know it's lifetime-safe.

## Testing Done
The game starts and sounds load.

## Performance Impact
idk, faster loading times?