### PR TITLE
fix(mechanics): Assign the correct planet to ships that cannot land with you

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1569,7 +1569,7 @@ void PlayerInfo::Land(UI *ui)
 						const Port &port = landingPlanet->GetPort();
 						ship->Recharge(landingPlanet->CanUseServices() ? port.GetRecharges() : Port::RechargeType::None,
 							port.HasService(Port::ServicesType::HireCrew));
-						ship->SetPlanet(planet);
+						ship->SetPlanet(landingPlanet);
 					}
 					else
 						ship->Recharge(Port::RechargeType::None, false);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug I noticed while debugging something else.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In the block of code that runs for ships that can't land with the player, the planet `planet` (which is the player's planet) is mistakenly assigned to them.

## Testing Done
none.

## Performance Impact
N/A
