### PR TITLE
fix(ui): Don't spam the landing message if you click on a planet you're already landing on

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2296,7 +2296,7 @@ void Engine::HandleMouseClicks()
 						if(!planet->CanLand(*flagship))
 							Messages::Add("The authorities on " + planet->DisplayName()
 									+ " refuse to let you land.", Messages::Importance::Highest);
-						else if(!flagship->IsDestroyed())
+						else if(!flagship->IsDestroyed() && !flagship->Commands().Has(Command::LAND))
 						{
 							activeCommands |= Command::LAND;
 							Messages::Add("Landing on " + planet->DisplayName() + ".", Messages::Importance::High);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in #11591.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Insert title here.

## Testing Done
Yes.
