### PR TITLE
fix: Use the text mode for writing save files on Windows

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -410,7 +410,7 @@ shared_ptr<iostream> Files::Open(const filesystem::path &path, bool write)
 	}
 
 	if(write)
-		return shared_ptr<iostream>{new fstream{path, ios::out | ios::binary}};
+		return shared_ptr<iostream>{new fstream{path, ios::out}};
 	return shared_ptr<iostream>{new fstream{path, ios::in | ios::binary}};
 }
 

--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -410,7 +410,11 @@ shared_ptr<iostream> Files::Open(const filesystem::path &path, bool write)
 	}
 
 	if(write)
+#ifdef _WIN32
 		return shared_ptr<iostream>{new fstream{path, ios::out}};
+#else
+		return shared_ptr<iostream>{new fstream{path, ios::out | ios::binary}};
+#endif
 	return shared_ptr<iostream>{new fstream{path, ios::in | ios::binary}};
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11613 (resolves #11613).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
With the iostream refactor it was changed so that files use the binary mode when writing, which doesn't convert `\n`s to `\r\n`s on Windows. As our data, including save files, is just plain text, and we don't write into zip files it's safe to use the text mode for writing.

Related: https://github.com/endless-sky/endless-sky/commit/5659a072a4f26aee15ee0a275387918c6165c1b3

## Testing Done
yes™.

## Performance Impact
N/A
