### PR TITLE
feat(enhancement): Allow hiding hardpoint sprites

### DIFF
--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -30,19 +30,17 @@ using namespace std;
 
 
 // Add a gun hardpoint (fixed-direction weapon).
-void Armament::AddGunPort(const Point &point, const Hardpoint::BaseAttributes &attributes,
-	bool isUnder, const Outfit *outfit)
+void Armament::AddGunPort(const Point &point, const Hardpoint::BaseAttributes &attributes, const Outfit *outfit)
 {
-	hardpoints.emplace_back(point, attributes, false, isUnder, outfit);
+	hardpoints.emplace_back(point, attributes, false, outfit);
 }
 
 
 
 // Add a turret hardpoint.
-void Armament::AddTurret(const Point &point, const Hardpoint::BaseAttributes &attributes,
-	bool isUnder, const Outfit *outfit)
+void Armament::AddTurret(const Point &point, const Hardpoint::BaseAttributes &attributes, const Outfit *outfit)
 {
-	hardpoints.emplace_back(point, attributes, true, isUnder, outfit);
+	hardpoints.emplace_back(point, attributes, true, outfit);
 }
 
 

--- a/source/Armament.h
+++ b/source/Armament.h
@@ -43,10 +43,8 @@ class Visual;
 class Armament {
 public:
 	// Add a gun or turret hard-point.
-	void AddGunPort(const Point &point, const Hardpoint::BaseAttributes &attributes,
-		bool isUnder, const Outfit *outfit = nullptr);
-	void AddTurret(const Point &point, const Hardpoint::BaseAttributes &attributes,
-		bool isUnder, const Outfit *outfit = nullptr);
+	void AddGunPort(const Point &point, const Hardpoint::BaseAttributes &attributes, const Outfit *outfit = nullptr);
+	void AddTurret(const Point &point, const Hardpoint::BaseAttributes &attributes, const Outfit *outfit = nullptr);
 	// This must be called after all the outfit data is loaded. If you add more
 	// of a given weapon than there are slots for it, the extras will not fire.
 	// But, the "gun ports" attribute should keep that from happening. To

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2853,11 +2853,11 @@ void Engine::DrawShipSprites(const Ship &ship)
 	};
 
 	for(const Hardpoint &hardpoint : ship.Weapons())
-		if(hardpoint.IsUnder())
+		if(hardpoint.GetSide() == Hardpoint::Side::UNDER)
 			drawHardpoint(hardpoint);
 	drawObject(ship);
 	for(const Hardpoint &hardpoint : ship.Weapons())
-		if(!hardpoint.IsUnder())
+		if(hardpoint.GetSide() == Hardpoint::Side::OVER)
 			drawHardpoint(hardpoint);
 
 	DrawEngineFlares(Ship::EnginePoint::OVER);

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -273,11 +273,11 @@ void HailPanel::Draw()
 				if(bay.side == Ship::Bay::UNDER)
 					addFighter(bay);
 		for(const Hardpoint &hardpoint : ship->Weapons())
-			if(hardpoint.IsUnder())
+			if(hardpoint.GetSide() == Hardpoint::Side::UNDER)
 				addHardpoint(hardpoint);
 		draw.Add(Body(*ship, center, Point(), facing, zoom));
 		for(const Hardpoint &hardpoint : ship->Weapons())
-			if(!hardpoint.IsUnder())
+			if(hardpoint.GetSide() == Hardpoint::Side::OVER)
 				addHardpoint(hardpoint);
 		if(hasFighters)
 			for(const Ship::Bay &bay : ship->Bays())

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -46,9 +46,9 @@ namespace {
 
 // Constructor.
 Hardpoint::Hardpoint(const Point &point, const BaseAttributes &attributes,
-	bool isTurret, bool isUnder, const Outfit *outfit)
+	bool isTurret, const Outfit *outfit)
 	: outfit(outfit), point(point * .5), baseAngle(attributes.baseAngle), baseAttributes(attributes),
-	isTurret(isTurret), isParallel(baseAttributes.isParallel), isUnder(isUnder)
+	isTurret(isTurret), isParallel(baseAttributes.isParallel)
 {
 	UpdateArc();
 }
@@ -158,9 +158,9 @@ bool Hardpoint::IsOmnidirectional() const
 
 
 
-bool Hardpoint::IsUnder() const
+Hardpoint::Side Hardpoint::GetSide() const
 {
-	return isUnder;
+	return baseAttributes.side;
 }
 
 

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -33,6 +33,12 @@ class Visual;
 // which may or may not have a weapon installed.
 class Hardpoint {
 public:
+	enum class Side {
+		OVER,
+		INSIDE,
+		UNDER
+	};
+
 	// The base attributes of a hardpoint, without considering additional limitations of the installed outfit.
 	struct BaseAttributes {
 		// The angle that this weapon is aimed at (without harmonization/convergence), relative to the ship.
@@ -42,6 +48,8 @@ public:
 		bool isParallel;
 		// An omnidirectional turret can rotate infinitely.
 		bool isOmnidirectional;
+		// Whether the hardpoint should be drawn over the ship, under it, or not at all.
+		Side side;
 		// Range over which the turret can turn, from leftmost position to rightmost position.
 		// (directional turret only)
 		Angle minArc;
@@ -55,7 +63,7 @@ public:
 public:
 	// Constructor. Hardpoints may or may not specify what weapon is in them.
 	Hardpoint(const Point &point, const BaseAttributes &attributes,
-		bool isTurret, bool isUnder, const Outfit *outfit = nullptr);
+		bool isTurret, const Outfit *outfit = nullptr);
 
 	// Get the weapon installed in this hardpoint (or null if there is none).
 	const Outfit *GetOutfit() const;
@@ -80,7 +88,7 @@ public:
 	bool IsTurret() const;
 	bool IsParallel() const;
 	bool IsOmnidirectional() const;
-	bool IsUnder() const;
+	Side GetSide() const;
 	bool IsHoming() const;
 	bool IsSpecial() const;
 	bool CanAim(const Ship &ship) const;
@@ -152,8 +160,6 @@ private:
 	bool isParallel = false;
 	// Indicates if this hardpoint is omnidirectional (turret only).
 	bool isOmnidirectional = true;
-	// Indicates whether the hardpoint sprite is drawn under the ship.
-	bool isUnder = false;
 
 	// Angle adjustment for convergence.
 	Angle angle;


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #11237 (closes #11237).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In addition to `under` and `over`, you can now place weapons `inside` the ship, hiding the hardpoint sprite.

## Testing Done
yes™.

## Wiki Update
soon.

## Performance Impact
N/A
