### PR TITLE
Variant map names for unfettered outfitted ships

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1290,6 +1290,7 @@ ship "Shield Beetle" "Shield Beetle (Unfettered)"
 		"Hyperdrive"
 
 ship "Shield Beetle" "Shield Beetle (Unfettered Shipyards)"
+	"variant map name" "Unfettered Shipyards"
 	outfits
 		"Ion Cannon" 2
 		"Hai Tracker" 420

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -165,6 +165,7 @@ ship "Aphid" "Aphid (Armed)"
 		"Hyperdrive"
 
 ship "Aphid" "Aphid (Unfettered)"
+	"variant map name" "Unfettered Shipyards"
 	outfits
 		"Chameleon Anti-Missile"
 		"Cargo Expansion" 2

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -679,6 +679,7 @@ ship "Lightning Bug" "Lightning Bug (Surveillance)"
 		"Hyperdrive"
 
 ship "Lightning Bug" "Lightning Bug (Unfettered Shipyards)"
+	"variant map name" "Unfettered Shipyards"
 	outfits
 		"Pulse Cannon"
 		"Pulse Turret" 2


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds "variant map name"s to the variants of the Shield Beetle, Lightning Bug, and Aphid sold by the Unfettered Hai.
Previously, the shipyard map would have two apparently identical entries for each of these ships, which led to confusion for players.
This PR means the variants sold on Unfettered worlds will have the subheading "Unfettered Shipyards" to differentiate them from the base models.

## Screenshots
before | after
-- | --
![image](https://github.com/user-attachments/assets/9e893cdd-c2a3-4a32-b3f9-426b248fd575) | ![image](https://github.com/user-attachments/assets/3b05dc53-bebd-4964-8651-eb9f00caf626)

## Usage examples
N/A

## Testing Done
Looked in the map shipyard.

## Save File
This save file can be used to test these changes:
[test hai.txt](https://github.com/user-attachments/files/21069113/test.hai.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
