### PR TITLE
refactor: Pass the area to FillShader as a Rectangle instead of two Points

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -126,7 +126,7 @@ void BoardingPanel::Draw()
 	const Color &dim = *GameData::Colors().Get("dim");
 	const Color &medium = *GameData::Colors().Get("medium");
 	const Color &bright = *GameData::Colors().Get("bright");
-	FillShader::Fill(Point(-155., -60.), Point(360., 250.), opaque);
+	FillShader::Fill({Point(-155., -60.), Point(360., 250.)}, opaque);
 
 	int index = (scroll - 10) / 20;
 	int y = -170 - scroll + 20 * index;
@@ -142,7 +142,7 @@ void BoardingPanel::Draw()
 		// Check if this is the selected row.
 		bool isSelected = (index == selected);
 		if(isSelected)
-			FillShader::Fill(Point(-155., y + 10.), Point(360., 20.), back);
+			FillShader::Fill({Point(-155., y + 10.), Point(360., 20.)}, back);
 
 		// Color the item based on whether you have space for it.
 		const Color &color = item.CanTake(*you) ? isSelected ? bright : medium : dim;

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -130,8 +130,8 @@ void ConversationPanel::Draw()
 	const Color &back = *GameData::Colors().Get("conversation background");
 	double boxWidth = WIDTH + 2. * MARGIN - 10.;
 	FillShader::Fill(
-		Point(Screen::Left() + .5 * boxWidth, 0.),
-		Point(boxWidth, Screen::Height()),
+		{Point(Screen::Left() + .5 * boxWidth, 0.),
+		Point(boxWidth, Screen::Height())},
 		back);
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + boxWidth);
@@ -182,14 +182,14 @@ void ConversationPanel::Draw()
 			}
 
 			// Color selected text box, or flicker if user attempts an error.
-			FillShader::Fill(center, fieldSize, (flickerTime % 6 > 3) ? dim : selectionColor);
+			FillShader::Fill({center, fieldSize}, (flickerTime % 6 > 3) ? dim : selectionColor);
 			if(flickerTime)
 				--flickerTime;
 			// Fill non-selected text box with dimmer color.
-			FillShader::Fill(unselected, fieldSize, dark);
+			FillShader::Fill({unselected, fieldSize}, dark);
 			// Draw the text cursor.
 			center.X() += font.FormattedWidth({choice ? lastName : firstName, layout}) - 67;
-			FillShader::Fill(center, Point(1., 16.), dim);
+			FillShader::Fill({center, Point(1., 16.)}, dim);
 		}
 
 		font.Draw("First name:", point + Point(40, 0), dim);
@@ -227,7 +227,7 @@ void ConversationPanel::Draw()
 				choice = index;
 
 			if(index == choice)
-				FillShader::Fill(center + Point(-5, 0), size + Point(30, 0), selectionColor);
+				FillShader::Fill({center + Point(-5, 0), size + Point(30, 0)}, selectionColor);
 			AddZone(zone, [this, index](){ this->ClickChoice(index); });
 			++index;
 

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -218,7 +218,7 @@ void Dialog::Draw()
 	// Draw the input, if any.
 	if(!isMission && (intFun || stringFun))
 	{
-		FillShader::Fill(inputPos, Point(Width() - HORIZONTAL_PADDING, INPUT_HEIGHT), back);
+		FillShader::Fill({inputPos, Point(Width() - HORIZONTAL_PADDING, INPUT_HEIGHT)}, back);
 
 		Point stringPos(
 			inputPos.X() - (Width() - HORIZONTAL_PADDING) * .5 + INPUT_LEFT_PADDING,
@@ -228,7 +228,7 @@ void Dialog::Draw()
 		font.Draw(inputText, stringPos, bright);
 
 		Point barPos(stringPos.X() + font.FormattedWidth(inputText) + INPUT_TOP_PADDING, inputPos.Y());
-		FillShader::Fill(barPos, Point(1., INPUT_HEIGHT - INPUT_VERTICAL_PADDING), dim);
+		FillShader::Fill({barPos, Point(1., INPUT_HEIGHT - INPUT_VERTICAL_PADDING)}, dim);
 	}
 }
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1229,7 +1229,7 @@ void Engine::Draw() const
 	}
 
 	if(flash)
-		FillShader::Fill(Point(), Point(Screen::Width(), Screen::Height()), Color(flash, flash));
+		FillShader::Fill({Point(), Screen::Dimensions()}, Color(flash, flash));
 
 	// Draw messages. Draw the most recent messages first, as some messages
 	// may be wrapped onto multiple lines.

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -934,5 +934,5 @@ void Interface::LineElement::Draw(const Rectangle &rect, const Information &info
 	// Avoid crashes for malformed interface elements that are not fully loaded.
 	if(!from.Get() && !to.Get())
 		return;
-	FillShader::Fill(rect.Center(), rect.Dimensions(), *color);
+	FillShader::Fill(rect, *color);
 }

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -109,7 +109,7 @@ void ItemInfoDisplay::DrawTooltips() const
 	if(topLeft.Y() + boxSize.Y() > Screen::Bottom())
 		topLeft.Y() -= boxSize.Y();
 
-	FillShader::Fill(topLeft + .5 * boxSize, boxSize, *GameData::Colors().Get("tooltip background"));
+	FillShader::Fill(Rectangle::FromCorner(topLeft, boxSize), *GameData::Colors().Get("tooltip background"));
 	hoverText.Draw(topLeft + Point(10., 10.), *GameData::Colors().Get("medium"));
 }
 

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -207,7 +207,7 @@ void LoadPanel::Draw()
 			alpha = min(alpha, 1.);
 
 			if(it.first == selectedPilot)
-				FillShader::Fill(zone.Center(), zone.Dimensions(), Color(.1 * alpha, 0.));
+				FillShader::Fill(zone, Color(.1 * alpha, 0.));
 			const int textWidth = pilotBox.Width() - 2. * hTextPad;
 			font.Draw({it.first, {textWidth, Truncate::BACK}}, textPoint, Color((isHighlighted ? .7 : .5) * alpha, 0.));
 		}
@@ -255,7 +255,7 @@ void LoadPanel::Draw()
 			alpha = min(alpha, 1.);
 
 			if(file == selectedFile)
-				FillShader::Fill(zone.Center(), zone.Dimensions(), Color(.1 * alpha, 0.));
+				FillShader::Fill(zone, Color(.1 * alpha, 0.));
 			size_t pos = file.find('~') + 1;
 			const string name = file.substr(pos, file.size() - 4 - pos);
 			const int textWidth = snapshotBox.Width() - 2. * hTextPad;
@@ -267,7 +267,7 @@ void LoadPanel::Draw()
 	{
 		Point boxSize(font.Width(hoverText) + 20., 30.);
 
-		FillShader::Fill(hoverPoint + .5 * boxSize, boxSize, *GameData::Colors().Get("tooltip background"));
+		FillShader::Fill(Rectangle::FromCorner(hoverPoint, boxSize), *GameData::Colors().Get("tooltip background"));
 		font.Draw(hoverText, hoverPoint + Point(10., 10.), *GameData::Colors().Get("medium"));
 	}
 }

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -78,18 +78,18 @@ void LogbookPanel::Draw()
 	// Draw the panel. The sidebar should be slightly darker than the rest.
 	const Color &sideColor = *GameData::Colors().Get("logbook sidebar");
 	FillShader::Fill(
-		Point(Screen::Left() + .5 * SIDEBAR_WIDTH, 0.),
-		Point(SIDEBAR_WIDTH, Screen::Height()),
+		{Point(Screen::Left() + .5 * SIDEBAR_WIDTH, 0.),
+		Point(SIDEBAR_WIDTH, Screen::Height())},
 		sideColor);
 	const Color &backColor = *GameData::Colors().Get("logbook background");
 	FillShader::Fill(
-		Point(Screen::Left() + SIDEBAR_WIDTH + .5 * TEXT_WIDTH, 0.),
-		Point(TEXT_WIDTH, Screen::Height()),
+		{Point(Screen::Left() + SIDEBAR_WIDTH + .5 * TEXT_WIDTH, 0.),
+		Point(TEXT_WIDTH, Screen::Height())},
 		backColor);
 	const Color &lineColor = *GameData::Colors().Get("logbook line");
 	FillShader::Fill(
-		Point(Screen::Left() + SIDEBAR_WIDTH - .5, 0.),
-		Point(1., Screen::Height()),
+		{Point(Screen::Left() + SIDEBAR_WIDTH - .5, 0.),
+		Point(1., Screen::Height())},
 		lineColor);
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + WIDTH);
@@ -112,8 +112,8 @@ void LogbookPanel::Draw()
 	{
 		if(selectedDate ? dates[i].Month() == selectedDate.Month() : selectedName == contents[i])
 		{
-			FillShader::Fill(pos + highlightOffset - Point(1., 0.), highlightSize + Point(0., 2.), lineColor);
-			FillShader::Fill(pos + highlightOffset, highlightSize, backColor);
+			FillShader::Fill({pos + highlightOffset - Point(1., 0.), highlightSize + Point(0., 2.)}, lineColor);
+			FillShader::Fill({pos + highlightOffset, highlightSize}, backColor);
 		}
 		font.Draw(contents[i], pos + textOffset, dates[i].Month() ? medium : bright);
 		pos.Y() += LINE_HEIGHT;

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -737,8 +737,7 @@ void MapDetailPanel::DrawInfo()
 		(planetCards.size()) * planetCardHeight) : 0.;
 	Point size(planetWidth, planetPanelHeight);
 	// This needs to fill from the start of the screen.
-	FillShader::Fill(Screen::TopLeft() + Point(size.X() / 2., size.Y() / 2.),
-		size, back);
+	FillShader::Fill(Rectangle::FromCorner(Screen::TopLeft(), size), back);
 
 	const double startingX = mapInterface->GetValue("starting X");
 	Point uiPoint(Screen::Left() + startingX, Screen::Top());

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -424,7 +424,7 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 			if(topLeft.Y() + size.Y() > Screen::Bottom())
 				topLeft.Y() -= size.Y();
 			// Draw the background fill and the tooltip text.
-			FillShader::Fill(topLeft + .5 * size, size, *GameData::Colors().Get("tooltip background"));
+			FillShader::Fill(Rectangle::FromCorner(topLeft, size), *GameData::Colors().Get("tooltip background"));
 			hoverText.Draw(topLeft + Point(10., 10.), *GameData::Colors().Get("medium"));
 		}
 	}

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -287,8 +287,8 @@ void MapPlanetCard::Highlight(double availableSpace) const
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
 	const double width = planetCardInterface->GetValue("width");
 
-	FillShader::Fill(Point(Screen::Left() + width / 2., yCoordinate + availableSpace / 2.),
-		Point(width, availableSpace), *GameData::Colors().Get("item selected"));
+	FillShader::Fill(Rectangle::FromCorner(Point(Screen::Left(), yCoordinate),
+		Point(width, availableSpace)), *GameData::Colors().Get("item selected"));
 }
 
 

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -278,8 +278,8 @@ void MapSalesPanel::DrawPanel() const
 {
 	const Color &back = *GameData::Colors().Get("map side panel background");
 	FillShader::Fill(
-		Point(Screen::Left() + WIDTH * .5, 0.),
-		Point(WIDTH, Screen::Height()),
+		{Point(Screen::Left() + WIDTH * .5, 0.),
+		Point(WIDTH, Screen::Height())},
 		back);
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + WIDTH);
@@ -308,7 +308,7 @@ void MapSalesPanel::DrawInfo() const
 		const Color &back = *GameData::Colors().Get("map side panel background");
 		Point size(width, height);
 		Point topLeft(Screen::Right() - size.X(), Screen::Top());
-		FillShader::Fill(topLeft + .5 * size, size, back);
+		FillShader::Fill(Rectangle::FromCorner(topLeft, size), back);
 
 		Point leftPos = topLeft + Point(
 			-.5 * left->Width(),
@@ -404,7 +404,7 @@ void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, const Swizzle *swi
 	if(corner.Y() < Screen::Bottom() && corner.Y() + ICON_HEIGHT >= Screen::Top())
 	{
 		if(isSelected)
-			FillShader::Fill(corner + .5 * blockSize, blockSize, selectionColor);
+			FillShader::Fill(Rectangle::FromCorner(corner, blockSize), selectionColor);
 
 		DrawSprite(corner, sprite, swizzle);
 

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -66,8 +66,8 @@ void MessageLogPanel::Draw()
 	// Draw the panel.
 	const Color &backColor = *GameData::Colors().Get("message log background");
 	FillShader::Fill(
-		Point(Screen::Left() + .5 * width, 0.),
-		Point(width, Screen::Height()),
+		{Point(Screen::Left() + .5 * width, 0.),
+		Point(width, Screen::Height())},
 		backColor);
 
 	Panel::DrawEdgeSprite(SpriteSet::Get("ui/right edge"), Screen::Left() + width);

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -773,7 +773,7 @@ Point MissionPanel::DrawPanel(Point pos, const string &label, int entries, bool 
 
 	// Draw the panel.
 	Point size(SIDE_WIDTH, 20 * entries + 40);
-	FillShader::Fill(pos + .5 * size, size, back);
+	FillShader::Fill(Rectangle::FromCorner(pos, size), back);
 
 	// Edges:
 	const Sprite *bottom = SpriteSet::Get("ui/bottom edge");
@@ -820,14 +820,14 @@ Point MissionPanel::DrawPanel(Point pos, const string &label, int entries, bool 
 		SpriteShader::Draw(rush[player.ShouldSortSeparateDeadline()], pos + Point(SIDE_WIDTH - 105., 7.5));
 
 		if(hoverSort >= 0)
-			FillShader::Fill(pos + Point(SIDE_WIDTH - 105. + 30 * hoverSort, 7.5), Point(22., 16.), highlight);
+			FillShader::Fill({pos + Point(SIDE_WIDTH - 105. + 30 * hoverSort, 7.5), Point(22., 16.)}, highlight);
 	}
 
 	// Panel title
 	font.Draw(label, pos, title);
 	FillShader::Fill(
-		pos + Point(.5 * size.X() - 5., 15.),
-		Point(size.X() - 10., 1.),
+		{pos + Point(.5 * size.X() - 5., 15.),
+		Point(size.X() - 10., 1.)},
 		separatorLine);
 
 	pos.Y() += 5.;
@@ -865,8 +865,8 @@ Point MissionPanel::DrawList(const list<Mission> &list, Point pos, const std::li
 		bool isSelected = it == selectIt;
 		if(isSelected)
 			FillShader::Fill(
-				pos + Point(.5 * SIDE_WIDTH - 5., 8.),
-				Point(SIDE_WIDTH - 10., 20.),
+				{pos + Point(.5 * SIDE_WIDTH - 5., 8.),
+				Point(SIDE_WIDTH - 10., 20.)},
 				highlight);
 
 		if(it->Deadline())
@@ -996,7 +996,7 @@ void MissionPanel::DrawTooltips()
 		size += Point(20., 20.);
 		Point topLeft = Point(Screen::Left() + SIDE_WIDTH - 120. + 30 * hoverSort, Screen::Top() + 30.);
 		// Draw the background fill and the tooltip text.
-		FillShader::Fill(topLeft + .5 * size, size, *GameData::Colors().Get("tooltip background"));
+		FillShader::Fill(Rectangle::FromCorner(topLeft, size), *GameData::Colors().Get("tooltip background"));
 		hoverText.Draw(topLeft + Point(10., 10.), *GameData::Colors().Get("medium"));
 	}
 }

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -305,7 +305,7 @@ void Panel::DrawBackdrop() const
 
 	// Darken everything but the dialog.
 	const Color &back = *GameData::Colors().Get("dialog backdrop");
-	FillShader::Fill(Point(), Point(Screen::Width(), Screen::Height()), back);
+	FillShader::Fill({Point(), Screen::Dimensions()}, back);
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -1239,7 +1239,7 @@ void PreferencesPanel::DrawTooltips()
 	if(topLeft.Y() + size.Y() > Screen::Bottom())
 		topLeft.Y() -= size.Y();
 	// Draw the background fill and the tooltip text.
-	FillShader::Fill(topLeft + .5 * size, size, *GameData::Colors().Get("tooltip background"));
+	FillShader::Fill(Rectangle::FromCorner(topLeft, size), *GameData::Colors().Get("tooltip background"));
 	hoverText.Draw(topLeft + Point(10., 10.), *GameData::Colors().Get("medium"));
 }
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
+#include "Rectangle.h"
 #include "Ship.h"
 #include "text/Table.h"
 
@@ -90,7 +91,7 @@ void ShipInfoDisplay::DrawAttributes(const Point &topLeft, const bool sale) cons
 		point = Draw(point, saleLabels, saleValues);
 
 		const Color &color = *GameData::Colors().Get("medium");
-		FillShader::Fill(point + Point(.5 * WIDTH, 5.), Point(WIDTH - 20., 1.), color);
+		FillShader::Fill({point + Point(.5 * WIDTH, 5.), Point(WIDTH - 20., 1.)}, color);
 	}
 	else
 		point -= Point(0, 10.);

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -84,7 +84,7 @@ namespace {
 
 		Point textSize(wrap.WrapWidth() + 2 * PAD, wrap.Height() + 2 * PAD - wrap.ParagraphBreak());
 		Point anchor = Point(hoverPoint.X(), min<double>(hoverPoint.Y() + textSize.Y(), Screen::Bottom()));
-		FillShader::Fill(anchor - .5 * textSize, textSize, backColor);
+		FillShader::Fill({anchor - .5 * textSize, textSize}, backColor);
 		wrap.Draw(anchor - textSize + Point(PAD, PAD), textColor);
 	}
 
@@ -758,12 +758,12 @@ void ShopPanel::DrawShipsSidebar()
 
 	// Fill in the background.
 	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH / 2, 0.),
-		Point(SIDEBAR_WIDTH, Screen::Height()),
+		{Point(Screen::Right() - SIDEBAR_WIDTH / 2, 0.),
+		Point(SIDEBAR_WIDTH, Screen::Height())},
 		*GameData::Colors().Get("panel background"));
 	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH, 0.),
-		Point(1, Screen::Height()),
+		{Point(Screen::Right() - SIDEBAR_WIDTH, 0.),
+		Point(1, Screen::Height())},
 		*GameData::Colors().Get("shop side panel background"));
 
 	// Draw this string, centered in the side panel:
@@ -853,8 +853,8 @@ void ShopPanel::DrawShipsSidebar()
 		if(ship->IsParked())
 		{
 			static const Point CORNER = .35 * Point(ICON_TILE, ICON_TILE);
-			FillShader::Fill(point + CORNER, Point(6., 6.), dark);
-			FillShader::Fill(point + CORNER, Point(4., 4.), isSelected ? bright : medium);
+			FillShader::Fill({point + CORNER, Point(6., 6.)}, dark);
+			FillShader::Fill({point + CORNER, Point(4., 4.)}, isSelected ? bright : medium);
 		}
 
 		point.X() += ICON_TILE;
@@ -903,12 +903,12 @@ void ShopPanel::DrawDetailsSidebar()
 	infobarScroll.Step();
 
 	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH, 0.),
-		Point(1., Screen::Height()),
+		{Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH, 0.),
+		Point(1., Screen::Height())},
 		line);
 	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH / 2, 0.),
-		Point(INFOBAR_WIDTH - 1., Screen::Height()),
+		{Point(Screen::Right() - SIDEBAR_WIDTH - INFOBAR_WIDTH / 2, 0.),
+		Point(INFOBAR_WIDTH - 1., Screen::Height())},
 		back);
 
 	Point point(
@@ -935,11 +935,11 @@ void ShopPanel::DrawButtons()
 {
 	// The last 70 pixels on the end of the side panel are for the buttons:
 	Point buttonSize(SIDEBAR_WIDTH, BUTTON_HEIGHT);
-	FillShader::Fill(Screen::BottomRight() - .5 * buttonSize, buttonSize,
+	FillShader::Fill({Screen::BottomRight() - .5 * buttonSize, buttonSize},
 		*GameData::Colors().Get("shop side panel background"));
 	FillShader::Fill(
-		Point(Screen::Right() - SIDEBAR_WIDTH / 2, Screen::Bottom() - BUTTON_HEIGHT),
-		Point(SIDEBAR_WIDTH, 1), *GameData::Colors().Get("shop side panel footer"));
+		{Point(Screen::Right() - SIDEBAR_WIDTH / 2, Screen::Bottom() - BUTTON_HEIGHT),
+		Point(SIDEBAR_WIDTH, 1)}, *GameData::Colors().Get("shop side panel footer"));
 
 	const Font &font = FontSet::Get(14);
 	const Color &bright = *GameData::Colors().Get("bright");
@@ -960,7 +960,7 @@ void ShopPanel::DrawButtons()
 	const Color &inactive = *GameData::Colors().Get("inactive");
 
 	const Point buyCenter = Screen::BottomRight() - Point(210, 25);
-	FillShader::Fill(buyCenter, Point(60, 30), back);
+	FillShader::Fill({buyCenter, Point(60, 30)}, back);
 	bool isOwned = IsAlreadyOwned();
 	const Color *buyTextColor;
 	if(!CanBuy(isOwned))
@@ -975,14 +975,14 @@ void ShopPanel::DrawButtons()
 		*buyTextColor);
 
 	const Point sellCenter = Screen::BottomRight() - Point(130, 25);
-	FillShader::Fill(sellCenter, Point(60, 30), back);
+	FillShader::Fill({sellCenter, Point(60, 30)}, back);
 	static const string SELL = "_Sell";
 	bigFont.Draw(SELL,
 		sellCenter - .5 * Point(bigFont.Width(SELL), bigFont.Height()),
 		CanSell() ? hoverButton == 's' ? hover : active : inactive);
 
 	const Point leaveCenter = Screen::BottomRight() - Point(45, 25);
-	FillShader::Fill(leaveCenter, Point(70, 30), back);
+	FillShader::Fill({leaveCenter, Point(70, 30)}, back);
 	static const string LEAVE = "_Leave";
 	bigFont.Draw(LEAVE,
 		leaveCenter - .5 * Point(bigFont.Width(LEAVE), bigFont.Height()),

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -120,7 +120,7 @@ void StartConditionsPanel::Draw()
 
 		bool isHighlighted = it == startIt || (hasHover && zone.Contains(hoverPoint));
 		if(it == startIt)
-			FillShader::Fill(zone.Center(), zone.Dimensions(), selectedBackground.Additive(opacity));
+			FillShader::Fill(zone, selectedBackground.Additive(opacity));
 
 		const auto name = DisplayText(it->GetDisplayName(), Truncate::BACK);
 		font.Draw(name, pos + entryTextPadding, (isHighlighted ? bright : medium).Transparent(opacity));

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -102,7 +102,7 @@ void TradingPanel::Draw()
 	{
 		const Point center(MIN_X + box.Width() / 2, FIRST_Y + 20 * selectedRow + 33);
 		const Point dimensions(box.Width() - 20., 20.);
-		FillShader::Fill(center, dimensions, back);
+		FillShader::Fill({center, dimensions}, back);
 	}
 
 	const Font &font = FontSet::Get(14);

--- a/source/shader/FillShader.cpp
+++ b/source/shader/FillShader.cpp
@@ -17,7 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "../Color.h"
 #include "../GameData.h"
-#include "../Point.h"
+#include "../Rectangle.h"
 #include "../Screen.h"
 #include "Shader.h"
 
@@ -71,7 +71,7 @@ void FillShader::Init()
 
 
 
-void FillShader::Fill(const Point &center, const Point &size, const Color &color)
+void FillShader::Fill(const Rectangle &area, const Color &color)
 {
 	if(!shader || !shader->Object())
 		throw std::runtime_error("FillShader: Draw() called before Init().");
@@ -82,10 +82,10 @@ void FillShader::Fill(const Point &center, const Point &size, const Color &color
 	GLfloat scale[2] = {2.f / Screen::Width(), -2.f / Screen::Height()};
 	glUniform2fv(scaleI, 1, scale);
 
-	GLfloat centerV[2] = {static_cast<float>(center.X()), static_cast<float>(center.Y())};
+	GLfloat centerV[2] = {static_cast<float>(area.Center().X()), static_cast<float>(area.Center().Y())};
 	glUniform2fv(centerI, 1, centerV);
 
-	GLfloat sizeV[2] = {static_cast<float>(size.X()), static_cast<float>(size.Y())};
+	GLfloat sizeV[2] = {static_cast<float>(area.Dimensions().X()), static_cast<float>(area.Dimensions().Y())};
 	glUniform2fv(sizeI, 1, sizeV);
 
 	glUniform4fv(colorI, 1, color.Get());

--- a/source/shader/FillShader.h
+++ b/source/shader/FillShader.h
@@ -16,7 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 class Color;
-class Point;
+class Rectangle;
 
 
 
@@ -26,5 +26,5 @@ class Point;
 class FillShader {
 public:
 	static void Init();
-	static void Fill(const Point &center, const Point &size, const Color &color);
+	static void Fill(const Rectangle &area, const Color &color);
 };

--- a/source/text/Table.cpp
+++ b/source/text/Table.cpp
@@ -238,7 +238,7 @@ void Table::DrawUnderline() const
 
 void Table::DrawUnderline(const Color &color) const
 {
-	FillShader::Fill(point + lineOff - Point(0., 2.), lineSize, color);
+	FillShader::Fill({point + lineOff - Point(0., 2.), lineSize}, color);
 }
 
 
@@ -253,7 +253,7 @@ void Table::DrawHighlight() const
 
 void Table::DrawHighlight(const Color &color) const
 {
-	FillShader::Fill(GetCenterPoint(), GetRowSize(), color);
+	FillShader::Fill(GetRowBounds(), color);
 }
 
 


### PR DESCRIPTION
**Refactor**

This PR addresses the bug/feature described in https://github.com/endless-sky/endless-sky/pull/11447#discussion_r2186402937.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Cause that's what Rectangles exist for. There were already cases where a Rectangle needed to be split into Points in order to pass to FillShader, some could benefit from Rectangle::FromCorner, and for the rest it's just a matter of constructing a Rectangle out of the Points that were passed before.

## Testing Done
Compiled, launched, and looked through some panels. So far haven't found anything broken.

## Performance Impact
N/A?
