### PR TITLE
ui: Rename the "line" element to "fill"

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -602,7 +602,7 @@ interface "plugins"
 		align top left
 		color bright
 	visible
-	line
+	fill
 		from -230 -222 to -10 -221
 	box "plugin list"
 		from -250 -216 to -10 184
@@ -638,7 +638,7 @@ interface "audio"
 	label "Music"
 		center -129.5 -228
 		color bright
-	line
+	fill
 		center -117.5 -208.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -668,7 +668,7 @@ interface "audio"
 	label "UI"
 		center -129.5 -168
 		color bright
-	line
+	fill
 		center -117.5 -148.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -698,7 +698,7 @@ interface "audio"
 	label "Anti-Missiles"
 		center -129.5 -108
 		color bright
-	line
+	fill
 		center -117.5 -88.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -728,7 +728,7 @@ interface "audio"
 	label "Weapons"
 		center -129.5 -48
 		color bright
-	line
+	fill
 		center -117.5 -28.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -758,7 +758,7 @@ interface "audio"
 	label "Engines"
 		center -129.5 12
 		color bright
-	line
+	fill
 		center -117.5 32.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -788,7 +788,7 @@ interface "audio"
 	label "Afterburners"
 		center -129.5 72
 		color bright
-	line
+	fill
 		center -117.5 92.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -818,7 +818,7 @@ interface "audio"
 	label "Hyperdrives"
 		center -129.5 132
 		color bright
-	line
+	fill
 		center -117.5 152.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -848,7 +848,7 @@ interface "audio"
 	label "Explosions"
 		center 129.5 -228
 		color bright
-	line
+	fill
 		center 117.5 -208.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -878,7 +878,7 @@ interface "audio"
 	label "Scans"
 		center 129.5 -168
 		color bright
-	line
+	fill
 		center 117.5 -148.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -908,7 +908,7 @@ interface "audio"
 	label "Environment"
 		center 129.5 -108
 		color bright
-	line
+	fill
 		center 117.5 -88.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -938,7 +938,7 @@ interface "audio"
 	label "Alerts"
 		center 129.5 -48
 		color bright
-	line
+	fill
 		center 117.5 -28.5
 		dimensions 210 10.5
 		color "volume bar background"
@@ -971,7 +971,7 @@ interface "preferences"
 		center 195 210
 		dimensions 120 30
 	value "master volume bar size" 220
-	line
+	fill
 		center 280.5 -97
 		dimensions 10.5 235
 		color "volume bar background"
@@ -1786,7 +1786,7 @@ interface "hiring"
 		color "bright"
 		align right
 	
-	line
+	fill
 		center 0 95
 		dimensions 480 1
 	
@@ -1883,7 +1883,7 @@ interface "hiring (small screen)"
 		color "bright"
 		align right
 	
-	line
+	fill
 		center -60 95
 		dimensions 480 1
 	
@@ -1968,7 +1968,7 @@ interface "trade"
 	box "content"
 		from -240 80 to 250 355
 	
-	line
+	fill
 		center 0 95
 		dimensions 480 1
 	
@@ -2000,7 +2000,7 @@ interface "trade (small screen)"
 	box "content"
 		from -310 80 to 190 355
 	
-	line
+	fill
 		center -60 95
 		dimensions 480 1
 	
@@ -2032,7 +2032,7 @@ interface "bank"
 	box "content"
 		from -250 78 to 250 355
 	
-	line
+	fill
 		center 0 95
 		dimensions 480 1
 	
@@ -2049,7 +2049,7 @@ interface "bank (small screen)"
 	box "content"
 		from -310 78 to 190 355
 	
-	line
+	fill
 		center -60 95
 		dimensions 480 1
 	

--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -135,8 +135,13 @@ void Interface::Load(const DataNode &node)
 				elements.push_back(new BarElement(child, anchor));
 			else if(key == "pointer")
 				elements.push_back(new PointerElement(child, anchor));
+			else if(key == "fill")
+				elements.push_back(new FillElement(child, anchor));
 			else if(key == "line")
-				elements.push_back(new LineElement(child, anchor));
+			{
+				child.PrintTrace("\"line\" is deprecated, please use \"fill\" instead:");
+				elements.push_back(new FillElement(child, anchor));
+			}
 			else
 			{
 				child.PrintTrace("Skipping unrecognized element:");
@@ -899,10 +904,10 @@ void Interface::PointerElement::Draw(const Rectangle &rect, const Information &i
 
 
 
-// Members of the LineElement class:
+// Members of the FillElement class:
 
 // Constructor.
-Interface::LineElement::LineElement(const DataNode &node, const Point &globalAnchor)
+Interface::FillElement::FillElement(const DataNode &node, const Point &globalAnchor)
 {
 	// This function will call ParseLine() for any line it does not recognize.
 	Load(node, globalAnchor);
@@ -916,7 +921,7 @@ Interface::LineElement::LineElement(const DataNode &node, const Point &globalAnc
 
 // Parse the given data line: one that is not recognized by Element
 // itself. This returns false if it does not recognize the line, either.
-bool Interface::LineElement::ParseLine(const DataNode &node)
+bool Interface::FillElement::ParseLine(const DataNode &node)
 {
 	if(node.Token(0) == "color" && node.Size() >= 2)
 		color = GameData::Colors().Get(node.Token(1));
@@ -929,7 +934,7 @@ bool Interface::LineElement::ParseLine(const DataNode &node)
 
 
 // Draw this element in the given rectangle.
-void Interface::LineElement::Draw(const Rectangle &rect, const Information &info, int state) const
+void Interface::FillElement::Draw(const Rectangle &rect, const Information &info, int state) const
 {
 	// Avoid crashes for malformed interface elements that are not fully loaded.
 	if(!from.Get() && !to.Get())

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -256,10 +256,10 @@ private:
 	};
 
 
-	// This class handles "line" elements.
-	class LineElement : public Element {
+	// This class handles "fill" elements.
+	class FillElement : public Element {
 	public:
-		LineElement(const DataNode &node, const Point &globalAnchor);
+		FillElement(const DataNode &node, const Point &globalAnchor);
 
 	protected:
 		// Parse the given data line: one that is not recognized by Element


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When I was writing the FillShader-Rectangle refactor, I started wondering "why do we use FillShader for drawing interface lines, don't we have LineShader for that?". We do, and the real line elements ("bar") use them. What is a "line", then? A filled rectangle. So went with "fill" as "box" is already used for defining bounding boxes.

## Testing Done
No.

## Wiki Update
soon.

## Performance Impact
N/A
