### PR TITLE
Remove the Windows file description metadata

### DIFF
--- a/source/WinApp.rc
+++ b/source/WinApp.rc
@@ -12,7 +12,7 @@ VS_VERSION_INFO VERSIONINFO
 		BLOCK "040904B0"
 		{
 			VALUE "CompanyName", "\0"
-			VALUE "FileDescription", "Space exploration and combat game\0"
+			VALUE "FileDescription", "Endless Sky\0"
 			VALUE "FileVersion", "0.10.15-alpha\0"
 			VALUE "InternalName", "Endless Sky\0"
 			VALUE "OriginalFilename", "Endless Sky.exe\0"


### PR DESCRIPTION
**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Replaced the game description in Windows metadata with "Endless Sky" as it shows up in unexpected places where it doesn't make sense, eg. Task Manager.