### PR TITLE
feat(conditions): Add conditions for reading gamerule values

### DIFF
--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -79,6 +79,55 @@ void Gamerules::Load(const DataNode &node)
 
 
 
+string Gamerules::GetString(const string &rule) const
+{
+	if(rule == "disabled fighters avoid projectiles")
+	{
+		if(fighterHitPolicy == FighterDodgePolicy::ALL)
+			return "all";
+		if(fighterHitPolicy == FighterDodgePolicy::NONE)
+			return "none";
+		if(fighterHitPolicy == FighterDodgePolicy::ONLY_PLAYER)
+			return "only player";
+	}
+	return "";
+}
+
+
+
+int Gamerules::GetValue(const string &rule) const
+{
+	if(rule == "universal ramscoop")
+		return universalRamscoop;
+	if(rule == "person spawn period")
+		return personSpawnPeriod;
+	if(rule == "no person spawn weight")
+		return noPersonSpawnWeight;
+	if(rule == "npc max mining time")
+		return npcMaxMiningTime;
+	if(rule == "universal frugal threshold")
+		return universalFrugalThreshold * 1000;
+	if(rule == "depreciation min")
+		return depreciationMin * 1000;
+	if(rule == "depreciation daily")
+		return depreciationDaily * 1000;
+	if(rule == "depreciation grace period")
+		return depreciationGracePeriod;
+	if(rule == "depreciation max age")
+		return depreciationMaxAge;
+	if(rule == "disabled fighters avoid projectiles")
+		return fighterHitPolicy != FighterDodgePolicy::NONE;
+	if(rule == "system departure min")
+		return systemDepartureMin * 1000;
+	if(rule == "system arrival min")
+		return systemArrivalMin * 1000;
+	if(rule == "fleet multiplier")
+		return fleetMultiplier * 1000;
+	return 0;
+}
+
+
+
 bool Gamerules::UniversalRamscoopActive() const
 {
 	return universalRamscoop;

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -15,6 +15,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <string>
+
 class DataNode;
 
 
@@ -35,6 +37,9 @@ public:
 
 	// Load a gamerules node.
 	void Load(const DataNode &node);
+
+	std::string GetString(const std::string &rule) const;
+	int GetValue(const std::string &rule) const;
 
 	bool UniversalRamscoopActive() const;
 	int PersonSpawnPeriod() const;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Files.h"
 #include "text/Format.h"
 #include "GameData.h"
+#include "Gamerules.h"
 #include "Government.h"
 #include "Logger.h"
 #include "Messages.h"
@@ -4173,6 +4174,17 @@ void PlayerInfo::RegisterDerivedConditions()
 		if(value <= 1)
 			return 0;
 		return Random::Int(value);
+	});
+
+	// Gamerule condition getter:
+	conditions["gamerule: "].ProvidePrefixed([](const ConditionEntry &ce) -> int64_t {
+		string input = ce.NameWithoutPrefix();
+		auto it = input.find("==");
+		if(it == string::npos)
+			return GameData::GetGamerules().GetValue(input);
+		string rule = input.substr(0, it);
+		string value = input.substr(it + 2);
+		return GameData::GetGamerules().GetString(rule) == value;
 	});
 
 	// Global conditions setters and getters:


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds a new autocondition:
* `"gamerule: <rule>[==<value>]"`: Read the value of a gamerule.
  * Integer gamerules return their value as-is.
  * Double gamerules return their value multiplied by 1000 and truncated to an integer. This is the same way we treat attributes when reading their values through conditions.
  * Boolean gamerules return 0 for false and and 1 for true.
  * String gamerules can be read using one of two options:
    * Using the same syntax as the other gamerules, returns 1 if in any setting that is active, and 0 if they have the inactive setting.
      * For example, `"gamerule: disabled fighters avoid projectiles"` would return 0 if using the "none" setting while returning 1 for all other settings.
    * You can also test for an exact string value by doing `<rule>==<value>` inside the condition to return 1 if the rule string matches the given value and 0 otherwise.
      * For example, `"gamerule: disabled fighters avoid projectiles==only player"` would return 1 if this gamerule were using the "only player" setting and 0 if it were something else. Using this syntax on non-string gamerules will always return 0.

## Testing 'n' Stuff

```
mission "gamerules"
	repeat
	on offer
		conversation
			`"universal ramscoop" = &[gamerule: universal ramscoop]`
			`"universal ramscoop" == "this won't work" = &[gamerule: universal ramscoop==this won't work]`
			`"person spawn period" = &[gamerule: person spawn period]`
			`"universal frugal threshold" = &[gamerule: universal frugal threshold]`
			`"disabled fighters avoid projectiles" = &[gamerule: disabled fighters avoid projectiles]`
			`"disabled fighters avoid projectiles" == "all" = &[gamerule: disabled fighters avoid projectiles==all]`
			`"disabled fighters avoid projectiles" == "only player" = &[gamerule: disabled fighters avoid projectiles==only player]`
			`"disabled fighters avoid projectiles" == "none" = &[gamerule: disabled fighters avoid projectiles==none]`
				decline

```
![image](https://github.com/user-attachments/assets/0be4cc28-a9d2-45ce-a599-a5c50733827b)


## Wiki Update

What if I just didn't do it?
