### PR TITLE
fix(mechanics): Correct depreciation calculation

### DIFF
--- a/source/Depreciation.cpp
+++ b/source/Depreciation.cpp
@@ -368,8 +368,9 @@ double Depreciation::Depreciate(int age) const
 	if(age >= MaxAge())
 		return Min();
 
-	double daily = pow(Daily(), age - GracePeriod());
-	double linear = static_cast<double>(MaxAge() - age) / (MaxAge() - GracePeriod());
+	int effectiveAge = age - GracePeriod();
+	double daily = pow(Daily(), effectiveAge);
+	double linear = static_cast<double>(MaxAge() - effectiveAge) / (MaxAge() - GracePeriod());
 	return Min() + (1. - Min()) * daily * linear;
 }
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

I was playing around with the depreciation calculations in Desmos and realized we're not accounting for the grace period in the exponential term of the depreciation calculation. This meant that close to the maximum age, the calculated value could actually be lower than the minimum value. In game this isn't very noticeable since the error rounds to 25% anyway, but at lower maximum age values, the amount of error could get rather extreme.

## Screenshots

Without the fix:
![image](https://github.com/user-attachments/assets/f4812758-dcbb-4edb-af3b-8590a70e0d62)

With the fix:
![image](https://github.com/user-attachments/assets/30c4ce3e-d282-4f85-86ad-9936cb525b94)

## Testing Done

Desmos is my testing.
