### PR TITLE
Generate compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG FALSE)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 # On Linux use relative RPATH.
 set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+# Generate compile commands for lsp parsers. This doesn't affect the build.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Setup vcpkg.
 if(ES_USE_VCPKG)


### PR DESCRIPTION
This is mostly for clangd, but other parsers can use this as well. This makes development a lot easier.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This causes cmake to generate a [compile_commands.json file](https://clang.llvm.org/docs/JSONCompilationDatabase.html) that clangd and other language parsers can use to extract relevant compile flags.

## Testing Done
I used a combination of visual studio code and the clang plugin. Before this change, clangd would complain about missing headers and c++20 features. After this change, clangd correctly parsed everything. 

## Performance Impact
This does not affect the generated binary or the data files at all. It only adds a new file to the build directory that can be used by the language parser.
