### PR TITLE
fix(ui): Select escorts when targeting them via commands

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -386,7 +386,7 @@ namespace {
 
 
 
-AI::AI(const PlayerInfo &player, const List<Ship> &ships,
+AI::AI(PlayerInfo &player, const List<Ship> &ships,
 		const List<Minable> &minables, const List<Flotsam> &flotsam)
 	: player(player), ships(ships), minables(minables), flotsam(flotsam)
 {
@@ -4308,12 +4308,17 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 			else if(selectNext && isPlayer == shift && other->IsTargetable())
 			{
 				ship.SetTargetShip(other);
+				if(isPlayer)
+					player.SelectShip(other.get(), false);
 				selectNext = false;
 				break;
 			}
 		}
 		if(selectNext)
+		{
 			ship.SetTargetShip(shared_ptr<Ship>());
+			player.SelectShip(nullptr, false);
+		}
 		else
 			UI::PlaySound(UI::UISound::TARGET);
 	}

--- a/source/AI.h
+++ b/source/AI.h
@@ -54,7 +54,7 @@ public:
 template <class Type>
 	using List = std::list<std::shared_ptr<Type>>;
 	// Constructor, giving the AI access to the player and various object lists.
-	AI(const PlayerInfo &player, const List<Ship> &ships,
+	AI(PlayerInfo &player, const List<Ship> &ships,
 			const List<Minable> &minables, const List<Flotsam> &flotsam);
 
 	// Fleet commands from the player.
@@ -220,7 +220,7 @@ private:
 
 private:
 	// TODO: Figure out a way to remove the player dependency.
-	const PlayerInfo &player;
+	PlayerInfo &player;
 	// Data from the game engine.
 	const List<Ship> &ships;
 	const List<Minable> &minables;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described [on Discord](https://discord.com/channels/251118043411775489/285540320823869441/1392502453059977256).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The escort selection is a code-wise separate from targeting ships, and currently works only when targeting escorts via mouse clicking.

With this PR, when you target your escort with Shift+N, it becomes selected (or replaces the current selection).
When you target nothing (same as clicking on empty space), your escort selection gets cleared. I'm not sure if it would be better to do this in all cases (current state of the PR), or only when your current target is your escort (so that when you N-cycle through the normal list you don't have the selection cleared accidentally, but you need to target an escort first and Shift+N-cycle to nothing if you do want to clear the selection).

## Testing Done
yes™.

## Performance Impact
N/A
