### PR TITLE
feat(content): Add a velocity override to the Firestorm to stop the game overestimating its range

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -1197,6 +1197,7 @@ outfit "Firestorm Battery"
 		"inaccuracy" 3
 		"lifetime" 1900
 		"velocity" 6.6
+		"velocity override" 5
 		"acceleration" .6
 		"drag" .12
 		"turn" 1.6


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Gives the Firestorm a velocity override of 5 (the velocity it actually achieves based on its drag and acceleration), so that the game can use that when calculating its range rahter than the launch velocity of 6.6

## Testing Done
none