### PR TITLE
fix: Choose correct hardpoint swizzle in the hail panel

### DIFF
--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -251,6 +251,8 @@ void HailPanel::Draw()
 					Point(),
 					facing + hardpoint.GetAngle(),
 					zoom);
+				if(body.InheritsParentSwizzle())
+					body.SetSwizzle(ship->GetSwizzle());
 				draw.Add(body);
 			}
 		};


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug I discovered while working on something else.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In #11596, I forgot that the hail panel renders the ship independently of the engine.

## Testing Done
None.

## Wiki Update
N/A

## Performance Impact
N/A
