### PR TITLE
refactor: Separate the Outfit and Weapon classes

### DIFF
--- a/source/AlertLabel.cpp
+++ b/source/AlertLabel.cpp
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Projectile.h"
 #include "shader/RingShader.h"
 #include "Ship.h"
+#include "Weapon.h"
 
 #include <algorithm>
 

--- a/source/AmmoDisplay.cpp
+++ b/source/AmmoDisplay.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "image/Sprite.h"
 #include "image/SpriteSet.h"
 #include "shader/SpriteShader.h"
+#include "Weapon.h"
 
 using namespace std;
 
@@ -52,8 +53,11 @@ void AmmoDisplay::Update(const Ship &flagship)
 	Reset();
 	for(const auto &it : flagship.Weapons())
 	{
-		const Outfit *secWeapon = it.GetOutfit();
-		if(!secWeapon || !secWeapon->Icon() || ammo.find(secWeapon) != ammo.end())
+		const Outfit *outfit = it.GetOutfit();
+		if(!outfit)
+			continue;
+		const Weapon *secWeapon = outfit->GetWeapon().get();
+		if(!secWeapon->Icon() || ammo.find(outfit) != ammo.end())
 			continue;
 
 		double ammoCount = -1.;
@@ -67,7 +71,7 @@ void AmmoDisplay::Update(const Ship &flagship)
 			// Decide what remaining ammunition value to display.
 			ammoCount = (ammoCount == -1. ? fuelAmmoCount : min(ammoCount, fuelAmmoCount));
 		}
-		ammo[secWeapon] = ammoCount;
+		ammo[outfit] = ammoCount;
 	}
 }
 
@@ -103,7 +107,7 @@ void AmmoDisplay::Draw(const Rectangle &ammoBox, const Point &iconDim) const
 		const auto &playerSelectedWeapons = player.SelectedSecondaryWeapons();
 		bool isSelected = (playerSelectedWeapons.find(it.first) != playerSelectedWeapons.end());
 
-		SpriteShader::Draw(it.first->Icon(), pos + iconOff);
+		SpriteShader::Draw(it.first->GetWeapon()->Icon(), pos + iconOff);
 		SpriteShader::Draw(isSelected ? selectedSprite : unselectedSprite, pos + boxOff);
 
 		auto iconCenter = Point(iconCenterX, pos.Y() + ammoIconHeight / 2.);

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -53,7 +53,10 @@ void Armament::AddTurret(const Point &point, const Hardpoint::BaseAttributes &at
 int Armament::Add(const Outfit *outfit, int count)
 {
 	// Make sure this really is a weapon.
-	if(!count || !outfit || !outfit->IsWeapon())
+	if(!count || !outfit)
+		return 0;
+	const Weapon *weapon = outfit->GetWeapon().get();
+	if(!weapon)
 		return 0;
 
 	int existing = 0;
@@ -107,7 +110,7 @@ int Armament::Add(const Outfit *outfit, int count)
 		// If this weapon is streamed, create a stream counter. If it is not
 		// streamed, or if the last of this weapon has been uninstalled, erase the
 		// stream counter (if there is one).
-		if(added > 0 && outfit->IsStreamed())
+		if(added > 0 && weapon->IsStreamed())
 			streamReload[outfit] = 0;
 		else
 			streamReload.erase(outfit);
@@ -141,7 +144,7 @@ void Armament::ReloadAll()
 
 			// If this weapon is streamed, create a stream counter.
 			const Outfit *outfit = hardpoint.GetOutfit();
-			if(outfit->IsStreamed())
+			if(outfit->GetWeapon()->IsStreamed())
 				streamReload[outfit] = 0;
 		}
 }
@@ -211,11 +214,11 @@ set<const Outfit *> Armament::RestockableAmmo() const
 	auto restockable = set<const Outfit *>{};
 	for(const Hardpoint &hardpoint : hardpoints)
 	{
-		const Weapon *weapon = hardpoint.GetOutfit();
-		if(weapon)
+		const Outfit *outfit = hardpoint.GetOutfit();
+		if(outfit)
 		{
-			const Outfit *ammo = weapon->Ammo();
-			if(ammo && !ammo->IsWeapon())
+			const Outfit *ammo = outfit->GetWeapon()->Ammo();
+			if(ammo && !ammo->GetWeapon())
 				restockable.emplace(ammo);
 		}
 	}
@@ -249,7 +252,7 @@ void Armament::Fire(unsigned index, Ship &ship, vector<Projectile> &projectiles,
 		{
 			if(it->second > 0)
 				return;
-			it->second += it->first->Reload() * hardpoints[index].BurstRemaining();
+			it->second += it->first->GetWeapon()->Reload() * hardpoints[index].BurstRemaining();
 		}
 	}
 	if(jammed)

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -261,7 +261,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 			// Keep track of how many you actually took.
 			count = 0;
 			for(const auto &it : you->Outfits())
-				if(it.first != outfit && it.first->Ammo() == outfit)
+				if(it.first != outfit && it.first->AmmoStoredOrUsed() == outfit)
 				{
 					// Figure out how many of these outfits you can install.
 					count = you->Attributes().CanAdd(*outfit, available);
@@ -595,7 +595,7 @@ bool BoardingPanel::Plunder::CanTake(const Ship &ship) const
 	// you can install it as an outfit.
 	if(outfit)
 		for(const auto &it : ship.Outfits())
-			if(it.first != outfit && it.first->Ammo() == outfit && ship.Attributes().CanAdd(*outfit))
+			if(it.first != outfit && it.first->AmmoStoredOrUsed() == outfit && ship.Attributes().CanAdd(*outfit))
 				return true;
 
 	return false;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2839,18 +2839,22 @@ void Engine::DrawShipSprites(const Ship &ship)
 
 	auto drawHardpoint = [&drawObject, &ship](const Hardpoint &hardpoint) -> void
 	{
-		if(hardpoint.GetOutfit() && hardpoint.GetOutfit()->HardpointSprite().HasSprite())
-		{
-			Body body(
-				hardpoint.GetOutfit()->HardpointSprite(),
-				ship.Position() + ship.Zoom() * ship.Facing().Rotate(hardpoint.GetPoint()),
-				ship.Velocity(),
-				ship.Facing() + hardpoint.GetAngle(),
-				ship.Zoom());
-			if(body.InheritsParentSwizzle())
-				body.SetSwizzle(ship.GetSwizzle());
-			drawObject(body);
-		}
+		const Outfit *outfit = hardpoint.GetOutfit();
+		if(!outfit)
+			return;
+		const Body &sprite = outfit->GetWeapon()->HardpointSprite();
+		if(!sprite.HasSprite())
+			return;
+
+		Body body(
+			sprite,
+			ship.Position() + ship.Zoom() * ship.Facing().Rotate(hardpoint.GetPoint()),
+			ship.Velocity(),
+			ship.Facing() + hardpoint.GetAngle(),
+			ship.Zoom());
+		if(body.InheritsParentSwizzle())
+			body.SetSwizzle(ship.GetSwizzle());
+		drawObject(body);
 	};
 
 	for(const Hardpoint &hardpoint : ship.Weapons())

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -35,6 +35,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "StellarObject.h"
 #include "System.h"
 #include "UI.h"
+#include "Weapon.h"
 #include "text/WrappedText.h"
 
 #include <algorithm>
@@ -243,16 +244,19 @@ void HailPanel::Draw()
 		bool hasFighters = ship->PositionFighters();
 		auto addHardpoint = [this, &draw, &center, zoom](const Hardpoint &hardpoint) -> void
 		{
-			if(hardpoint.GetOutfit() && hardpoint.GetOutfit()->HardpointSprite().HasSprite())
-			{
-				Body body(
-					hardpoint.GetOutfit()->HardpointSprite(),
-					center + zoom * facing.Rotate(hardpoint.GetPoint()),
-					Point(),
-					facing + hardpoint.GetAngle(),
-					zoom);
-				draw.Add(body);
-			}
+			const Outfit *outfit = hardpoint.GetOutfit();
+			if(!outfit)
+				return;
+			const Body &sprite = outfit->GetWeapon()->HardpointSprite();
+			if(!sprite.HasSprite())
+				return;
+			Body body(
+				sprite,
+				center + zoom * facing.Rotate(hardpoint.GetPoint()),
+				Point(),
+				facing + hardpoint.GetAngle(),
+				zoom);
+			draw.Add(body);
 		};
 		auto addFighter = [this, &draw, &center, zoom](const Ship::Bay &bay) -> void
 		{

--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Random.h"
 #include "Ship.h"
 #include "Visual.h"
+#include "Weapon.h"
 
 #include <algorithm>
 #include <cmath>
@@ -47,7 +48,8 @@ namespace {
 // Constructor.
 Hardpoint::Hardpoint(const Point &point, const BaseAttributes &attributes,
 	bool isTurret, bool isUnder, const Outfit *outfit)
-	: outfit(outfit), point(point * .5), baseAngle(attributes.baseAngle), baseAttributes(attributes),
+	: outfit(outfit && outfit->GetWeapon() ? outfit : nullptr), point(point * .5),
+	baseAngle(attributes.baseAngle), baseAttributes(attributes),
 	isTurret(isTurret), isParallel(baseAttributes.isParallel), isUnder(isUnder)
 {
 	UpdateArc();
@@ -55,7 +57,8 @@ Hardpoint::Hardpoint(const Point &point, const BaseAttributes &attributes,
 
 
 
-// Get the weapon in this hardpoint. This returns null if there is none.
+// Get the weapon installed in this hardpoint (or null if there is none).
+// The Outfit is guaranteed to have a Weapon.
 const Outfit *Hardpoint::GetOutfit() const
 {
 	return outfit;
@@ -118,7 +121,7 @@ Angle Hardpoint::HarmonizedAngle() const
 	// Find the point of convergence of shots fired from this gun. That is,
 	// find the angle where the projectile's X offset will be zero when it
 	// reaches the very end of its range.
-	double d = outfit->Range();
+	double d = outfit->GetWeapon()->Range();
 	// Projectiles with a range of zero should fire straight forward. A
 	// special check is needed to avoid divide by zero errors.
 	return Angle(d <= 0. ? 0. : -asin(refPoint.X() / d) * TO_DEG);
@@ -130,7 +133,7 @@ double Hardpoint::TurnRate(const Ship &ship) const
 {
 	if(!outfit)
 		return 0.;
-	return outfit->TurretTurn()
+	return outfit->GetWeapon()->TurretTurn()
 		* (1. + ship.Attributes().Get("turret turn multiplier") + baseAttributes.turnMultiplier);
 }
 
@@ -168,7 +171,7 @@ bool Hardpoint::IsUnder() const
 // Find out if this hardpoint has a homing weapon installed.
 bool Hardpoint::IsHoming() const
 {
-	return outfit && outfit->Homing();
+	return outfit && outfit->GetWeapon()->Homing();
 }
 
 
@@ -177,7 +180,10 @@ bool Hardpoint::IsHoming() const
 // (e.g. anti-missile, tractor beam).
 bool Hardpoint::IsSpecial() const
 {
-	return outfit && (outfit->AntiMissile() || outfit->TractorBeam());
+	if(!outfit)
+		return false;
+	const Weapon *weapon = outfit->GetWeapon().get();
+	return weapon->AntiMissile() || weapon->TractorBeam();
 }
 
 
@@ -237,7 +243,7 @@ void Hardpoint::Step()
 		--reload;
 	// If the full reload time is elapsed, reset the burst counter.
 	if(reload <= 0.)
-		burstCount = outfit->BurstCount();
+		burstCount = outfit->GetWeapon()->BurstCount();
 	if(burstReload > 0.)
 		--burstReload;
 	// If the burst reload time has elapsed, this weapon will not count as firing
@@ -279,24 +285,27 @@ void Hardpoint::Fire(Ship &ship, vector<Projectile> &projectiles, vector<Visual>
 {
 	// Since this is only called internally by Armament (no one else has non-
 	// const access), assume Armament checked that this is a valid call.
+
+	const Weapon *weapon = outfit->GetWeapon().get();
+
 	Angle aim = ship.Facing();
 	Point start = ship.Position() + aim.Rotate(point);
 
 	// Apply the aim and hardpoint offset.
 	aim += angle;
-	start += aim.Rotate(outfit->HardpointOffset());
+	start += aim.Rotate(weapon->HardpointOffset());
 
 	// Apply the weapon's inaccuracy to the aim. This allows firing effects
 	// to share the same inaccuracy as the projectile.
-	aim += Distribution::GenerateInaccuracy(outfit->Inaccuracy(), outfit->InaccuracyDistribution());
+	aim += Distribution::GenerateInaccuracy(weapon->Inaccuracy(), weapon->InaccuracyDistribution());
 
 	// Create a new projectile, originating from this hardpoint.
 	// In order to get projectiles to start at the right position they are drawn
 	// at an offset of (.5 * velocity). See BatchDrawList.cpp for more details.
-	projectiles.emplace_back(ship, start - .5 * ship.Velocity(), aim, outfit);
+	projectiles.emplace_back(ship, start - .5 * ship.Velocity(), aim, weapon);
 
 	// Create any effects this weapon creates when it is fired.
-	CreateEffects(outfit->FireEffects(), start, ship.Velocity(), aim, visuals);
+	CreateEffects(weapon->FireEffects(), start, ship.Velocity(), aim, visuals);
 
 	// Update the reload and burst counters, and expend ammunition if applicable.
 	Fire(ship, start, aim);
@@ -308,7 +317,7 @@ void Hardpoint::Fire(Ship &ship, vector<Projectile> &projectiles, vector<Visual>
 bool Hardpoint::FireAntiMissile(Ship &ship, const Projectile &projectile, vector<Visual> &visuals)
 {
 	// Make sure this hardpoint really is an anti-missile.
-	int strength = outfit->AntiMissile();
+	int strength = outfit->GetWeapon()->AntiMissile();
 	if(!strength)
 		return false;
 
@@ -326,7 +335,7 @@ bool Hardpoint::FireAntiMissile(Ship &ship, const Projectile &projectile, vector
 bool Hardpoint::FireTractorBeam(Ship &ship, const Flotsam &flotsam, std::vector<Visual> &visuals)
 {
 	// Make sure this hardpoint really is a tractor beam.
-	double strength = outfit->TractorBeam();
+	double strength = outfit->GetWeapon()->TractorBeam();
 	if(!strength)
 		return false;
 
@@ -345,9 +354,11 @@ void Hardpoint::Jam()
 	// Since this is only called internally by Armament (no one else has non-
 	// const access), assume Armament checked that this is a valid call.
 
+	const Weapon *weapon = outfit->GetWeapon().get();
+
 	// Reset the reload count.
-	reload += outfit->Reload();
-	burstReload += outfit->BurstReload();
+	reload += weapon->Reload();
+	burstReload += weapon->BurstReload();
 	--burstCount;
 }
 
@@ -359,7 +370,7 @@ void Hardpoint::Install(const Outfit *outfit)
 {
 	// If the given outfit is not a valid weapon, this hardpoint becomes empty.
 	// Also check that the type of the weapon (gun or turret) is right.
-	if(!outfit || !outfit->IsWeapon() || (isTurret == !outfit->Get("turret mounts")))
+	if(!outfit || !outfit->GetWeapon() || (isTurret == !outfit->Get("turret mounts")))
 		Uninstall();
 	else
 	{
@@ -375,7 +386,7 @@ void Hardpoint::Install(const Outfit *outfit)
 		// Weapons that fire parallel beams don't get a harmonized angle.
 		// And some hardpoints/gunslots are configured not to get harmonized.
 		// So only harmonize when both the port and the outfit supports it.
-		if(!isParallel && !outfit->IsParallel())
+		if(!isParallel && !outfit->GetWeapon()->IsParallel())
 		{
 			const Angle harmonized = baseAngle + HarmonizedAngle();
 			// The harmonized angle might be out of the arc of a turret.
@@ -394,7 +405,7 @@ void Hardpoint::Reload()
 {
 	reload = 0.;
 	burstReload = 0.;
-	burstCount = outfit ? outfit->BurstCount() : 0;
+	burstCount = outfit ? outfit->GetWeapon()->BurstCount() : 0;
 }
 
 
@@ -422,9 +433,11 @@ const Hardpoint::BaseAttributes &Hardpoint::GetBaseAttributes() const
 // or tractor beam system and create visuals if it is.
 bool Hardpoint::FireSpecialSystem(Ship &ship, const Body &body, std::vector<Visual> &visuals)
 {
+	const Weapon *weapon = outfit->GetWeapon().get();
+
 	// Get the weapon range. Anti-missile and tractor beam shots always last a
 	// single frame, so their range is equal to their velocity.
-	double range = outfit->Velocity();
+	double range = weapon->Velocity();
 	Angle facing = ship.Facing();
 
 	// Check if the body is within range of this hardpoint.
@@ -444,19 +457,19 @@ bool Hardpoint::FireSpecialSystem(Ship &ship, const Body &body, std::vector<Visu
 	}
 
 	// Precompute the number of visuals that will be added.
-	visuals.reserve(visuals.size() + outfit->FireEffects().size()
-		+ outfit->HitEffects().size() + outfit->DieEffects().size());
+	visuals.reserve(visuals.size() + weapon->FireEffects().size()
+		+ weapon->HitEffects().size() + weapon->DieEffects().size());
 
 	angle = aim - facing;
-	start += aim.Rotate(outfit->HardpointOffset());
-	CreateEffects(outfit->FireEffects(), start, ship.Velocity(), aim, visuals);
+	start += aim.Rotate(weapon->HardpointOffset());
+	CreateEffects(weapon->FireEffects(), start, ship.Velocity(), aim, visuals);
 
 	// Figure out where the hit effect should be placed. Anti-missile and tractor
 	// beam systems do not create projectiles; they just create a blast animation.
-	CreateEffects(outfit->HitEffects(), start + (.5 * range) * aim.Unit(), ship.Velocity(), aim, visuals);
+	CreateEffects(weapon->HitEffects(), start + (.5 * range) * aim.Unit(), ship.Velocity(), aim, visuals);
 
 	// Die effects are displayed at the body, whether or not it actually "dies."
-	CreateEffects(outfit->DieEffects(), body.Position(), body.Velocity(), aim, visuals);
+	CreateEffects(weapon->DieEffects(), body.Position(), body.Velocity(), aim, visuals);
 
 	// Update the reload and burst counters, and expend ammunition if applicable.
 	Fire(ship, start, aim);
@@ -472,24 +485,27 @@ void Hardpoint::Fire(Ship &ship, const Point &start, const Angle &aim)
 	// Since this is only called internally, it is safe to assume that the
 	// outfit pointer is not null.
 
+	const Weapon *weapon = outfit->GetWeapon().get();
+
 	// Reset the reload count.
-	reload += outfit->Reload();
-	burstReload += outfit->BurstReload();
+	reload += weapon->Reload();
+	burstReload += weapon->BurstReload();
 	--burstCount;
 	isFiring = true;
 
 	// Anti-missile sounds can be specified either in the outfit itself or in
 	// the effect they create.
-	if(outfit->WeaponSound())
-		Audio::Play(outfit->WeaponSound(), start, IsSpecial() ? SoundCategory::ANTI_MISSILE : SoundCategory::WEAPON);
+	const Sound *weaponSound = weapon->WeaponSound();
+	if(weaponSound)
+		Audio::Play(weaponSound, start, IsSpecial() ? SoundCategory::ANTI_MISSILE : SoundCategory::WEAPON);
 	// Apply any "kick" from firing this weapon.
-	double force = outfit->FiringForce();
+	double force = weapon->FiringForce();
 	if(force)
 		ship.ApplyForce(aim.Unit() * -force);
 
 	// Expend any ammo that this weapon uses. Do this as the very last thing, in
 	// case the outfit is its own ammunition.
-	ship.ExpendAmmo(*outfit);
+	ship.ExpendAmmo(*weapon);
 }
 
 
@@ -517,7 +533,7 @@ void Hardpoint::UpdateArc()
 
 	// The installed weapon restricts the arc of fire.
 	const double hardpointsArc = (maxArc - minArc).AbsDegrees();
-	const double weaponsArc = outfit->Arc();
+	const double weaponsArc = outfit->GetWeapon()->Arc();
 	if(weaponsArc < 360. && (isOmnidirectional || weaponsArc < hardpointsArc))
 	{
 		isOmnidirectional = false;

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -58,6 +58,7 @@ public:
 		bool isTurret, bool isUnder, const Outfit *outfit = nullptr);
 
 	// Get the weapon installed in this hardpoint (or null if there is none).
+	// The Outfit is guaranteed to have a Weapon.
 	const Outfit *GetOutfit() const;
 	// Get the location, relative to the center of the ship, from which
 	// projectiles of this weapon should originate. This point must be
@@ -134,7 +135,7 @@ private:
 
 
 private:
-	// The weapon installed in this hardpoint.
+	// The Outfit installed in this hardpoint is guaranteed to have a Weapon.
 	const Outfit *outfit = nullptr;
 	// Hardpoint location, in world coordinates relative to the ship's center.
 	Point point;

--- a/source/Hazard.cpp
+++ b/source/Hazard.cpp
@@ -34,7 +34,7 @@ void Hazard::Load(const DataNode &node)
 	{
 		const string &key = child.Token(0);
 		if(key == "weapon")
-			LoadWeapon(child);
+			Weapon::Load(child);
 		else if(key == "constant strength")
 			deviates = false;
 		else if(key == "system-wide")

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Effect.h"
 #include "GameData.h"
 #include "image/SpriteSet.h"
+#include "Weapon.h"
 
 #include <algorithm>
 #include <cmath>
@@ -216,6 +217,8 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 
 	isDefined = true;
 
+	shared_ptr<Weapon> newWeapon;
+
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
@@ -277,14 +280,9 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 		else if(key == "thumbnail" && hasValue)
 			thumbnail = SpriteSet::Get(child.Token(1));
 		else if(key == "weapon")
-			LoadWeapon(child);
+			newWeapon = shared_ptr<Weapon>{new Weapon(child)};
 		else if(key == "ammo" && hasValue)
-		{
-			// Non-weapon outfits can have ammo so that storage outfits
-			// properly remove excess ammo when the storage is sold, instead
-			// of blocking the sale of the outfit until the ammo is sold first.
-			ammo = make_pair(GameData::Outfits().Get(child.Token(1)), 0);
-		}
+			ammoStored = GameData::Outfits().Get(child.Token(1));
 		else if(key == "description" && hasValue)
 			description.Load(child, playerConditions);
 		else if(key == "cost" && hasValue)
@@ -355,13 +353,19 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 	if(isJumpDrive && attributes.Get("jump range"))
 		GameData::AddJumpRange(attributes.Get("jump range"));
 
-	// Legacy support for turrets that don't specify a turn rate:
-	if(IsWeapon() && attributes.Get("turret mounts") && !TurretTurn()
-		&& !AntiMissile() && !TractorBeam())
+	if(newWeapon)
 	{
-		SetTurretTurn(4.);
-		node.PrintTrace("Warning: Deprecated use of a turret without specified \"turret turn\":");
+		// Legacy support for turrets that don't specify a turn rate:
+		if(attributes.Get("turret mounts") && !newWeapon->TurretTurn()
+			&& !newWeapon->AntiMissile() && !newWeapon->TractorBeam())
+		{
+			newWeapon->turretTurn = 4.;
+			node.PrintTrace("Warning: Deprecated use of a turret without specified \"turret turn\":");
+		}
+
+		weapon = std::move(newWeapon);
 	}
+
 	// Convert any legacy cargo / outfit scan definitions into power & speed,
 	// so no runtime code has to check for both.
 	auto convertScan = [&](string &&kind) -> void
@@ -588,6 +592,20 @@ void Outfit::AddLicenses(const Outfit &other)
 void Outfit::Set(const char *attribute, double value)
 {
 	attributes[attribute] = value;
+}
+
+
+
+const Outfit *Outfit::AmmoStored() const
+{
+	return ammoStored;
+}
+
+
+
+const Outfit *Outfit::AmmoStoredOrUsed() const
+{
+	return weapon ? weapon->Ammo() : ammoStored;
 }
 
 

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -15,12 +15,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "Weapon.h"
-
 #include "Dictionary.h"
 #include "Paragraphs.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,6 +30,7 @@ class DataNode;
 class Effect;
 class Sound;
 class Sprite;
+class Weapon;
 
 
 
@@ -40,7 +40,7 @@ class Sprite;
 // set of attributes unique to them, and outfits can also specify additional
 // information like the sprite to use in the outfitter panel for selling them,
 // or the sprite or sound to be used for an engine flare.
-class Outfit : public Weapon {
+class Outfit {
 public:
 	// These are all the possible category strings for outfits.
 	static const std::vector<std::string> CATEGORIES;
@@ -87,6 +87,12 @@ public:
 	// Modify this outfit's attributes. Note that this cannot be used to change
 	// special attributes, like cost and mass.
 	void Set(const char *attribute, double value);
+
+	const std::shared_ptr<const Weapon> &GetWeapon() const;
+	// Get the ammo if this is an ammo storage outfit.
+	const Outfit *AmmoStored() const;
+	// Get the ammo used if this is a weapon, or stored ammo if this is a storage.
+	const Outfit *AmmoStoredOrUsed() const;
 
 	// Get this outfit's engine flare sprites, if any.
 	const std::vector<std::pair<Body, int>> &FlareSprites() const;
@@ -136,6 +142,12 @@ private:
 
 	Dictionary attributes;
 
+	std::shared_ptr<const Weapon> weapon;
+	// Non-weapon outfits can have ammo so that storage outfits
+	// properly remove excess ammo when the storage is sold, instead
+	// of blocking the sale of the outfit until the ammo is sold first.
+	const Outfit *ammoStored = nullptr;
+
 	// The integers in these pairs/maps indicate the number of
 	// sprites/effects/sounds to be placed/played.
 	std::vector<std::pair<Body, int>> flareSprites;
@@ -162,3 +174,4 @@ private:
 // These get called a lot, so inline them for speed.
 inline int64_t Outfit::Cost() const { return cost; }
 inline double Outfit::Mass() const { return mass; }
+inline const std::shared_ptr<const Weapon> &Outfit::GetWeapon() const { return weapon; }

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
+#include "Weapon.h"
 
 #include <algorithm>
 #include <cmath>
@@ -473,7 +474,8 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		hasNormalAttributes = true;
 	}
 
-	if(!outfit.IsWeapon())
+	const Weapon *weapon = outfit.GetWeapon().get();
+	if(!weapon)
 		return;
 
 	// Insert padding if any normal attributes were listed above.
@@ -484,26 +486,26 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributesHeight += 10;
 	}
 
-	if(outfit.Ammo())
+	if(weapon->Ammo())
 	{
 		attributeLabels.emplace_back("ammo:");
-		attributeValues.emplace_back(outfit.Ammo()->DisplayName());
+		attributeValues.emplace_back(weapon->Ammo()->DisplayName());
 		attributesHeight += 20;
-		if(outfit.AmmoUsage() != 1)
+		if(weapon->AmmoUsage() != 1)
 		{
 			attributeLabels.emplace_back("ammo usage:");
-			attributeValues.emplace_back(Format::Number(outfit.AmmoUsage()));
+			attributeValues.emplace_back(Format::Number(weapon->AmmoUsage()));
 			attributesHeight += 20;
 		}
 	}
 
-	double range = outfit.Range();
+	double range = weapon->Range();
 	attributeLabels.emplace_back("range:");
 	attributeValues.emplace_back(Format::Number(range));
 	attributesHeight += 20;
 
 	attributeLabels.emplace_back("velocity:");
-	double velocity = outfit.WeightedVelocity();
+	double velocity = weapon->WeightedVelocity();
 	if(velocity == range)
 		attributeValues.emplace_back("instantaneous");
 	else
@@ -511,7 +513,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	attributesHeight += 20;
 
 	// Identify the dropoff at range and inform the player.
-	double fullDropoff = outfit.MaxDropoff();
+	double fullDropoff = weapon->MaxDropoff();
 	if(fullDropoff != 1.)
 	{
 		attributeLabels.emplace_back("dropoff modifier:");
@@ -519,7 +521,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		attributesHeight += 20;
 		// Identify the ranges between which the dropoff takes place.
 		attributeLabels.emplace_back("dropoff range:");
-		const pair<double, double> &ranges = outfit.DropoffRanges();
+		const pair<double, double> &ranges = weapon->DropoffRanges();
 		attributeValues.emplace_back(Format::Number(ranges.first)
 			+ " - " + Format::Number(ranges.second));
 		attributesHeight += 20;
@@ -567,48 +569,48 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	};
 
 	vector<double> values = {
-		outfit.ShieldDamage(),
-		outfit.HullDamage(),
-		outfit.MinableDamage() != outfit.HullDamage() ? outfit.MinableDamage() : 0.,
-		outfit.FuelDamage(),
-		outfit.HeatDamage(),
-		outfit.EnergyDamage(),
-		outfit.IonDamage() * 100.,
-		outfit.ScramblingDamage() * 100.,
-		outfit.SlowingDamage() * 100.,
-		outfit.DisruptionDamage() * 100.,
-		outfit.DischargeDamage() * 100.,
-		outfit.CorrosionDamage() * 100.,
-		outfit.LeakDamage() * 100.,
-		outfit.BurnDamage() * 100.,
-		outfit.RelativeShieldDamage() * 100.,
-		outfit.RelativeHullDamage() * 100.,
-		outfit.RelativeMinableDamage() != outfit.RelativeHullDamage() ? outfit.RelativeMinableDamage() * 100. : 0.,
-		outfit.RelativeFuelDamage() * 100.,
-		outfit.RelativeHeatDamage() * 100.,
-		outfit.RelativeEnergyDamage() * 100.,
-		outfit.FiringEnergy(),
-		outfit.FiringHeat(),
-		outfit.FiringFuel(),
-		outfit.FiringHull(),
-		outfit.FiringShields(),
-		outfit.FiringIon() * 100.,
-		outfit.FiringScramble() * 100.,
-		outfit.FiringSlowing() * 100.,
-		outfit.FiringDisruption() * 100.,
-		outfit.FiringDischarge() * 100.,
-		outfit.FiringCorrosion() * 100.,
-		outfit.FiringLeak() * 100.,
-		outfit.FiringBurn() * 100.,
-		outfit.RelativeFiringEnergy() * 100.,
-		outfit.RelativeFiringHeat() * 100.,
-		outfit.RelativeFiringFuel() * 100.,
-		outfit.RelativeFiringHull() * 100.,
-		outfit.RelativeFiringShields() * 100.
+		weapon->ShieldDamage(),
+		weapon->HullDamage(),
+		weapon->MinableDamage() != weapon->HullDamage() ? weapon->MinableDamage() : 0.,
+		weapon->FuelDamage(),
+		weapon->HeatDamage(),
+		weapon->EnergyDamage(),
+		weapon->IonDamage() * 100.,
+		weapon->ScramblingDamage() * 100.,
+		weapon->SlowingDamage() * 100.,
+		weapon->DisruptionDamage() * 100.,
+		weapon->DischargeDamage() * 100.,
+		weapon->CorrosionDamage() * 100.,
+		weapon->LeakDamage() * 100.,
+		weapon->BurnDamage() * 100.,
+		weapon->RelativeShieldDamage() * 100.,
+		weapon->RelativeHullDamage() * 100.,
+		weapon->RelativeMinableDamage() != weapon->RelativeHullDamage() ? weapon->RelativeMinableDamage() * 100. : 0.,
+		weapon->RelativeFuelDamage() * 100.,
+		weapon->RelativeHeatDamage() * 100.,
+		weapon->RelativeEnergyDamage() * 100.,
+		weapon->FiringEnergy(),
+		weapon->FiringHeat(),
+		weapon->FiringFuel(),
+		weapon->FiringHull(),
+		weapon->FiringShields(),
+		weapon->FiringIon() * 100.,
+		weapon->FiringScramble() * 100.,
+		weapon->FiringSlowing() * 100.,
+		weapon->FiringDisruption() * 100.,
+		weapon->FiringDischarge() * 100.,
+		weapon->FiringCorrosion() * 100.,
+		weapon->FiringLeak() * 100.,
+		weapon->FiringBurn() * 100.,
+		weapon->RelativeFiringEnergy() * 100.,
+		weapon->RelativeFiringHeat() * 100.,
+		weapon->RelativeFiringFuel() * 100.,
+		weapon->RelativeFiringHull() * 100.,
+		weapon->RelativeFiringShields() * 100.
 	};
 
 	// Add any per-second values to the table.
-	double reload = outfit.Reload();
+	double reload = weapon->Reload();
 	if(reload)
 	{
 		static const string PER_SECOND = " / second:";
@@ -621,36 +623,36 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			}
 	}
 
-	bool oneFrame = (outfit.TotalLifetime() == 1.);
+	bool oneFrame = (weapon->TotalLifetime() == 1.);
 	bool isContinuous = (reload <= 1. && oneFrame);
-	bool isContinuousBurst = (outfit.BurstCount() > 1 && outfit.BurstReload() <= 1. && oneFrame);
+	bool isContinuousBurst = (weapon->BurstCount() > 1 && weapon->BurstReload() <= 1. && oneFrame);
 	attributeLabels.emplace_back("shots / second:");
 	if(isContinuous)
 		attributeValues.emplace_back("continuous");
 	else if(isContinuousBurst)
-		attributeValues.emplace_back("continuous (" + Format::Number(lround(outfit.BurstReload() * 100. / reload)) + "%)");
+		attributeValues.emplace_back("continuous (" + Format::Number(lround(weapon->BurstReload() * 100. / reload)) + "%)");
 	else
 		attributeValues.emplace_back(Format::Number(60. / reload));
 	attributesHeight += 20;
 
-	double turretTurn = outfit.TurretTurn() * 60.;
+	double turretTurn = weapon->TurretTurn() * 60.;
 	if(turretTurn)
 	{
 		attributeLabels.emplace_back("turret turn rate:");
 		attributeValues.emplace_back(Format::Number(turretTurn));
 		attributesHeight += 20;
 	}
-	double arc = outfit.Arc();
+	double arc = weapon->Arc();
 	if(arc < 360.)
 	{
 		attributeLabels.emplace_back("arc:");
 		attributeValues.emplace_back(Format::Number(arc));
 		attributesHeight += 20;
 	}
-	if(outfit.Homing())
+	if(weapon->Homing())
 	{
 		attributeLabels.emplace_back("homing type:");
-		attributeValues.emplace_back(outfit.Leading() ? "leading" : "direct");
+		attributeValues.emplace_back(weapon->Leading() ? "leading" : "direct");
 		attributesHeight += 20;
 	}
 	static const vector<string> PERCENT_NAMES = {
@@ -661,11 +663,11 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"piercing:"
 	};
 	vector<double> percentValues = {
-		outfit.Tracking(),
-		outfit.OpticalTracking(),
-		outfit.InfraredTracking(),
-		outfit.RadarTracking(),
-		outfit.Piercing()
+		weapon->Tracking(),
+		weapon->OpticalTracking(),
+		weapon->InfraredTracking(),
+		weapon->RadarTracking(),
+		weapon->Piercing()
 	};
 	for(unsigned i = 0; i < PERCENT_NAMES.size(); ++i)
 		if(percentValues[i])
@@ -675,13 +677,13 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			attributeValues.push_back(Format::Number(percent) + "%");
 			attributesHeight += 20;
 		}
-	if(outfit.ThrottleControl())
+	if(weapon->ThrottleControl())
 	{
 		attributeLabels.emplace_back("Projectiles can control thrust.");
 		attributeValues.emplace_back(" ");
 		attributesHeight += 20;
 	}
-	if(outfit.HasBlindspot())
+	if(weapon->HasBlindspot())
 	{
 		attributeLabels.emplace_back("Cannot track targets behind it.");
 		attributeValues.emplace_back(" ");
@@ -716,12 +718,12 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 		"mining precision:",
 	};
 	vector<double> otherValues = {
-		outfit.Inaccuracy(),
-		outfit.BlastRadius(),
-		static_cast<double>(outfit.MissileStrength()),
-		static_cast<double>(outfit.AntiMissile()),
-		outfit.TractorBeam() * 60.,
-		outfit.Prospecting() && outfit.MinableDamage() ? outfit.Prospecting() / outfit.MinableDamage() : 0.,
+		weapon->Inaccuracy(),
+		weapon->BlastRadius(),
+		static_cast<double>(weapon->MissileStrength()),
+		static_cast<double>(weapon->AntiMissile()),
+		weapon->TractorBeam() * 60.,
+		weapon->Prospecting() && weapon->MinableDamage() ? weapon->Prospecting() / weapon->MinableDamage() : 0.,
 	};
 
 	for(unsigned i = 0; i < OTHER_NAMES.size(); ++i)

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -37,6 +37,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "shader/SpriteShader.h"
 #include "text/Truncate.h"
 #include "UI.h"
+#include "Weapon.h"
 
 #include <algorithm>
 #include <limits>
@@ -52,15 +53,16 @@ namespace {
 	set<const Outfit *> GetRefillableAmmunition(const Ship &ship) noexcept
 	{
 		auto toRefill = set<const Outfit *>{};
-		auto armed = set<const Outfit *>{};
 		for(auto &&it : ship.Weapons())
-			if(it.GetOutfit())
+		{
+			const Outfit *outfit = it.GetOutfit();
+			if(outfit)
 			{
-				const Outfit *weapon = it.GetOutfit();
-				armed.emplace(weapon);
+				const Weapon *weapon = outfit->GetWeapon().get();
 				if(weapon->Ammo() && weapon->AmmoUsage() > 0)
 					toRefill.emplace(weapon->Ammo());
 			}
+		}
 
 		// Carriers may be configured to supply ammunition for carried ships found
 		// within the fleet. Since a particular ammunition outfit is not bound to
@@ -69,8 +71,8 @@ namespace {
 		for(auto &&it : ship.Outfits())
 		{
 			const Outfit *outfit = it.first;
-			if(outfit->Ammo() && !outfit->IsWeapon() && !armed.contains(outfit))
-				toRefill.emplace(outfit->Ammo());
+			if(!outfit->GetWeapon() && outfit->AmmoStored())
+				toRefill.emplace(outfit->AmmoStored());
 		}
 		return toRefill;
 	}
@@ -670,7 +672,7 @@ void OutfitterPanel::Sell(bool toStorage)
 				player.AddStock(selectedOutfit, 1);
 			}
 
-			const Outfit *ammo = selectedOutfit->Ammo();
+			const Outfit *ammo = selectedOutfit->AmmoStoredOrUsed();
 			if(ammo && ship->OutfitCount(ammo))
 			{
 				// Determine how many of this ammo I must sell to also sell the launcher.
@@ -851,7 +853,7 @@ bool OutfitterPanel::ShipCanSell(const Ship *ship, const Outfit *outfit)
 
 	// If this outfit requires ammo, check if we could sell it if we sold all
 	// the ammo for it first.
-	const Outfit *ammo = outfit->Ammo();
+	const Outfit *ammo = outfit->AmmoStoredOrUsed();
 	if(ammo && ship->OutfitCount(ammo))
 	{
 		Outfit attributes = ship->Attributes();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -44,6 +44,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "StellarObject.h"
 #include "System.h"
 #include "UI.h"
+#include "Weapon.h"
 
 #include <algorithm>
 #include <cassert>
@@ -2975,12 +2976,15 @@ void PlayerInfo::SelectNextSecondary()
 
 	// Find the next secondary weapon.
 	for( ; it != flagship->Outfits().end(); ++it)
-		if(it->first->Icon())
+	{
+		const Weapon *weapon = it->first->GetWeapon().get();
+		if(weapon && weapon->Icon())
 		{
 			selectedWeapons.clear();
 			selectedWeapons.insert(it->first);
 			return;
 		}
+	}
 
 	// If no weapon was selected and we didn't find any weapons at this point,
 	// then the player just doesn't have any secondary weapons.
@@ -2990,8 +2994,11 @@ void PlayerInfo::SelectNextSecondary()
 	// Reached the end of the list. Select all possible secondary weapons here.
 	it = flagship->Outfits().begin();
 	for( ; it != flagship->Outfits().end(); ++it)
-		if(it->first->Icon())
+	{
+		const Weapon *weapon = it->first->GetWeapon().get();
+		if(weapon && weapon->Icon())
 			selectedWeapons.insert(it->first);
+	}
 
 	// If we have only one weapon selected at this point, then the player
 	// only has a single secondary weapon. Clear the list, since the weapon

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Ship.h"
 #include "Shop.h"
 #include "System.h"
+#include "Weapon.h"
 
 #include <iostream>
 #include <map>
@@ -261,12 +262,15 @@ namespace {
 					+ attributes.Get("cloaking heat");
 
 				for(const auto &oit : ship.Outfits())
-					if(oit.first->IsWeapon() && oit.first->Reload())
+				{
+					const Weapon *weapon = oit.first->GetWeapon().get();
+					if(weapon && weapon->Reload())
 					{
-						double reload = oit.first->Reload();
-						energyConsumed += oit.second * oit.first->FiringEnergy() / reload;
-						heatProduced += oit.second * oit.first->FiringHeat() / reload;
+						double reload = weapon->Reload();
+						energyConsumed += oit.second * weapon->FiringEnergy() / reload;
+						heatProduced += oit.second * weapon->FiringHeat() / reload;
 					}
+				}
 				cout << 60. * (attributes.Get("energy generation") + attributes.Get("solar collection")) << ',';
 				cout << 60. * energyConsumed << ',';
 				cout << attributes.Get("energy capacity") << ',';
@@ -292,9 +296,11 @@ namespace {
 
 				double deterrence = 0.;
 				for(const Hardpoint &hardpoint : ship.Weapons())
-					if(hardpoint.GetOutfit())
+				{
+					const Outfit *outfit = hardpoint.GetOutfit();
+					if(outfit)
 					{
-						const Outfit *weapon = hardpoint.GetOutfit();
+						const Weapon *weapon = outfit->GetWeapon().get();
 						if(weapon->Ammo() && !ship.OutfitCount(weapon->Ammo()))
 							continue;
 						double damage = weapon->ShieldDamage() + weapon->HullDamage()
@@ -302,6 +308,7 @@ namespace {
 							+ (weapon->RelativeHullDamage() * ship.MaxHull());
 						deterrence += .12 * damage / weapon->Reload();
 					}
+				}
 				cout << deterrence << '\n';
 			}
 		};
@@ -364,32 +371,33 @@ namespace {
 			for(auto &it : GameData::Outfits())
 			{
 				// Skip non-weapons and submunitions.
-				if(!it.second.IsWeapon() || it.second.Category().empty())
+				const Outfit &outfit = it.second;
+				const Weapon *weapon = outfit.GetWeapon().get();
+				if(!weapon || outfit.Category().empty())
 					continue;
 
-				const Outfit &outfit = it.second;
 				cout << DataWriter::Quote(it.first)<< ',';
 				cout << DataWriter::Quote(outfit.Category()) << ',';
 				cout << outfit.Cost() << ',';
 				cout << -outfit.Get("weapon capacity") << ',';
 
-				cout << outfit.Range() << ',';
+				cout << weapon->Range() << ',';
 
-				double reload = outfit.Reload();
+				double reload = weapon->Reload();
 				cout << reload << ',';
-				cout << outfit.BurstCount() << ',';
-				cout << outfit.BurstReload() << ',';
-				cout << outfit.TotalLifetime() << ',';
+				cout << weapon->BurstCount() << ',';
+				cout << weapon->BurstReload() << ',';
+				cout << weapon->TotalLifetime() << ',';
 				double fireRate = 60. / reload;
 				cout << fireRate << ',';
 
-				double firingEnergy = outfit.FiringEnergy();
+				double firingEnergy = weapon->FiringEnergy();
 				cout << firingEnergy << ',';
 				firingEnergy *= fireRate;
-				double firingHeat = outfit.FiringHeat();
+				double firingHeat = weapon->FiringHeat();
 				cout << firingHeat << ',';
 				firingHeat *= fireRate;
-				double firingForce = outfit.FiringForce();
+				double firingForce = weapon->FiringForce();
 				cout << firingForce << ',';
 				firingForce *= fireRate;
 
@@ -397,41 +405,41 @@ namespace {
 				cout << firingHeat << ',';
 				cout << firingForce << ',';
 
-				double shieldDmg = outfit.ShieldDamage() * fireRate;
+				double shieldDmg = weapon->ShieldDamage() * fireRate;
 				cout << shieldDmg << ',';
-				double dischargeDmg = outfit.DischargeDamage() * 100. * fireRate;
+				double dischargeDmg = weapon->DischargeDamage() * 100. * fireRate;
 				cout << dischargeDmg << ',';
-				double hullDmg = outfit.HullDamage() * fireRate;
+				double hullDmg = weapon->HullDamage() * fireRate;
 				cout << hullDmg << ',';
-				double corrosionDmg = outfit.CorrosionDamage() * 100. * fireRate;
+				double corrosionDmg = weapon->CorrosionDamage() * 100. * fireRate;
 				cout << corrosionDmg << ',';
-				double heatDmg = outfit.HeatDamage() * fireRate;
+				double heatDmg = weapon->HeatDamage() * fireRate;
 				cout << heatDmg << ',';
-				double burnDmg = outfit.BurnDamage() * 100. * fireRate;
+				double burnDmg = weapon->BurnDamage() * 100. * fireRate;
 				cout << burnDmg << ',';
-				double energyDmg = outfit.EnergyDamage() * fireRate;
+				double energyDmg = weapon->EnergyDamage() * fireRate;
 				cout << energyDmg << ',';
-				double ionDmg = outfit.IonDamage() * 100. * fireRate;
+				double ionDmg = weapon->IonDamage() * 100. * fireRate;
 				cout << ionDmg << ',';
-				double scramblingDmg = outfit.ScramblingDamage() * 100. * fireRate;
+				double scramblingDmg = weapon->ScramblingDamage() * 100. * fireRate;
 				cout << scramblingDmg << ',';
-				double slowDmg = outfit.SlowingDamage() * fireRate;
+				double slowDmg = weapon->SlowingDamage() * fireRate;
 				cout << slowDmg << ',';
-				double disruptDmg = outfit.DisruptionDamage() * fireRate;
+				double disruptDmg = weapon->DisruptionDamage() * fireRate;
 				cout << disruptDmg << ',';
-				cout << outfit.Piercing() << ',';
-				double fuelDmg = outfit.FuelDamage() * fireRate;
+				cout << weapon->Piercing() << ',';
+				double fuelDmg = weapon->FuelDamage() * fireRate;
 				cout << fuelDmg << ',';
-				double leakDmg = outfit.LeakDamage() * 100. * fireRate;
+				double leakDmg = weapon->LeakDamage() * 100. * fireRate;
 				cout << leakDmg << ',';
-				double hitforce = outfit.HitForce() * fireRate;
+				double hitforce = weapon->HitForce() * fireRate;
 				cout << hitforce << ',';
 
-				double strength = outfit.MissileStrength() + outfit.AntiMissile();
+				double strength = weapon->MissileStrength() + weapon->AntiMissile();
 				cout << strength << ',';
 
-				double damage = outfit.ShieldDamage() + outfit.HullDamage();
-				double deterrence = .12 * damage / outfit.Reload();
+				double damage = weapon->ShieldDamage() + weapon->HullDamage();
+				double deterrence = .12 * damage / weapon->Reload();
 				cout << deterrence << '\n';
 			}
 

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -140,7 +140,7 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 				if(lifetime > -100 ? it.spawnOnNaturalDeath : it.spawnOnAntiMissileDeath)
 					for(size_t i = 0; i < it.count; ++i)
 					{
-						const Weapon *const subWeapon = it.weapon;
+						const Weapon *const subWeapon = it.weapon.get();
 						Angle inaccuracy = Distribution::GenerateInaccuracy(subWeapon->Inaccuracy(),
 								subWeapon->InaccuracyDistribution());
 						projectiles.emplace_back(*this, it.offset, it.facing + inaccuracy, subWeapon);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -45,6 +45,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Swizzle.h"
 #include "System.h"
 #include "Visual.h"
+#include "Weapon.h"
 #include "Wormhole.h"
 
 #include <algorithm>
@@ -623,7 +624,7 @@ void Ship::FinishLoading(bool isNewInstance)
 	if(GameData::Ships().Has(trueModelName))
 	{
 		const Ship *model = GameData::Ships().Get(trueModelName);
-		explosionWeapon = &model->BaseAttributes();
+		explosionWeapon = model->BaseAttributes().GetWeapon().get();
 		if(displayModelName.empty())
 			displayModelName = model->displayModelName;
 		if(pluralModelName.empty())
@@ -723,7 +724,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			LogWarning(VariantName(), Name(),
 					"outfit \"" + it.first->TrueName() + "\" equipped but not included in outfit list.");
 		}
-		else if(!it.first->IsWeapon())
+		else if(!it.first->GetWeapon())
 			// This ship was specified with a non-weapon outfit in a
 			// hardpoint. Hardpoint::Install removes it, but issue a
 			// warning so the definition can be fixed.
@@ -761,7 +762,7 @@ void Ship::FinishLoading(bool isNewInstance)
 		// Some ship variant definitions do not specify which weapons
 		// are placed in which hardpoint. Add any weapons that are not
 		// yet installed to the ship's armament.
-		if(it.first->IsWeapon())
+		if(it.first->GetWeapon())
 		{
 			int count = it.second;
 			auto eit = equipped.find(it.first);
@@ -1365,11 +1366,14 @@ vector<string> Ship::FlightCheck() const
 				checks.emplace_back("no fuel?");
 		}
 		for(const auto &it : outfits)
-			if(it.first->IsWeapon() && it.first->FiringEnergy() > energy)
+		{
+			const Weapon *weapon = it.first->GetWeapon().get();
+			if(weapon && weapon->FiringEnergy() > energy)
 			{
 				checks.emplace_back("insufficient energy to fire?");
 				break;
 			}
+		}
 	}
 
 	return checks;
@@ -2089,9 +2093,10 @@ void Ship::Fire(vector<Projectile> &projectiles, vector<Visual> &visuals, vector
 	const vector<Hardpoint> &hardpoints = armament.Get();
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
 	{
-		const Weapon *weapon = hardpoints[i].GetOutfit();
-		if(!weapon)
+		const Outfit *outfit = hardpoints[i].GetOutfit();
+		if(!outfit)
 			continue;
+		const Weapon *weapon = outfit->GetWeapon().get();
 		CanFireResult canFire = CanFire(weapon);
 		if(canFire == CanFireResult::CAN_FIRE)
 		{
@@ -2152,8 +2157,11 @@ bool Ship::FireAntiMissile(const Projectile &projectile, vector<Visual> &visuals
 	const vector<Hardpoint> &hardpoints = armament.Get();
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
 	{
-		const Weapon *weapon = hardpoints[i].GetOutfit();
-		if(weapon && CanFire(weapon) == CanFireResult::CAN_FIRE)
+		const Outfit *outfit = hardpoints[i].GetOutfit();
+		if(!outfit)
+			continue;
+		const Weapon *weapon = outfit->GetWeapon().get();
+		if(CanFire(weapon) == CanFireResult::CAN_FIRE)
 			if(armament.FireAntiMissile(i, *this, projectile, visuals, Random::Real() < jamChance))
 				return true;
 	}
@@ -2192,8 +2200,11 @@ Point Ship::FireTractorBeam(const Flotsam &flotsam, vector<Visual> &visuals)
 	const vector<Hardpoint> &hardpoints = armament.Get();
 	for(unsigned i = 0; i < hardpoints.size(); ++i)
 	{
-		const Weapon *weapon = hardpoints[i].GetOutfit();
-		if(weapon && CanFire(weapon) == CanFireResult::CAN_FIRE)
+		const Outfit *outfit = hardpoints[i].GetOutfit();
+		if(!outfit)
+			continue;
+		const Weapon *weapon = outfit->GetWeapon().get();
+		if(CanFire(weapon) == CanFireResult::CAN_FIRE)
 			if(armament.FireTractorBeam(i, *this, flotsam, visuals, Random::Real() < jamChance))
 			{
 				Point hardpointPos = Position() + Zoom() * Facing().Rotate(hardpoints[i].GetPoint());
@@ -3591,7 +3602,7 @@ void Ship::AddOutfit(const Outfit *outfit, int count)
 		}
 		int after = outfits.count(outfit);
 		attributes.Add(*outfit, count);
-		if(outfit->IsWeapon())
+		if(outfit->GetWeapon())
 		{
 			armament.Add(outfit, count);
 			// Only the player's ships make use of attraction and deterrence.
@@ -3640,11 +3651,9 @@ const vector<Hardpoint> &Ship::Weapons() const
 
 // Check if we are able to fire the given weapon (i.e. there is enough
 // energy, ammo, and fuel to fire it).
+// Assume the weapon is valid.
 Ship::CanFireResult Ship::CanFire(const Weapon *weapon) const
 {
-	if(!weapon || !weapon->IsWeapon())
-		return CanFireResult::INVALID;
-
 	if(weapon->Ammo())
 	{
 		auto it = outfits.find(weapon->Ammo());
@@ -3701,7 +3710,7 @@ void Ship::ExpendAmmo(const Weapon &weapon)
 		heat -= weapon.AmmoUsage() * .5 * ammo->Mass() * MAXIMUM_TEMPERATURE * Heat();
 		AddOutfit(ammo, -weapon.AmmoUsage());
 		// Recalculate the AI to account for the loss of this weapon.
-		if(!OutfitCount(ammo) && ammo->AmmoUsage())
+		if(!OutfitCount(ammo) && ammo->GetWeapon() && ammo->GetWeapon()->AmmoUsage())
 			aiCache.Calibrate(*this);
 	}
 
@@ -5176,9 +5185,11 @@ double Ship::CalculateDeterrence() const
 {
 	double tempDeterrence = 0.;
 	for(const Hardpoint &hardpoint : Weapons())
-		if(hardpoint.GetOutfit())
+	{
+		const Outfit *outfit = hardpoint.GetOutfit();
+		if(outfit)
 		{
-			const Outfit *weapon = hardpoint.GetOutfit();
+			const Weapon *weapon = outfit->GetWeapon().get();
 			// 1 DoT damage of type X = 100 damage of type X over an extended period of time
 			// (~95 damage after 5 seconds, ~99 damage after 8 seconds). Therefore, multiply
 			// DoT damage types by 100. Disruption, scrambling, and slowing don't have an
@@ -5218,6 +5229,7 @@ double Ship::CalculateDeterrence() const
 					+ scramblingFactor + slowingFactor + disruptionFactor);
 			tempDeterrence += .12 * strength / weapon->Reload();
 		}
+	}
 	return tempDeterrence;
 }
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -120,7 +120,6 @@ public:
 	};
 
 	enum class CanFireResult {
-		INVALID,
 		NO_AMMO,
 		NO_ENERGY,
 		NO_FUEL,
@@ -490,6 +489,7 @@ public:
 	const std::vector<Hardpoint> &Weapons() const;
 	// Check if we are able to fire the given weapon (i.e. there is enough
 	// energy, ammo, and fuel to fire it).
+	// Assume the weapon is valid.
 	CanFireResult CanFire(const Weapon *weapon) const;
 	// Fire the given weapon (i.e. deduct whatever energy, ammo, or fuel it uses
 	// and add whatever heat it generates). Assume that CanFire() is true.
@@ -666,7 +666,7 @@ private:
 	Outfit attributes;
 	Outfit baseAttributes;
 	bool addAttributes = false;
-	const Outfit *explosionWeapon = nullptr;
+	const Weapon *explosionWeapon = nullptr;
 	std::map<const Outfit *, int> outfits;
 	CargoHold cargo;
 	std::list<std::shared_ptr<Flotsam>> jettisoned;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "PlayerInfo.h"
 #include "Ship.h"
 #include "text/Table.h"
+#include "Weapon.h"
 
 #include <algorithm>
 #include <map>
@@ -365,11 +366,14 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	double firingEnergy = 0.;
 	double firingHeat = 0.;
 	for(const auto &it : ship.Outfits())
-		if(it.first->IsWeapon() && it.first->Reload())
+	{
+		const Weapon *weapon = it.first->GetWeapon().get();
+		if(weapon && weapon->Reload())
 		{
-			firingEnergy += it.second * it.first->FiringEnergy() / it.first->Reload();
-			firingHeat += it.second * it.first->FiringHeat() / it.first->Reload();
+			firingEnergy += it.second * weapon->FiringEnergy() / weapon->Reload();
+			firingHeat += it.second * weapon->FiringHeat() / weapon->Reload();
 		}
+	}
 	tableLabels.push_back("firing:");
 	energyTable.push_back(Format::Number(-60. * firingEnergy));
 	heatTable.push_back(Format::Number(60. * firingHeat));

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -28,10 +28,18 @@ using namespace std;
 
 
 
-// Load from a "weapon" node, either in an outfit or in a ship (explosion).
-void Weapon::LoadWeapon(const DataNode &node)
+Weapon::Weapon(const DataNode &node)
 {
-	isWeapon = true;
+	Load(node);
+}
+
+
+
+// Load from a "weapon" node, either in an outfit or in a ship (explosion).
+void Weapon::Load(const DataNode &node)
+{
+	isLoaded = true;
+
 	bool isClustered = false;
 	calculatedDamage = false;
 	doesDamage = false;
@@ -152,7 +160,7 @@ void Weapon::LoadWeapon(const DataNode &node)
 		else if(key == "submunition")
 		{
 			submunitions.emplace_back(
-				GameData::Outfits().Get(child.Token(1)),
+				GameData::Outfits().Get(child.Token(1))->GetWeapon(),
 				(child.Size() >= 3) ? child.Value(2) : 1);
 			for(const DataNode &grand : child)
 			{
@@ -441,9 +449,9 @@ void Weapon::LoadWeapon(const DataNode &node)
 
 
 
-bool Weapon::IsWeapon() const
+bool Weapon::IsLoaded() const
 {
-	return isWeapon;
+	return isLoaded;
 }
 
 
@@ -556,7 +564,7 @@ double Weapon::TotalLifetime() const
 	{
 		totalLifetime = 0.;
 		for(const auto &it : submunitions)
-			totalLifetime = max(totalLifetime, it.weapon->TotalLifetime());
+			totalLifetime = max(totalLifetime, it.weapon ? it.weapon->TotalLifetime() : 0.);
 		totalLifetime += lifetime;
 	}
 	return totalLifetime;
@@ -605,15 +613,6 @@ const pair<double, double> &Weapon::DropoffRanges() const
 
 
 
-// Legacy support: allow turret outfits with no turn rate to specify a
-// default turnrate.
-void Weapon::SetTurretTurn(double rate)
-{
-	turretTurn = rate;
-}
-
-
-
 double Weapon::TotalDamage(int index) const
 {
 	if(!calculatedDamage)
@@ -622,7 +621,7 @@ double Weapon::TotalDamage(int index) const
 		for(int i = 0; i < DAMAGE_TYPES; ++i)
 		{
 			for(const auto &it : submunitions)
-				damage[i] += it.weapon->TotalDamage(i) * it.count;
+				damage[i] += it.weapon ? it.weapon->TotalDamage(i) * it.count : 0.;
 			doesDamage |= (damage[i] > 0.);
 		}
 	}

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -51,7 +51,7 @@ const Hazard *Weather::GetHazard() const
 // Whether the hazard of this weather deals damage or not.
 bool Weather::HasWeapon() const
 {
-	return hazard->IsWeapon();
+	return hazard->Weapon::IsLoaded();
 }
 
 

--- a/source/ship/ShipAICache.cpp
+++ b/source/ship/ShipAICache.cpp
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "../Outfit.h"
 #include "../pi.h"
 #include "../Ship.h"
+#include "../Weapon.h"
 
 #include <algorithm>
 #include <cmath>
@@ -44,39 +45,40 @@ void ShipAICache::Calibrate(const Ship &ship)
 
 	for(const Hardpoint &hardpoint : ship.Weapons())
 	{
-		const Outfit *weapon = hardpoint.GetOutfit();
-		if(weapon && !hardpoint.IsSpecial())
+		const Outfit *outfit = hardpoint.GetOutfit();
+		if(!outfit || hardpoint.IsSpecial())
+			continue;
+		const Weapon *weapon = outfit->GetWeapon().get();
+
+		hasWeapons = true;
+		bool lackingAmmo = (weapon->Ammo() && weapon->AmmoUsage() && !ship.OutfitCount(weapon->Ammo()));
+		// Weapons without ammo might as well not exist, so don't even consider them
+		if(lackingAmmo)
+			continue;
+		canFight = true;
+
+		// Calculate the damage per second,
+		// ignoring any special effects. (could be improved to account for those, maybe be based on cost instead)
+		double DPS = (weapon->ShieldDamage() + weapon->HullDamage()
+			+ (weapon->RelativeShieldDamage() * ship.MaxShields())
+			+ (weapon->RelativeHullDamage() * ship.MaxHull()))
+			/ weapon->Reload();
+		totalDPS += DPS;
+
+		// Exploding weaponry that can damage this ship requires special consideration.
+		if(weapon->SafeRange())
 		{
-			hasWeapons = true;
-			bool lackingAmmo = (weapon->Ammo() && weapon->AmmoUsage() && !ship.OutfitCount(weapon->Ammo()));
-			// Weapons without ammo might as well not exist, so don't even consider them
-			if(lackingAmmo)
-				continue;
-			canFight = true;
+			minSafeDistance = max(weapon->SafeRange(), minSafeDistance);
+			splashDPS += DPS;
+		}
 
-			// Calculate the damage per second,
-			// ignoring any special effects. (could be improved to account for those, maybe be based on cost instead)
-			double DPS = (weapon->ShieldDamage() + weapon->HullDamage()
-				+ (weapon->RelativeShieldDamage() * ship.MaxShields())
-				+ (weapon->RelativeHullDamage() * ship.MaxHull()))
-				/ weapon->Reload();
-			totalDPS += DPS;
-
-			// Exploding weaponry that can damage this ship requires special consideration.
-			if(weapon->SafeRange())
-			{
-				minSafeDistance = max(weapon->SafeRange(), minSafeDistance);
-				splashDPS += DPS;
-			}
-
-			// The artillery AI should be applied at 1000 pixels range, or 500 if the weapon is homing.
-			double range = weapon->Range();
-			shortestRange = min(range, shortestRange);
-			if(range >= 1000. || (weapon->Homing() && range >= 500.))
-			{
-				shortestArtillery = min(range, shortestArtillery);
-				artilleryDPS += DPS;
-			}
+		// The artillery AI should be applied at 1000 pixels range, or 500 if the weapon is homing.
+		double range = weapon->Range();
+		shortestRange = min(range, shortestRange);
+		if(range >= 1000. || (weapon->Homing() && range >= 500.))
+		{
+			shortestArtillery = min(range, shortestArtillery);
+			artilleryDPS += DPS;
 		}
 	}
 
@@ -112,8 +114,11 @@ void ShipAICache::Calibrate(const Ship &ship)
 	// Get the weapon ranges for this ship, so the AI can call it.
 	for(const auto &hardpoint : ship.Weapons())
 	{
-		const Weapon *weapon = hardpoint.GetOutfit();
-		if(!weapon || hardpoint.IsSpecial() || (weapon->Ammo() && !ship.OutfitCount(weapon->Ammo())) || !weapon->DoesDamage())
+		const Outfit *outfit = hardpoint.GetOutfit();
+		if(!outfit || hardpoint.IsSpecial())
+			continue;
+		const Weapon *weapon = outfit->GetWeapon().get();
+		if((weapon->Ammo() && !ship.OutfitCount(weapon->Ammo())) || !weapon->DoesDamage())
 			continue;
 		double weaponRange = weapon->Range() + hardpoint.GetPoint().Length();
 		if(hardpoint.IsTurret())


### PR DESCRIPTION
**Refactor**

Similar to #9859.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
`Outfit` no longer inherits from `Weapon`, and instead has a pointer to the weapon defined inside its definition, so outfits that aren't weapons should take up less space in memory than before.
When an outfit is installed on a Hardpoint, it checks if the outfit actually has a Weapon. This means that in the context of Hardpoints it's safe to dereference the installed Outfit's pointer to the Weapon (if the pointer to the Outfit isn't null).

## Testing Done
Loaded the game, went to Mesuket, watched the battle. Didn't notice anything odd.

## Performance Impact
Unnoticeable.