### PR TITLE
Fix local map minable mapping

### DIFF
--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -530,7 +530,7 @@ outfit "Local Map"
 	cost 1000
 	thumbnail "outfit/map"
 	"map" 12
-	"map minable" 1
+	"map minables" 1
 	description "This data chip contains complete information on the twelve star systems closest to this one: planets, ports, governments, trade prices, available services, etc. You can get all the same information just by exploring those systems yourself, but having a map can save you from making wrong turns if you are trying to travel through new territory to reach a certain system quickly."
 
 


### PR DESCRIPTION
**Bug fix**

Thanks to @MidnightPlugins for reporting this on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Endless Sky looks for the attribute "map minables" on map outfits to determine if they should reveal minables in the region they map.
The Local Map has the "map minable" attribute, which is ignored.
This PR corrects the attribute name.

## Screenshots
Not today.

## Usage examples
N/A

## Testing Done
I will not.

## Save File
This save file can be used to test these changes:
Just start a new game. It's right htere.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
