### PR TITLE
refactor(ui): Create a Tooltip class

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -307,6 +307,8 @@ target_sources(EndlessSkyLib PRIVATE
 	TextArea.h
 	TextReplacements.cpp
 	TextReplacements.h
+	Tooltip.cpp
+	Tooltip.h
 	Trade.cpp
 	Trade.h
 	TradingPanel.cpp

--- a/source/ItemInfoDisplay.h
+++ b/source/ItemInfoDisplay.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "Point.h"
+#include "Tooltip.h"
 #include "text/WrappedText.h"
 
 #include <string>
@@ -71,7 +72,6 @@ protected:
 	// For tooltips:
 	Point hoverPoint;
 	mutable std::string hover;
-	mutable int hoverCount = 0;
+	mutable Tooltip tooltip;
 	bool hasHover = false;
-	mutable WrappedText hoverText;
 };

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "LoadPanel.h"
 
+#include "text/Alignment.h"
 #include "Color.h"
 #include "Command.h"
 #include "ConversationPanel.h"
@@ -109,10 +110,6 @@ namespace {
 			}
 		return date;
 	}
-
-	// Only show tooltips if the mouse has hovered in one place for this amount
-	// of time.
-	const int HOVER_TIME = 60;
 }
 
 
@@ -120,7 +117,8 @@ namespace {
 LoadPanel::LoadPanel(PlayerInfo &player, UI &gamePanels)
 	: player(player), gamePanels(gamePanels), selectedPilot(player.Identifier()),
 	pilotBox(GameData::Interfaces().Get("load menu")->GetBox("pilots")),
-	snapshotBox(GameData::Interfaces().Get("load menu")->GetBox("snapshots"))
+	snapshotBox(GameData::Interfaces().Get("load menu")->GetBox("snapshots")),
+	tooltip(180, Alignment::LEFT, Tooltip::Direction::LEFT, Tooltip::Corner::TOP_LEFT)
 {
 	// If you have a player loaded, and the player is on a planet, make sure
 	// the player is saved so that any snapshot you create will be of the
@@ -213,12 +211,8 @@ void LoadPanel::Draw()
 		}
 	}
 
-	// The hover count "decays" over time if not hovering over a saved game.
-	if(hoverCount)
-		--hoverCount;
-	string hoverText;
-
 	// Draw the list of snapshots for the selected pilot.
+	bool hasHoverZone = false;
 	if(!selectedPilot.empty() && files.contains(selectedPilot))
 	{
 		const Point topLeft = snapshotBox.TopLeft();
@@ -244,9 +238,13 @@ void LoadPanel::Draw()
 			bool isHighlighted = (file == selectedFile || isHovering);
 			if(isHovering)
 			{
-				hoverCount = min(HOVER_TIME, hoverCount + 2);
-				if(hoverCount == HOVER_TIME)
-					hoverText = TimestampString(it.second);
+				hasHoverZone = true;
+				tooltip.IncrementCount();
+				if(tooltip.ShouldDraw())
+				{
+					tooltip.SetText(TimestampString(it.second));
+					tooltip.SetZone(zone);
+				}
 			}
 
 			double alpha = min((drawPoint.Y() - (top - fadeOut)) * .1,
@@ -263,13 +261,10 @@ void LoadPanel::Draw()
 		}
 	}
 
-	if(!hoverText.empty())
-	{
-		Point boxSize(font.Width(hoverText) + 20., 30.);
-
-		FillShader::Fill(hoverPoint + .5 * boxSize, boxSize, *GameData::Colors().Get("tooltip background"));
-		font.Draw(hoverText, hoverPoint + Point(10., 10.), *GameData::Colors().Get("medium"));
-	}
+	if(!hasHoverZone)
+		tooltip.DecrementCount();
+	else
+		tooltip.Draw();
 }
 
 
@@ -483,8 +478,8 @@ bool LoadPanel::Hover(int x, int y)
 	// Tooltips should not pop up unless the mouse stays in one place for the
 	// full hover time. Otherwise, every time the user scrubs the mouse over the
 	// list, tooltips will appear after one second.
-	if(hoverCount < HOVER_TIME)
-		hoverCount = 0;
+	if(!tooltip.ShouldDraw())
+		tooltip.ResetCount();
 
 	return true;
 }

--- a/source/LoadPanel.h
+++ b/source/LoadPanel.h
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Point.h"
 #include "Rectangle.h"
 #include "SavedGame.h"
+#include "Tooltip.h"
 
 #include <ctime>
 #include <filesystem>
@@ -80,7 +81,7 @@ private:
 	const Rectangle snapshotBox;
 
 	Point hoverPoint;
-	int hoverCount = 0;
+	Tooltip tooltip;
 	bool hasHover = false;
 	bool sideHasFocus = false;
 	double sideScroll = 0;

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -20,7 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Color.h"
 #include "DistanceMap.h"
 #include "Point.h"
-#include "text/WrappedText.h"
+#include "Tooltip.h"
 
 #include <map>
 #include <string>
@@ -162,10 +162,8 @@ protected:
 	void UpdateCache();
 
 	// For tooltips:
-	int hoverCount = 0;
 	const System *hoverSystem = nullptr;
-	std::string tooltip;
-	WrappedText hoverText;
+	Tooltip tooltip;
 
 	// An X offset in pixels to be applied to the selected system UI if something
 	// else gets in the way of its default position.

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -56,9 +56,6 @@ using namespace std;
 namespace {
 	constexpr int SIDE_WIDTH = 280;
 
-	// Hovering over sort buttons for this many frames activates the tooltip.
-	const int HOVER_TIME = 60;
-
 	// Check if the mission involves the given system,
 	bool Involves(const Mission &mission, const System *system)
 	{
@@ -131,7 +128,8 @@ MissionPanel::MissionPanel(PlayerInfo &player)
 	available(player.AvailableJobs()),
 	accepted(player.Missions()),
 	availableIt(player.AvailableJobs().begin()),
-	acceptedIt(player.AvailableJobs().empty() ? accepted.begin() : accepted.end())
+	acceptedIt(player.AvailableJobs().empty() ? accepted.begin() : accepted.end()),
+	tooltip(150, Alignment::LEFT, Tooltip::Direction::RIGHT, Tooltip::Corner::BOTTOM_LEFT)
 {
 	// Re-do job sorting since something could have changed
 	player.SortAvailable();
@@ -168,7 +166,8 @@ MissionPanel::MissionPanel(const MapPanel &panel)
 	accepted(player.Missions()),
 	availableIt(player.AvailableJobs().begin()),
 	acceptedIt(player.AvailableJobs().empty() ? accepted.begin() : accepted.end()),
-	availableScroll(0), acceptedScroll(0), dragSide(0)
+	availableScroll(0), acceptedScroll(0), dragSide(0),
+	tooltip(150, Alignment::LEFT, Tooltip::Direction::RIGHT, Tooltip::Corner::BOTTOM_LEFT)
 {
 	Audio::Pause();
 
@@ -248,8 +247,11 @@ void MissionPanel::Draw()
 {
 	MapPanel::Draw();
 
-	// Update the tooltip timer [0-60].
-	hoverSortCount += hoverSort >= 0 ? (hoverSortCount < HOVER_TIME) : (hoverSortCount ? -1 : 0);
+	// Update the tooltip timer.
+	if(hoverSort >= 0)
+		tooltip.IncrementCount();
+	else
+		tooltip.DecrementCount();
 
 	const Set<Color> &colors = GameData::Colors();
 
@@ -437,7 +439,7 @@ bool MissionPanel::Click(int x, int y, int clicks)
 				else if(hoverSort == 2)
 				{
 					player.NextAvailableSortType();
-					tooltip.clear();
+					tooltip.Clear();
 				}
 				else if(hoverSort == 3)
 					player.ToggleSortAscending();
@@ -639,7 +641,7 @@ bool MissionPanel::Hover(int x, int y)
 	}
 
 	if(oldSort != hoverSort)
-		tooltip.clear();
+		tooltip.Clear();
 
 	return dragSide || MapPanel::Hover(x, y);
 }
@@ -820,7 +822,11 @@ Point MissionPanel::DrawPanel(Point pos, const string &label, int entries, bool 
 		SpriteShader::Draw(rush[player.ShouldSortSeparateDeadline()], pos + Point(SIDE_WIDTH - 105., 7.5));
 
 		if(hoverSort >= 0)
-			FillShader::Fill(pos + Point(SIDE_WIDTH - 105. + 30 * hoverSort, 7.5), Point(22., 16.), highlight);
+		{
+			Rectangle zone = Rectangle(pos + Point(SIDE_WIDTH - 105. + 30 * hoverSort, 7.5), Point(22., 16.));
+			tooltip.SetZone(zone);
+			FillShader::Fill(zone.Center(), zone.Dimensions(), highlight);
+		}
 	}
 
 	// Panel title
@@ -955,50 +961,42 @@ void MissionPanel::DrawMissionInfo()
 
 void MissionPanel::DrawTooltips()
 {
-	if(hoverSort < 0 || hoverSortCount < HOVER_TIME)
+	if(hoverSort < 0 || !tooltip.ShouldDraw())
 		return;
 
 	// Create the tooltip text.
-	if(tooltip.empty())
+	if(!tooltip.HasText())
 	{
+		string text;
 		if(hoverSort == 0)
-			tooltip = "Filter out missions with a deadline";
+			text = "Filter out missions with a deadline";
 		else if(hoverSort == 1)
-			tooltip = "Filter out missions that you can't accept";
+			text = "Filter out missions that you can't accept";
 		else if(hoverSort == 2)
 		{
 			switch(player.GetAvailableSortType())
 			{
 				case 0:
-					tooltip = "Sort alphabetically";
+					text = "Sort alphabetically";
 					break;
 				case 1:
-					tooltip = "Sort by payment";
+					text = "Sort by payment";
 					break;
 				case 2:
-					tooltip = "Sort by distance";
+					text = "Sort by distance";
 					break;
 				case 3:
-					tooltip = "Sort by convenience: "
+					text = "Sort by convenience: "
 							"Prioritize missions going to a planet or system that is already a destination of one of your missions";
 					break;
 			}
 		}
 		else if(hoverSort == 3)
-			tooltip = "Sort direction";
+			text = "Sort direction";
+		tooltip.SetText(text);
+	}
 
-		hoverText.Wrap(tooltip);
-	}
-	if(!tooltip.empty())
-	{
-		// Add 10px margin to all sides of the text.
-		Point size(hoverText.WrapWidth(), hoverText.Height() - hoverText.ParagraphBreak());
-		size += Point(20., 20.);
-		Point topLeft = Point(Screen::Left() + SIDE_WIDTH - 120. + 30 * hoverSort, Screen::Top() + 30.);
-		// Draw the background fill and the tooltip text.
-		FillShader::Fill(topLeft + .5 * size, size, *GameData::Colors().Get("tooltip background"));
-		hoverText.Draw(topLeft + Point(10., 10.), *GameData::Colors().Get("medium"));
-	}
+	tooltip.Draw();
 }
 
 

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -81,6 +81,7 @@ private:
 	// Centers on the next involved system for the clicked mission from the mission list
 	void CycleInvolvedSystems(const Mission &mission);
 
+
 private:
 	const Interface *missionInterface;
 
@@ -95,8 +96,11 @@ private:
 	bool canDrag = true;
 
 	int dragSide = 0;
-	int hoverSortCount = 0;
-	int hoverSort = -1; // 0 to 3 for each UI element
+
+	// 0 to 3 for each UI element
+	int hoverSort = -1;
+	mutable Tooltip tooltip;
+
 	std::shared_ptr<TextArea> description;
 	bool descriptionVisible = false;
 };

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -88,8 +88,6 @@ namespace {
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;
 	const int SETTINGS_PAGE_COUNT = 2;
-	// Hovering a preference for this many frames activates the tooltip.
-	const int HOVER_TIME = 60;
 
 	const map<string, SoundCategory> volumeBars = {
 		{"volume", SoundCategory::MASTER},
@@ -110,7 +108,8 @@ namespace {
 
 
 PreferencesPanel::PreferencesPanel(PlayerInfo &player)
-	: player(player), editing(-1), selected(0), hover(-1)
+	: player(player), editing(-1), selected(0), hover(-1),
+	tooltip(250, Alignment::LEFT, Tooltip::Direction::LEFT, Tooltip::Corner::TOP_LEFT)
 {
 	// Select the first valid plugin.
 	for(const auto &plugin : Plugins::Get())
@@ -121,11 +120,6 @@ PreferencesPanel::PreferencesPanel(PlayerInfo &player)
 		}
 
 	SetIsFullScreen(true);
-
-	// Initialize a centered tooltip.
-	hoverText.SetFont(FontSet::Get(14));
-	hoverText.SetWrapWidth(250);
-	hoverText.SetAlignment(Alignment::LEFT);
 
 	// Set the initial plugin list and description scroll ranges.
 	const Interface *pluginUi = GameData::Interfaces().Get("plugins");
@@ -373,20 +367,32 @@ bool PreferencesPanel::Hover(int x, int y)
 	hoverPoint = Point(x, y);
 
 	hoverItem.clear();
-	tooltip.clear();
+	tooltip.Clear();
 
 	hover = -1;
 	for(unsigned index = 0; index < zones.size(); ++index)
-		if(zones[index].Contains(hoverPoint))
+	{
+		const auto &zone = zones[index];
+		if(zone.Contains(hoverPoint))
+		{
 			hover = index;
+			tooltip.SetZone(zone);
+		}
+	}
 
 	for(const auto &zone : prefZones)
 		if(zone.Contains(hoverPoint))
+		{
 			hoverItem = zone.Value();
+			tooltip.SetZone(zone);
+		}
 
 	for(const auto &zone : pluginZones)
 		if(zone.Contains(hoverPoint))
+		{
 			hoverItem = zone.Value();
+			tooltip.SetZone(zone);
+		}
 
 	return true;
 }
@@ -1209,38 +1215,17 @@ void PreferencesPanel::DrawTooltips()
 {
 	if(hoverItem.empty())
 	{
-		// Step the tooltip timer back.
-		hoverCount -= hoverCount ? 1 : 0;
+		tooltip.DecrementCount();
 		return;
 	}
-
-	// Step the tooltip timer forward [0-60].
-	hoverCount += hoverCount < HOVER_TIME;
-
-	if(hoverCount < HOVER_TIME)
+	tooltip.IncrementCount();
+	if(!tooltip.ShouldDraw())
 		return;
+	
+	if(!tooltip.HasText())
+		tooltip.SetText(GameData::Tooltip(hoverItem));
 
-	// Create the tooltip text.
-	if(tooltip.empty())
-	{
-		tooltip = GameData::Tooltip(hoverItem);
-		// No tooltip for this item.
-		if(tooltip.empty())
-			return;
-		hoverText.Wrap(tooltip);
-	}
-
-	Point size(hoverText.WrapWidth(), hoverText.Height() - hoverText.ParagraphBreak());
-	size += Point(20., 20.);
-	Point topLeft = hoverPoint;
-	// Do not overflow the screen dimensions.
-	if(topLeft.X() + size.X() > Screen::Right())
-		topLeft.X() -= size.X();
-	if(topLeft.Y() + size.Y() > Screen::Bottom())
-		topLeft.Y() -= size.Y();
-	// Draw the background fill and the tooltip text.
-	FillShader::Fill(topLeft + .5 * size, size, *GameData::Colors().Get("tooltip background"));
-	hoverText.Draw(topLeft + Point(10., 10.), *GameData::Colors().Get("medium"));
+	tooltip.Draw();
 }
 
 

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -21,7 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Command.h"
 #include "Point.h"
 #include "ScrollVar.h"
-#include "text/WrappedText.h"
+#include "Tooltip.h"
 
 #include <memory>
 #include <string>
@@ -91,11 +91,9 @@ private:
 	char page = 'c';
 
 	Point hoverPoint;
-	int hoverCount = 0;
+	Tooltip tooltip;
 	std::string selectedItem;
 	std::string hoverItem;
-	std::string tooltip;
-	WrappedText hoverText;
 
 	int currentControlsPage = 0;
 	int currentSettingsPage = 0;

--- a/source/Rectangle.cpp
+++ b/source/Rectangle.cpp
@@ -159,6 +159,22 @@ Point Rectangle::TopLeft() const
 
 
 
+// Get the top right conrer - that is, the maximum x and minimum y.
+Point Rectangle::TopRight() const
+{
+	return center + Point(.5 * dimensions.X(), -.5 * dimensions.Y());
+}
+
+
+
+// Get the bottom left corner - that is, the minimum x and maximum y.
+Point Rectangle::BottomLeft() const
+{
+	return center + Point(-.5 * dimensions.X(), .5 * dimensions.Y());
+}
+
+
+
 // Get the bottom right corner - that is, the maximum x and y.
 Point Rectangle::BottomRight() const
 {

--- a/source/Rectangle.h
+++ b/source/Rectangle.h
@@ -55,6 +55,8 @@ public:
 	double Right() const;
 	double Bottom() const;
 	Point TopLeft() const;
+	Point TopRight() const;
+	Point BottomLeft() const;
 	Point BottomRight() const;
 
 	// Check if a point is inside this rectangle.

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -24,6 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ScrollBar.h"
 #include "ScrollVar.h"
 #include "ShipInfoDisplay.h"
+#include "Tooltip.h"
 
 #include <map>
 #include <set>
@@ -221,7 +222,7 @@ private:
 	Point hoverPoint;
 	std::string shipName;
 	std::string warningType;
-	int hoverCount = 0;
+	Tooltip tooltip;
 
 	bool checkedHelp = false;
 };

--- a/source/Tooltip.cpp
+++ b/source/Tooltip.cpp
@@ -1,0 +1,189 @@
+/* Tooltip.cpp
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Tooltip.h"
+
+#include "shader/FillShader.h"
+#include "text/Font.h"
+#include "text/FontSet.h"
+#include "GameData.h"
+#include "Point.h"
+#include "Screen.h"
+
+using namespace std;
+
+namespace {
+	// Only show tooltips if the mouse has hovered in one place for this amount
+	// of time.
+	const int HOVER_TIME = 60;
+}
+
+
+
+Tooltip::Tooltip(int width, Alignment alignment, Direction direction, Corner corner)
+	: width(width), direction(direction), corner(corner),
+	normal(GameData::Colors().Get("tooltip background")), 
+	warning(GameData::Colors().Get("warning back")), 
+	error(GameData::Colors().Get("error back")), 
+	fontColor(GameData::Colors().Get("medium"))
+{
+	text.SetFont(FontSet::Get(14));
+	// 10 pixels of padding will be left on either side of the tooltip box.
+	text.SetWrapWidth(width - 20);
+	text.SetAlignment(alignment);
+}
+
+
+
+void Tooltip::IncrementCount()
+{
+	if(hoverCount < HOVER_TIME)
+		++hoverCount;
+}
+
+
+
+void Tooltip::DecrementCount()
+{
+	if(hoverCount)
+		--hoverCount;
+}
+
+
+
+void Tooltip::MaxCount()
+{
+	hoverCount = HOVER_TIME;
+}
+
+
+
+void Tooltip::ResetCount()
+{
+	hoverCount = 0;
+}
+
+
+
+bool Tooltip::ShouldDraw() const
+{
+	return hoverCount >= HOVER_TIME;
+}
+
+
+
+void Tooltip::SetZone(const Point &center, const Point &dimensions)
+{
+	zone = Rectangle(center, dimensions);
+}
+
+
+
+void Tooltip::SetZone(const Rectangle &zone)
+{
+	this->zone = zone;
+}
+
+
+
+void Tooltip::SetText(const string &text)
+{
+	this->text.Wrap(text);
+	/*
+	int longest = wrap.LongestLineWidth();
+	if(longest < wrap.WrapWidth())
+	{
+		wrap.SetWrapWidth(longest);
+		wrap.Wrap(text);
+	}
+	*/
+}
+
+
+
+bool Tooltip::HasText() const
+{
+	return text.Height();
+}
+
+
+
+void Tooltip::Clear()
+{
+	text.Wrap("");
+}
+
+
+
+void Tooltip::SetState(State state)
+{
+	this->state = state;
+}
+
+
+
+void Tooltip::Draw() const
+{
+	if(!ShouldDraw() || !HasText())
+		return;
+
+	Point point;
+	if(corner == Corner::TOP_LEFT)
+		point = zone.TopLeft();
+	else if(corner == Corner::TOP_RIGHT)
+		point = zone.TopRight();
+	else if(corner == Corner::BOTTOM_LEFT)
+		point = zone.BottomLeft();
+	else if(corner == Corner::BOTTOM_RIGHT)
+		point = zone.BottomRight();
+	Draw(point);
+}
+
+
+
+void Tooltip::Draw(const Point &point) const
+{
+	Point textSize(text.WrapWidth(), text.Height() - text.ParagraphBreak());
+	Point boxSize = textSize + Point(20., 20.);
+
+	Point corner = direction == Direction::RIGHT ? point : point - Point(boxSize.X(), 0);
+	Rectangle box = Rectangle::FromCorner(corner, boxSize);
+
+	// If the chosen point would push the box off-screen, adjust the box's position.
+	// Instead of nudging the box by the amount of overflow, flip it over one of its axes
+	// Doing this ensures we don't overlap any useful information hat would be covered by
+	// simply nudging the box.
+	if(box.Top() < Screen::Top())
+		box += Point(0, boxSize.Y());
+	if(box.Left() < Screen::Left())
+		box += Point(boxSize.X(), 0);
+	if(box.Right() > Screen::Right())
+		box -= Point(boxSize.X(), 0);
+	if(box.Bottom() > Screen::Bottom())
+		box -= Point(0, boxSize.Y());
+
+	// Determine the background color that should be used given the current state
+	// of this tooltip.
+	const Color *background = nullptr;
+	if(state == State::NORMAL)
+		background = normal;
+	else if(state == State::WARNING)
+		background = warning;
+	else
+		background = error;
+
+	FillShader::Fill(box.Center(), boxSize, *background);
+	text.Draw(box.TopLeft() + Point(10., 10.), *fontColor);
+}

--- a/source/Tooltip.h
+++ b/source/Tooltip.h
@@ -1,0 +1,93 @@
+/* Tooltip.h
+Copyright (c) 2025 by Amazinite
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "text/Alignment.h"
+#include "Rectangle.h"
+#include "text/WrappedText.h"
+
+#include <string>
+
+class Color;
+class Point;
+
+
+
+// A class for drawing the tooltips in a UI panel.
+class Tooltip {
+public:
+	// The direction from the draw point that the tooltip should be drawn in.
+	enum class Direction {
+		LEFT,
+		RIGHT
+	};
+
+	// The corner from the drawn rectangle that the tooltip should be drawn from.
+	enum class Corner {
+		TOP_LEFT,
+		TOP_RIGHT,
+		BOTTOM_LEFT,
+		BOTTOM_RIGHT,
+	};
+
+	// The tooltip's state determines its background color.
+	enum class State {
+		NORMAL,
+		WARNING,
+		ERROR
+	};
+
+
+public:
+	Tooltip(int width, Alignment alignment, Direction direction, Corner corner);
+
+	void IncrementCount();
+	void DecrementCount();
+	void MaxCount();
+	void ResetCount();
+	bool ShouldDraw() const;
+
+	void SetZone(const Point &center, const Point &dimensions);
+	void SetZone(const Rectangle &zone);
+	void SetText(const std::string &text);
+	bool HasText() const;
+	void Clear();
+
+	void SetState(State state);
+
+	void Draw() const;
+
+
+private:
+	void Draw(const Point &point) const;
+
+
+private:
+	int width;
+	Direction direction;
+	Corner corner;
+	State state = State::NORMAL;
+
+	const Color *normal;
+	const Color *warning;
+	const Color *error;
+	const Color *fontColor;
+
+	Rectangle zone;
+	WrappedText text;
+
+	int hoverCount = 0;
+};


### PR DESCRIPTION
**Refactor + UI**

This PR addresses the feature described in issue #9864.
Closes #9864.
Closes #9887.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

As of right now, every UI panel that has a tooltip implements its own tooltip code. This is hideous and I hate it. This PR changes that by creating a Tooltip class that handles the creation of a tooltip for the following classes:
* LoadPanel: When hovering over a save file to see its date.
* MissionPanel: When hovering over the mission sorting buttons to describe what they do.
* MapPanel: When hovering over a system to list how many of your ships are in it.
* PreferencesPanel: When hovering over a setting/command to read its tooltip from the data.
* ItemInfoDisplay: When hovering over a ship/outfit attribute to read its tooltip from the data.
* ShopPanel: When hovering over your credits to get an exact readout, or over your ship icons to see their name and any warnings/errors.

## Screenshots

I'll make some later.

## Testing Done

Yeah.