### PR TITLE
fix(content): Remove duplicate `Dagger (Miner)` definition

### DIFF
--- a/data/hai/hai reveal 7 epilogue.txt
+++ b/data/hai/hai reveal 7 epilogue.txt
@@ -686,16 +686,6 @@ ship "Boxwing" "Boxwing (Miner)"
 		"X1200 Ion Steering"
 
 
-ship "Dagger" "Dagger (Miner)"
-	outfits
-		"Beam Laser" 2
-		"Small Radar Jammer"
-		"nGVF-BB Fuel Cell"
-		"Supercapacitor"
-		"X1700 Ion Thruster"
-		"X1200 Ion Steering"
-
-
 fleet "Cardax Miners"
 	government "Republic"
 	names "republic fighter"


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
`Dagger (Miner)` is already defined in `variants.txt`.
https://github.com/endless-sky/endless-sky/blob/f0edbc44b3be5ed4b19da4eb21d3484462c9f6d7/data/human/variants.txt#L1431-L1440

## Testing Done
Nil.