### PR TITLE
fix(ui): Clear old messages every frame, and fix ship overheat message spam

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -727,7 +727,7 @@ void Engine::Step(bool isActive)
 	}
 
 	if(flagship && flagship->IsOverheated())
-		Messages::Add("Your ship has overheated.", Messages::Importance::Overheat);
+		Messages::Add("Your ship has overheated.", Messages::Importance::HighestNoRepeat);
 
 	// Clear the HUD information from the previous frame.
 	info = Information();

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -727,7 +727,7 @@ void Engine::Step(bool isActive)
 	}
 
 	if(flagship && flagship->IsOverheated())
-		Messages::Add("Your ship has overheated.", Messages::Importance::Highest);
+		Messages::Add("Your ship has overheated.", Messages::Importance::Overheat);
 
 	// Clear the HUD information from the previous frame.
 	info = Information();

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -84,7 +84,7 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 
 		// If this message is not important and it is already being shown in the
 		// list, ignore it.
-		if(importance == Importance::Low || importance == Importance::Overheat)
+		if(importance == Importance::Low || importance == Importance::HighestNoRepeat)
 		{
 			bool skip = false;
 			for(const Messages::Entry &entry : recent)
@@ -102,7 +102,7 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 				it.step -= 60;
 			// For each incoming message, if it exactly matches an existing message,
 			// replace that one with this new one by scheduling the old one for removal.
-			if(importance != Importance::Low && importance != Importance::Overheat
+			if(importance != Importance::Low && importance != Importance::HighestNoRepeat
 					&& it.message == message && it.deathStep < 0)
 				it.deathStep = step + animationDuration;
 		}
@@ -139,7 +139,7 @@ const Color *Messages::GetColor(Importance importance, bool isLogPanel)
 	switch(importance)
 	{
 		case Messages::Importance::Highest:
-		case Messages::Importance::Overheat:
+		case Messages::Importance::HighestNoRepeat:
 			return GameData::Colors().Get(prefix + "highest");
 		case Messages::Importance::High:
 			return GameData::Colors().Get(prefix + "high");

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -66,6 +66,16 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 {
 	lock_guard<mutex> lock(incomingMutex);
 
+	// Erase messages that have reached the end of their lifetime.
+	auto it = recent.begin();
+	while(it != recent.end())
+	{
+		if(step - it->step > 1000 + animationDuration || (it->deathStep >= 0 && it->deathStep <= step))
+			it = recent.erase(it);
+		else
+			++it;
+	}
+
 	// Load the incoming messages.
 	for(const pair<string, Importance> &item : incoming)
 	{
@@ -74,7 +84,7 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 
 		// If this message is not important and it is already being shown in the
 		// list, ignore it.
-		if(importance == Importance::Low)
+		if(importance == Importance::Low || importance == Importance::Overheat)
 		{
 			bool skip = false;
 			for(const Messages::Entry &entry : recent)
@@ -83,24 +93,18 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 				continue;
 		}
 
-		auto it = recent.begin();
-		while(it != recent.end())
+		for(auto &it : recent)
 		{
-			int age = step - it->step;
 			// Each time a new message comes in, "age" all the existing ones,
 			// except for cases where it would interrupt an animation, to
 			// limit how many of them appear at once.
-			if(age > animationDuration)
-				it->step -= 60;
+			if(step - it.step > animationDuration)
+				it.step -= 60;
 			// For each incoming message, if it exactly matches an existing message,
 			// replace that one with this new one by scheduling the old one for removal.
-			if(importance != Importance::Low && it->message == message && it->deathStep < 0)
-				it->deathStep = step + animationDuration;
-			// Erase messages that have reached the end of their lifetime.
-			if(age > 1000 + animationDuration || (it->deathStep >= 0 && it->deathStep <= step))
-				it = recent.erase(it);
-			else
-				++it;
+			if(importance != Importance::Low && importance != Importance::Overheat
+					&& it.message == message && it.deathStep < 0)
+				it.deathStep = step + animationDuration;
 		}
 		recent.emplace_back(step, message, importance);
 	}
@@ -135,6 +139,7 @@ const Color *Messages::GetColor(Importance importance, bool isLogPanel)
 	switch(importance)
 	{
 		case Messages::Importance::Highest:
+		case Messages::Importance::Overheat:
 			return GameData::Colors().Get(prefix + "highest");
 		case Messages::Importance::High:
 			return GameData::Colors().Get(prefix + "high");

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -37,7 +37,8 @@ public:
 		High,
 		Info,
 		Daily,
-		Low
+		Low,
+		Overheat
 	};
 
 	class Entry {

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -38,7 +38,7 @@ public:
 		Info,
 		Daily,
 		Low,
-		Overheat
+		HighestNoRepeat
 	};
 
 	class Entry {


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11640 (closes #11640).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a new special message importance level that uses the "highest" color, but "low" deduplication strategy, which means new messages will be added to the list only if there are no entries with the same text already.

Also noticed that removing old and invisible entries _after_ a new message appears, although doesn't make any difference for most importance levels, makes the "low"-deduplicated messages appear less frequently than they should: a new message isn't added because there already exists an invisible entry with the same text, and that entry doesn't get checked for removal, because the new message doesn't end up being added.

## Testing Done
yes™.

## Performance Impact
None.