### PR TITLE
fix(ui): Hide the spaceport description when the player has died

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -93,6 +93,8 @@ void PlanetPanel::Step()
 	if(player.IsDead())
 	{
 		player.SetPlanet(nullptr);
+		if(selectedPanel)
+			GetUI()->Pop(selectedPanel);
 		GetUI()->Pop(this);
 		return;
 	}


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug reported on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The spaceport panel is now popped explicitly if the planet panel is closed because of the player's death. It's the same code that already gets called on a normal takeoff.

## Testing Done
yes™.

## Save File
https://discord.com/channels/251118043411775489/536900466655887360/1394699642557698129

## Performance Impact
N/A
