### PR TITLE
refactor(ui): Mouse click event unification

### DIFF
--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -316,8 +316,11 @@ bool BankPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 // Handle mouse clicks.
-bool BankPanel::Click(int x, int y, int clicks)
+bool BankPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	const Interface *bankUi = GameData::Interfaces().Get(Screen::Width() < 1280 ? "bank (small screen)" : "bank");
 	const Rectangle box = bankUi->GetBox("content");
 	const int MIN_X = box.Left();

--- a/source/BankPanel.h
+++ b/source/BankPanel.h
@@ -37,7 +37,7 @@ public:
 protected:
 	// Overrides from Panel.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 
 
 private:

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -467,8 +467,11 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 
 
 // Handle mouse clicks.
-bool BoardingPanel::Click(int x, int y, int clicks)
+bool BoardingPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	// Was the click inside the plunder list?
 	if(x >= -330 && x < 20 && y >= -180 && y < 60)
 	{

--- a/source/BoardingPanel.h
+++ b/source/BoardingPanel.h
@@ -44,7 +44,7 @@ public:
 protected:
 	// Overrides from Panel.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -195,6 +195,7 @@ target_sources(EndlessSkyLib PRIVATE
 	MissionPanel.h
 	Mortgage.cpp
 	Mortgage.h
+	MouseButton.h
 	NPC.cpp
 	NPC.h
 	NPCAction.cpp

--- a/source/Dialog.cpp
+++ b/source/Dialog.cpp
@@ -336,8 +336,10 @@ bool Dialog::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool i
 
 
 
-bool Dialog::Click(int x, int y, int clicks)
+bool Dialog::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
 	Point clickPos(x, y);
 
 	const Sprite *sprite = SpriteSet::Get("ui/dialog cancel");

--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -95,7 +95,7 @@ protected:
 	// The user can click "ok" or "cancel", or use the tab key to toggle which
 	// button is highlighted and the enter key to select it.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 
 
 private:

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -423,10 +423,12 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
-bool LoadPanel::Click(int x, int y, int clicks)
+bool LoadPanel::Click(int x, int y, MouseButton button, int clicks)
 {
 	// When the user clicks, clear the hovered state.
 	hasHover = false;
+	if(button != MouseButton::LEFT)
+		return false;
 
 	const Point click(x, y);
 

--- a/source/LoadPanel.h
+++ b/source/LoadPanel.h
@@ -46,7 +46,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -247,8 +247,11 @@ bool LogbookPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 
 
 
-bool LogbookPanel::Click(int x, int y, int clicks)
+bool LogbookPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	x -= Screen::Left();
 	y -= Screen::Top();
 	if(x < SIDEBAR_WIDTH)

--- a/source/LogbookPanel.h
+++ b/source/LogbookPanel.h
@@ -41,7 +41,7 @@ public:
 protected:
 	// Event handlers.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;
 	virtual bool Hover(int x, int y) override;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -258,7 +258,7 @@ bool MainPanel::Click(int x, int y, MouseButton button, int clicks)
 		engine.RClick(Point(x, y));
 		return true;
 	}
-	else if(button != MouseButton::LEFT)
+	if(button != MouseButton::LEFT)
 		return false;
 
 	// Don't respond to clicks if another panel is active.

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -293,8 +293,11 @@ bool MainPanel::Drag(double dx, double dy)
 
 
 
-bool MainPanel::Release(int x, int y)
+bool MainPanel::Release(int x, int y, MouseButton button)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	if(isDragging)
 	{
 		dragPoint = Point(x, y);

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -251,8 +251,16 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
-bool MainPanel::Click(int x, int y, int clicks)
+bool MainPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button == MouseButton::RIGHT)
+	{
+		engine.RClick(Point(x, y));
+		return true;
+	}
+	else if(button != MouseButton::LEFT)
+		return false;
+
 	// Don't respond to clicks if another panel is active.
 	if(!canClick)
 		return true;
@@ -267,15 +275,6 @@ bool MainPanel::Click(int x, int y, int clicks)
 	hasControl = (mod & KMOD_CTRL);
 
 	engine.Click(dragSource, dragSource, hasShift, hasControl);
-
-	return true;
-}
-
-
-
-bool MainPanel::RClick(int x, int y)
-{
-	engine.RClick(Point(x, y));
 
 	return true;
 }

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -53,8 +53,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
-	virtual bool RClick(int x, int y) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Release(int x, int y) override;
 	virtual bool Scroll(double dx, double dy) override;

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -55,7 +55,7 @@ protected:
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
 	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Drag(double dx, double dy) override;
-	virtual bool Release(int x, int y) override;
+	virtual bool Release(int x, int y, MouseButton button) override;
 	virtual bool Scroll(double dx, double dy) override;
 
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -364,10 +364,39 @@ bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command
 
 
 
-bool MapDetailPanel::Click(int x, int y, int clicks)
+bool MapDetailPanel::Click(int x, int y, MouseButton button, int clicks)
 {
-	if(scroll.Scrollable() && scrollbar.SyncClick(scroll, x, y, clicks))
+	if(scroll.Scrollable() && scrollbar.SyncClick(scroll, x, y, button, clicks))
 		return true;
+
+	if(button == MouseButton::RIGHT)
+	{
+		if(!Preferences::Has("System map sends move orders"))
+			return true;
+		// TODO: rewrite the map panels to be driven from interfaces.txt so these XY
+		// positions aren't hard-coded.
+		else if(x >= Screen::Right() - 240 && y >= Screen::Top() + 10 && y <= Screen::Top() + 270)
+		{
+			// Only handle clicks on the actual orbits element, rather than the whole UI region.
+			// (Note: this isn't perfect, and the clickable area extends into the angled sides a bit.)
+			const Point orbitCenter(Screen::TopRight() + Point(-120., 160.));
+			auto uiClick = Point(x, y) - orbitCenter;
+			if(uiClick.Length() > 130)
+				return true;
+
+			// Only issue movement orders if the player is in-flight.
+			if(player.GetPlanet())
+				GetUI()->Push(new Dialog("You cannot issue fleet movement orders while docked."));
+			else if(!player.CanView(*selectedSystem))
+				GetUI()->Push(new Dialog("You must visit this system before you can send your fleet there."));
+			else
+				player.SetEscortDestination(selectedSystem, uiClick / scale);
+		}
+		return true;
+	}
+
+	if(button != MouseButton::LEFT)
+		return MapPanel::Click(x, y, button, clicks);
 
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
 	const double planetCardWidth = planetCardInterface->GetValue("width");
@@ -466,39 +495,10 @@ bool MapDetailPanel::Click(int x, int y, int clicks)
 	}
 
 	// The click was not on an interface element, so check if it was on a system.
-	MapPanel::Click(x, y, clicks);
+	MapPanel::Click(x, y, button, clicks);
 	// If the system just changed, the selected planet is no longer valid.
 	if(selectedPlanet && !selectedPlanet->IsInSystem(selectedSystem))
 		selectedPlanet = nullptr;
-	return true;
-}
-
-
-
-bool MapDetailPanel::RClick(int x, int y)
-{
-	if(!Preferences::Has("System map sends move orders"))
-		return true;
-	// TODO: rewrite the map panels to be driven from interfaces.txt so these XY
-	// positions aren't hard-coded.
-	else if(x >= Screen::Right() - 240 && y >= Screen::Top() + 10 && y <= Screen::Top() + 270)
-	{
-		// Only handle clicks on the actual orbits element, rather than the whole UI region.
-		// (Note: this isn't perfect, and the clickable area extends into the angled sides a bit.)
-		const Point orbitCenter(Screen::TopRight() + Point(-120., 160.));
-		auto uiClick = Point(x, y) - orbitCenter;
-		if(uiClick.Length() > 130)
-			return true;
-
-		// Only issue movement orders if the player is in-flight.
-		if(player.GetPlanet())
-			GetUI()->Push(new Dialog("You cannot issue fleet movement orders while docked."));
-		else if(!player.CanView(*selectedSystem))
-			GetUI()->Push(new Dialog("You must visit this system before you can send your fleet there."));
-		else
-			player.SetEscortDestination(selectedSystem, uiClick / scale);
-	}
-
 	return true;
 }
 

--- a/source/MapDetailPanel.h
+++ b/source/MapDetailPanel.h
@@ -58,9 +58,7 @@ protected:
 
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
 	// Handle single & double-clicks on commodities, planet information, or objects in the "orbits" display.
-	virtual bool Click(int x, int y, int clicks) override;
-	// Handle right-clicks within the "orbits" display.
-	virtual bool RClick(int x, int y) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 
 
 private:

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -520,8 +520,11 @@ bool MapPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool
 
 
 
-bool MapPanel::Click(int x, int y, int clicks)
+bool MapPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	// Figure out if a system was clicked on.
 	Point click = Point(x, y) / Zoom() - center;
 	for(const auto &it : GameData::Systems())

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -95,7 +95,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -134,8 +134,11 @@ bool MapSalesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 
 
 
-bool MapSalesPanel::Click(int x, int y, int clicks)
+bool MapSalesPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return MapPanel::Click(x, y, button, clicks);
+
 	if(x < Screen::Left() + WIDTH)
 	{
 		const Point point(x, y);
@@ -183,7 +186,7 @@ bool MapSalesPanel::Click(int x, int y, int clicks)
 		}
 	}
 	else
-		return MapPanel::Click(x, y, clicks);
+		return MapPanel::Click(x, y, button, clicks);
 
 	return true;
 }

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -43,7 +43,7 @@ public:
 
 protected:
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -223,8 +223,11 @@ bool MenuPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
-bool MenuPanel::Click(int x, int y, int clicks)
+bool MenuPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	// Double clicking on the credits pauses/resumes the credits scroll.
 	if(clicks == 2 && mainMenuUi->GetBox("credits").Contains(Point(x, y)))
 	{

--- a/source/MenuPanel.h
+++ b/source/MenuPanel.h
@@ -41,7 +41,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 
 
 private:

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -409,8 +409,11 @@ bool MissionPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 
 
 
-bool MissionPanel::Click(int x, int y, int clicks)
+bool MissionPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return MapPanel::Click(x, y, button, clicks);
+
 	dragSide = 0;
 
 	if(x > Screen::Right() - 80 && y > Screen::Bottom() - 50)

--- a/source/MissionPanel.h
+++ b/source/MissionPanel.h
@@ -43,7 +43,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Scroll(double dx, double dy) override;

--- a/source/MouseButton.h
+++ b/source/MouseButton.h
@@ -1,0 +1,27 @@
+/* MouseButton.h
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+
+
+enum class MouseButton {
+	NONE = 0,
+	LEFT,
+	MIDDLE,
+	RIGHT,
+	X1,
+	X2
+};

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -204,7 +204,7 @@ bool Panel::Scroll(double dx, double dy)
 
 
 
-bool Panel::Release(int x, int y)
+bool Panel::Release(int x, int y, MouseButton button)
 {
 	return false;
 }
@@ -239,9 +239,9 @@ bool Panel::DoDrag(double dx, double dy)
 
 
 
-bool Panel::DoRelease(int x, int y)
+bool Panel::DoRelease(int x, int y, MouseButton button)
 {
-	return EventVisit(&Panel::Release, x, y);
+	return EventVisit(&Panel::Release, x, y, button);
 }
 
 

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -176,14 +176,7 @@ bool Panel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool is
 
 
 
-bool Panel::Click(int x, int y, int clicks)
-{
-	return false;
-}
-
-
-
-bool Panel::RClick(int x, int y)
+bool Panel::Click(int x, int y, MouseButton button, int clicks)
 {
 	return false;
 }
@@ -225,16 +218,9 @@ bool Panel::DoKeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool 
 
 
 
-bool Panel::DoClick(int x, int y, int clicks)
+bool Panel::DoClick(int x, int y, MouseButton button, int clicks)
 {
-	return EventVisit(&Panel::Click, x, y, clicks);
-}
-
-
-
-bool Panel::DoRClick(int x, int y)
-{
-	return EventVisit(&Panel::RClick, x, y);
+	return EventVisit(&Panel::Click, x, y, button, clicks);
 }
 
 

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "MouseButton.h"
 #include "Rectangle.h"
 
 #include <functional>
@@ -80,8 +81,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress);
-	virtual bool Click(int x, int y, int clicks);
-	virtual bool RClick(int x, int y);
+	virtual bool Click(int x, int y, MouseButton button, int clicks);
 	virtual bool Hover(int x, int y);
 	virtual bool Drag(double dx, double dy);
 	virtual bool Release(int x, int y);
@@ -137,8 +137,7 @@ private:
 	// handle the event first, before calling the virtual method for the derived
 	// class to handle it.
 	bool DoKeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress);
-	bool DoClick(int x, int y, int clicks);
-	bool DoRClick(int x, int y);
+	bool DoClick(int x, int y, MouseButton button, int clicks);
 	bool DoHover(int x, int y);
 	bool DoDrag(double dx, double dy);
 	bool DoRelease(int x, int y);

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -84,7 +84,7 @@ protected:
 	virtual bool Click(int x, int y, MouseButton button, int clicks);
 	virtual bool Hover(int x, int y);
 	virtual bool Drag(double dx, double dy);
-	virtual bool Release(int x, int y);
+	virtual bool Release(int x, int y, MouseButton button);
 	virtual bool Scroll(double dx, double dy);
 	// If a clickable zone is clicked while editing is happening, the panel may
 	// need to know to exit editing mode before handling the click.
@@ -140,7 +140,7 @@ private:
 	bool DoClick(int x, int y, MouseButton button, int clicks);
 	bool DoHover(int x, int y);
 	bool DoDrag(double dx, double dy);
-	bool DoRelease(int x, int y);
+	bool DoRelease(int x, int y, MouseButton button);
 	bool DoScroll(double dx, double dy);
 
 	void DoDraw();

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -582,8 +582,10 @@ bool PlayerInfoPanel::Drag(double dx, double dy)
 
 
 
-bool PlayerInfoPanel::Release(int /* x */, int /* y */)
+bool PlayerInfoPanel::Release(int /* x */, int /* y */, MouseButton button)
 {
+	if(button != MouseButton::LEFT)
+		return false;
 	if(!isDragging)
 		return true;
 	isDragging = false;

--- a/source/PlayerInfoPanel.cpp
+++ b/source/PlayerInfoPanel.cpp
@@ -511,8 +511,11 @@ bool PlayerInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comman
 
 
 
-bool PlayerInfoPanel::Click(int x, int y, int clicks)
+bool PlayerInfoPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	// Sort the ships if the click was on one of the column headers.
 	Point mouse = Point(x, y);
 	for(auto &zone : menuZones)

--- a/source/PlayerInfoPanel.h
+++ b/source/PlayerInfoPanel.h
@@ -49,7 +49,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Release(int x, int y) override;

--- a/source/PlayerInfoPanel.h
+++ b/source/PlayerInfoPanel.h
@@ -52,7 +52,7 @@ protected:
 	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
-	virtual bool Release(int x, int y) override;
+	virtual bool Release(int x, int y, MouseButton button) override;
 	virtual bool Scroll(double dx, double dy) override;
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -283,8 +283,10 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 
 
 
-bool PreferencesPanel::Click(int x, int y, int clicks)
+bool PreferencesPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
 	EndEditing();
 
 	Point point(x, y);

--- a/source/PreferencesPanel.h
+++ b/source/PreferencesPanel.h
@@ -46,7 +46,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Scroll(double dx, double dy) override;
 	virtual bool Drag(double dx, double dy) override;

--- a/source/ScrollBar.cpp
+++ b/source/ScrollBar.cpp
@@ -120,8 +120,11 @@ bool ScrollBar::Drag(double dx, double dy)
 	return true;
 }
 
-bool ScrollBar::Click(int x, int y, int clicks)
+bool ScrollBar::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	Point clickPos(x, y);
 	if((clickPos - from).Length() < 10.)
 	{

--- a/source/ScrollBar.h
+++ b/source/ScrollBar.h
@@ -46,7 +46,7 @@ public:
 	void DrawAt(const Point &from);
 	bool Hover(int x, int y) override;
 	bool Drag(double dx, double dy) override;
-	bool Click(int x, int y, int clicks) override;
+	bool Click(int x, int y, MouseButton button, int clicks) override;
 
 	// Match the state of this scrollbar with the state from the ScrollVar.
 	template<typename T>
@@ -59,7 +59,7 @@ public:
 	void SyncDraw(const ScrollVar<T> &scroll, const Point &from, const Point &to, bool animated = true);
 	// Handle a click event, automatically syncing into the given ScrollVar if anything changed.
 	template<typename T>
-	bool SyncClick(ScrollVar<T> &scroll, int x, int y, int clicks);
+	bool SyncClick(ScrollVar<T> &scroll, int x, int y, MouseButton button, int clicks);
 	// Handle a drag event, automatically syncing into the given ScrollVar if anything changed.
 	template<typename T>
 	bool SyncDrag(ScrollVar<T> &scroll, double dx, double dy);
@@ -109,9 +109,9 @@ void ScrollBar::SyncDraw(const ScrollVar<T> &scroll, const Point &from, const Po
 
 
 template<typename T>
-bool ScrollBar::SyncClick(ScrollVar<T> &scroll, int x, int y, int clicks)
+bool ScrollBar::SyncClick(ScrollVar<T> &scroll, int x, int y, MouseButton button, int clicks)
 {
-	if(Click(x, y, clicks))
+	if(Click(x, y, button, clicks))
 	{
 		SyncInto(scroll);
 		return true;

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -272,8 +272,10 @@ bool ShipInfoPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 
 
 
-bool ShipInfoPanel::Click(int x, int y, int /* clicks */)
+bool ShipInfoPanel::Click(int x, int y, MouseButton button, int /* clicks */)
 {
+	if(button != MouseButton::LEFT)
+		return false;
 	if(shipIt == panelState.Ships().end())
 		return true;
 

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -314,8 +314,11 @@ bool ShipInfoPanel::Drag(double dx, double dy)
 
 
 
-bool ShipInfoPanel::Release(int /* x */, int /* y */)
+bool ShipInfoPanel::Release(int /* x */, int /* y */, MouseButton button)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	if(draggingIndex >= 0 && hoverIndex >= 0 && hoverIndex != draggingIndex)
 		(**shipIt).GetArmament().Swap(hoverIndex, draggingIndex);
 

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -51,7 +51,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Release(int x, int y) override;

--- a/source/ShipInfoPanel.h
+++ b/source/ShipInfoPanel.h
@@ -54,7 +54,7 @@ protected:
 	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
-	virtual bool Release(int x, int y) override;
+	virtual bool Release(int x, int y, MouseButton button) override;
 
 
 private:

--- a/source/ShipNameDialog.cpp
+++ b/source/ShipNameDialog.cpp
@@ -44,8 +44,10 @@ void ShipNameDialog::Draw()
 
 
 
-bool ShipNameDialog::Click(int x, int y, int clicks)
+bool ShipNameDialog::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return Dialog::Click(x, y, button, clicks);
 	Point off = Point(x, y) - randomPos;
 	if(fabs(off.X()) < 40. && fabs(off.Y()) < 20.)
 	{
@@ -53,5 +55,5 @@ bool ShipNameDialog::Click(int x, int y, int clicks)
 		input = GameData::Phrases().Get("civilian")->Get();
 		return true;
 	}
-	return Dialog::Click(x, y, clicks);
+	return Dialog::Click(x, y, button, clicks);
 }

--- a/source/ShipNameDialog.h
+++ b/source/ShipNameDialog.h
@@ -37,7 +37,7 @@ public:
 
 
 protected:
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 
 
 private:

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -662,8 +662,11 @@ bool ShopPanel::Drag(double dx, double dy)
 
 
 
-bool ShopPanel::Release(int x, int y)
+bool ShopPanel::Release(int x, int y, MouseButton button)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	dragShip = nullptr;
 	isDraggingShip = false;
 	return true;

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -495,25 +495,28 @@ bool ShopPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 
 
 
-bool ShopPanel::Click(int x, int y, int clicks)
+bool ShopPanel::Click(int x, int y, MouseButton button, int clicks)
 {
-	dragShip = nullptr;
-	// Handle clicks on the buttons.
-	char button = CheckButton(x, y);
-	if(button)
-		return DoKey(button);
-
-	auto ScrollbarClick = [x, y, clicks](ScrollBar &scrollbar, ScrollVar<double> &scroll)
+	auto ScrollbarClick = [x, y, button, clicks](ScrollBar &scrollbar, ScrollVar<double> &scroll)
 	{
-		return ScrollbarMaybeUpdate([x, y, clicks](ScrollBar &scrollbar)
+		return ScrollbarMaybeUpdate([x, y, button, clicks](ScrollBar &scrollbar)
 			{
-				return scrollbar.Click(x, y, clicks);
+				return scrollbar.Click(x, y, button, clicks);
 			}, scrollbar, scroll, true);
 	};
 	if(ScrollbarClick(mainScrollbar, mainScroll)
 			|| ScrollbarClick(sidebarScrollbar, sidebarScroll)
 			|| ScrollbarClick(infobarScrollbar, infobarScroll))
 		return true;
+
+	if(button != MouseButton::LEFT)
+		return false;
+
+	dragShip = nullptr;
+	// Handle clicks on the buttons.
+	char zoneButton = CheckButton(x, y);
+	if(zoneButton)
+		return DoKey(zoneButton);
 
 	const Point clickPoint(x, y);
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -102,7 +102,7 @@ protected:
 	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
-	virtual bool Release(int x, int y) override;
+	virtual bool Release(int x, int y, MouseButton button) override;
 	virtual bool Scroll(double dx, double dy) override;
 
 	void DoFind(const std::string &text);

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -99,7 +99,7 @@ protected:
 
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Release(int x, int y) override;

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -178,10 +178,13 @@ bool StartConditionsPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &c
 
 
 
-bool StartConditionsPanel::Click(int x, int y, int /* clicks */)
+bool StartConditionsPanel::Click(int x, int y, MouseButton button, int /* clicks */)
 {
 	// When the user clicks, clear the hovered state.
 	hasHover = false;
+
+	if(button != MouseButton::LEFT)
+		return false;
 
 	// Only clicks within the list of scenarios should have an effect.
 	if(!entriesContainer.Contains(Point(x, y)))

--- a/source/StartConditionsPanel.h
+++ b/source/StartConditionsPanel.h
@@ -44,7 +44,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override final;
-	virtual bool Click(int x, int y, int clicks) override final;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override final;
 	virtual bool Hover(int x, int y) override final;
 	virtual bool Drag(double dx, double dy) override final;
 	virtual bool Scroll(double dx, double dy) override final;

--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -162,13 +162,15 @@ void TextArea::Draw()
 
 
 
-bool TextArea::Click(int x, int y, int clicks)
+bool TextArea::Click(int x, int y, MouseButton button, int clicks)
 {
-	if(scroll.Scrollable() && scrollBar.SyncClick(scroll, x, y, clicks))
+	if(scroll.Scrollable() && scrollBar.SyncClick(scroll, x, y, button, clicks))
 	{
 		bufferIsValid = false;
 		return true;
 	}
+	if(button != MouseButton::LEFT)
+		return false;
 
 	if(!buffer)
 		return false;

--- a/source/TextArea.cpp
+++ b/source/TextArea.cpp
@@ -199,8 +199,11 @@ bool TextArea::Drag(double dx, double dy)
 
 
 
-bool TextArea::Release(int x, int y)
+bool TextArea::Release(int x, int y, MouseButton button)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	bool ret = dragging;
 	dragging = false;
 	return ret;

--- a/source/TextArea.h
+++ b/source/TextArea.h
@@ -54,7 +54,7 @@ public:
 protected:
 	virtual void Draw() override;
 	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
-	virtual bool Release(int x, int y) override;
+	virtual bool Release(int x, int y, MouseButton button) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Hover(int x, int y) override;
 	virtual bool Scroll(double dx, double dy) override;

--- a/source/TextArea.h
+++ b/source/TextArea.h
@@ -53,7 +53,7 @@ public:
 
 protected:
 	virtual void Draw() override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 	virtual bool Release(int x, int y) override;
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Hover(int x, int y) override;

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -283,8 +283,11 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 
 
 
-bool TradingPanel::Click(int x, int y, int clicks)
+bool TradingPanel::Click(int x, int y, MouseButton button, int clicks)
 {
+	if(button != MouseButton::LEFT)
+		return false;
+
 	const Interface *tradeUi = GameData::Interfaces().Get(Screen::Width() < 1280 ? "trade (small screen)" : "trade");
 	const Rectangle box = tradeUi->GetBox("content");
 	const int MIN_X = box.Left();

--- a/source/TradingPanel.h
+++ b/source/TradingPanel.h
@@ -38,7 +38,7 @@ public:
 protected:
 	// Only override the ones you need; the default action is to return false.
 	virtual bool KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress) override;
-	virtual bool Click(int x, int y, int clicks) override;
+	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
 
 
 private:

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -58,13 +58,9 @@ bool UI::Handle(const SDL_Event &event)
 			int x = Screen::Left() + event.button.x * 100 / Screen::Zoom();
 			int y = Screen::Top() + event.button.y * 100 / Screen::Zoom();
 			if(event.button.button == 1)
-			{
 				handled = (*it)->ZoneClick(Point(x, y));
-				if(!handled)
-					handled = (*it)->DoClick(x, y, event.button.clicks);
-			}
-			else if(event.button.button == 3)
-				handled = (*it)->DoRClick(x, y);
+			if(!handled)
+				handled = (*it)->DoClick(x, y, static_cast<MouseButton>(event.button.button), event.button.clicks);
 		}
 		else if(event.type == SDL_MOUSEBUTTONUP)
 		{

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -66,7 +66,7 @@ bool UI::Handle(const SDL_Event &event)
 		{
 			int x = Screen::Left() + event.button.x * 100 / Screen::Zoom();
 			int y = Screen::Top() + event.button.y * 100 / Screen::Zoom();
-			handled = (*it)->DoRelease(x, y);
+			handled = (*it)->DoRelease(x, y, static_cast<MouseButton>(event.button.button));
 		}
 		else if(event.type == SDL_MOUSEWHEEL)
 			handled = (*it)->DoScroll(event.wheel.x, event.wheel.y);


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When thinking about #4647, I realized our panel stack supports only two mouse buttons.

In this refactor, I've removed the RClick method from panels, merging it with Click, which now receives a button ID as a parameter. This means it's now possible to detect multiple clicks with buttons other than the left button. Additionally panels are able to handle not only the left and right buttons, but also the middle and two side buttons (theoretically we could have even more, but we're limited with what SDL supports).

An alternative would be something like #11084 partially implements, but I don't think having a separate method for every button is the cleanest solution long-term, especially if we consider a possibility of SDL adding support for more buttons at some point.

## Testing Done
Launched the game, tested the menu and the controls panel, loaded a pilot, departed, tested the player/ship info panels, made sure left and right buttons still work on the main and map panels.

## Performance Impact
Haven't noticed.
