### PR TITLE
feat(ui): Smooth map zoom animation

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2214,6 +2214,7 @@ interface "map buttons (small screen)" bottom right
 interface "map"
 	value "max zoom" 2
 	value "min zoom" -2
+	value "zoom animation duration" 10
 
 	anchor top
 	string "route error"

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1380,9 +1380,9 @@ void MapPanel::DrawNames()
 {
 	// Draw names for all systems you have visited.
 	double zoom = Zoom();
-	static constexpr double BIGGER_TARGET_ZOOM = 2. / 3.;
 	if(zoom <= .5)
 		return;
+	static constexpr double BIGGER_TARGET_ZOOM = 2. / 3.;
 	double alpha = zoom >= BIGGER_TARGET_ZOOM ? 1. : (.5 - zoom) / (.5 - BIGGER_TARGET_ZOOM);
 	bool useBigFont = (zoom > 2.);
 	const Font &font = FontSet::Get(useBigFont ? 18 : 14);

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1380,8 +1380,10 @@ void MapPanel::DrawNames()
 {
 	// Draw names for all systems you have visited.
 	double zoom = Zoom();
-	static constexpr double biggerTargetZoom = 2. / 3.;
-	double alpha = zoom < biggerTargetZoom ? zoom < .5 ? 0. : (.5 - zoom) / (.5 - biggerTargetZoom) : 1.;
+	static constexpr double BIGGER_TARGET_ZOOM = 2. / 3.;
+	if(zoom <= .5)
+		return;
+	double alpha = zoom >= BIGGER_TARGET_ZOOM ? 1. : (.5 - zoom) / (.5 - BIGGER_TARGET_ZOOM);
 	bool useBigFont = (zoom > 2.);
 	const Font &font = FontSet::Get(useBigFont ? 18 : 14);
 	Point offset(useBigFont ? 8. : 6., -.5 * font.Height());

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Panel.h"
 
+#include "Animate.h"
 #include "Color.h"
 #include "DistanceMap.h"
 #include "Point.h"
@@ -144,6 +145,7 @@ protected:
 	Point center;
 	Point recenterVector;
 	int recentering = 0;
+	Animate<double> zoom;
 	int commodity;
 	int step = 0;
 	std::string buttonCondition;
@@ -214,6 +216,9 @@ private:
 	void DrawNames();
 	void DrawMissions();
 	void DrawPointer(const System *system, unsigned &systemCount, unsigned max, const Color &color, bool bigger = false);
+
+	void IncrementZoom();
+	void DecrementZoom();
 
 
 private:


### PR DESCRIPTION
**Feature**

Re-PRed (kind of) #10163.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Changing zoom on the map now has an animation implemented with the Animate class. The duration can be customized in the interface (defaults to 10 frames).

## Testing Done
yes™.

## Performance Impact
N/A
