### PR TITLE
Fix blurry text on the planet description

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1436,7 +1436,7 @@ interface "planet"
 		dimensions 720 360
 	
 	box "content"
-		from -240 80 to 240 355
+		from -240 80 to 240 320
 	
 	visible if "has shipyard"
 	sprite "ui/planet dialog button"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11660

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The planet description content box is taller than it should be. I think the odd height contributes to the blurriness described in the linked issue.
This PR fixes the height.

## Screenshots
No

## Usage examples
N/A

## Testing Done
@Anarchist2 said "i think that fixed it".

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
