### PR TITLE
feat(audio): Add FLAC support for music playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ find_path(LIBMAD_INCLUDE_DIR mad.h)
 find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
 
+# FLAC's config is missing find_dependency(Threads), so include it here
+find_package(Threads REQUIRED)
+find_package(FLAC CONFIG REQUIRED)
+
 # Find the zip-reading component of zlib.
 find_package(ZLIB REQUIRED)
 
@@ -149,7 +153,7 @@ endif()
 
 # Link with the general libraries.
 target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG OpenAL::OpenAL ${MINIZIP_LIBRARIES}
-	"$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
+	FLAC::FLAC++ "$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.
 if(WIN32)

--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -70,7 +70,7 @@ In addition to the below dependencies, you will also need CMake 3.19 or newer, h
 <summary>DEB-based distros</summary>
 
 ```
-g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libminizip-dev libopenal-dev libmad0-dev uuid-dev
+g++ cmake ninja-build curl libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libminizip-dev libopenal-dev libmad0-dev libflac++-dev uuid-dev
 ```
 If your CMake version is less than 3.31, you will also need
 ```
@@ -89,7 +89,7 @@ While sufficient versions of other dependencies are available, Ubuntu 22.04 does
 <summary>RPM-based distros</summary>
 
 ```
-gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel minizip-devel openal-soft-devel libmad-devel libuuid-devel
+gcc-c++ cmake ninja-build SDL2-devel libpng-devel libjpeg-turbo-devel mesa-libGL-devel glew-devel minizip-devel openal-soft-devel libmad-devel flac-devel libuuid-devel
 ```
 If your CMake version is less than 3.31, you will also need
 ```

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -344,8 +344,12 @@ target_sources(EndlessSkyLib PRIVATE
 	audio/player/AudioPlayer.h
 	audio/player/MusicPlayer.cpp
 	audio/player/MusicPlayer.h
+	audio/supplier/AsyncAudioSupplier.cpp
+	audio/supplier/AsyncAudioSupplier.h
 	audio/supplier/AudioSupplier.cpp
 	audio/supplier/AudioSupplier.h
+	audio/supplier/FlacSupplier.cpp
+	audio/supplier/FlacSupplier.h
 	audio/supplier/Mp3Supplier.cpp
 	audio/supplier/Mp3Supplier.h
 	audio/supplier/WavSupplier.cpp

--- a/source/audio/Music.cpp
+++ b/source/audio/Music.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Music.h"
 
 #include "../Files.h"
+#include "supplier/FlacSupplier.h"
 #include "../text/Format.h"
 #include "supplier/Mp3Supplier.h"
 
@@ -25,7 +26,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	map<string, filesystem::path> paths;
+	enum class MusicFileType
+	{
+		MP3, FLAC
+	};
+
+	map<string, pair<filesystem::path, MusicFileType>> paths;
 }
 
 
@@ -40,12 +46,12 @@ void Music::Init(const vector<filesystem::path> &sources)
 
 		for(const auto &path : files)
 		{
-			// Sanity check on the path length.
-			if(Format::LowerCase(path.extension().string()) != ".mp3")
-				continue;
-
 			string name = (path.parent_path() / path.stem()).lexically_relative(root).generic_string();
-			paths[name] = path;
+			string extension = Format::LowerCase(path.extension().string());
+			if(extension == ".mp3")
+				paths[name] = {path, MusicFileType::MP3};
+			else if(extension == ".flac")
+				paths[name] = {path, MusicFileType::FLAC};
 		}
 	}
 }
@@ -55,7 +61,14 @@ void Music::Init(const vector<filesystem::path> &sources)
 unique_ptr<AudioSupplier> Music::CreateSupplier(const string &name, bool looping)
 {
 	if(paths.contains(name))
-		return unique_ptr<AudioSupplier>{
-			new Mp3Supplier{Files::Open(paths[name]), looping}};
+		switch(paths[name].second)
+		{
+			case MusicFileType::MP3:
+				return unique_ptr<AudioSupplier>{
+					new Mp3Supplier{Files::Open(paths[name].first), looping}};
+			case MusicFileType::FLAC:
+				return unique_ptr<AudioSupplier>{
+					new FlacSupplier{Files::Open(paths[name].first), looping}};
+		}
 	return {};
 }

--- a/source/audio/Music.h
+++ b/source/audio/Music.h
@@ -20,8 +20,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <filesystem>
 #include <memory>
 
-// The Music class streams mp3 audio from a file and delivers it to the program
-// on "block" at a time, so it never needs to hold the entire decoded file in
+// The Music class streams audio from a file and delivers it to the program
+// one "block" at a time, so it never needs to hold the entire decoded file in
 // memory. Each block is 16-bit stereo, 44100 Hz. If no file is specified, or if
 // the decoding thread is not done yet, it returns silence rather than blocking,
 // so the game won't freeze if the music stops for some reason.

--- a/source/audio/supplier/AsyncAudioSupplier.cpp
+++ b/source/audio/supplier/AsyncAudioSupplier.cpp
@@ -111,12 +111,8 @@ size_t AsyncAudioSupplier::ReadInput(char *output, size_t bytesToRead)
 	if(done)
 		return 0;
 	// Read a chunk of data from the file.
-	size_t read = 0;
-	while(!data->eof() && read < bytesToRead)
-	{
-		data->read(output + read, bytesToRead - read);
-		read += data->gcount();
-	}
+	data->read(output, bytesToRead);
+	size_t read = data->gcount();
 	// If we get the end of the file, loop around to the beginning.
 	if(data->eof() && looping)
 	{

--- a/source/audio/supplier/AsyncAudioSupplier.cpp
+++ b/source/audio/supplier/AsyncAudioSupplier.cpp
@@ -1,0 +1,126 @@
+/* AsyncAudioSupplier.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "AsyncAudioSupplier.h"
+
+#include <cmath>
+#include <cstring>
+#include <thread>
+#include <utility>
+
+using namespace std;
+
+
+
+AsyncAudioSupplier::AsyncAudioSupplier(shared_ptr<iostream> data, bool looping)
+	: looping(looping), data(std::move(data))
+{
+	// Don't start the thread until this object is fully constructed.
+	thread = std::thread(&AsyncAudioSupplier::Decode, this);
+}
+
+
+
+AsyncAudioSupplier::~AsyncAudioSupplier()
+{
+	// Tell the decoding thread to stop.
+	{
+		lock_guard<mutex> lock(bufferMutex);
+		done = true;
+	}
+	bufferCondition.notify_all();
+	thread.join();
+}
+
+
+
+size_t AsyncAudioSupplier::MaxChunks() const
+{
+	if(done && buffer.size() < OUTPUT_CHUNK)
+		return 0;
+
+	return max(static_cast<size_t>(2), AvailableChunks());
+}
+
+
+
+size_t AsyncAudioSupplier::AvailableChunks() const
+{
+	return buffer.size() / OUTPUT_CHUNK;
+}
+
+
+vector<AudioSupplier::sample_t> AsyncAudioSupplier::NextDataChunk()
+{
+	if(AvailableChunks())
+	{
+		lock_guard<mutex> lock(bufferMutex);
+
+		vector<sample_t> temp{buffer.begin(), buffer.begin() + OUTPUT_CHUNK};
+		buffer.erase(buffer.begin(), buffer.begin() + OUTPUT_CHUNK);
+		bufferCondition.notify_all();
+		return temp;
+	}
+	else
+		return vector<sample_t>(OUTPUT_CHUNK);
+}
+
+
+
+void AsyncAudioSupplier::AwaitBufferSpace()
+{
+	unique_lock<mutex> lock(bufferMutex);
+	while(!done && buffer.size() > (BUFFER_CHUNK_SIZE - 1) * OUTPUT_CHUNK)
+		bufferCondition.wait(lock);
+}
+
+
+
+void AsyncAudioSupplier::AddBufferData(std::vector<sample_t>& samples)
+{
+	lock_guard<mutex> lock(bufferMutex);
+	buffer.insert(buffer.end(), samples.begin(), samples.end());
+	samples.clear();
+	if(done)
+		PadBuffer();
+}
+
+
+
+void AsyncAudioSupplier::PadBuffer()
+{
+	buffer.resize(OUTPUT_CHUNK * ceil(static_cast<double>(buffer.size()) / static_cast<double>(OUTPUT_CHUNK)));
+}
+
+
+
+
+size_t AsyncAudioSupplier::ReadInput(char* output, size_t bytesToRead)
+{
+	if(done)
+		return 0;
+	// Read a chunk of data from the file.
+	data->read(output, bytesToRead);
+	// If you get the end of the file, loop around to the beginning.
+	size_t read = data->gcount();
+	if(data->eof() && looping)
+	{
+		data->clear();
+		data->seekg(0, iostream::beg);
+	}
+	else if(data->eof())
+		done = true;
+	return read;
+}

--- a/source/audio/supplier/AsyncAudioSupplier.cpp
+++ b/source/audio/supplier/AsyncAudioSupplier.cpp
@@ -111,9 +111,13 @@ size_t AsyncAudioSupplier::ReadInput(char *output, size_t bytesToRead)
 	if(done)
 		return 0;
 	// Read a chunk of data from the file.
-	data->read(output, bytesToRead);
-	// If you get the end of the file, loop around to the beginning.
-	size_t read = data->gcount();
+	size_t read = 0;
+	while(!data->eof() && read < bytesToRead)
+	{
+		data->read(output + read, bytesToRead - read);
+		read += data->gcount();
+	}
+	// If we get the end of the file, loop around to the beginning.
 	if(data->eof() && looping)
 	{
 		data->clear();

--- a/source/audio/supplier/AsyncAudioSupplier.h
+++ b/source/audio/supplier/AsyncAudioSupplier.h
@@ -1,0 +1,72 @@
+/* AsyncAudioSupplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "AudioSupplier.h"
+
+#include <condition_variable>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+
+
+/// Generic implementation for async suppliers that stream data decoded on another thread.
+class AsyncAudioSupplier : public AudioSupplier {
+public:
+	explicit AsyncAudioSupplier(std::shared_ptr<std::iostream> data, bool looping = false);
+	~AsyncAudioSupplier() override;
+
+	// Inherited pure virtual methods
+	size_t MaxChunks() const override;
+	size_t AvailableChunks() const override;
+	std::vector<sample_t> NextDataChunk() override;
+
+
+protected:
+	/// This is the entry point for the decoding thread.
+	virtual void Decode() = 0;
+
+	void AwaitBufferSpace();
+	/// Adds data to the output buffer, then clears the given sample vector.
+	/// If the supplier is done, pads the output buffer to a full chunk with silence.
+	void AddBufferData(std::vector<sample_t> &samples);
+	/// Pads the buffer to a full output chunk with silence.
+	void PadBuffer();
+
+	/// Reads file input. Returns the number of bytes read.
+	/// The returned byte count is only less than the requested number if the end of the input was reached.
+	/// If the supplier is looping, the next call will still read data. Otherwise, "done" is set to true.
+	size_t ReadInput(char *output, size_t bytesToRead);
+
+protected:
+	bool done = false;
+	const bool looping;
+
+	std::shared_ptr<std::iostream> data;
+
+
+private:
+	/// The number of chunks to queue up in the buffer.
+	static constexpr size_t BUFFER_CHUNK_SIZE = 3;
+	/// The decoded data.
+	std::vector<sample_t> buffer;
+
+	// Sync management
+	std::thread thread;
+	std::mutex bufferMutex;
+	std::condition_variable bufferCondition;
+};

--- a/source/audio/supplier/FlacSupplier.cpp
+++ b/source/audio/supplier/FlacSupplier.cpp
@@ -1,0 +1,135 @@
+/* FlacSupplier.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "FlacSupplier.h"
+
+#include "../../Logger.h"
+
+#include <utility>
+
+using namespace std;
+
+
+
+FlacSupplier::FlacSupplier(shared_ptr<iostream> data, bool looping)
+	: AsyncAudioSupplier(std::move(data), looping)
+{
+}
+
+
+
+FLAC__StreamDecoderWriteStatus FlacSupplier::write_callback(const FLAC__Frame *frame, const FLAC__int32 *const buffer[])
+{
+	const size_t channels = frame->header.channels;
+	const size_t blocksize = frame->header.blocksize;
+
+	AwaitBufferSpace();
+	static vector<int16_t> samples;
+	for(size_t i = 0; i < blocksize; ++i)
+		for(size_t ch = 0; ch < channels; ++ch)
+			samples.push_back(static_cast<int16_t>(buffer[ch][i]));
+
+	AddBufferData(samples);
+	/// Allow looping back to the beginning of the file on the next read.
+	return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
+}
+
+
+
+void FlacSupplier::metadata_callback(const FLAC__StreamMetadata *metadata)
+{
+	if(metadata->data.stream_info.channels != 2)
+	{
+		Logger::LogError("FLAC channel count should be two, but is "
+			+ to_string(metadata->data.stream_info.channels) + ". The audio may be corrupt.");
+		done = true;
+	}
+	if(metadata->data.stream_info.bits_per_sample != 16)
+	{
+		Logger::LogError("FLAC should use 16-bit samples, but is "
+			+ to_string(metadata->data.stream_info.bits_per_sample) + "-bit instead. The audio may be corrupt.");
+		done = true;
+	}
+	if(metadata->data.stream_info.sample_rate != SAMPLE_RATE)
+	{
+		Logger::LogError("FLAC should use " + to_string(SAMPLE_RATE) + " sample rate, but is "
+			+ to_string(metadata->data.stream_info.sample_rate) + ". The audio may be corrupt.");
+		done = true;
+	}
+}
+
+
+
+
+void FlacSupplier::error_callback(FLAC__StreamDecoderErrorStatus status)
+{
+	Logger::LogError("FLAC error " + string(FLAC__StreamDecoderErrorStatusString[status]));
+	done = true;
+	PadBuffer();
+}
+
+
+
+FLAC__StreamDecoderReadStatus FlacSupplier::read_callback(FLAC__byte buffer[], size_t *bytes)
+{
+	size_t requestedBytes = *bytes;
+	size_t readBytes = ReadInput(reinterpret_cast<char*>(buffer), *bytes);
+	*bytes = readBytes;
+	if(readBytes != requestedBytes)
+		lastReadWasEof = true;
+
+	return done ? FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM : FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+}
+
+
+
+FLAC__StreamDecoderSeekStatus FlacSupplier::seek_callback(FLAC__uint64 absolute_byte_offset)
+{
+	return FLAC__STREAM_DECODER_SEEK_STATUS_UNSUPPORTED;
+}
+
+
+
+FLAC__StreamDecoderTellStatus FlacSupplier::tell_callback(FLAC__uint64 *absolute_byte_offset)
+{
+	return FLAC__STREAM_DECODER_TELL_STATUS_UNSUPPORTED;
+}
+
+
+
+FLAC__StreamDecoderLengthStatus FlacSupplier::length_callback(FLAC__uint64 *stream_length)
+{
+	return FLAC__STREAM_DECODER_LENGTH_STATUS_UNSUPPORTED;
+}
+
+
+
+bool FlacSupplier::eof_callback()
+{
+	return done || lastReadWasEof;
+}
+
+
+
+void FlacSupplier::Decode()
+{
+	init();
+	do {
+		lastReadWasEof = false;
+		process_until_end_of_stream();
+		reset();
+	} while(!done && lastReadWasEof);
+	finish();
+}

--- a/source/audio/supplier/FlacSupplier.h
+++ b/source/audio/supplier/FlacSupplier.h
@@ -1,0 +1,53 @@
+/* FlacSupplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "AsyncAudioSupplier.h"
+
+#include <FLAC++/decoder.h>
+
+
+
+/// Streams audio from a FLAC file.
+class FlacSupplier : public AsyncAudioSupplier, protected FLAC::Decoder::Stream {
+public:
+	explicit FlacSupplier(std::shared_ptr<std::iostream> data, bool looping = false);
+
+
+private:
+	/// A flac frame has been processed; forward the samples to the output buffer
+	FLAC__StreamDecoderWriteStatus write_callback(const FLAC__Frame *frame, const FLAC__int32 * const buffer[]) override;
+	/// Metadata was read from the file
+	void metadata_callback(const FLAC__StreamMetadata *metadata) override;
+	void error_callback(FLAC__StreamDecoderErrorStatus status) override;
+
+	/// Read bytes of input into the buffer.
+	FLAC__StreamDecoderReadStatus read_callback(FLAC__byte buffer[], size_t *bytes) override;
+
+	/// Seeking is not supported, and shouldn't be called in runtime.
+	FLAC__StreamDecoderSeekStatus seek_callback(FLAC__uint64 absolute_byte_offset) override;
+	FLAC__StreamDecoderTellStatus tell_callback(FLAC__uint64 *absolute_byte_offset) override;
+	FLAC__StreamDecoderLengthStatus length_callback(FLAC__uint64 *stream_length) override;
+	bool eof_callback() override;
+
+	/// This is the entry point for the decoding thread.
+	void Decode() override;
+
+
+private:
+	/// If the last read reached the end of the file, we may have to loop back by resetting the decoder.
+	bool lastReadWasEof = false;
+};

--- a/source/audio/supplier/FlacSupplier.h
+++ b/source/audio/supplier/FlacSupplier.h
@@ -22,7 +22,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 /// Streams audio from a FLAC file.
-class FlacSupplier : public AsyncAudioSupplier, protected FLAC::Decoder::Stream {
+class FlacSupplier : protected FLAC::Decoder::Stream, public AsyncAudioSupplier {
+// Maintenance note: the order of the parents is important. AsyncAudioSupplier must be destructed first,
+// otherwise the FLAC::Decoder::Stream may free the resources with the decoder thread running.
 public:
 	explicit FlacSupplier(std::shared_ptr<std::iostream> data, bool looping = false);
 

--- a/source/audio/supplier/Mp3Supplier.h
+++ b/source/audio/supplier/Mp3Supplier.h
@@ -15,45 +15,17 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "AudioSupplier.h"
-
-#include <condition_variable>
-#include <iostream>
-#include <memory>
-#include <thread>
+#include "AsyncAudioSupplier.h"
 
 
 
-/// Streams audio from an MP3 file. This is an async data supplier.
-class Mp3Supplier : public AudioSupplier {
+/// Streams audio from an MP3 file.
+class Mp3Supplier : public AsyncAudioSupplier {
 public:
 	explicit Mp3Supplier(std::shared_ptr<std::iostream> data, bool looping = false);
-	~Mp3Supplier();
-
-	// Inherited pure virtual methods
-	size_t MaxChunks() const override;
-	size_t AvailableChunks() const override;
-	std::vector<sample_t> NextDataChunk() override;
 
 
 private:
 	/// This is the entry point for the decoding thread.
-	void Decode();
-
-
-private:
-	/// The number of chunks to queue up in the buffer.
-	static constexpr size_t BUFFER_CHUNK_SIZE = 12;
-	/// The decoded data.
-	std::vector<sample_t> buffer;
-
-	/// The MP3 input stream.
-	std::shared_ptr<std::iostream> data;
-
-	bool done = false;
-	bool looping;
-
-	std::thread thread;
-	std::mutex decodeMutex;
-	std::condition_variable condition;
+	void Decode() override;
 };

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,7 @@
 					"name": "libuuid",
 					"platform": "linux"
 				},
+				"libflac",
 				"minizip",
 				"openal-soft",
 				{
@@ -45,6 +46,7 @@
 			"dependencies": [
 				"libmad",
 				"catch2",
+				"libflac",
 				"minizip"
 			]
 		},


### PR DESCRIPTION
**Feature**

This PR adds the often-requested FLAC support to music, so either mp3 of flac files can be used.

## Acknowledgement

- [x] I acknowledge that I have totally read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
**This PR is based on and includes changes from #11065. It will be rebased with changes made there.**

As we don't want to cache music in memory, flac also uses a threaded decoder, like mp3. The common functionality was lifted out to a superclass so the thread management code isn't duplicated between flac and mp3.

The flac files are decoded via libflac.

## Usage examples
Flac music?

## Testing Done
I tested both looping and non-looping playback with mp3 and flac, both works fine.
Some short test files: [ambient.zip](https://github.com/user-attachments/files/21321586/ambient.zip)

## Performance Impact
Shouldn't be much.