### PR TITLE
fix(content): Fix bug where Cutthroats wouldn't spawn

### DIFF
--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -1692,7 +1692,7 @@ mission "FW Bloodsea 1.2A"
 
 
 
-mission "Pirates Use Cutthroat"
+mission "Pirates Use Cutthroats"
 	landing
 	invisible
 	to offer
@@ -1702,7 +1702,7 @@ mission "Pirates Use Cutthroat"
 		fail
 
 event "pirates use cutthroat"
-	fleet "Large Southern Pirate"
+	fleet "Large Southern Pirates"
 		add variant 2
 			"Cutthroat" 3
 		add variant 1


### PR DESCRIPTION
This PR addresses the bug described by Dagoth on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
"Pirates Use Cutthroat" changes a fleet named "Large Southern Pirate", but the actual fleet is named "Large Southern Pirates". This PR fixes the typo and renames the mission to let it trigger on saves that already have the broken version of the event.

## Testing Done
None.
