### PR TITLE
fix(code): Fix test_point failing abs test on ARM64

### DIFF
--- a/tests/unit/src/test_point.cpp
+++ b/tests/unit/src/test_point.cpp
@@ -19,8 +19,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "../../../source/Point.h"
 
 // ... and any system includes needed for the test file.
-#include <limits>
 #include <cmath>
+#include <limits>
 
 
 

--- a/tests/unit/src/test_point.cpp
+++ b/tests/unit/src/test_point.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 // ... and any system includes needed for the test file.
 #include <limits>
+#include <cmath>
 
 
 
@@ -397,8 +398,8 @@ SCENARIO( "Calculating absolute value", "[Point][abs]" ) {
 		Point first = Point(5.4321, -10.987654321);
 		WHEN( "Calculating abs" ) {
 			THEN( "The result is correct" ) {
-				CHECK( abs(first.X()) == abs(first).X() );
-				CHECK( abs(first.Y()) == abs(first).Y() );
+				CHECK( std::abs(first.X()) == abs(first).X() );
+				CHECK( std::abs(first.Y()) == abs(first).Y() );
 			}
 		}
 	}


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11623 in part.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Use `std::abs(double)` from cmath instead of the default abs on arm64, which used to return int and fail test_point

## Testing Done

https://launchpadlibrarian.net/806416697/buildlog_ubuntu-questing-arm64.endless-sky_0.10.14-1_BUILDING.txt.gz

Before applying the fix:

```
1/1 Test #89: unit .............................***Failed    0.19 sec
Randomness seeded to: 202319588

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
endless-sky-tests is a Catch2 v3.7.1 host application.
Run with -? for options

-------------------------------------------------------------------------------
Scenario: Calculating absolute value
      Given: any Point
       When: Calculating abs
       Then: The result is correct
-------------------------------------------------------------------------------
./tests/unit/src/test_point.cpp:399
...............................................................................

./tests/unit/src/test_point.cpp:400: FAILED:
  CHECK( abs(first.X()) == abs(first).X() )
with expansion:
  5 == 5.43210000000000015

./tests/unit/src/test_point.cpp:401: FAILED:
  CHECK( abs(first.Y()) == abs(first).Y() )
with expansion:
  10 == 10.98765432100000083

===============================================================================
test cases:    94 |    93 passed | 1 failed
assertions: 76650 | 76648 passed | 2 failed
```

After applying fix:

```
Randomness seeded to: 4247058142
===============================================================================
All tests passed (76647 assertions in 94 test cases)
```

## Performance Impact
N/A