### PR TITLE
Quarg Ship Self-Destruction

### DIFF
--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -29,7 +29,8 @@ ship "Quarg Lindwyrm"
 		"cargo space" 400
 		"outfit space" 460
 		"weapon capacity" 140
-		"engine capacity" 100
+		"engine capacity" 
+		"self destruct" .5
 		weapon
 			"blast radius" 150
 			"shield damage" 15000
@@ -80,6 +81,7 @@ ship "Quarg Guivre"
 		"outfit space" 720
 		"weapon capacity" 280
 		"engine capacity" 140
+		"self destruct" .5
 		weapon
 			"blast radius" 300
 			"shield damage" 30000
@@ -130,6 +132,7 @@ ship "Quarg Drake"
 		"outfit space" 450
 		"weapon capacity" 140
 		"engine capacity" 80
+		"self destruct" .67
 		weapon
 			"blast radius" 120
 			"shield damage" 12000
@@ -182,6 +185,7 @@ ship "Quarg Wardragon"
 		"outfit space" 510
 		"weapon capacity" 180
 		"engine capacity" 100
+		"self destruct" .67
 		weapon
 			"blast radius" 135
 			"shield damage" 13500
@@ -233,6 +237,7 @@ ship "Quarg Wyvern"
 		"outfit space" 575
 		"weapon capacity" 250
 		"engine capacity" 120
+		"self destruct" .67
 		weapon
 			"blast radius" 200
 			"shield damage" 20000
@@ -285,6 +290,7 @@ ship "Quarg Hydra"
 		"outfit space" 925
 		"weapon capacity" 380
 		"engine capacity" 170
+		"self destruct" .67
 		weapon
 			"blast radius" 390
 			"shield damage" 39000

--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -29,7 +29,7 @@ ship "Quarg Lindwyrm"
 		"cargo space" 400
 		"outfit space" 460
 		"weapon capacity" 140
-		"engine capacity" 
+		"engine capacity" 100
 		"self destruct" .5
 		weapon
 			"blast radius" 150


### PR DESCRIPTION
## Quarg Ship Self-Destruction

This PR shall address an inconsistency in regard to Player-Quarg relations.

Quarg consider the pure ownership of their technology and ships to be an atrocity. For that they sentence First Last to lifelong prison (aka Death aka Game Over) without any trial. Hence, it is highly illogical that they won't equip their ships with self-destruction mechanisms.

Therefore this PR introduces self-destruction values to all Quarg ships -- 0.5 for civilian ships and 0.67 for military ships.

At that the value lower than 1 is a concession to the urge of many players to capture Quarg ships, which still can be explained somehow lorewise (self-destruct mechanisms can be damaged during fights, the Quarg simply suck at self-destruction unlike the Automata, or whatever).


## Acknowledgement

- [ ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Performance Impact
Lore performance improved by 5%.