### PR TITLE
Feat(UI): Credit change message on day advancing

### DIFF
--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Format.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <numeric>
 #include <sstream>
 
@@ -257,7 +258,10 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 
 	// If you didn't make any payments, no need to continue further.
 	if(!(salariesPaid + maintenancePaid + mortgagesPaid + finesPaid + debtPaid))
+	{
+		totalPreviousPayment = 0;
 		return out.str();
+	}
 	else if(missedPayment)
 		out << " ";
 
@@ -274,6 +278,11 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 		typesPaid["fines"] = finesPaid;
 	if(debtPaid)
 		typesPaid["debt"] = debtPaid;
+
+	// Record the total payment
+	totalPreviousPayment = 0;
+	for(const auto &paid : typesPaid)
+		totalPreviousPayment += paid.second;
 
 	out << Format::List<map, string, int64_t>(typesPaid,
 		[](const pair<string, int64_t> &it)
@@ -435,6 +444,13 @@ int64_t Account::TotalDebt(const string &type) const
 			total += mortgage.Principal();
 
 	return total;
+}
+
+
+
+int64_t Account::TotalPreviousPayment() const
+{
+	return totalPreviousPayment;
 }
 
 

--- a/source/Account.h
+++ b/source/Account.h
@@ -71,6 +71,7 @@ public:
 	// mortgages if a blank string is provided.
 	int64_t TotalDebt(const std::string &type = "") const;
 
+	int64_t TotalPreviousPayment() const;
 
 private:
 	int64_t YearlyRevenue() const;
@@ -86,6 +87,9 @@ private:
 	int64_t maintenanceDue = 0;
 	// Your credit score determines the interest rate on your mortgages.
 	int creditScore = 400;
+
+	// Keep track of how many credits were paid in the last step
+	int64_t totalPreviousPayment = 0;
 
 	std::vector<Mortgage> mortgages;
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -48,6 +48,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <functional>
@@ -4886,6 +4887,18 @@ void PlayerInfo::DoAccounting()
 	string message = accounts.Step(assets, Salaries(), balance.maintenanceCosts);
 	if(!message.empty())
 		Messages::Add(message, Messages::Importance::High, true);
+
+	// Total the income and payments made, printing a message if non-zero.
+	int64_t totalCreditChange = -accounts.TotalPreviousPayment();
+	for(const auto &gain : income)
+		totalCreditChange += gain.second;
+	if(totalCreditChange)
+	{
+		string changeMsg = "You ";
+		if(totalCreditChange > 0){ changeMsg += "gained ";} else { changeMsg += "lost ";}
+		changeMsg += Format::CreditString(abs(totalCreditChange)) + " yesterday.";
+		Messages::Add(changeMsg, Messages::Importance::High);
+	}
 }
 
 


### PR DESCRIPTION
**Feature**


This PR fixes #2945 
Related: #9484 is orphaned so should no longer block this
#10290 was the last itteration, over a year old so I just redid it all. 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Displays a message (if applicable) with the total gain or loss from sources of income (salary, tribute, and anything from outfits/ships) and payments made (crew salaries, maintenance, mortgages, fines, debt) on each day change. 

I decided to not display anything additional on net 0 but am in no way married to that.

## Screenshots
<img width="464" height="113" alt="Screenshot_2025-07-22T13:48:14-EDT" src="https://github.com/user-attachments/assets/8db4f82a-f2bb-47d4-ae8a-cd46f75306d4" />
<img width="310" height="95" alt="Screenshot_2025-07-22T14:10:36-EDT" src="https://github.com/user-attachments/assets/35174a26-db21-4bf7-aa63-b713d68027c5" />
<img width="315" height="89" alt="Screenshot_2025-07-22T14:12:57-EDT" src="https://github.com/user-attachments/assets/c971ad7c-d582-4185-8217-8f230399c7ed" />


## Usage examples
N/A

## Testing Done
Tested with various different saves, checking the message made sense in all contexts (gaining credits, losing credits, no change)

## Save File
This save file can be used to test these changes (Any save file with income and payments can be used):
[CreditMessage Friithian.txt](https://github.com/user-attachments/files/21373131/CreditMessage.Friithian.txt)


## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Negligible negative impact on day step and player accounting

