### PR TITLE
fix(mechanics): Properly despawn carriers when they land

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4653,7 +4653,7 @@ bool Ship::DoLandingLogic()
 					const auto escort = it.lock();
 					// Check if escorts are also landed, destroyed, disabled, or being carried.
 					if(!escort || escort->IsDestroyed() || escort->IsDisabled() || escort->zoom == 0.f
-						|| escort->GetSystem() != currentSystem)
+							|| !escort->GetSystem())
 						continue;
 					escortsLanded = false;
 					break;


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a ship lands, it waits for all its escorts to also land or be destroyed before despawning. However, carried ships do not trigger the "landing" condition, nor do they count as destroyed, resulting in the carrier never despawning, causing status overlays to persist and (more importantly) faction strength calculations to incorrectly include the landed ship, in turn affecting fleet spawning.

This PR adds a check to see if the escort is in a different system as the landed ship, which will always be true for a carried ship. It also checks for disabled ships, preventing spawns from being blocked if one fighter/escort gets disabled but every other ship in a fleet lands.

## Testing Done
Used the ship status overlays as an indicator of ships despawning. Saw the rings permanently visible when a carrier landed without this PR, while the rings eventually disappeared for all ships with this PR.

## Performance Impact
Nil.
