### PR TITLE
feat(mechanics): Allow targeting minables with homing projectiles

### DIFF
--- a/source/AlertLabel.cpp
+++ b/source/AlertLabel.cpp
@@ -40,7 +40,7 @@ AlertLabel::AlertLabel(const Point &position, const Projectile &projectile, cons
 	isTargetingFlagship = false;
 	if(flagship)
 	{
-		isTargetingFlagship = projectile.TargetPtr() == flagship;
+		isTargetingFlagship = projectile.Target() == flagship.get();
 		double maxHP = flagship->MaxHull() + flagship->MaxShields();
 		double missileDamage = projectile.GetWeapon().HullDamage() + projectile.GetWeapon().ShieldDamage();
 		isDangerous = (missileDamage / maxHP) > DANGEROUS_ABOVE;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2388,7 +2388,7 @@ void Engine::DoCollisions(Projectile &projectile)
 		// "Phasing" projectiles that have a target will never hit any other ship.
 		// They also don't care whether the weapon has "no ship collisions" on, as
 		// otherwise a phasing projectile would never hit anything.
-		shared_ptr<Ship> target = projectile.TargetPtr();
+		shared_ptr<Body> target = projectile.TargetPtr();
 		if(target)
 		{
 			Point offset = projectile.Position() - target->Position();

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -85,14 +85,14 @@ public:
 	// Get information on how this projectile impacted a ship.
 	ImpactInfo GetInfo(double intersection) const;
 
-	// Find out which ship or government this projectile is targeting. Note:
+	// Find out which body or government this projectile is targeting. Note:
 	// this pointer is not guaranteed to be dereferenceable, so only use it
 	// for comparing.
-	const Ship *Target() const;
+	const Body *Target() const;
 	const Government *TargetGovernment() const;
 	// This function is much more costly, so use it only if you need to get a
-	// non-const shared pointer to the target ship.
-	std::shared_ptr<Ship> TargetPtr() const;
+	// non-const shared pointer to the target body.
+	std::shared_ptr<Body> TargetPtr() const;
 	// Clear the targeting information on this projectile.
 	void BreakTarget();
 
@@ -118,8 +118,9 @@ private:
 private:
 	const Weapon *weapon = nullptr;
 
-	std::weak_ptr<Ship> targetShip;
-	const Ship *cachedTarget = nullptr;
+	bool targetIsShip;
+	std::weak_ptr<Body> target;
+	const Body *cachedTarget = nullptr;
 	bool targetDisabled = false;
 	const Government *targetGovernment = nullptr;
 


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #3305 (closes #3305).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
You can now fire homing weapons at a minable (if you have one targeted via a minable scanner) and expect it to work.

Opening as a draft: for now, the projectiles always maintain their lock, but I'm planning to add an option to set attributes on minables to make jamming checks possible. I think a class positioned between Body and Ship/Minable in the inheritance relations would be the best solution (so we can avoid making everything virtual).

## Testing Done
Tested using a Pug Seeker.

## Wiki Update
Don't think one is needed, unless I missed something in CreatingOutfits.

## Performance Impact
Negligible.
