### PR TITLE
feat(balance): Rebalance Korath Afterburners

### DIFF
--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -255,10 +255,10 @@ outfit "Afterburner (Asteroid Class)"
 	"engine capacity" -5
 	"fuel capacity" 100
 	"ramscoop" 0.25
-	"afterburner thrust" 13.9
-	"afterburner energy" 0.32
-	"afterburner heat" 3.4
-	"afterburner fuel" 0.0375
+	"afterburner thrust" 18.28
+	"afterburner energy" 0.38
+	"afterburner heat" 4
+	"afterburner fuel" 0.05
 	"afterburner effect" "korath afterburner tiny"
 	description "The smallest of afterburners is as much Fuel Processor as it is afterburner. It allows Korath small craft operators to squeeze a hyperdrive into otherwise intrasystem ships and dispense with conventional thrusters entirely."
 	description "	Korath afterburners pump super-heated hyperspace fuel directly into a thruster's plasma stream, resulting in a phenomenal explosion that may nearly melt the thruster."
@@ -273,10 +273,10 @@ outfit "Afterburner (Comet Class)"
 	"mass" 19
 	"outfit space" -19
 	"engine capacity" -19
-	"afterburner thrust" 93.6
-	"afterburner energy" 2.1
+	"afterburner thrust" 104.2
+	"afterburner energy" 2.16
 	"afterburner heat" 22.75
-	"afterburner fuel" 0.225
+	"afterburner fuel" 0.258
 	"afterburner effect" "korath afterburner small"
 	description "Adding these afterburners to an interceptor allows it to reach absurd speeds; however, the heat produced ensures that running them for any substantial period of time will require some serious cooling."
 	description "	Korath afterburners pump super-heated hyperspace fuel directly into a thruster's plasma stream, resulting in a phenomenal explosion that nearly melts the thruster."
@@ -291,10 +291,10 @@ outfit "Afterburner (Lunar Class)"
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
-	"afterburner thrust" 170.1
+	"afterburner thrust" 185.4
 	"afterburner energy" 3.9
 	"afterburner heat" 41.65
-	"afterburner fuel" 0.4
+	"afterburner fuel" 0.442
 	"afterburner effect" "korath afterburner medium"
 	description "Although these afterburners produce an incredible amount of thrust for their fuel usage, the prospect of installing one brings to mind many safety concerns."
 	description "	Korath afterburners pump super-heated hyperspace fuel directly into a thruster's plasma stream, resulting in a phenomenal explosion that nearly melts the thruster."
@@ -309,10 +309,10 @@ outfit "Afterburner (Planetary Class)"
 	"mass" 55
 	"outfit space" -55
 	"engine capacity" -55
-	"afterburner thrust" 317.8
+	"afterburner thrust" 338.6
 	"afterburner energy" 7.1
 	"afterburner heat" 79.45
-	"afterburner fuel" 0.725
+	"afterburner fuel" 0.783
 	"afterburner effect" "korath afterburner large"
 	"heat capacity" 150
 	description "These enormous afterburners have dedicated reaction chambers with cooling vents to keep the fuel-plasma explosion from destroying the thruster."
@@ -328,10 +328,10 @@ outfit "Afterburner (Stellar Class)"
 	"mass" 94
 	"outfit space" -94
 	"engine capacity" -94
-	"afterburner thrust" 579.1
-	"afterburner energy" 12.65
+	"afterburner thrust" 619.9
+	"afterburner energy" 13.05
 	"afterburner heat" 148
-	"afterburner fuel" 1.25
+	"afterburner fuel" 1.367
 	"afterburner effect" "korath afterburner huge"
 	"active cooling" 8
 	"cooling energy" 0.4

--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -255,9 +255,9 @@ outfit "Afterburner (Asteroid Class)"
 	"engine capacity" -5
 	"fuel capacity" 100
 	"ramscoop" 0.25
-	"afterburner thrust" 23.1
-	"afterburner energy" 0.6
-	"afterburner heat" 6.25
+	"afterburner thrust" 13.9
+	"afterburner energy" 0.32
+	"afterburner heat" 3.4
 	"afterburner fuel" 0.0375
 	"afterburner effect" "korath afterburner tiny"
 	description "The smallest of afterburners is as much Fuel Processor as it is afterburner. It allows Korath small craft operators to squeeze a hyperdrive into otherwise intrasystem ships and dispense with conventional thrusters entirely."
@@ -274,9 +274,9 @@ outfit "Afterburner (Comet Class)"
 	"outfit space" -19
 	"engine capacity" -19
 	"afterburner thrust" 93.6
-	"afterburner energy" 2.25
+	"afterburner energy" 2.1
 	"afterburner heat" 22.75
-	"afterburner fuel" 0.125
+	"afterburner fuel" 0.225
 	"afterburner effect" "korath afterburner small"
 	description "Adding these afterburners to an interceptor allows it to reach absurd speeds; however, the heat produced ensures that running them for any substantial period of time will require some serious cooling."
 	description "	Korath afterburners pump super-heated hyperspace fuel directly into a thruster's plasma stream, resulting in a phenomenal explosion that nearly melts the thruster."
@@ -291,10 +291,10 @@ outfit "Afterburner (Lunar Class)"
 	"mass" 32
 	"outfit space" -32
 	"engine capacity" -32
-	"afterburner thrust" 178.5
+	"afterburner thrust" 170.1
 	"afterburner energy" 3.9
 	"afterburner heat" 41.65
-	"afterburner fuel" 0.225
+	"afterburner fuel" 0.4
 	"afterburner effect" "korath afterburner medium"
 	description "Although these afterburners produce an incredible amount of thrust for their fuel usage, the prospect of installing one brings to mind many safety concerns."
 	description "	Korath afterburners pump super-heated hyperspace fuel directly into a thruster's plasma stream, resulting in a phenomenal explosion that nearly melts the thruster."
@@ -309,10 +309,10 @@ outfit "Afterburner (Planetary Class)"
 	"mass" 55
 	"outfit space" -55
 	"engine capacity" -55
-	"afterburner thrust" 345.6
+	"afterburner thrust" 317.8
 	"afterburner energy" 7.1
 	"afterburner heat" 79.45
-	"afterburner fuel" 0.4
+	"afterburner fuel" 0.725
 	"afterburner effect" "korath afterburner large"
 	"heat capacity" 150
 	description "These enormous afterburners have dedicated reaction chambers with cooling vents to keep the fuel-plasma explosion from destroying the thruster."
@@ -328,10 +328,10 @@ outfit "Afterburner (Stellar Class)"
 	"mass" 94
 	"outfit space" -94
 	"engine capacity" -94
-	"afterburner thrust" 662.4
+	"afterburner thrust" 579.1
 	"afterburner energy" 12.65
 	"afterburner heat" 148
-	"afterburner fuel" 0.725
+	"afterburner fuel" 1.25
 	"afterburner effect" "korath afterburner huge"
 	"active cooling" 8
 	"cooling energy" 0.4


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Right now, Korath afterburners are very, very strong. A Lunar-class Afterburner and 5 Wanderer Ramscoops requires 67 outfit space, one less than the 68-ton Planetary-class Thruster, but the afterburner provides around 50% more thrust than the thruster while requiring half as much energy. While there is some risk of running out of fuel, even a prolonged fight in a medium-wind system like Wah Ki will only make a slight dent in your fuel gauge. A majority of the space needed for the Afterburner setup also isn't engine space, but regular outfit space, letting the Lunar Afterburner fit on more ships than the Planetary Thruster.

The problem with this is three-fold:
1. The Korath are one of the easiest factions to farm outfits off of. They're right outside of human space, are roughly on-par with Hai ships and Kor Ak'Mari acts as a reliable spawning location without leaving you prone to being overrun, meaning that it isn't too difficult to get a stockpile of Korath Afterburners in a small fleet, or even a solo ship. This contributes to the next problem:
2. Having Korath Afterburners be this powerful crushes out the use cases of most other thrusters. Why bother with Wanderer thrusters when Korath Afterburners let you get the same amount of cooling through all the outfit space they save? Why bother with Coalition thrusters when Korath Afterburners are also much smaller than other engines while still being efficient? Why bother with Successor thrusters when Korath Afterburners provide more thrust without shredding your shields?
3. In practice, Korath Afterburners feel less like "afterburners" and more like engines that happen to use some fuel. You rarely have to think when choosing between the speed boost or saving fuel, and it takes less outfit space to ignore the cost entirely than what you would lose by using traditional thrusters instead.

This PR aims to bring Korath Afterburners in line both with other engines and with other afterburners.

## Methodology
The first step is to figure out how powerful Korath Afterburners should be. An A250 Atomic thruster is 34 tons of outfit space and produces 165,375 thrust in-game (45.9375 raw), giving it a thrust/ton of ~4,864 (1.351 raw). A Caldera afterburner is 37 tons and produces 648,000 thrust (180 raw), resulting in a thrust/ton of ~17,514 (4.865 raw), or 3.6 times the efficiency of the Atomic thruster.

While Korath afterburners tends to be substantially different sizes compared to Korath thrusters, it's possible to extrapolate the expected thrust/ton of a thruster through interpolation. Using the Asteroid and Comet Thrusters, a 20-ton Korath thruster would have a thrust/ton of ~5,484 (1.523 raw), indicating that the 19-ton Comet afterburner should have a thrust/ton of ~19,742 (5.484 raw), or a base thrust of 375,098 (104.194 raw). This is actually more than the Comet afterburner's current thrust of 336,960 (93.6); indeed, the Lunar-class afterburner also sees a thrust increase from 642,600 to ~667,469 from this change. However, at larger sizes, Korath afterburners lose thrust, with the Planetary-class Afterburner going from 1,244,160 to ~1,218,789 and the Stellar-class falling from 2,384,640 to ~2,231,748.

The one exception is the Afterburner (Asteroid-class). Along with being an afterburner, the Asteroid afterburner also comes with some fuel and ramscoop. The afterburner requires 5 tons of engine space out of 9 outfit space total, but given that the most efficient fuel storage only goes down to 4.75 tons to fit 100 fuel, it seems more likely to me that the fuel and ramscoop take up 5 tons, one of which is engine space, making the actual afterburner only 4 tons. The vast difference between the actual size of the Asteroid afterburner and the next biggest afterburner, the Comet-class, is most similar to the difference between the Volcano and Caldera afterburners, which see a ~16% drop in thrust/space from the Caldera to the Volcano. Using this same methodology with the Asteroid-class and the Comet results in a thrust/space of ~16,452 (4.570), or a base thrust of ~65,807 (18.280).

The second step is balancing fuel costs. The most straightforward way to balance how much fuel an outfit should need is by converting it into outfit space. When accounting for energy usage and the space taken up by by extra fuel capacity needed, the Refueling Module produces ~0.149 fuel per second per outfit space (0.00248 fuel per frame per outfit space). The Caldera afterburner requires 30 fuel per second, which converts to ~201 outfit space, raising its total space to 238 and reducing its thrust/ton to ~2,723 (0.756), which falls further to 2,521 (0.700) when also including space spent on cooling (using Large Heat Shunts (135 cooling per ton) as the base). This is 81.5% of the thrust/ton of the A250 when accounting for its energy (using the Blue Sun Reactor (11.09 energy per ton) as the base) and heat costs (~3,092 in-game, 0.859 raw).

The current Korath afterburners have significantly greater thrust/total space than Korath thrusters (~3,678 for the 19-ton Comet-class afterburner, ~3,627 for the 118-ton Stellar-class thruster), largely due to their inflated fuel efficiency. To combat this, fuel costs for the Korath afterburners have been raised so that their thrust/total space is roughly equal to 81.5% of the thrust/total space of a same-sized Korath thruster.

The `afterburner energy` and `afterburner heat` on some of the Korath afterburners have also been altered. Rather than size, Thrust/Energy and Heat/Energy has the most correlation with the type of engine, with any engine rarely being more than 100 in-game Thrust/Energy (~0.278 raw) away from a different-sized engine in the same series (and if there is any trend with size, it's that engines get less energy and heat efficient as they get bigger, not more). With the changes to thrust values, the Korath afterburners largely follow this pattern well with the exception of Asteroid-class and Comet-class afterburner, which needed their costs dropped, and the Stellar-class afterburner, which has had its energy usage raised.

## Outcome
These changes don't make the Korath Afterburners useless as an engine replacement: they still allow you to cheat more thrust and turn onto ships with relatively low engine space, like the Hurricane, and if you're looking for the absolute fastest ship possible, they're still the best semi-sustainable option. However, forgoing traditional engines entirely will now require more significant sacrifices when outfitting, preventing Korath Afterburners from making most thrusters irrelevant and making them more suited for their intended role as a temporary-use speed boost.