### PR TITLE
fix(audio): Adjust sound category of landing and takeoff sounds

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1502,7 +1502,7 @@ void PlayerInfo::Land(UI *ui)
 
 	if(!freshlyLoaded)
 	{
-		Audio::Play(Audio::Get("landing"), SoundCategory::ENGINE);
+		Audio::Play(Audio::Get("landing"), SoundCategory::ENVIRONMENT);
 		Audio::PlayMusic(planet->MusicName());
 	}
 
@@ -1655,7 +1655,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 		return false;
 
 	shouldLaunch = false;
-	Audio::Play(Audio::Get("takeoff"), SoundCategory::ENGINE);
+	Audio::Play(Audio::Get("takeoff"), SoundCategory::ENVIRONMENT);
 
 	// Jobs are only available when you are landed.
 	availableJobs.clear();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1502,7 +1502,7 @@ void PlayerInfo::Land(UI *ui)
 
 	if(!freshlyLoaded)
 	{
-		Audio::Play(Audio::Get("landing"), SoundCategory::ENVIRONMENT);
+		Audio::Play(Audio::Get("landing"), SoundCategory::UI);
 		Audio::PlayMusic(planet->MusicName());
 	}
 
@@ -1655,7 +1655,7 @@ bool PlayerInfo::TakeOff(UI *ui, const bool distributeCargo)
 		return false;
 
 	shouldLaunch = false;
-	Audio::Play(Audio::Get("takeoff"), SoundCategory::ENVIRONMENT);
+	Audio::Play(Audio::Get("takeoff"), SoundCategory::UI);
 
 	// Jobs are only available when you are landed.
 	availableJobs.clear();


### PR DESCRIPTION
**Bug fix**

This PR addresses something people were complaining about with the landing sounds.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Changes the category of the sounds to use the ui slider.

## Testing Done
I tested that they were now controlled by the ui slider.
