### PR TITLE
Run CI on changes to images or sounds only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     paths:
     - 'source/**'
     - 'data/**'
+    - 'images/**'
+    - 'sounds/**'
     - 'tests/**'
     - '.github/workflows/**'
     - '.github/path-filters.yml'


### PR DESCRIPTION
**CI/CD/Testing**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
A little while ago, we expanded the "test parse" CI job to also check images and sounds for some things. But, the CI jobs won't run if only stuff in the images or sounds folders was changed.
This PR updates the path filter on the CI workflow so that it will run on changes in those folders.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
None.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
