### PR TITLE
fix: Reset the Person database when reloading saves

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -85,6 +85,7 @@ namespace {
 	Set<Shop<Ship>> defaultShipSales;
 	Set<Shop<Outfit>> defaultOutfitSales;
 	Set<Wormhole> defaultWormholes;
+	Set<Person> defaultPersons;
 	TextReplacements defaultSubstitutions;
 
 	Politics politics;
@@ -258,6 +259,7 @@ void GameData::FinishLoading()
 	defaultOutfitSales = objects.outfitSales;
 	defaultSubstitutions = objects.substitutions;
 	defaultWormholes = objects.wormholes;
+	defaultPersons = objects.persons;
 	playerGovernment = objects.governments.Get("Escort");
 
 	politics.Reset();
@@ -432,8 +434,7 @@ void GameData::Revert()
 	objects.outfitSales.Revert(defaultOutfitSales);
 	objects.substitutions.Revert(defaultSubstitutions);
 	objects.wormholes.Revert(defaultWormholes);
-	for(auto &it : objects.persons)
-		it.second.Restore();
+	objects.persons.Revert(defaultPersons);
 
 	politics.Reset();
 	purchases.clear();

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -29,6 +29,7 @@ using namespace std;
 void Person::Load(const DataNode &node, const ConditionsStore *playerConditions,
 	const set<const System *> *visitedSystems, const set<const Planet *> *visitedPlanets)
 {
+	isLoaded = true;
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
@@ -71,6 +72,13 @@ void Person::FinishLoading()
 		if(formationPattern)
 			ship->SetFormationPattern(formationPattern);
 	}
+}
+
+
+
+bool Person::IsLoaded() const
+{
+	return isLoaded;
 }
 
 

--- a/source/Person.h
+++ b/source/Person.h
@@ -38,6 +38,7 @@ public:
 		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets);
 	// Finish loading all the ships in this person specification.
 	void FinishLoading();
+	bool IsLoaded() const;
 	// Prevent this person from being spawned in any system.
 	void NeverSpawn();
 
@@ -64,6 +65,7 @@ public:
 
 
 private:
+	bool isLoaded = false;
 	LocationFilter location;
 	int frequency = 100;
 

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -315,6 +315,10 @@ void UniverseObjects::CheckReferences()
 	for(const auto &it : swizzles)
 		if(!it.second.IsLoaded())
 			Warn("swizzle", it.first);
+	// Persons can be referred to when marking them as destroyed.
+	for(const auto &it : persons)
+		if(!it.second.IsLoaded())
+			Warn("person", it.first);
 }
 
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When you load a save that has some undefined (for example from removed plugins) persons marked as destroyed, they will get added to the persons GameData set, just like any other new data. However, currently the set isn't hard-reset to the default state, but instead the individual persons get restored. This means all undefined persons are added to the set never to be removed (until you relaunch the whole game). If you then load another pilot and save it, the persons will get added there too, since they are still in the set without any ships assigned, which makes IsDestroyed return true.

This PR changes the Restore loop to a full reset of the data, removing the persons that aren't in the default set and automatically resetting the rest to their default state. Additionally, the references to undefined persons are now properly logged.

An alternative would be to just drop any undefined persons when writing out the list into save files, but that would be problematic when you remove a plugin and then add it back, clearing the status.

## Testing Done
yes™.

## Performance Impact
N/A
