### PR TITLE
refactor: Make reverse thrust work properly

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2621,7 +2621,7 @@ void AI::CircleAround(const Ship &ship, Command &command, const Body &target)
 			command |= Command::AFTERBURNER;
 	}
 	else
-		// TODO: This will look goofy for reverse-only ships, as they face the other way when thrusting.
+		// This will look goofy for reverse-only ships, as they face the other way when thrusting.
 		// This can also happen with mixed-thrust ships, so we can't easily fix it.
 		command.SetTurn(TurnToward(ship, direction));
 }

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -372,7 +372,7 @@ namespace {
 
 	// The minimum and maximum weapon range of the ship.
 	// If the ship has no weapons, return {0, inf}.
-	std::pair<double, double> WeaponsRange(const Ship &ship)
+	pair<double, double> WeaponsRange(const Ship &ship)
 	{
 		double minRange = std::numeric_limits<double>::infinity();
 		double maxRange = 0.;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2499,7 +2499,7 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 	}
 	else if(facingAgainstTarget)
 	{
-		double maxSpeed = min(hasCruiseSpeed ? cruiseSpeed : std::numeric_limits<double>::infinity(),
+		double maxSpeed = min(hasCruiseSpeed ? cruiseSpeed : numeric_limits<double>::infinity(),
 			ship.MaxReverseVelocity() * .99);
 		if(!movingTowardsTarget || velocity.Length() < maxSpeed)
 			command |= Command::BACK;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2532,9 +2532,9 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 		return .8 + .2 / (1. + stopTime * stopTime * stopTime * .001);
 	};
 
-	double relativeFacing = acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
-	double finalFacing = direction ? acos(min(1., max(-1., direction.Unit().Dot(-velocity.Unit())))) : 0.;
-	double finalReverseFacing = direction ? acos(min(1., max(-1., direction.Unit().Dot(angle.Unit())))) : 0.;
+	double relativeFacing = acos(clamp(-velocity.Unit().Dot(angle.Unit()), -1., 1.));
+	double finalFacing = direction ? acos(clamp(direction.Unit().Dot(-velocity.Unit()), -1., 1.)) : 0.;
+	double finalReverseFacing = direction ? acos(clamp(direction.Unit().Dot(angle.Unit()), -1., 1.)) : 0.;
 	double turnRate = TO_RAD * ship.TrueTurnRate();
 
 	// How long it takes for a ship to stop, given a facing angle and final angle relative to its velocity.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3504,7 +3504,7 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 		// The average term's value will be v / 2. So:
 		return v * (angle / turn) + .5 * v * v / acceleration;
 	};
-	double relativeFacing = acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
+	double relativeFacing = acos(clamp(-velocity.Unit().Dot(angle.Unit()), -1., 1.));
 	double turnRate = TO_RAD * ship.TrueTurnRate();
 
 	double forwardDistance = stopDistance(v, relativeFacing, ship.TrueAcceleration(), turnRate);

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -374,7 +374,7 @@ namespace {
 	// If the ship has no weapons, return {0, inf}.
 	pair<double, double> WeaponsRange(const Ship &ship)
 	{
-		double minRange = std::numeric_limits<double>::infinity();
+		double minRange = numeric_limits<double>::infinity();
 		double maxRange = 0.;
 		for(const Hardpoint &hardpoint : ship.Weapons())
 			if(hardpoint.GetOutfit() && !hardpoint.IsSpecial())
@@ -2527,7 +2527,7 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 	// This is a fudge factor for how straight you must be facing: it increases
 	// from 0.8 when it will take many frames to stop, to nearly 1 when it will
 	// take less than 1 frame to stop.
-	const auto &limit = [](double stopTime)
+	const auto limit = [](double stopTime)
 	{
 		return .8 + .2 / (1. + stopTime * stopTime * stopTime * .001);
 	};
@@ -2538,7 +2538,7 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 	double turnRate = TO_RAD * ship.TrueTurnRate();
 
 	// How long it takes for a ship to stop, given a facing angle and final angle relative to its velocity.
-	const auto &stoppingTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
+	const auto stoppingTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
 		double finalFacing)
 	{
 		return velocity / acceleration + (abs(facingAngle) + abs(finalFacing)) / turningRate;
@@ -3497,7 +3497,7 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 		v = maxVelocity;
 	}
 
-	const auto &stopDistance = [](double v, double angle, double acceleration, double turn)
+	const auto stopDistance = [](double v, double angle, double acceleration, double turn)
 	{
 		// Sum of: v + (v - a) + (v - 2a) + ... + 0.
 		// The number of terms will be v / a.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -382,7 +382,7 @@ namespace {
 				minRange = min(hardpoint.GetOutfit()->Range(), minRange);
 				maxRange = max(hardpoint.GetOutfit()->Range(), maxRange);
 			}
-		return {min(minRange, maxRange), max(minRange, maxRange)};
+		return minRange < maxRange ? {minRange, maxRange} : {maxRange, minRange};
 	}
 
 	// Constants for the invisible fence timer.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2464,7 +2464,7 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 	double relativeFacing = acos(clamp(wantedAcceleration.Unit().Dot(angle.Unit()), -1., 1.));
 
 	// How long it takes for a ship to match both position and velocity with a given target.
-	const auto &interceptTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
+	const auto interceptTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
 		double distance)
 	{
 		if(!acceleration)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2534,7 +2534,7 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 
 	double relativeFacing = acos(clamp(-velocity.Unit().Dot(angle.Unit()), -1., 1.));
 	double finalFacing = direction ? acos(clamp(direction.Unit().Dot(-velocity.Unit()), -1., 1.)) : 0.;
-	double finalReverseFacing = direction ? acos(clamp(direction.Unit().Dot(angle.Unit()), -1., 1.)) : 0.;
+	double finalReverseFacing = direction ? acos(clamp(direction.Unit().Dot(velocity.Unit()), -1., 1.)) : 0.;
 	double turnRate = TO_RAD * ship.TrueTurnRate();
 
 	// How long it takes for a ship to stop, given a facing angle and final angle relative to its velocity.
@@ -2549,17 +2549,14 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 		finalReverseFacing);
 
 	if(forwardTime < reverseTime)
-	{
 		command.SetTurn(TurnToward(ship, -velocity));
-		if(velocity.Unit().Dot(angle.Unit()) < -limit(forwardTime))
-			command |= Command::FORWARD;
-	}
 	else
-	{
 		command.SetTurn(TurnToward(ship, velocity));
-		if(velocity.Unit().Dot(angle.Unit()) > limit(reverseTime))
-			command |= Command::BACK;
-	}
+	double currentRelFacing = velocity.Unit().Dot(angle.Unit());
+	if(currentRelFacing < -limit(forwardTime))
+		command |= Command::FORWARD;
+	else if(currentRelFacing > limit(reverseTime))
+		command |= Command::BACK;
 	return false;
 }
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -382,7 +382,7 @@ namespace {
 				minRange = min(hardpoint.GetOutfit()->Range(), minRange);
 				maxRange = max(hardpoint.GetOutfit()->Range(), maxRange);
 			}
-		return minRange < maxRange ? {minRange, maxRange} : {maxRange, minRange};
+		return minRange < maxRange ? pair{minRange, maxRange} : pair{maxRange, minRange};
 	}
 
 	// Constants for the invisible fence timer.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2468,7 +2468,7 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 		double distance)
 	{
 		if(!acceleration)
-			return std::numeric_limits<double>::infinity();
+			return numeric_limits<double>::infinity();
 		double timeToTurn = facingAngle / turningRate;
 		// Calculate the intersection time assuming maximum acceleration. This won't be exact, as it ignores the
 		// other body's movement while we are turning, but usually it's close enough.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2850,7 +2850,7 @@ void AI::PickUp(const Ship &ship, Command &command, const Body &target)
 	MoveTo(ship, command, target.Position(), (target.Velocity() + ship.Velocity()) / 2.,
 		ship.Radius(), 100.);
 	if(ship.Position().DistanceSquared(target.Position()) > 600. * 600. &&
-			ship.Facing().Unit().Dot((target.Position() - ship.Position()).Unit()) > 0.9 &&
+			ship.Facing().Unit().Dot((target.Position() - ship.Position()).Unit()) > .9 &&
 			ShouldUseAfterburner(ship))
 		command |= Command::AFTERBURNER;
 }

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -376,7 +376,7 @@ namespace {
 	{
 		double minRange = std::numeric_limits<double>::infinity();
 		double maxRange = 0.;
-		for(const Hardpoint& hardpoint : ship.Weapons())
+		for(const Hardpoint &hardpoint : ship.Weapons())
 			if(hardpoint.GetOutfit() && !hardpoint.IsSpecial())
 			{
 				minRange = min(hardpoint.GetOutfit()->Range(), minRange);
@@ -2464,7 +2464,7 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 	double relativeFacing = acos(clamp(wantedAcceleration.Unit().Dot(angle.Unit()), -1., 1.));
 
 	// How long it takes for a ship to match both position and velocity with a given target.
-	const auto& interceptTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
+	const auto &interceptTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
 		double distance)
 	{
 		if(!acceleration)
@@ -2527,7 +2527,7 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 	// This is a fudge factor for how straight you must be facing: it increases
 	// from 0.8 when it will take many frames to stop, to nearly 1 when it will
 	// take less than 1 frame to stop.
-	const auto& limit = [](double stopTime)
+	const auto &limit = [](double stopTime)
 	{
 		return .8 + .2 / (1. + stopTime * stopTime * stopTime * .001);
 	};
@@ -2538,7 +2538,7 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 	double turnRate = TO_RAD * ship.TrueTurnRate();
 
 	// How long it takes for a ship to stop, given a facing angle and final angle relative to its velocity.
-	const auto& stoppingTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
+	const auto &stoppingTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
 		double finalFacing)
 	{
 		return velocity / acceleration + (abs(facingAngle) + abs(finalFacing)) / turningRate;
@@ -3497,7 +3497,7 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 		v = maxVelocity;
 	}
 
-	const auto& stopDistance = [](double v, double angle, double acceleration, double turn)
+	const auto &stopDistance = [](double v, double angle, double acceleration, double turn)
 	{
 		// Sum of: v + (v - a) + (v - 2a) + ... + 0.
 		// The number of terms will be v / a.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2492,7 +2492,7 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 
 	if(facingTowardsTarget)
 	{
-		double maxSpeed = min(hasCruiseSpeed ? cruiseSpeed : std::numeric_limits<double>::infinity(),
+		double maxSpeed = min(hasCruiseSpeed ? cruiseSpeed : numeric_limits<double>::infinity(),
 			ship.MaxVelocity() * .99);
 		if(!movingTowardsTarget || velocity.Length() < maxSpeed)
 			command |= Command::FORWARD;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2839,7 +2839,7 @@ void AI::MoveToAttack(const Ship &ship, Command &command, const Body &target)
 	MoveTo(ship, command, target.Position(), target.Velocity(), minRange, 10.);
 	if(ship.Position().DistanceSquared(target.Position()) < maxRange * maxRange)
 		AimToAttack(ship, command, target);
-	else if(ship.Facing().Unit().Dot((target.Position() - ship.Position()).Unit()) > 0.9 && ShouldUseAfterburner(ship))
+	else if(ship.Facing().Unit().Dot((target.Position() - ship.Position()).Unit()) > .9 && ShouldUseAfterburner(ship))
 		command |= Command::AFTERBURNER;
 }
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -370,6 +370,21 @@ namespace {
 		return true;
 	}
 
+	// The minimum and maximum weapon range of the ship.
+	// If the ship has no weapons, return {0, inf}.
+	std::pair<double, double> WeaponsRange(const Ship &ship)
+	{
+		double minRange = std::numeric_limits<double>::infinity();
+		double maxRange = 0.;
+		for(const Hardpoint& hardpoint : ship.Weapons())
+			if(hardpoint.GetOutfit() && !hardpoint.IsSpecial())
+			{
+				minRange = min(hardpoint.GetOutfit()->Range(), minRange);
+				maxRange = max(hardpoint.GetOutfit()->Range(), maxRange);
+			}
+		return {min(minRange, maxRange), max(minRange, maxRange)};
+	}
+
 	// Constants for the invisible fence timer.
 	const int FENCE_DECAY = 4;
 	const int FENCE_MAX = 600;
@@ -2443,45 +2458,52 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 	bool shouldReverse = false;
 	dp = targetPosition - StoppingPoint(ship, targetVelocity, shouldReverse);
 
-	// Calculate target vector required to get where we want to be.
-	Point tv = dp;
+	double distance = dp.Length();
+	double turnRate = TO_RAD * ship.TrueTurnRate();
+	Point wantedAcceleration = dp + dv;
+	double relativeFacing = acos(clamp(wantedAcceleration.Unit().Dot(angle.Unit()), -1., 1.));
+
+	// How long it takes for a ship to match both position and velocity with a given target.
+	const auto& interceptTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
+		double distance)
+	{
+		if(!acceleration)
+			return std::numeric_limits<double>::infinity();
+		double timeToTurn = facingAngle / turningRate;
+		// Calculate the intersection time assuming maximum acceleration. This won't be exact, as it ignores the
+		// other body's movement while we are turning, but usually it's close enough.
+		double timeToIntersect = (-velocity + sqrt(velocity * velocity + 2 * acceleration * distance)) / acceleration;
+		return timeToTurn + timeToIntersect;
+	};
+
+	// Approximate intersect time without factoring in maximum velocities
+	double forwardTime = interceptTime(speed, relativeFacing, ship.TrueAcceleration(), turnRate, distance);
+	double reverseTime = interceptTime(speed, PI - relativeFacing, ship.TrueReverseAcceleration(), turnRate, distance);
+
+	bool movingTowardsTarget = velocity.Unit().Dot(wantedAcceleration.Unit()) > .9;
+	bool facingTowardsTarget = angle.Unit().Dot(wantedAcceleration.Unit()) > .9;
+	bool facingAgainstTarget = angle.Unit().Dot(-wantedAcceleration.Unit()) > .9;
 	bool hasCruiseSpeed = (cruiseSpeed > 0.);
-	if(hasCruiseSpeed)
-	{
-		// The ship prefers a velocity at cruise-speed towards the target, so we need
-		// to compare this preferred velocity to the current velocity and apply the
-		// delta to get to the preferred velocity.
-		tv = (dp.Unit() * cruiseSpeed) - velocity;
-		// If we are moving close to our preferred velocity, then face towards the target.
-		if(tv.LengthSquared() < .01)
-			tv = dp;
-	}
 
-	bool isFacing = (tv.Unit().Dot(angle.Unit()) > .95);
-	if(!isClose || (!isFacing && !shouldReverse))
-		command.SetTurn(TurnToward(ship, tv));
+	if(reverseTime < forwardTime)
+		command.SetTurn(TurnToward(ship, -wantedAcceleration));
+	else
+		command.SetTurn(TurnToward(ship, wantedAcceleration));
 
-	// Drag is not applied when not thrusting, so stop thrusting when close to max speed
-	// to save energy. Work with a slightly lower maximum velocity to avoid border cases.
-	// In order for a ship to use their afterburner, they must also have the forward
-	// command active. Therefore, if this ship should use its afterburner, use the
-	// max velocity with afterburner thrust included.
-	double maxVelocity = ship.MaxVelocity(ShouldUseAfterburner(ship)) * .99;
-	if(isFacing && (velocity.LengthSquared() <= maxVelocity * maxVelocity
-			|| dp.Unit().Dot(velocity.Unit()) < .95))
+	if(facingTowardsTarget)
 	{
-		// We set full forward power when we don't have a cruise-speed, when we are below
-		// cruise-speed or when we need to do course corrections.
-		bool movingTowardsTarget = (velocity.Unit().Dot(dp.Unit()) > .95);
-		if(!hasCruiseSpeed || !movingTowardsTarget || velocity.Length() < cruiseSpeed)
+		double maxSpeed = min(hasCruiseSpeed ? cruiseSpeed : std::numeric_limits<double>::infinity(),
+			ship.MaxVelocity() * .99);
+		if(!movingTowardsTarget || velocity.Length() < maxSpeed)
 			command |= Command::FORWARD;
 	}
-	else if(shouldReverse)
+	else if(facingAgainstTarget)
 	{
-		command.SetTurn(TurnToward(ship, velocity));
-		command |= Command::BACK;
+		double maxSpeed = min(hasCruiseSpeed ? cruiseSpeed : std::numeric_limits<double>::infinity(),
+			ship.MaxReverseVelocity() * .99);
+		if(!movingTowardsTarget || velocity.Length() < maxSpeed)
+			command |= Command::BACK;
 	}
-
 	return false;
 }
 
@@ -2505,49 +2527,39 @@ bool AI::Stop(const Ship &ship, Command &command, double maxSpeed, const Point &
 	// This is a fudge factor for how straight you must be facing: it increases
 	// from 0.8 when it will take many frames to stop, to nearly 1 when it will
 	// take less than 1 frame to stop.
-	double stopTime = speed / ship.Acceleration();
-	double limit = .8 + .2 / (1. + stopTime * stopTime * stopTime * .001);
-
-	// If you have a reverse thruster, figure out whether using it is faster
-	// than turning around and using your main thruster.
-	if(ship.Attributes().Get("reverse thrust"))
+	const auto& limit = [](double stopTime)
 	{
-		// Figure out your stopping time using your main engine:
-		double degreesToTurn = TO_DEG * acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
-		double forwardTime = degreesToTurn / ship.TurnRate();
-		forwardTime += stopTime;
+		return .8 + .2 / (1. + stopTime * stopTime * stopTime * .001);
+	};
 
-		// Figure out your reverse thruster stopping time:
-		double reverseTime = (180. - degreesToTurn) / ship.TurnRate();
-		reverseTime += speed / ship.ReverseAcceleration();
+	double relativeFacing = acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
+	double finalFacing = direction ? acos(min(1., max(-1., direction.Unit().Dot(-velocity.Unit())))) : 0.;
+	double finalReverseFacing = direction ? acos(min(1., max(-1., direction.Unit().Dot(angle.Unit())))) : 0.;
+	double turnRate = TO_RAD * ship.TrueTurnRate();
 
-		// If you want to end up facing a specific direction, add the extra turning time.
-		if(direction)
-		{
-			// Time to turn from facing backwards to target:
-			double degreesFromBackwards = TO_DEG * acos(min(1., max(-1., direction.Unit().Dot(-velocity.Unit()))));
-			double turnFromBackwardsTime = degreesFromBackwards / ship.TurnRate();
-			forwardTime += turnFromBackwardsTime;
+	// How long it takes for a ship to stop, given a facing angle and final angle relative to its velocity.
+	const auto& stoppingTime = [](double velocity, double facingAngle, double acceleration, double turningRate,
+		double finalFacing)
+	{
+		return velocity / acceleration + (abs(facingAngle) + abs(finalFacing)) / turningRate;
+	};
 
-			// Time to turn from facing forwards to target:
-			double degreesFromForward = TO_DEG * acos(min(1., max(-1., direction.Unit().Dot(angle.Unit()))));
-			double turnFromForwardTime = degreesFromForward / ship.TurnRate();
-			reverseTime += turnFromForwardTime;
-		}
+	double forwardTime = stoppingTime(speed, relativeFacing, ship.TrueAcceleration(), turnRate, finalFacing);
+	double reverseTime = stoppingTime(speed, PI - relativeFacing, ship.TrueReverseAcceleration(), turnRate,
+		finalReverseFacing);
 
-		if(reverseTime < forwardTime)
-		{
-			command.SetTurn(TurnToward(ship, velocity));
-			if(velocity.Unit().Dot(angle.Unit()) > limit)
-				command |= Command::BACK;
-			return false;
-		}
+	if(forwardTime < reverseTime)
+	{
+		command.SetTurn(TurnToward(ship, -velocity));
+		if(velocity.Unit().Dot(angle.Unit()) < -limit(forwardTime))
+			command |= Command::FORWARD;
 	}
-
-	command.SetTurn(TurnBackward(ship));
-	if(velocity.Unit().Dot(angle.Unit()) < -limit)
-		command |= Command::FORWARD;
-
+	else
+	{
+		command.SetTurn(TurnToward(ship, velocity));
+		if(velocity.Unit().Dot(angle.Unit()) > limit(reverseTime))
+			command |= Command::BACK;
+	}
 	return false;
 }
 
@@ -2582,27 +2594,11 @@ void AI::PrepareForHyperspace(const Ship &ship, Command &command)
 		if(fabs(deviation) > scramThreshold)
 		{
 			// Need to maneuver; not ready to jump
-			if((ship.Facing().Unit().Dot(normal) < 0) == (deviation < 0))
-				// Thrusting from this angle is counterproductive
-				direction = -deviation * normal;
-			else
-			{
-				command |= Command::FORWARD;
-
-				// How much correction will be applied to deviation by thrusting
-				// as I turn back toward the jump direction.
-				double turnRateRadians = ship.TurnRate() * TO_RAD;
-				double cos = ship.Facing().Unit().Dot(direction);
-				// integral(t*sin(r*x), angle/r, 0) = t/r * (1 - cos(angle)), so:
-				double correctionWhileTurning = fabs(1 - cos) * ship.Acceleration() / turnRateRadians;
-				// (Note that this will always underestimate because thrust happens before turn)
-
-				if(fabs(deviation) - correctionWhileTurning > scramThreshold)
-					// Want to thrust from an even sharper angle
-					direction = -deviation * normal;
-			}
+			Point goodVelocity = direction * max(ship.Velocity().Unit().Dot(direction), 0.);
+			MoveTo(ship, command, ship.Position() + goodVelocity, goodVelocity, 1., .1);
 		}
-		command.SetTurn(TurnToward(ship, direction));
+		else
+			command.SetTurn(TurnToward(ship, direction));
 	}
 	// If we're a jump drive, just stop.
 	else if(isJump)
@@ -2617,17 +2613,17 @@ void AI::PrepareForHyperspace(const Ship &ship, Command &command)
 void AI::CircleAround(const Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
-	command.SetTurn(TurnToward(ship, direction));
-
 	double length = direction.Length();
-	if(length > 200. && ship.Facing().Unit().Dot(direction) >= 0.)
+	if(length > 200.)
 	{
-		command |= Command::FORWARD;
-
-		// If the ship is far away enough the ship should use the afterburner.
-		if(length > 750. && ShouldUseAfterburner(ship))
+		MoveTo(ship, command, direction.Unit() * 200. + ship.Position(), target.Velocity(), 1., .1);
+		if(length > 750. && ShouldUseAfterburner(ship) && ship.Facing().Unit().Dot(direction) > 0.)
 			command |= Command::AFTERBURNER;
 	}
+	else
+		// TODO: This will look goofy for reverse-only ships, as they face the other way when thrusting.
+		// This can also happen with mixed-thrust ships, so we can't easily fix it.
+		command.SetTurn(TurnToward(ship, direction));
 }
 
 
@@ -2635,7 +2631,7 @@ void AI::CircleAround(const Ship &ship, Command &command, const Body &target)
 void AI::Swarm(const Ship &ship, Command &command, const Body &target)
 {
 	Point direction = target.Position() - ship.Position();
-	double maxSpeed = ship.MaxVelocity();
+	double maxSpeed = max(ship.MaxVelocity(), ship.MaxReverseVelocity());
 	double rendezvousTime = RendezvousTime(direction, target.Velocity(), maxSpeed);
 	if(std::isnan(rendezvousTime) || rendezvousTime > 600.)
 		rendezvousTime = 600.;
@@ -2656,9 +2652,12 @@ void AI::KeepStation(const Ship &ship, Command &command, const Body &target)
 	static const double THRUST_DEADBAND = .5;
 
 	// Current properties of the two ships:
-	double maxV = ship.MaxVelocity();
-	double accel = ship.Acceleration();
-	double turn = ship.TurnRate();
+	double forwardV = ship.MaxVelocity();
+	double reverseV = ship.MaxReverseVelocity();
+	bool useReverse = reverseV > forwardV;
+	double maxV = max(forwardV, reverseV);
+	double accel = useReverse ? ship.TrueReverseAcceleration() : ship.TrueAcceleration();
+	double turn = ship.TrueTurnRate();
 	double mass = ship.InertialMass();
 	Point unit = ship.Facing().Unit();
 	double currentAngle = ship.Facing().Degrees();
@@ -2700,6 +2699,8 @@ void AI::KeepStation(const Ship &ship, Command &command, const Body &target)
 	Point facingGoal = rendezvous.Unit() * positionWeight
 		+ velocityDelta.Unit() * velocityWeight
 		+ target.Facing().Unit() * facingWeight;
+	if(useReverse)
+		facingGoal = -facingGoal;
 	double targetAngle = Angle(facingGoal).Degrees() - currentAngle;
 	if(abs(targetAngle) > 180.)
 		targetAngle += (targetAngle < 0. ? 360. : -360.);
@@ -2786,7 +2787,7 @@ void AI::Attack(const Ship &ship, Command &command, const Ship &target)
 		bool useReverse = reverseSpeed && (reverseSpeed >= min(target.MaxVelocity(), ship.MaxVelocity())
 				|| target.Velocity().Dot(-direction.Unit()) <= reverseSpeed);
 		slowdownDistance = approachSpeed * approachSpeed / (useReverse ?
-			ship.ReverseAcceleration() : (ship.Acceleration() + 160. / ship.TurnRate())) / 2.;
+			ship.TrueReverseAcceleration() : (ship.TrueAcceleration() + 160. / ship.TrueTurnRate())) / 2.;
 
 		// If we're too close, run away.
 		if(direction.Length() <
@@ -2834,64 +2835,24 @@ void AI::AimToAttack(const Ship &ship, Command &command, const Body &target)
 
 void AI::MoveToAttack(const Ship &ship, Command &command, const Body &target)
 {
-	Point direction = target.Position() - ship.Position();
-
-	// First of all, aim in the direction that will hit this target.
-	AimToAttack(ship, command, target);
-
-	// Calculate this ship's "turning radius"; that is, the smallest circle it
-	// can make while at its current speed.
-	double stepsInFullTurn = 360. / ship.TurnRate();
-	double circumference = stepsInFullTurn * ship.Velocity().Length();
-	double diameter = max(200., circumference / PI);
-
-	const auto facing = ship.Facing().Unit().Dot(direction.Unit());
-	// If the ship has reverse thrusters and the target is behind it, we can
-	// use them to reach the target more quickly.
-	if(facing < -.75 && ship.Attributes().Get("reverse thrust"))
-		command |= Command::BACK;
-	// Only apply thrust if either:
-	// This ship is within 90 degrees of facing towards its target and far enough away not to overshoot
-	// if it accelerates while needing to turn further, or:
-	// This ship is moving away from its target but facing mostly towards it.
-	else if((facing >= 0. && direction.Length() > diameter)
-			|| (ship.Velocity().Dot(direction) < 0. && facing >= .9))
-	{
-		command |= Command::FORWARD;
-		// Use afterburner, if applicable.
-		if(direction.Length() > 600. && ShouldUseAfterburner(ship))
-			command |= Command::AFTERBURNER;
-	}
+	const auto [minRange, maxRange] = WeaponsRange(ship);
+	MoveTo(ship, command, target.Position(), target.Velocity(), minRange, 10.);
+	if(ship.Position().DistanceSquared(target.Position()) < maxRange * maxRange)
+		AimToAttack(ship, command, target);
+	else if(ship.Facing().Unit().Dot((target.Position() - ship.Position()).Unit()) > 0.9 && ShouldUseAfterburner(ship))
+		command |= Command::AFTERBURNER;
 }
 
 
 
 void AI::PickUp(const Ship &ship, Command &command, const Body &target)
 {
-	// Figure out the target's velocity relative to the ship.
-	Point p = target.Position() - ship.Position();
-	Point v = target.Velocity() - ship.Velocity();
-	double vMax = ship.MaxVelocity();
-
-	// Estimate where the target will be by the time we reach it.
-	double time = RendezvousTime(p, v, vMax);
-	if(std::isnan(time))
-		time = p.Length() / vMax;
-	double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
-	time += degreesToTurn / ship.TurnRate();
-	p += v * time;
-
-	// Move toward the target.
-	command.SetTurn(TurnToward(ship, p));
-	double dp = p.Unit().Dot(ship.Facing().Unit());
-	if(dp > .7)
-		command |= Command::FORWARD;
-
-	// Use the afterburner if it will not cause you to miss your target.
-	double squareDistance = p.LengthSquared();
-	if(command.Has(Command::FORWARD) && ShouldUseAfterburner(ship))
-		if(dp > max(.9, min(.9999, 1. - squareDistance / 10000000.)))
-			command |= Command::AFTERBURNER;
+	MoveTo(ship, command, target.Position(), (target.Velocity() + ship.Velocity()) / 2.,
+		ship.Radius(), 100.);
+	if(ship.Position().DistanceSquared(target.Position()) > 600. * 600. &&
+			ship.Facing().Unit().Dot((target.Position() - ship.Position()).Unit()) > 0.9 &&
+			ShouldUseAfterburner(ship))
+		command |= Command::AFTERBURNER;
 }
 
 
@@ -3197,6 +3158,8 @@ void AI::DoMining(Ship &ship, Command &command)
 	command.SetTurn(TurnToward(ship, heading));
 	if(ship.Velocity().Dot(heading.Unit()) < .7 * ship.MaxVelocity())
 		command |= Command::FORWARD;
+	else if(ship.Velocity().Dot(-heading.Unit()) < .7 * ship.MaxReverseVelocity())
+		command |= Command::BACK;
 }
 
 
@@ -3235,13 +3198,15 @@ bool AI::DoHarvesting(Ship &ship, Command &command) const
 
 			// Estimate how long it would take to intercept this flotsam.
 			Point v = it->Velocity() - ship.Velocity();
-			double vMax = ship.MaxVelocity();
+			double vMax = max(ship.MaxVelocity(), ship.MaxReverseVelocity());
 			double time = RendezvousTime(p, v, vMax);
 			if(std::isnan(time))
 				continue;
 
 			double degreesToTurn = TO_DEG * acos(min(1., max(-1., p.Unit().Dot(ship.Facing().Unit()))));
-			time += degreesToTurn / ship.TurnRate();
+			if(ship.MaxReverseVelocity() > ship.MaxVelocity())
+				degreesToTurn = 180. - degreesToTurn;
+			time += degreesToTurn / ship.TrueTurnRate();
 			if(time < bestTime)
 			{
 				bestTime = time;
@@ -3438,7 +3403,7 @@ void AI::DoScatter(const Ship &ship, Command &command) const
 
 	double flip = command.Has(Command::BACK) ? -1 : 1;
 	double turnRate = ship.TurnRate();
-	double acceleration = ship.Acceleration();
+	double acceleration = flip ? ship.TrueReverseAcceleration() : ship.TrueAcceleration();
 	// TODO: If there are many ships, use CollisionSet::Circle or another
 	// suitable method to limit which ships are checked.
 	for(const shared_ptr<Ship> &other : ships)
@@ -3452,13 +3417,15 @@ void AI::DoScatter(const Ship &ship, Command &command) const
 		Point offset = other->Position() - ship.Position();
 		if(offset.LengthSquared() > 400.)
 			continue;
-		if(fabs(other->TurnRate() / turnRate - 1.) > .05)
+		if(fabs(other->TrueTurnRate() / turnRate - 1.) > .05)
 			continue;
-		if(fabs(other->Acceleration() / acceleration - 1.) > .05)
+
+		double otherFlip = other->Commands().Has(Command::BACK) ? -1 : 1;
+		if(fabs((otherFlip < 0 ? other->TrueReverseAcceleration() : other->ReverseAcceleration()) / acceleration - 1.) > .05)
 			continue;
 
 		// We are too close to this ship. Turn away from it if we aren't already facing away.
-		if(fabs(other->Facing().Unit().Dot(ship.Facing().Unit())) > 0.99) // 0.99 => 8 degrees
+		if(fabs((other->Facing().Unit() * otherFlip).Dot(flip * ship.Facing().Unit())) > 0.99) // 0.99 => 8 degrees
 			command.SetTurn(flip * offset.Cross(ship.Facing().Unit()) > 0. ? 1. : -1.);
 		return;
 	}
@@ -3512,8 +3479,6 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 	Point position = ship.Position();
 	Point velocity = ship.Velocity() - targetVelocity;
 	Angle angle = ship.Facing();
-	double acceleration = ship.CrewAcceleration();
-	double turnRate = ship.CrewTurnRate();
 	shouldReverse = false;
 
 	// If I were to turn around and stop now the relative movement, where would that put me?
@@ -3532,29 +3497,21 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 		v = maxVelocity;
 	}
 
-	// This assumes you're facing exactly the wrong way.
-	double degreesToTurn = TO_DEG * acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
-	double stopDistance = v * (degreesToTurn / turnRate);
-	// Sum of: v + (v - a) + (v - 2a) + ... + 0.
-	// The number of terms will be v / a.
-	// The average term's value will be v / 2. So:
-	stopDistance += .5 * v * v / acceleration;
-
-	if(ship.Attributes().Get("reverse thrust"))
+	const auto& stopDistance = [](double v, double angle, double acceleration, double turn)
 	{
-		// Figure out your reverse thruster stopping distance:
-		double reverseAcceleration = ship.Attributes().Get("reverse thrust") / ship.InertialMass();
-		double reverseDistance = v * (180. - degreesToTurn) / turnRate;
-		reverseDistance += .5 * v * v / reverseAcceleration;
+		// Sum of: v + (v - a) + (v - 2a) + ... + 0.
+		// The number of terms will be v / a.
+		// The average term's value will be v / 2. So:
+		return v * (angle / turn) + .5 * v * v / acceleration;
+	};
+	double relativeFacing = acos(min(1., max(-1., -velocity.Unit().Dot(angle.Unit()))));
+	double turnRate = TO_RAD * ship.TrueTurnRate();
 
-		if(reverseDistance < stopDistance)
-		{
-			shouldReverse = true;
-			stopDistance = reverseDistance;
-		}
-	}
+	double forwardDistance = stopDistance(v, relativeFacing, ship.TrueAcceleration(), turnRate);
+	double reverseDistance = stopDistance(v, PI - relativeFacing, ship.TrueReverseAcceleration(), turnRate);
 
-	return position + stopDistance * velocity.Unit();
+	shouldReverse = reverseDistance < forwardDistance;
+	return position + min(reverseDistance, forwardDistance) * velocity.Unit();
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3119,15 +3119,10 @@ double Ship::TurnRate() const
 
 double Ship::TrueTurnRate() const
 {
-	return TurnRate() * 1. / (1. + slowness * .05);
-}
-
-
-
-double Ship::CrewTurnRate() const
-{
 	// If RequiredCrew() is 0, the ratio is either inf or nan, which should return 1.
-	return TurnRate() * min(1., static_cast<double>(Crew()) / RequiredCrew());
+	double crewMultiplier = min(1., static_cast<double>(Crew()) / RequiredCrew());
+	double slownessMultiplier = 1. / (1. + slowness * .05);
+	return TurnRate() * crewMultiplier * slownessMultiplier;
 }
 
 
@@ -3143,15 +3138,10 @@ double Ship::Acceleration() const
 
 double Ship::TrueAcceleration() const
 {
-	return Acceleration() * 1. / (1. + slowness * .05);
-}
-
-
-
-double Ship::CrewAcceleration() const
-{
 	// If RequiredCrew() is 0, the ratio is either inf or nan, which should return 1.
-	return Acceleration() * min(1., static_cast<double>(Crew()) / RequiredCrew());
+	double crewMultiplier = min(1., static_cast<double>(Crew()) / RequiredCrew());
+	double slownessMultiplier = 1. / (1. + slowness * .05);
+	return Acceleration() * crewMultiplier * slownessMultiplier;
 }
 
 
@@ -3172,6 +3162,16 @@ double Ship::ReverseAcceleration() const
 {
 	return attributes.Get("reverse thrust") / InertialMass()
 		* (1. + attributes.Get("acceleration multiplier"));
+}
+
+
+
+double Ship::TrueReverseAcceleration() const
+{
+	// If RequiredCrew() is 0, the ratio is either inf or nan, which should return 1.
+	double crewMultiplier = min(1., static_cast<double>(Crew()) / RequiredCrew());
+	double slownessMultiplier = 1. / (1. + slowness * .05);
+	return ReverseAcceleration() * crewMultiplier * slownessMultiplier;
 }
 
 
@@ -4996,11 +4996,11 @@ void Ship::StepTargeting()
 
 			// Check if the ship will still be pointing to the same side of the target
 			// angle if it turns by this amount.
-			facing += TurnRate() * turn;
+			facing += TrueTurnRate() * turn;
 			bool stillLeft = target->Unit().Cross(facing.Unit()) < 0.;
 			if(left != stillLeft)
 				turn = 0.;
-			angle += TurnRate() * turn;
+			angle += TrueTurnRate() * turn;
 
 			velocity += dv.Unit() * .1;
 			position += dp.Unit() * .5;

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -425,13 +425,11 @@ public:
 	double MaxVelocity(bool withAfterburner = false) const;
 	double ReverseAcceleration() const;
 	double MaxReverseVelocity() const;
-	// These two values are the ship's current maximum acceleration and turn rate, accounting for the effects of slow.
+	// These values are the ship's current maximum acceleration and turn rate,
+	// accounting for factors such as slowing and crew count.
 	double TrueAcceleration() const;
 	double TrueTurnRate() const;
-	// These two values are the ship's effective maximum acceleration and turn rate,
-	// accounting for the effects of insufficient crew.
-	double CrewAcceleration() const;
-	double CrewTurnRate() const;
+	double TrueReverseAcceleration() const;
 	// The ship's current speed right now
 	double CurrentSpeed() const;
 


### PR DESCRIPTION
**Refactor**

This PR addresses the bug described in issue #7577, #6667 and #6604. (closes #7577, closes #6667, closes #6604)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In most cases, this PR makes forward and reverse thrusters work the same way, without special handling. It also makes use of the True... values to better account for crew or slowing-related effects for navigation.

In most cases, reverse thruster support can be achieved by simply decomposing the "what to do" problem into two independent sub-problems: "is forward or reverse better in the long run", and "is forward or reverse useful right now". We adjust the facing angle based on the preferred long-term thruster, and set the current thrust based on the current facing. If a ship has both forward and reverse thrusters, this usually makes it behave even nicer than before; and with only one set of thrusters, they will be used properly regardless of the way they are facing.

- `MoveTo()` now works with reverse thrusters.
- `Stop()` now works with reverse thrusters.
- The scram drive alignment now uses `MoveTo()` with custom vectors.
  - It takes the aligned part of the velocity vector, and uses that to create a "wanted" position and velocity each frame that the ship should move towards. This bleeds off the excess velocity really quickly, and is a massive upgrade for any ship with a reverse thruster, as it no longer has to turn around.
- `CircleAround()` now uses `MoveTo()`.
- `Swarm()` now checks the maximum forward _or reverse_ velocity.
- `KeepStation()` now works with reverse thrusters.
- `MoveToAttack()` now uses `MoveTo()`.
- `PickUp()` now uses `MoveTo()`.
- `DoHarvesting()` now checks the maximum forward _or reverse_ velocity.
- `DoScatter()` now checks whether the two ships use forward or reverse thrusters.
- `StoppingPoint()` now works with reverse thrusters.

Some of these look a bit goofy with reverse thrusters; for instance, `CircleAround()` has the ship reversing towards the center, but makes it turn around when it's getting close (as it's intended to face the target).

Overall, we ended up with more features and less code.

## Usage examples
Reverse thrusters go rrrrrrrrB.

## Testing Done
Most functions were tested individually, by goofing around with ships. Some of them were tested in generic gameplay.

## Save File
This save file can be used to test these changes: [Omnis Omnis.txt](https://github.com/user-attachments/files/21975497/Omnis.Omnis.txt)

## Performance Impact
More attribute checks and a bit more maths, but shouldn't be major.