### PR TITLE
style(code): EsUuid cleanup and style fixes

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -355,6 +355,7 @@ target_sources(EndlessSkyLib PRIVATE
 	comparators/ByGivenOrder.h
 	comparators/ByName.h
 	comparators/BySeriesAndIndex.h
+	comparators/UUIDComparator.h
 	orders/OrderSet.cpp
 	orders/OrderSet.h
 	orders/OrderSingle.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -355,7 +355,7 @@ target_sources(EndlessSkyLib PRIVATE
 	comparators/ByGivenOrder.h
 	comparators/ByName.h
 	comparators/BySeriesAndIndex.h
-	comparators/UUIDComparator.h
+	comparators/ByUUID.h
 	orders/OrderSet.cpp
 	orders/OrderSet.h
 	orders/OrderSingle.cpp

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -16,14 +16,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "EsUuid.h"
 
 #include "Logger.h"
-#if defined(_WIN32)
+#ifdef _WIN32
 #include "text/Utf8.h"
 #endif
 
 
 #include <stdexcept>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #define STRICT
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -35,7 +35,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 namespace es_uuid {
 namespace detail {
-#if defined(_WIN32)
+#ifdef _WIN32
 // Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
 EsUuid::UuidType MakeUuid()
 {

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -90,7 +90,7 @@ namespace {
 	string Serialize(const UUID &id)
 	{
 		wchar_t *buf = nullptr;
-		RPC_STATUS status = UuidToStringW(const_cast<UUID *>(&id), reinterpret_cast<RPC_WSTR *>(&buf));
+		RPC_STATUS status = UuidToStringW(&id, reinterpret_cast<RPC_WSTR *>(&buf));
 
 		string result = (status == RPC_S_OK) ? Utf8::ToUTF8(buf) : string{};
 		if(result.empty())

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -30,8 +30,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 
-namespace es_uuid {
-namespace detail {
+namespace {
 #ifdef _WIN32
 // Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
 EsUuid::UuidType MakeUuid()
@@ -128,8 +127,6 @@ signed int Compare(const EsUuid::UuidType &a, const EsUuid::UuidType &b) noexcep
 }
 #endif
 }
-}
-using namespace es_uuid::detail;
 
 
 

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -131,7 +131,7 @@ EsUuid EsUuid::FromString(const std::string &input)
 
 
 // Explicitly copy the value of the other UUID.
-void EsUuid::clone(const EsUuid &other)
+void EsUuid::Clone(const EsUuid &other)
 {
 	value = other.Value();
 }

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -30,8 +30,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
-
-
 namespace {
 #ifndef _WIN32
 	constexpr size_t UUID_BUFFER_LENGTH = 37;

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -32,99 +32,99 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 namespace {
 #ifdef _WIN32
-// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
-EsUuid::UuidType MakeUuid()
-{
-	EsUuid::UuidType value;
-	RPC_STATUS status = UuidCreate(&value.id);
-	if(status == RPC_S_UUID_LOCAL_ONLY)
-		Logger::LogError("Created locally unique UUID only");
-	else if(status == RPC_S_UUID_NO_ADDRESS)
-		throw std::runtime_error("Failed to create UUID");
+	// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
+	EsUuid::UuidType MakeUuid()
+	{
+		EsUuid::UuidType value;
+		RPC_STATUS status = UuidCreate(&value.id);
+		if(status == RPC_S_UUID_LOCAL_ONLY)
+			Logger::LogError("Created locally unique UUID only");
+		else if(status == RPC_S_UUID_NO_ADDRESS)
+			throw std::runtime_error("Failed to create UUID");
 
-	return value;
-}
+		return value;
+	}
 
-EsUuid::UuidType ParseUuid(const std::string &str)
-{
-	EsUuid::UuidType value;
-	auto data = Utf8::ToUTF16(str, false);
-	RPC_STATUS status = UuidFromStringW(reinterpret_cast<RPC_WSTR>(&data[0]), &value.id);
-	if(status == RPC_S_INVALID_STRING_UUID)
-		throw std::invalid_argument("Cannot convert \"" + str + "\" into a UUID");
-	else if(status != RPC_S_OK)
-		throw std::runtime_error("Fatal error parsing \"" + str + "\" as a UUID");
+	EsUuid::UuidType ParseUuid(const std::string &str)
+	{
+		EsUuid::UuidType value;
+		auto data = Utf8::ToUTF16(str, false);
+		RPC_STATUS status = UuidFromStringW(reinterpret_cast<RPC_WSTR>(&data[0]), &value.id);
+		if(status == RPC_S_INVALID_STRING_UUID)
+			throw std::invalid_argument("Cannot convert \"" + str + "\" into a UUID");
+		else if(status != RPC_S_OK)
+			throw std::runtime_error("Fatal error parsing \"" + str + "\" as a UUID");
 
-	return value;
-}
+		return value;
+	}
 
-bool IsNil(const UUID &id) noexcept
-{
-	RPC_STATUS status;
-	return UuidIsNil(const_cast<UUID *>(&id), &status);
-}
+	bool IsNil(const UUID &id) noexcept
+	{
+		RPC_STATUS status;
+		return UuidIsNil(const_cast<UUID *>(&id), &status);
+	}
 
-std::string Serialize(const UUID &id)
-{
-	wchar_t *buf = nullptr;
-	RPC_STATUS status = UuidToStringW(const_cast<UUID *>(&id), reinterpret_cast<RPC_WSTR *>(&buf));
+	std::string Serialize(const UUID &id)
+	{
+		wchar_t *buf = nullptr;
+		RPC_STATUS status = UuidToStringW(const_cast<UUID *>(&id), reinterpret_cast<RPC_WSTR *>(&buf));
 
-	std::string result = (status == RPC_S_OK) ? Utf8::ToUTF8(buf) : "";
-	if(result.empty())
-		Logger::LogError("Failed to serialize UUID!");
-	else
-		RpcStringFreeW(reinterpret_cast<RPC_WSTR *>(&buf));
+		std::string result = (status == RPC_S_OK) ? Utf8::ToUTF8(buf) : "";
+		if(result.empty())
+			Logger::LogError("Failed to serialize UUID!");
+		else
+			RpcStringFreeW(reinterpret_cast<RPC_WSTR *>(&buf));
 
-	return result;
-}
+		return result;
+	}
 
-signed int Compare(const EsUuid::UuidType &a, const EsUuid::UuidType &b)
-{
-	RPC_STATUS status;
-	auto result = UuidCompare(const_cast<UUID *>(&a.id), const_cast<UUID *>(&b.id), &status);
-	if(status != RPC_S_OK)
-		throw std::runtime_error("Fatal error comparing UUIDs \"" + Serialize(a.id) + "\" and \"" + Serialize(b.id) + "\"");
-	return result;
-}
+	signed int Compare(const EsUuid::UuidType &a, const EsUuid::UuidType &b)
+	{
+		RPC_STATUS status;
+		auto result = UuidCompare(const_cast<UUID *>(&a.id), const_cast<UUID *>(&b.id), &status);
+		if(status != RPC_S_OK)
+			throw std::runtime_error("Fatal error comparing UUIDs \"" + Serialize(a.id) + "\" and \"" + Serialize(b.id) + "\"");
+		return result;
+	}
 #else
-constexpr std::size_t UUID_BUFFER_LENGTH = 37;
+	constexpr std::size_t UUID_BUFFER_LENGTH = 37;
 
-// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
-EsUuid::UuidType MakeUuid()
-{
-	EsUuid::UuidType value;
-	uuid_generate_random(value.id);
-	return value;
-}
+	// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
+	EsUuid::UuidType MakeUuid()
+	{
+		EsUuid::UuidType value;
+		uuid_generate_random(value.id);
+		return value;
+	}
 
-EsUuid::UuidType ParseUuid(const std::string &str)
-{
-	EsUuid::UuidType value;
-	auto result = uuid_parse(str.data(), value.id);
-	if(result == -1)
-		throw std::invalid_argument("Cannot convert \"" + str + "\" into a UUID");
-	else if(result != 0)
-		throw std::runtime_error("Fatal error parsing \"" + str + "\" as a UUID");
+	EsUuid::UuidType ParseUuid(const std::string &str)
+	{
+		EsUuid::UuidType value;
+		auto result = uuid_parse(str.data(), value.id);
+		if(result == -1)
+			throw std::invalid_argument("Cannot convert \"" + str + "\" into a UUID");
+		else if(result != 0)
+			throw std::runtime_error("Fatal error parsing \"" + str + "\" as a UUID");
 
-	return value;
-}
+		return value;
+	}
 
-bool IsNil(const uuid_t &id) noexcept
-{
-	return uuid_is_null(id) == 1;
-}
+	bool IsNil(const uuid_t &id) noexcept
+	{
+		return uuid_is_null(id) == 1;
+	}
 
-std::string Serialize(const uuid_t &id)
-{
-	char buf[UUID_BUFFER_LENGTH];
-	uuid_unparse_lower(id, buf);
-	return std::string(buf);
-}
+	std::string Serialize(const uuid_t &id)
+	{
+		char buf[UUID_BUFFER_LENGTH];
+		uuid_unparse_lower(id, buf);
+		return std::string(buf);
+	}
 
-signed int Compare(const EsUuid::UuidType &a, const EsUuid::UuidType &b) noexcept
-{
-	return uuid_compare(a.id, b.id);
-}
+	signed int Compare(const EsUuid::UuidType &a, const EsUuid::UuidType &b) noexcept
+	{
+		return uuid_compare(a.id, b.id);
+	}
 #endif
 }
 

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -37,22 +37,6 @@ namespace {
 	constexpr size_t UUID_BUFFER_LENGTH = 37;
 #endif
 
-	// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
-	EsUuid::UuidType MakeUuid()
-	{
-		EsUuid::UuidType value;
-#ifdef _WIN32
-		RPC_STATUS status = UuidCreate(&value.id);
-		if(status == RPC_S_UUID_LOCAL_ONLY)
-			Logger::LogError("Created locally unique UUID only");
-		else if(status == RPC_S_UUID_NO_ADDRESS)
-			throw runtime_error("Failed to create UUID");
-#else
-		uuid_generate_random(value.id);
-#endif
-		return value;
-	}
-
 	EsUuid::UuidType ParseUuid(const string &str)
 	{
 		EsUuid::UuidType value;
@@ -121,6 +105,24 @@ namespace {
 		return uuid_compare(a.id, b.id);
 #endif
 	}
+}
+
+
+
+// Get a version 4 (random) Universally Unique Identifier (see IETF RFC 4122).
+EsUuid::UuidType EsUuid::MakeUuid()
+{
+	EsUuid::UuidType value;
+#ifdef _WIN32
+	RPC_STATUS status = UuidCreate(&value.id);
+	if(status == RPC_S_UUID_LOCAL_ONLY)
+		Logger::LogError("Created locally unique UUID only");
+	else if(status == RPC_S_UUID_NO_ADDRESS)
+		throw runtime_error("Failed to create UUID");
+#else
+	uuid_generate_random(value.id);
+#endif
+	return value;
 }
 
 

--- a/source/EsUuid.cpp
+++ b/source/EsUuid.cpp
@@ -18,18 +18,15 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Logger.h"
 #ifdef _WIN32
 #include "text/Utf8.h"
-#endif
 
-
-#include <stdexcept>
-
-#ifdef _WIN32
 #define STRICT
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #else
 #include <uuid/uuid.h>
 #endif
+
+#include <stdexcept>
 
 
 

--- a/source/EsUuid.h
+++ b/source/EsUuid.h
@@ -23,7 +23,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <uuid/uuid.h>
 #endif
 
-#include <memory>
 #include <string>
 
 
@@ -83,23 +82,4 @@ private:
 
 private:
 	mutable UuidType value;
-};
-
-
-
-template <class T>
-struct UUIDComparator {
-	// Comparator for collections of shared_ptr<T>
-	bool operator() (const std::shared_ptr<T> &a, const std::shared_ptr<T> &b) const noexcept(false)
-	{
-		return a->UUID() < b->UUID();
-	}
-
-	// Comparator for collections of T*, e.g. set<T *>
-	bool operator()(const T *a, const T *b) const noexcept(false)
-	{
-		return a->UUID() < b->UUID();
-	}
-	// No comparator for collections of T, as std containers generally perform copy operations
-	// and copying this class will eventually be disabled.
 };

--- a/source/EsUuid.h
+++ b/source/EsUuid.h
@@ -68,7 +68,7 @@ public:
 	bool operator<(const EsUuid &other) const noexcept(false);
 
 	// Explicitly clone this UUID.
-	void clone(const EsUuid &other);
+	void Clone(const EsUuid &other);
 
 	// Get a string representation of this ID, e.g. for serialization.
 	std::string ToString() const noexcept(false);

--- a/source/EsUuid.h
+++ b/source/EsUuid.h
@@ -15,9 +15,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include <memory>
-#include <string>
-
 #ifdef _WIN32
 // Don't include <windows.h>, which will shadow our Rectangle class.
 #define RPC_NO_WINDOWS_H
@@ -25,6 +22,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #else
 #include <uuid/uuid.h>
 #endif
+
+#include <memory>
+#include <string>
 
 
 

--- a/source/EsUuid.h
+++ b/source/EsUuid.h
@@ -48,7 +48,11 @@ public:
 
 
 public:
+	static UuidType MakeUuid();
 	static EsUuid FromString(const std::string &input);
+
+
+public:
 	EsUuid() noexcept = default;
 	~EsUuid() noexcept = default;
 	// Copying a UUID does not copy its value. (This allows us to use simple copy operations on stock

--- a/source/EsUuid.h
+++ b/source/EsUuid.h
@@ -18,7 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <string>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 // Don't include <windows.h>, which will shadow our Rectangle class.
 #define RPC_NO_WINDOWS_H
 #include <rpc.h>

--- a/source/EsUuid.h
+++ b/source/EsUuid.h
@@ -38,7 +38,7 @@ public:
 		UuidType &operator=(UuidType &&) = default;
 		~UuidType() = default;
 		UuidType &operator=(const UuidType &other) { return *this = UuidType(other); }
-#if defined(_WIN32)
+#ifdef _WIN32
 		UuidType(const UuidType &other) = default;
 		UUID id = {};
 #else

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1186,7 +1186,7 @@ const Ship *PlayerInfo::GiftShip(const Ship *model, const string &name, const st
 
 	// If an id was given, associate and store it with the UUID of the gifted ship.
 	if(!id.empty())
-		giftedShips[id].clone(ships.back()->UUID());
+		giftedShips[id].Clone(ships.back()->UUID());
 
 	return ships.back().get();
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1180,7 +1180,7 @@ const EsUuid &Ship::UUID() const noexcept
 
 void Ship::SetUUID(const EsUuid &id)
 {
-	uuid.clone(id);
+	uuid.Clone(id);
 }
 
 

--- a/source/comparators/ByUUID.h
+++ b/source/comparators/ByUUID.h
@@ -1,4 +1,4 @@
-/* UUIDComparator.h
+/* ByUUID.h
 Copyright (c) 2021 by Benjamin Hauch
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
@@ -20,7 +20,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 template <class T>
-struct UUIDComparator {
+class ByUUID {
+public:
 	// Comparator for collections of shared_ptr<T>
 	bool operator()(const std::shared_ptr<T> &a, const std::shared_ptr<T> &b) const noexcept(false)
 	{

--- a/source/comparators/UUIDComparator.h
+++ b/source/comparators/UUIDComparator.h
@@ -22,7 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 template <class T>
 struct UUIDComparator {
 	// Comparator for collections of shared_ptr<T>
-	bool operator() (const std::shared_ptr<T> &a, const std::shared_ptr<T> &b) const noexcept(false)
+	bool operator()(const std::shared_ptr<T> &a, const std::shared_ptr<T> &b) const noexcept(false)
 	{
 		return a->UUID() < b->UUID();
 	}

--- a/source/comparators/UUIDComparator.h
+++ b/source/comparators/UUIDComparator.h
@@ -1,0 +1,37 @@
+/* UUIDComparator.h
+Copyright (c) 2021 by Benjamin Hauch
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <memory>
+
+
+
+template <class T>
+struct UUIDComparator {
+	// Comparator for collections of shared_ptr<T>
+	bool operator() (const std::shared_ptr<T> &a, const std::shared_ptr<T> &b) const noexcept(false)
+	{
+		return a->UUID() < b->UUID();
+	}
+
+	// Comparator for collections of T*, e.g. set<T *>
+	bool operator()(const T *a, const T *b) const noexcept(false)
+	{
+		return a->UUID() < b->UUID();
+	}
+	// No comparator for collections of T, as std containers generally perform copy operations
+	// and copying this class will eventually be disabled.
+};

--- a/tests/unit/src/test_esuuid.cpp
+++ b/tests/unit/src/test_esuuid.cpp
@@ -17,8 +17,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "output-capture.hpp"
 
 // Include only the tested classes' headers.
-#include "../../../source/EsUuid.h"
 #include "../../../source/comparators/ByUUID.h"
+#include "../../../source/EsUuid.h"
 
 #include "../../../source/Random.h"
 

--- a/tests/unit/src/test_esuuid.cpp
+++ b/tests/unit/src/test_esuuid.cpp
@@ -16,14 +16,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "es-test.hpp"
 #include "output-capture.hpp"
 
-// Include only the tested class's header.
+// Include only the tested classes' headers.
 #include "../../../source/EsUuid.h"
-// Declare the existence of the class internals that will be tested.
-namespace es_uuid {
-namespace detail {
-	EsUuid::UuidType MakeUuid();
-}
-}
+#include "../../../source/comparators/UUIDComparator.h"
+
 #include "../../../source/Random.h"
 
 // ... and any system includes needed for the test file.
@@ -186,7 +182,7 @@ SCENARIO( "Comparing IDs", "[uuid][comparison]" ) {
 				CHECK_FALSE( id == other );
 			}
 			WHEN( "the second clones the first" ) {
-				other.clone(id);
+				other.Clone(id);
 				THEN( "the two are equal" ) {
 					CHECK( other == id );
 					CHECK_FALSE( other != id );
@@ -239,7 +235,7 @@ SCENARIO( "Copying uniquely identifiable objects", "[uuid][copying]" ) {
 		}
 		WHEN( "a copy is explicitly requested" ) {
 			Identifiable other;
-			other.id.clone(source.id);
+			other.id.Clone(source.id);
 			THEN( "the copy has the same ID string" ) {
 				CHECK( other.id.ToString() == sourceId );
 			}
@@ -349,7 +345,7 @@ SCENARIO( "Mapping identifiable collections", "[uuid][comparison][collections]" 
 	GIVEN( "two objects with the same UUID" ) {
 		auto source = std::make_shared<T>();
 		auto cloned = std::make_shared<T>();
-		cloned->id.clone(source->UUID());
+		cloned->id.Clone(source->UUID());
 		WHEN( "the collection has a default comparator" ) {
 			auto collection = std::set<std::shared_ptr<T>>{};
 			REQUIRE( collection.emplace(source).second );
@@ -385,8 +381,8 @@ SCENARIO( "Mapping identifiable collections", "[uuid][comparison][collections]" 
 		std::string secondName = "two";
 		collection.insert({ {firstName, EsUuid()}, {secondName, EsUuid()} });
 		WHEN( "we use strings to find the corresponding UUID in the collection" ) {
-			collection.at(firstName).clone(first.id);
-			collection.at(secondName).clone(second.id);
+			collection.at(firstName).Clone(first.id);
+			collection.at(secondName).Clone(second.id);
 			THEN( "we can use them to identify the items in a unique way" ) {
 				CHECK( collection.at(firstName) == first.id );
 				CHECK( collection.at(secondName) == second.id );
@@ -409,7 +405,7 @@ SCENARIO( "Mapping identifiable collections", "[uuid][comparison][collections]" 
 #ifdef CATCH_CONFIG_ENABLE_BENCHMARKING
 TEST_CASE( "Benchmark UUID Creation", "[!benchmark][uuid]" ) {
 	BENCHMARK( "MakeUuid" ) {
-		return es_uuid::detail::MakeUuid();
+		return EsUuid::MakeUuid();
 	};
 }
 #endif

--- a/tests/unit/src/test_esuuid.cpp
+++ b/tests/unit/src/test_esuuid.cpp
@@ -18,7 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 // Include only the tested classes' headers.
 #include "../../../source/EsUuid.h"
-#include "../../../source/comparators/UUIDComparator.h"
+#include "../../../source/comparators/ByUUID.h"
 
 #include "../../../source/Random.h"
 
@@ -354,7 +354,7 @@ SCENARIO( "Mapping identifiable collections", "[uuid][comparison][collections]" 
 			}
 		}
 		WHEN( "the collection uses an ID comparator" ) {
-			auto collection = std::set<std::shared_ptr<T>, UUIDComparator<T>>{};
+			auto collection = std::set<std::shared_ptr<T>, ByUUID<T>>{};
 			REQUIRE( collection.emplace(source).second );
 			THEN( "only one object may be added" ) {
 				CHECK_FALSE( collection.emplace(cloned).second );
@@ -362,7 +362,7 @@ SCENARIO( "Mapping identifiable collections", "[uuid][comparison][collections]" 
 		}
 	}
 	GIVEN( "a collection of items with UUIDs" ) {
-		auto collection = std::map<std::shared_ptr<T>, int, UUIDComparator<T>>{};
+		auto collection = std::map<std::shared_ptr<T>, int, ByUUID<T>>{};
 		auto first = std::make_shared<T>();
 		auto second = std::make_shared<T>();
 		collection.insert({ {first, -1}, {second, -2} });


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
1. Replaced `#if defined(WIN32)` with `#ifdef _WIN32`.
2. Fixed the [order of `#include`s](https://github.com/endless-sky/endless-sky/wiki/C++-Style-Guide#order-of-includes-in-a-h-file).
3. Dropped the custom `es_uuid::detail::` [namespace](https://github.com/endless-sky/endless-sky/wiki/C++-Style-Guide#namespaces). One function from it is needed outside (in the test), so made it a public static member of `EsUuid`.
4. Fixed a capitalization error in a [function name](https://github.com/endless-sky/endless-sky/wiki/C++-Style-Guide#function-names).
5. Moved the portions of platform-specific code with the same functionality together.
6. Added a proper [`using namespace std` declaration](https://github.com/endless-sky/endless-sky/wiki/C++-Style-Guide#the-std-namespace) to the .cpp file.
7. Removed an unneeded const_cast.
8. Moved the comparator class [to its own file](https://github.com/endless-sky/endless-sky/wiki/C++-Style-Guide#one-class-per-file). It's currently unused, but so are the other comparators, so I guess it's fine to leave it there.

## Testing Done
Let's see what the CI says.