### PR TITLE
fix(UI): Outfitter and Shipyard views on the map sort by Series and Index

### DIFF
--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -15,7 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "MapOutfitterPanel.h"
 
-#include "comparators/ByName.h"
+#include "comparators/BySeriesAndIndex.h"
 #include "CategoryList.h"
 #include "CoreStartData.h"
 #include "text/Format.h"
@@ -305,5 +305,5 @@ void MapOutfitterPanel::Init()
 
 	// Sort the vectors.
 	for(auto &it : catalog)
-		sort(it.second.begin(), it.second.end(), ByDisplayName<Outfit>());
+		sort(it.second.begin(), it.second.end(), BySeriesAndIndexMap<Outfit>());
 }

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "MapShipyardPanel.h"
 
+#include "comparators/BySeriesAndIndex.h"
 #include "CategoryList.h"
 #include "CoreStartData.h"
 #include "text/Format.h"
@@ -288,6 +289,5 @@ void MapShipyardPanel::Init()
 		}
 
 	for(auto &it : catalog)
-		sort(it.second.begin(), it.second.end(),
-			[](const Ship *a, const Ship *b) { return a->DisplayModelName() < b->DisplayModelName(); });
+		sort(it.second.begin(), it.second.end(), BySeriesAndIndexMap<Ship>());
 }

--- a/source/comparators/BySeriesAndIndex.h
+++ b/source/comparators/BySeriesAndIndex.h
@@ -61,3 +61,30 @@ public:
 		return Helper(*outfitA, *outfitB, nameA, nameB);
 	}
 };
+
+template<class T>
+class BySeriesAndIndexMap;
+
+template<>
+class BySeriesAndIndexMap<Ship> {
+public:
+	bool operator()(const Ship *shipA, const Ship *shipB) const
+	{
+		const Outfit &a = shipA->Attributes();
+		const Outfit &b = shipB->Attributes();
+		const std::string &nameA = shipA->TrueModelName();
+		const std::string &nameB = shipB->TrueModelName();
+		return Helper(a, b, nameA, nameB);
+	}
+};
+
+template<>
+class BySeriesAndIndexMap<Outfit> {
+public:
+	bool operator()(const Outfit *a, const Outfit *b) const
+	{
+		const std::string &nameA = a->TrueName();
+		const std::string &nameB = b->TrueName();
+		return Helper(*a, *b, nameA, nameB);
+	}
+};


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
While outfits in the outfitter and ships in the shipyard can be sorted uses series and indices, outfits and ships are always sorted by alphabetical order in the Outfitter and Shipyard tab on the map. This PR changes those tabs to use the same sorting as the Outfitter/Shipyard.

## Screenshots
Before:
<img width="298" height="668" alt="image" src="https://github.com/user-attachments/assets/4157dd3e-a773-449b-98e6-9ae88b30ae80" />

After:
<img width="305" height="669" alt="image" src="https://github.com/user-attachments/assets/b2ba79b6-1783-499a-a653-ea80f3a7646f" />

## Testing Done
Loaded up the game, looked at the Outfitter view on the map, and saw that outfits were being sorted by series and index over pure alphabetical order.

## Performance Impact
Negligible.
