### PR TITLE
feat(enhancement): Dynamic music system

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -341,6 +341,14 @@ target_sources(EndlessSkyLib PRIVATE
 	audio/Sound.cpp
 	audio/Sound.h
 	audio/SoundCategory.h
+	audio/music/Layer.cpp
+	audio/music/Layer.h
+	audio/music/Playlist.cpp
+	audio/music/Playlist.h
+	audio/music/Track.cpp
+	audio/music/Track.h
+	audio/music/TrackSupplier.cpp
+	audio/music/TrackSupplier.h
 	audio/player/AudioPlayer.cpp
 	audio/player/AudioPlayer.h
 	audio/player/MusicPlayer.cpp
@@ -353,6 +361,8 @@ target_sources(EndlessSkyLib PRIVATE
 	audio/supplier/FlacSupplier.h
 	audio/supplier/Mp3Supplier.cpp
 	audio/supplier/Mp3Supplier.h
+	audio/supplier/SilenceSupplier.cpp
+	audio/supplier/SilenceSupplier.h
 	audio/supplier/WavSupplier.cpp
 	audio/supplier/WavSupplier.h
 	audio/supplier/effect/Fade.cpp

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1437,7 +1437,7 @@ void Engine::EnterSystem()
 	const Date &today = player.GetDate();
 
 	const System *system = flagship->GetSystem();
-	Audio::PlayMusic(system->MusicName());
+	Audio::PlayMusic(system->Music());
 	GameData::SetHaze(system->Haze(), false);
 
 	Messages::Add("Entering the " + system->DisplayName() + " system on "

--- a/source/GameAction.cpp
+++ b/source/GameAction.cpp
@@ -29,11 +29,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Random.h"
 #include "Ship.h"
 #include "System.h"
+#include "audio/music/Track.h"
 #include "UI.h"
 
 #include <cstdlib>
-
-#include "audio/music/Track.h"
 
 using namespace std;
 

--- a/source/GameAction.h
+++ b/source/GameAction.h
@@ -34,6 +34,7 @@ class Outfit;
 class PlayerInfo;
 class Ship;
 class System;
+class Track;
 class UI;
 
 
@@ -100,7 +101,9 @@ private:
 	int64_t fine = 0;
 	std::vector<Debt> debt;
 
-	std::optional<std::string> music;
+	const Track *music = nullptr;
+	bool useAmbientMusic = false;
+	bool isMute = false;
 
 	std::set<const System *> mark;
 	std::set<const System *> unmark;

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -711,6 +711,13 @@ const Set<Mission> &GameData::Missions()
 
 
 
+const Set<Playlist>& GameData::Playlists()
+{
+	return objects.playlists;
+}
+
+
+
 const Set<News> &GameData::SpaceportNews()
 {
 	return objects.news;
@@ -781,6 +788,20 @@ const Set<TestData> &GameData::TestDataSets()
 
 
 
+const Set<Track>& GameData::Tracks()
+{
+	return objects.tracks;
+}
+
+
+
+const Set<set<string>> &GameData::VariantTracks()
+{
+	return objects.variantTracks;
+}
+
+
+
 ConditionsStore &GameData::GlobalConditions()
 {
 	return globalConditions;
@@ -805,6 +826,20 @@ const Set<System> &GameData::Systems()
 const Set<Wormhole> &GameData::Wormholes()
 {
 	return objects.wormholes;
+}
+
+
+
+const Track *GameData::GetOrCreateTrack(const string &track, double duration)
+{
+	Track *t;
+	if(duration > 0.)
+		t = objects.tracks.Get(track + " " + to_string(duration));
+	else
+		t = objects.tracks.Get(track);
+	if(!t->Valid())
+		*t = Track(track, duration);
+	return t;
 }
 
 

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -55,6 +55,7 @@ class Person;
 class Phrase;
 class Planet;
 class PlayerInfo;
+class Playlist;
 class Point;
 class Politics;
 class Shader;
@@ -67,6 +68,7 @@ class TaskQueue;
 class Test;
 class TestData;
 class TextReplacements;
+class Track;
 class UniverseObjects;
 class Wormhole;
 
@@ -134,6 +136,7 @@ public:
 	static const Set<Interface> &Interfaces();
 	static const Set<Minable> &Minables();
 	static const Set<Mission> &Missions();
+	static const Set<Playlist> &Playlists();
 	static const Set<News> &SpaceportNews();
 	static const Set<Outfit> &Outfits();
 	static const Set<Shop<Outfit>> &Outfitters();
@@ -146,7 +149,11 @@ public:
 	static const Set<System> &Systems();
 	static const Set<Test> &Tests();
 	static const Set<TestData> &TestDataSets();
+	static const Set<Track> &Tracks();
+	static const Set<std::set<std::string>> &VariantTracks();
 	static const Set<Wormhole> &Wormholes();
+
+	static const Track *GetOrCreateTrack(const std::string &track, double duration = -1.);
 
 	static ConditionsStore &GlobalConditions();
 

--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -92,7 +92,7 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 	}
 
 	if(player.GetPlanet())
-		Audio::PlayMusic(player.GetPlanet()->MusicName());
+		Audio::PlayMusic(player.GetPlanet()->Music());
 
 	if(!scrollSpeed)
 		scrollSpeed = 1;

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -100,7 +100,7 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 			if(key == "display name")
 				displayName.clear();
 			else if(key == "music")
-				music.clear();
+				music = nullptr;
 			else if(key == "attributes")
 				attributes.clear();
 			else if(key == "description")
@@ -186,7 +186,12 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 		else if(key == "landscape")
 			landscape = SpriteSet::Get(value);
 		else if(key == "music")
-			music = value;
+		{
+			if(child.Size() > valueIndex + 1)
+				music = GameData::GetOrCreateTrack(value, child.Value(valueIndex + 1));
+			else
+				music = GameData::GetOrCreateTrack(value);
+		}
 		else if(key == "description")
 			description.Load(child, playerConditions);
 		else if(key == "spaceport")
@@ -380,8 +385,8 @@ const Sprite *Planet::Landscape() const
 
 
 
-// Get the name of the ambient audio to play on this planet.
-const string &Planet::MusicName() const
+// Get the ambient audio to play on this planet.
+const Track *Planet::Music() const
 {
 	return music;
 }

--- a/source/Planet.h
+++ b/source/Planet.h
@@ -35,6 +35,7 @@ class PlayerInfo;
 class Ship;
 class Sprite;
 class System;
+class Track;
 class Wormhole;
 
 
@@ -74,8 +75,8 @@ public:
 	const Paragraphs &Description() const;
 	// Get the landscape sprite.
 	const Sprite *Landscape() const;
-	// Get the name of the ambient audio to play on this planet.
-	const std::string &MusicName() const;
+	// Get the ambient audio to play on this planet.
+	const Track *Music() const;
 
 	// Get the list of "attributes" of the planet.
 	const std::set<std::string> &Attributes() const;
@@ -172,7 +173,7 @@ private:
 	Paragraphs description;
 	Port port;
 	const Sprite *landscape = nullptr;
-	std::string music;
+	const Track *music = nullptr;
 
 	std::set<std::string> attributes;
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1503,7 +1503,7 @@ void PlayerInfo::Land(UI *ui)
 	if(!freshlyLoaded)
 	{
 		Audio::Play(Audio::Get("landing"), SoundCategory::ENGINE);
-		Audio::PlayMusic(planet->MusicName());
+		Audio::PlayMusic(planet->Music());
 	}
 
 	// Mark this planet as visited.

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -138,7 +138,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 			else if(key == "government")
 				government = nullptr;
 			else if(key == "music")
-				music.clear();
+				music = nullptr;
 			else if(key == "attributes")
 				attributes.clear();
 			else if(key == "link")
@@ -387,7 +387,12 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 		else if(key == "government")
 			government = GameData::Governments().Get(value);
 		else if(key == "music")
-			music = value;
+		{
+			if(child.Size() > valueIndex + 1)
+				music = GameData::GetOrCreateTrack(value, child.Value(valueIndex + 1));
+			else
+				music = GameData::GetOrCreateTrack(value);
+		}
 		else if(key == "habitable")
 			habitable = child.Value(valueIndex);
 		else if(key == "jump range")
@@ -642,8 +647,8 @@ const vector<const Sprite *> &System::GetMapIcons() const
 
 
 
-// Get the name of the ambient audio to play in this system.
-const string &System::MusicName() const
+// Get the ambient audio to play in this system.
+const Track *System::Music() const
 {
 	return music;
 }

--- a/source/System.h
+++ b/source/System.h
@@ -37,6 +37,7 @@ class Outfit;
 class Planet;
 class Ship;
 class Sprite;
+class Track;
 
 
 
@@ -94,8 +95,8 @@ public:
 	const Government *GetGovernment() const;
 	// Get this system's map icons.
 	const std::vector<const Sprite *> &GetMapIcons() const;
-	// Get the name of the ambient audio to play in this system.
-	const std::string &MusicName() const;
+	// Get the ambient audio to play in this system.
+	const Track *Music() const;
 
 	// Get the list of "attributes" of the planet.
 	const std::set<std::string> &Attributes() const;
@@ -221,7 +222,7 @@ private:
 	Point position;
 	const Government *government = nullptr;
 	std::vector<const Sprite *> mapIcons;
-	std::string music;
+	const Track *music = nullptr;
 
 	// All possible hyperspace links to other systems.
 	std::set<const System *> links;

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -391,6 +391,8 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 			phrases.Get(node.Token(1))->Load(node);
 		else if(key == "planet" && hasValue)
 			planets.Get(node.Token(1))->Load(node, wormholes, playerConditions);
+		else if(key == "playlist" && hasValue)
+			playlists.Get(node.Token(1))->Load(node, playerConditions, visitedSystems, visitedPlanets);
 		else if(key == "ship" && hasValue)
 		{
 			// Allow multiple named variants of the same ship model.
@@ -422,6 +424,8 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 			tests.Get(node.Token(1))->Load(node, playerConditions);
 		else if(key == "test-data" && hasValue)
 			testDataSets.Get(node.Token(1))->Load(node, path);
+		else if(key == "track" && hasValue)
+			tracks.Get(node.Token(1))->Load(node);
 		else if(key == "trade")
 			trade.Load(node);
 		else if(key == "landing message" && hasValue)
@@ -488,6 +492,13 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 		}
 		else if(key == "substitutions" && node.HasChildren())
 			substitutions.Load(node, playerConditions);
+		else if(key == "variant" && hasValue)
+		{
+			for(int i = 1; i < node.Size(); ++i)
+				for(int j = 1; j < node.Size(); ++j)
+					if(i != j)
+						variantTracks.Get(node.Token(i))->emplace(node.Token(j));
+		}
 		else if(key == "wormhole" && hasValue)
 			wormholes.Get(node.Token(1))->Load(node);
 		else if(key == "gamerules" && node.HasChildren())

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -38,6 +38,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Person.h"
 #include "Phrase.h"
 #include "Planet.h"
+#include "audio/music/Playlist.h"
 #include "shader/Shader.h"
 #include "Ship.h"
 #include "StartConditions.h"
@@ -46,6 +47,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "test/Test.h"
 #include "test/TestData.h"
 #include "TextReplacements.h"
+#include "audio/music/Track.h"
 #include "Trade.h"
 #include "Wormhole.h"
 
@@ -124,13 +126,16 @@ private:
 	Set<Person> persons;
 	Set<Phrase> phrases;
 	Set<Planet> planets;
+	Set<Playlist> playlists;
 	Set<Shader> shaders;
 	Set<Ship> ships;
 	Set<System> systems;
 	Set<Test> tests;
 	Set<TestData> testDataSets;
+	Set<Track> tracks;
 	Set<Shop<Ship>> shipSales;
 	Set<Shop<Outfit>> outfitSales;
+	Set<std::set<std::string>> variantTracks;
 	Set<Wormhole> wormholes;
 	std::set<double> neighborDistances;
 

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -495,7 +495,7 @@ void Audio::Step(bool isFastForward, const PlayerInfo &playerInfo)
 					// If we chose a variant track, make sure it's selected first.
 					if(next)
 						swap<const Track *>(*find(remainingTracks.begin(), remainingTracks.end(), next), remainingTracks.back());
-					else if(foundVariant)
+					else if(foundVariant || (current && currentPlaylist->Tracks().contains(current)))
 					{
 						const set<string> *variants = GameData::VariantTracks().Get(current->Name());
 						for(auto it = remainingTracks.begin(); it != remainingTracks.end(); ++it)
@@ -512,6 +512,8 @@ void Audio::Step(bool isFastForward, const PlayerInfo &playerInfo)
 				// Play the next track.
 				if(trackSupplier->GetCurrentTrack() == remainingTracks.back() || foundVariant)
 					trackSupplier->SetNextTrack(remainingTracks.back(), TrackSupplier::SwitchPriority::PREFERRED, false, true);
+				else if(currentPlaylist->Tracks().contains(trackSupplier->GetCurrentTrack()))
+					trackSupplier->SetNextTrack(remainingTracks.back(), TrackSupplier::SwitchPriority::END_OF_TRACK);
 				else
 					trackSupplier->SetNextTrack(remainingTracks.back(), trackSupplier->GetNextTrackPriority());
 				remainingTracks.pop_back();

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -22,10 +22,12 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "../Logger.h"
 #include "player/MusicPlayer.h"
 #include "../Planet.h"
+#include "../PlayerInfo.h"
 #include "music/Playlist.h"
 #include "../Point.h"
 #include "../Random.h"
 #include "Sound.h"
+#include "../System.h"
 #include "music/TrackSupplier.h"
 
 #include <AL/al.h>
@@ -41,9 +43,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <thread>
 #include <vector>
-
-#include "../PlayerInfo.h"
-#include "../System.h"
 
 using namespace std;
 

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -435,7 +435,7 @@ void Audio::Step(bool isFastForward, const PlayerInfo &playerInfo)
 		{
 			if(currentPlaylist->Tracks().contains(trackSupplier->GetNextTrack()) &&
 					trackSupplier->GetNextTrackPriority() != TrackSupplier::SwitchPriority::IMMEDIATE)
-				trackSupplier->SetNextTrack(nullptr, TrackSupplier::SwitchPriority::PREFERRED);
+				trackSupplier->SetNextTrack(nullptr, TrackSupplier::SwitchPriority::END_OF_TRACK);
 			currentPlaylist = nullptr;
 			remainingTracks.clear();
 		}

--- a/source/audio/Audio.cpp
+++ b/source/audio/Audio.cpp
@@ -297,7 +297,7 @@ void Audio::Play(const Sound *sound, const Point &position, SoundCategory catego
 /// Force changing to the given track.
 void Audio::PlayMusic(const Track *track)
 {
-	if(!isInitialized)
+	if(!isInitialized || !musicPlayer)
 		return;
 	TrackSupplier *supplier = reinterpret_cast<TrackSupplier *>(musicPlayer->Supplier());
 	supplier->SetNextTrack(track, track ? TrackSupplier::SwitchPriority::IMMEDIATE :
@@ -425,7 +425,7 @@ void Audio::Step(bool isFastForward, const PlayerInfo &playerInfo)
 
 	// Schedule the next track for playback.
 	++musicCheckFrameCounter;
-	if(musicCheckFrameCounter >= 5)
+	if(musicCheckFrameCounter >= 5 && musicPlayer)
 	{
 		musicCheckFrameCounter = 0;
 		TrackSupplier *trackSupplier = reinterpret_cast<TrackSupplier *>(musicPlayer->Supplier());

--- a/source/audio/Audio.h
+++ b/source/audio/Audio.h
@@ -21,8 +21,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+class PlayerInfo;
 class Point;
 class Sound;
+class Track;
 
 
 
@@ -64,8 +66,8 @@ public:
 	// "listener". This will make it softer and change the left / right balance.
 	static void Play(const Sound *sound, const Point &position, SoundCategory category);
 
-	// Play the given music. An empty string means to play nothing.
-	static void PlayMusic(const std::string &name);
+	/// Force changing to the given track.
+	static void PlayMusic(const Track *track);
 
 	// Pause all active sound sources. Doesn't cause new streams to be paused, and doesn't pause the music source.
 	static void Pause();
@@ -76,7 +78,7 @@ public:
 	/// Begin playing all the sounds that have been added since the last time
 	/// this function was called.
 	/// If the game is in fast forward mode, the fast version of sounds is played.
-	static void Step(bool isFastForward);
+	static void Step(bool isFastForward, const PlayerInfo &player);
 
 	// Shut down the audio system (because we're about to quit).
 	static void Quit();

--- a/source/audio/music/Layer.cpp
+++ b/source/audio/music/Layer.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 
 
-void Layer::AddSource(const function<unique_ptr<AudioSupplier>(bool)>& source)
+void Layer::AddSource(const function<unique_ptr<AudioSupplier>(bool)> &source)
 {
 	sources.emplace_back(source);
 }
@@ -35,7 +35,7 @@ void Layer::Clear()
 
 
 
-std::unique_ptr<AudioSupplier> Layer::CreateSupplier(bool loop) const
+unique_ptr<AudioSupplier> Layer::CreateSupplier(bool loop) const
 {
 	if(sources.empty())
 		return {};

--- a/source/audio/music/Layer.cpp
+++ b/source/audio/music/Layer.cpp
@@ -1,0 +1,43 @@
+/* Layer.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Layer.h"
+
+#include "../../Random.h"
+
+using namespace std;
+
+
+
+void Layer::AddSource(const function<unique_ptr<AudioSupplier>(bool)>& source)
+{
+	sources.emplace_back(source);
+}
+
+
+
+void Layer::Clear()
+{
+	sources.clear();
+}
+
+
+
+std::unique_ptr<AudioSupplier> Layer::CreateSupplier(bool loop) const
+{
+	if(sources.empty())
+		return {};
+	return sources[Random::Int(sources.size())](loop);
+}

--- a/source/audio/music/Layer.h
+++ b/source/audio/music/Layer.h
@@ -1,0 +1,38 @@
+/* Layer.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../supplier/AudioSupplier.h"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+
+
+/// A layer plays a random sound from a selection.
+class Layer {
+public:
+	Layer() = default;
+
+	void AddSource(const std::function<std::unique_ptr<AudioSupplier>(bool)>& source);
+	void Clear();
+	std::unique_ptr<AudioSupplier> CreateSupplier(bool loop) const;
+
+
+private:
+	std::vector<std::function<std::unique_ptr<AudioSupplier>(bool)>> sources;
+};

--- a/source/audio/music/Layer.h
+++ b/source/audio/music/Layer.h
@@ -28,7 +28,7 @@ class Layer {
 public:
 	Layer() = default;
 
-	void AddSource(const std::function<std::unique_ptr<AudioSupplier>(bool)>& source);
+	void AddSource(const std::function<std::unique_ptr<AudioSupplier>(bool)> &source);
 	void Clear();
 	std::unique_ptr<AudioSupplier> CreateSupplier(bool loop) const;
 

--- a/source/audio/music/Playlist.cpp
+++ b/source/audio/music/Playlist.cpp
@@ -26,17 +26,17 @@ using namespace std;
 
 
 void Playlist::Load(const DataNode &data, const ConditionsStore *conditions, const set<const System *> *visitedSystems,
-	const set<const Planet*> *visitedPlanets)
+	const set<const Planet *> *visitedPlanets)
 {
 	if(data.Size() > 1)
 		name = data.Token(1);
 	else
 		Logger::LogError("Playlists must have a name");
-	for (const DataNode &child: data)
+	for(const DataNode &child : data)
 	{
 		if(child.Token(0) == "tracks")
 		{
-			for (const DataNode &trackNode : child)
+			for(const DataNode &trackNode : child)
 			{
 				const Track *track;
 				if(trackNode.Size() > 1)
@@ -57,7 +57,7 @@ void Playlist::Load(const DataNode &data, const ConditionsStore *conditions, con
 
 
 
-bool Playlist::Matches(const PlayerInfo& player) const
+bool Playlist::Matches(const PlayerInfo &player) const
 {
 	if(!toPlay.Evaluate())
 		return false;
@@ -72,14 +72,14 @@ bool Playlist::Matches(const PlayerInfo& player) const
 
 
 
-const std::set<const Track*>& Playlist::Tracks() const
+const set<const Track*> &Playlist::Tracks() const
 {
 	return tracks;
 }
 
 
 
-const std::string& Playlist::Name() const
+const string &Playlist::Name() const
 {
 	return name;
 }

--- a/source/audio/music/Playlist.cpp
+++ b/source/audio/music/Playlist.cpp
@@ -1,0 +1,85 @@
+/* Playlist.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Playlist.h"
+
+#include "../../DataNode.h"
+#include "../../GameData.h"
+#include "../../Logger.h"
+#include "../../PlayerInfo.h"
+#include "../../UniverseObjects.h"
+
+using namespace std;
+
+
+
+void Playlist::Load(const DataNode &data, const ConditionsStore *conditions, const set<const System *> *visitedSystems,
+	const set<const Planet*> *visitedPlanets)
+{
+	if(data.Size() > 1)
+		name = data.Token(1);
+	else
+		Logger::LogError("Playlists must have a name");
+	for (const DataNode &child: data)
+	{
+		if(child.Token(0) == "tracks")
+		{
+			for (const DataNode &trackNode : child)
+			{
+				const Track *track;
+				if(trackNode.Size() > 1)
+					track = GameData::GetOrCreateTrack(trackNode.Token(0), trackNode.Value(1));
+				else
+					track = GameData::GetOrCreateTrack(trackNode.Token(0));
+				tracks.emplace(track);
+			}
+		}
+		else if(child.Token(0) == "to play")
+			toPlay.Load(child, conditions);
+		else if(child.Token(0) == "play at")
+			playAt.Load(child, visitedSystems, visitedPlanets);
+		else
+			child.PrintTrace("Skipping unrecognized attribute:");
+	}
+}
+
+
+
+bool Playlist::Matches(const PlayerInfo& player) const
+{
+	if(!toPlay.Evaluate())
+		return false;
+	LocationFilter filter = playAt.SetOrigin(player.GetSystem());
+	bool value;
+	if(player.Flagship())
+		value = filter.Matches(*player.Flagship());
+	else
+		value = filter.Matches(player.GetSystem());
+	return value;
+}
+
+
+
+const std::set<const Track*>& Playlist::Tracks() const
+{
+	return tracks;
+}
+
+
+
+const std::string& Playlist::Name() const
+{
+	return name;
+}

--- a/source/audio/music/Playlist.h
+++ b/source/audio/music/Playlist.h
@@ -1,0 +1,47 @@
+/* Playlist.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../../ConditionSet.h"
+#include "../../LocationFilter.h"
+
+#include <set>
+#include <string>
+
+class DataNode;
+class Track;
+class PlayerInfo;
+
+
+
+/// A grouping of tracks under shared conditions.
+class Playlist
+{
+public:
+	void Load(const DataNode &data, const ConditionsStore *conditions, const std::set<const System *> *visitedSystems,
+		const std::set<const Planet*> *visitedPlanets);
+
+	bool Matches(const PlayerInfo &player) const;
+	const std::set<const Track *> &Tracks() const;
+	const std::string &Name() const;
+
+
+private:
+	std::string name;
+	std::set<const Track *> tracks;
+	ConditionSet toPlay;
+	LocationFilter playAt;
+};

--- a/source/audio/music/Playlist.h
+++ b/source/audio/music/Playlist.h
@@ -32,7 +32,7 @@ class Playlist
 {
 public:
 	void Load(const DataNode &data, const ConditionsStore *conditions, const std::set<const System *> *visitedSystems,
-		const std::set<const Planet*> *visitedPlanets);
+		const std::set<const Planet *> *visitedPlanets);
 
 	bool Matches(const PlayerInfo &player) const;
 	const std::set<const Track *> &Tracks() const;

--- a/source/audio/music/Track.cpp
+++ b/source/audio/music/Track.cpp
@@ -28,7 +28,7 @@ namespace {
 		if(data == "silence")
 		{
 			if(duration > 0.)
-				return [duration](bool loop){return std::make_unique<SilenceSupplier>(loop ? 999999. : duration);};
+				return [duration](bool loop){return make_unique<SilenceSupplier>(duration, loop);};
 			else
 			{
 				Logger::LogError("\"silence\" source requires a positive duration");
@@ -42,7 +42,7 @@ namespace {
 
 
 
-Track::Track(const std::string &name, double duration) : name(name)
+Track::Track(const string &name, double duration) : name(name)
 {
 	background.AddSource(ParseLine(name, duration));
 	this->name = name;
@@ -59,6 +59,7 @@ void Track::Load(const DataNode &data)
 		name = data.Token(1);
 	else
 		Logger::LogError("Tracks must have a name");
+	bool hadBackground = false;
 	for(const DataNode &child : data)
 	{
 		if(child.Token(0) == "background")
@@ -68,6 +69,7 @@ void Track::Load(const DataNode &data)
 			else
 			{
 				background.Clear();
+				hadBackground = true;
 				if(child.Size() > 2)
 					background.AddSource(ParseLine(child.Token(1), child.Value(2)));
 				else
@@ -93,11 +95,16 @@ void Track::Load(const DataNode &data)
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}
+	if(!hadBackground)
+	{
+		data.PrintTrace("Missing node \"background\":");
+		background.AddSource(ParseLine("silence", 1.));
+	}
 }
 
 
 
-const std::string &Track::Name() const
+const string &Track::Name() const
 {
 	return name;
 }

--- a/source/audio/music/Track.cpp
+++ b/source/audio/music/Track.cpp
@@ -1,0 +1,122 @@
+/* Track.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Track.h"
+
+#include "../../DataNode.h"
+#include "../../Logger.h"
+#include "../Music.h"
+#include "../supplier/SilenceSupplier.h"
+
+using namespace std;
+
+namespace {
+	function<unique_ptr<AudioSupplier>(bool)> ParseLine(const string &data, double duration = -1.)
+	{
+		if(data == "silence")
+		{
+			if(duration > 0.)
+				return [duration](bool loop){return std::make_unique<SilenceSupplier>(loop ? 999999. : duration);};
+			else
+			{
+				Logger::LogError("\"silence\" source requires a positive duration");
+				return [](bool){return unique_ptr<AudioSupplier>{};};
+			}
+		}
+		else
+			return [data](bool loop) {return Music::CreateSupplier(data, loop);};
+	}
+}
+
+
+
+Track::Track(const std::string &name, double duration) : name(name)
+{
+	background.AddSource(ParseLine(name, duration));
+	this->name = name;
+}
+
+
+
+void Track::Load(const DataNode &data)
+{
+	background.Clear();
+	foreground.clear();
+
+	if(data.Size() > 1)
+		name = data.Token(1);
+	else
+		Logger::LogError("Tracks must have a name");
+	for(const DataNode &child : data)
+	{
+		if(child.Token(0) == "background")
+		{
+			if(child.Size() < 2)
+				Logger::LogError("\"background\" node must have a value");
+			else
+			{
+				background.Clear();
+				if(child.Size() > 2)
+					background.AddSource(ParseLine(child.Token(1), child.Value(2)));
+				else
+					background.AddSource(ParseLine(child.Token(1)));
+			}
+		}
+		else if(child.Token(0) == "foreground")
+		{
+			if(!child.HasChildren())
+				Logger::LogError("\"foreground\" node must have children");
+			else
+			{
+				foreground.emplace_back();
+				for(const DataNode &source : child)
+				{
+					if(source.Size() == 1)
+						foreground.back().AddSource(ParseLine(source.Token(0)));
+					else
+						foreground.back().AddSource(ParseLine(source.Token(0), source.Value(1)));
+				}
+			}
+		}
+		else
+			child.PrintTrace("Skipping unrecognized attribute:");
+	}
+}
+
+
+
+const std::string &Track::Name() const
+{
+	return name;
+}
+
+
+
+bool Track::Valid() const
+{
+	return !name.empty();
+}
+
+
+
+vector<reference_wrapper<const Layer>> Track::Layers() const
+{
+	vector<reference_wrapper<const Layer>> layers;
+	layers.reserve(foreground.size() + 1);
+	layers.emplace_back(background);
+	for(const Layer &layer : foreground)
+		layers.emplace_back(layer);
+	return layers;
+}

--- a/source/audio/music/Track.h
+++ b/source/audio/music/Track.h
@@ -33,9 +33,9 @@ class Track {
 public:
 	Track() = default;
 	/// A track created for an audio file.
-	explicit Track(const std::string& name, double duration = -1.);
+	explicit Track(const std::string &name, double duration = -1.);
 	/// A track created with a custom name and data.
-	void Load(const DataNode& data);
+	void Load(const DataNode &data);
 	/// The name of the track. This is unique for all tracks
 	/// except for "silence", which can be duplicated.
 	const std::string &Name() const;

--- a/source/audio/music/Track.h
+++ b/source/audio/music/Track.h
@@ -1,0 +1,50 @@
+/* Track.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../../DataNode.h"
+#include "Layer.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+class DataNode;
+
+
+
+/// A track is a collection of sounds that play together within a playlist.
+/// Each track has exactly one file that plays in the background,
+/// but can have several feature tracks playing in the foreground.
+class Track {
+public:
+	Track() = default;
+	/// A track created for an audio file.
+	explicit Track(const std::string& name, double duration = -1.);
+	/// A track created with a custom name and data.
+	void Load(const DataNode& data);
+	/// The name of the track. This is unique for all tracks
+	/// except for "silence", which can be duplicated.
+	const std::string &Name() const;
+	bool Valid() const;
+
+	std::vector<std::reference_wrapper<const Layer>> Layers() const;
+
+private:
+	std::string name;
+	Layer background;
+	std::vector<Layer> foreground;
+};

--- a/source/audio/music/TrackSupplier.cpp
+++ b/source/audio/music/TrackSupplier.cpp
@@ -259,7 +259,7 @@ void TrackSupplier::Decode()
 			// If we can't read data, wait for it to become available.
 			// This would normally be managed in some I/O operation for async suppliers,
 			// but we aren't reading from any file here.
-			this_thread::sleep_for(50ms);
+			this_thread::sleep_for(chrono::milliseconds(50));
 		}
 	}
 }

--- a/source/audio/music/TrackSupplier.cpp
+++ b/source/audio/music/TrackSupplier.cpp
@@ -27,33 +27,33 @@ namespace
 {
 	size_t Available(const vector<unique_ptr<AudioSupplier>> &suppliers)
 	{
-		size_t available = suppliers.empty() ? 0 : suppliers.front()->AvailableChunks();
+		size_t available = suppliers.empty() ? 0 : (suppliers.front() ? suppliers.front()->AvailableChunks() : 0);
 		for(const auto &supplier : suppliers)
-			available = min(available, supplier->AvailableChunks());
+			available = min(available, supplier ? supplier->AvailableChunks() : 0);
 		return available;
 	}
 
 	size_t MaxAvailable(const vector<unique_ptr<AudioSupplier>> &suppliers)
 	{
-		size_t available = suppliers.empty() ? 0 : suppliers.front()->AvailableChunks();
+		size_t available = suppliers.empty() ? 0 : (suppliers.front() ? suppliers.front()->AvailableChunks() : 0);
 		for(const auto &supplier : suppliers)
-			available = max(available, supplier->AvailableChunks());
+			available = max(available, supplier ? supplier->AvailableChunks() : 0);
 		return available;
 	}
 
 	size_t MinRemaining(const vector<unique_ptr<AudioSupplier>> &suppliers)
 	{
-		size_t remaining = suppliers.empty() ? 0 : suppliers.front()->MaxChunks();
+		size_t remaining = suppliers.empty() ? 0 : (suppliers.front() ? suppliers.front()->MaxChunks() : 0);
 		for(const auto &supplier : suppliers)
-			remaining = min(remaining, supplier->MaxChunks());
+			remaining = min(remaining, supplier ? supplier->MaxChunks() : 0);
 		return remaining;
 	}
 
 	size_t Remaining(const vector<unique_ptr<AudioSupplier>> &suppliers)
 	{
-		size_t remaining = suppliers.empty() ? 0 : suppliers.front()->MaxChunks();
+		size_t remaining = suppliers.empty() ? 0 : (suppliers.front() ? suppliers.front()->MaxChunks() : 0);
 		for(const auto &supplier : suppliers)
-			remaining = max(remaining, supplier->MaxChunks());
+			remaining = max(remaining, supplier ? supplier->MaxChunks() : 0);
 		return remaining;
 	}
 }

--- a/source/audio/music/TrackSupplier.cpp
+++ b/source/audio/music/TrackSupplier.cpp
@@ -1,0 +1,238 @@
+/* TrackSupplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "TrackSupplier.h"
+
+#include "../supplier/effect/Fade.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+using namespace std;
+
+namespace
+{
+	size_t Available(const vector<unique_ptr<AudioSupplier>> &suppliers)
+	{
+		size_t available = suppliers.empty() ? 0 : suppliers.front()->AvailableChunks();
+		for(const auto &supplier : suppliers)
+			available = min(available, supplier->AvailableChunks());
+		return available;
+	}
+
+	size_t Remaining(const vector<unique_ptr<AudioSupplier>> &suppliers)
+	{
+		size_t remaining = suppliers.empty() ? 0 : suppliers.front()->MaxChunks();
+		for(const auto &supplier : suppliers)
+			remaining = max(remaining, supplier->MaxChunks());
+		return remaining;
+	}
+}
+
+
+TrackSupplier::TrackSupplier() : AsyncAudioSupplier({})
+{
+}
+
+
+const Track *TrackSupplier::GetCurrentTrack() const
+{
+	lock_guard guard(lock);
+	return current;
+}
+
+
+const Track *TrackSupplier::GetNextTrack() const
+{
+	lock_guard guard(lock);
+	return next;
+}
+
+
+
+const TrackSupplier::SwitchPriority TrackSupplier::GetNextTrackPriority() const
+{
+	lock_guard guard(lock);
+	return nextPriority;
+}
+
+
+
+void TrackSupplier::SetNextTrack(const Track* track, SwitchPriority priority, bool loop, bool sync)
+{
+	lock_guard guard(lock);
+	if(track == current)
+	{
+		// Special case: switching back to the current track.
+		// Just clear any previous change requests.
+		next = nullptr;
+		nextPriority = SwitchPriority::END_OF_TRACK;
+		nextIsLooping = false;
+		nextIsSynced = false;
+	}
+	else
+	{
+		next = track;
+		nextPriority = priority;
+		nextIsLooping = loop;
+		nextIsSynced = sync && track;
+	}
+}
+
+
+
+void TrackSupplier::Decode()
+{
+	// The audio suppliers used for playback.
+	// The first one is a Fade used for the background,
+	// which is preserved when switching tracks.
+	vector<unique_ptr<AudioSupplier>> suppliers;
+	suppliers.emplace_back(make_unique<Fade>());
+	const AudioSupplier *currentBackground = nullptr;
+	// Preload the suppliers for the next track.
+	vector<unique_ptr<AudioSupplier>> nextSuppliers;
+	const Track* cachedNext = nullptr;
+	// How many iterations the next track was scheduled for.
+	int nextCounter = 0;
+	// How many iterations to wait before switching to a "preferred" track. Chosen arbitrarily.
+	constexpr int PREFERRED_COUNTER_LIMIT = 50;
+	constexpr int SILENCE_PREFERRED_COUNTER_LIMIT = 10;
+
+	while(!done)
+	{
+		AwaitBufferSpace();
+		if(done)
+		{
+			PadBuffer();
+			break;
+		}
+
+		// Validate the cached suppliers.
+		{
+			lock_guard guard(lock);
+			if(cachedNext != next)
+			{
+				cachedNext = next;
+				nextSuppliers.clear();
+				nextCounter = 0;
+				if(next)
+				{
+					auto layers = next->Layers();
+					if(!layers.empty())
+					{
+						nextSuppliers.emplace_back(layers.front().get().CreateSupplier(looping));
+						for(size_t i = 1; i < layers.size(); ++i)
+							nextSuppliers.emplace_back(layers[i].get().CreateSupplier(nextIsLooping));
+					}
+				}
+			}
+			if(nextPriority == SwitchPriority::PREFERRED)
+				++nextCounter;
+			else
+				nextCounter = 0;
+		}
+
+		// Switch to the next supplier, if this one is exhausted.
+		// If the switch is forced, only switch once the cached chunks run out.
+		// This helps to reduce accidental switching when travelling between systems.
+		bool wantsToChange = false;
+		{
+			lock_guard guard(lock);
+			bool shouldChange = Available(nextSuppliers) || !next;
+			switch(nextPriority)
+			{
+				case SwitchPriority::IMMEDIATE:
+					wantsToChange = true;
+					break;
+				case SwitchPriority::PREFERRED:
+					wantsToChange = nextCounter >= ((next && current) ? PREFERRED_COUNTER_LIMIT : SILENCE_PREFERRED_COUNTER_LIMIT);
+					break;
+				case SwitchPriority::END_OF_TRACK:
+					wantsToChange = !Remaining(suppliers);
+					break;
+			}
+			shouldChange &= wantsToChange;
+			if(nextIsSynced && currentBackground)
+			{
+				while(nextSuppliers.front()->ConsumedBuffers() < currentBackground->ConsumedBuffers() &&
+						Available(nextSuppliers))
+					nextSuppliers.front()->NextDataChunk();
+				shouldChange &= nextSuppliers.front()->ConsumedBuffers() == currentBackground->ConsumedBuffers();
+			}
+
+			if(shouldChange)
+			{
+				current = next;
+				next = nullptr;
+				nextCounter = 0;
+				nextPriority = SwitchPriority::END_OF_TRACK;
+				cachedNext = nullptr;
+				nextIsLooping = false;
+
+				suppliers.resize(1);
+				currentBackground = nextSuppliers.empty() ? nullptr : nextSuppliers.front().get();
+				if(nextSuppliers.empty())
+					reinterpret_cast<Fade*>(suppliers[0].get())->AddSource({});
+				else
+					reinterpret_cast<Fade*>(suppliers[0].get())->AddSource(std::move(nextSuppliers.front()));
+				for(size_t i = 1; i < nextSuppliers.size(); ++i)
+					suppliers.emplace_back(std::move(nextSuppliers[i]));
+				nextSuppliers.clear();
+			}
+		}
+
+		// Advance the foreground layers to the next file.
+		if(current && currentBackground && currentBackground->MaxChunks() && !wantsToChange)
+		{
+			for(size_t i = 1; i < suppliers.size(); ++i)
+				if(!suppliers[i]->MaxChunks())
+					suppliers[i] = current->Layers()[i].get().CreateSupplier(false);
+		}
+
+		// Get the next chunk from each supplier, and blend them together.
+		// As the audio samples represent the amplitudes of the sound waves, they can be combined simply by
+		// adding them together. However, this can overflow the sample type when the waves amplify each other.
+		// A good soft limiter is tanh(): it transforms all values into the [-1, 1] range while being almost linear
+		// for small values (tanh(1) = 0.8). This also avoids lower harmonic distortion for a reasonable input volume
+		// that is caused by all nonlinear limiters.
+		if(Available(suppliers))
+		{
+			vector<float> mergedInputs(OUTPUT_CHUNK);
+			for (const auto &supplier : suppliers)
+			{
+				vector<sample_t> samples = supplier->NextDataChunk();
+				// Convert the samples to 32-bit float so we can add them together without overflow.
+				for(size_t i = 0; i < OUTPUT_CHUNK; ++i)
+					mergedInputs[i] += static_cast<float>(samples[i]) / numeric_limits<sample_t>::max();
+			}
+			// Blend the samples
+			vector<sample_t> samples;
+			samples.reserve(OUTPUT_CHUNK);
+			for (float sample : mergedInputs)
+			{
+				samples.emplace_back(round(tanh(sample) * numeric_limits<sample_t>::max()));
+			}
+			AddBufferData(samples);
+		}
+		else if(!done)
+		{
+			// If we can't read data, wait for it to become available.
+			// This would normally be managed in some I/O operation for async suppliers,
+			// but we aren't reading from any file here.
+			this_thread::sleep_for(50ms);
+		}
+	}
+}

--- a/source/audio/music/TrackSupplier.cpp
+++ b/source/audio/music/TrackSupplier.cpp
@@ -61,7 +61,16 @@ namespace
 
 TrackSupplier::TrackSupplier() : AsyncAudioSupplier({})
 {
+	Start();
 }
+
+
+
+TrackSupplier::~TrackSupplier()
+{
+	Stop();
+}
+
 
 
 const Track *TrackSupplier::GetCurrentTrack() const

--- a/source/audio/music/TrackSupplier.h
+++ b/source/audio/music/TrackSupplier.h
@@ -1,0 +1,60 @@
+/* TrackSuppler.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../supplier/AsyncAudioSupplier.h"
+#include "Track.h"
+
+#include <mutex>
+
+
+
+/// Handles track switching logic, and supplies audio from the current track.
+class TrackSupplier : public AsyncAudioSupplier
+{
+public:
+	enum class SwitchPriority {
+		IMMEDIATE, PREFERRED, END_OF_TRACK
+	};
+
+
+public:
+	TrackSupplier();
+
+	const Track *GetCurrentTrack() const;
+	const Track *GetNextTrack() const;
+	const SwitchPriority GetNextTrackPriority() const;
+	/// Configures what track to play after the current one.
+	/// If forced, the supplier switches to the new track as soon as
+	/// the cached buffers of the old track run out. Otherwise, it waits for
+	/// the current track to finish.
+	void SetNextTrack(const Track *track, SwitchPriority priority = SwitchPriority::END_OF_TRACK, bool loop = false,
+		bool sync = false);
+
+	// Inherited pure virtual methods
+	void Decode() override;
+
+
+private:
+	friend class Audio;
+
+	const Track *current = nullptr;
+	const Track *next = nullptr;
+	SwitchPriority nextPriority = SwitchPriority::END_OF_TRACK;
+	bool nextIsLooping = false;
+	bool nextIsSynced = false;
+	mutable std::mutex lock;
+};

--- a/source/audio/music/TrackSupplier.h
+++ b/source/audio/music/TrackSupplier.h
@@ -1,4 +1,4 @@
-/* TrackSuppler.h
+/* TrackSupplier.h
 Copyright (c) 2025 by tibetiroka
 
 Endless Sky is free software: you can redistribute it and/or modify it under the
@@ -36,7 +36,8 @@ public:
 
 	const Track *GetCurrentTrack() const;
 	const Track *GetNextTrack() const;
-	const SwitchPriority GetNextTrackPriority() const;
+	SwitchPriority GetNextTrackPriority() const;
+	std::recursive_mutex &GetMutex() const;
 	/// Configures what track to play after the current one.
 	/// If forced, the supplier switches to the new track as soon as
 	/// the cached buffers of the old track run out. Otherwise, it waits for
@@ -56,5 +57,5 @@ private:
 	SwitchPriority nextPriority = SwitchPriority::END_OF_TRACK;
 	bool nextIsLooping = false;
 	bool nextIsSynced = false;
-	mutable std::mutex lock;
+	mutable std::recursive_mutex lock;
 };

--- a/source/audio/music/TrackSupplier.h
+++ b/source/audio/music/TrackSupplier.h
@@ -33,6 +33,7 @@ public:
 
 public:
 	TrackSupplier();
+	~TrackSupplier() override;
 
 	const Track *GetCurrentTrack() const;
 	const Track *GetNextTrack() const;

--- a/source/audio/supplier/AsyncAudioSupplier.cpp
+++ b/source/audio/supplier/AsyncAudioSupplier.cpp
@@ -34,13 +34,7 @@ AsyncAudioSupplier::AsyncAudioSupplier(shared_ptr<iostream> data, bool looping)
 
 AsyncAudioSupplier::~AsyncAudioSupplier()
 {
-	// Tell the decoding thread to stop.
-	{
-		lock_guard<mutex> lock(bufferMutex);
-		done = true;
-	}
-	bufferCondition.notify_all();
-	thread.join();
+	Stop();
 }
 
 
@@ -75,6 +69,20 @@ vector<AudioSupplier::sample_t> AsyncAudioSupplier::NextDataChunk()
 	}
 	else
 		return vector<sample_t>(OUTPUT_CHUNK);
+}
+
+
+
+void AsyncAudioSupplier::Stop()
+{
+	// Tell the decoding thread to stop.
+	{
+		lock_guard<mutex> lock(bufferMutex);
+		done = true;
+	}
+	bufferCondition.notify_all();
+	if(thread.joinable())
+		thread.join();
 }
 
 

--- a/source/audio/supplier/AsyncAudioSupplier.cpp
+++ b/source/audio/supplier/AsyncAudioSupplier.cpp
@@ -26,8 +26,6 @@ using namespace std;
 AsyncAudioSupplier::AsyncAudioSupplier(shared_ptr<iostream> data, bool looping)
 	: looping(looping), data(std::move(data))
 {
-	// Don't start the thread until this object is fully constructed.
-	thread = std::thread(&AsyncAudioSupplier::Decode, this);
 }
 
 
@@ -69,6 +67,13 @@ vector<AudioSupplier::sample_t> AsyncAudioSupplier::NextDataChunk()
 	}
 	else
 		return vector<sample_t>(OUTPUT_CHUNK);
+}
+
+
+
+void AsyncAudioSupplier::Start()
+{
+	thread = std::thread(&AsyncAudioSupplier::Decode, this);
 }
 
 

--- a/source/audio/supplier/AsyncAudioSupplier.cpp
+++ b/source/audio/supplier/AsyncAudioSupplier.cpp
@@ -67,6 +67,7 @@ vector<AudioSupplier::sample_t> AsyncAudioSupplier::NextDataChunk()
 	{
 		lock_guard<mutex> lock(bufferMutex);
 
+		++consumedBuffers;
 		vector<sample_t> temp{buffer.begin(), buffer.begin() + OUTPUT_CHUNK};
 		buffer.erase(buffer.begin(), buffer.begin() + OUTPUT_CHUNK);
 		bufferCondition.notify_all();

--- a/source/audio/supplier/AsyncAudioSupplier.h
+++ b/source/audio/supplier/AsyncAudioSupplier.h
@@ -39,6 +39,7 @@ public:
 protected:
 	/// This is the entry point for the decoding thread.
 	virtual void Decode() = 0;
+	void Start();
 	void Stop();
 
 	void AwaitBufferSpace();

--- a/source/audio/supplier/AsyncAudioSupplier.h
+++ b/source/audio/supplier/AsyncAudioSupplier.h
@@ -62,7 +62,7 @@ protected:
 
 private:
 	/// The number of chunks to queue up in the buffer.
-	static constexpr size_t BUFFER_CHUNK_SIZE = 3;
+	static constexpr size_t BUFFER_CHUNK_SIZE = 6;
 	/// The decoded data.
 	std::vector<sample_t> buffer;
 

--- a/source/audio/supplier/AsyncAudioSupplier.h
+++ b/source/audio/supplier/AsyncAudioSupplier.h
@@ -39,6 +39,7 @@ public:
 protected:
 	/// This is the entry point for the decoding thread.
 	virtual void Decode() = 0;
+	void Stop();
 
 	void AwaitBufferSpace();
 	/// Adds data to the output buffer, then clears the given sample vector.

--- a/source/audio/supplier/AsyncAudioSupplier.h
+++ b/source/audio/supplier/AsyncAudioSupplier.h
@@ -62,7 +62,7 @@ protected:
 
 private:
 	/// The number of chunks to queue up in the buffer.
-	static constexpr size_t BUFFER_CHUNK_SIZE = 6;
+	static constexpr size_t BUFFER_CHUNK_SIZE = 3;
 	/// The decoded data.
 	std::vector<sample_t> buffer;
 

--- a/source/audio/supplier/AudioSupplier.cpp
+++ b/source/audio/supplier/AudioSupplier.cpp
@@ -42,6 +42,13 @@ AudioSupplier::AudioSupplier(bool is3x, bool isLooping)
 
 
 
+size_t AudioSupplier::ConsumedBuffers() const
+{
+	return consumedBuffers;
+}
+
+
+
 void AudioSupplier::Set3x(bool is3x)
 {
 	nextPlaybackIs3x = is3x;

--- a/source/audio/supplier/AudioSupplier.h
+++ b/source/audio/supplier/AudioSupplier.h
@@ -47,6 +47,8 @@ public:
 	/// Gets the next, fixed-size chunk of audio samples. If there is no available chunk, a silence chunk is returned.
 	/// This returns the raw samples that would be put into an OpenAL buffer via a NextChunk() call.
 	virtual std::vector<sample_t> NextDataChunk() = 0;
+	/// How many buffers were supplied via NextChunk() or NextDataChunk() calls, excluding silence.
+	virtual size_t ConsumedBuffers() const;
 
 	/// Configures 3x audio playback.
 	virtual void Set3x(bool is3x);
@@ -79,6 +81,8 @@ protected:
 	bool nextPlaybackIs3x = false;
 	/// A looping player will stream data forever.
 	bool isLooping = false;
+	/// How many buffers were sent by this supplier.
+	size_t consumedBuffers = 0;
 
 	/// The index of the first sample to be processed
 	size_t currentSample = 0;

--- a/source/audio/supplier/FlacSupplier.cpp
+++ b/source/audio/supplier/FlacSupplier.cpp
@@ -30,6 +30,13 @@ FlacSupplier::FlacSupplier(shared_ptr<iostream> data, bool looping)
 
 
 
+FlacSupplier::~FlacSupplier()
+{
+	Stop();
+}
+
+
+
 FLAC__StreamDecoderWriteStatus FlacSupplier::write_callback(const FLAC__Frame *frame, const FLAC__int32 *const buffer[])
 {
 	const size_t channels = frame->header.channels;

--- a/source/audio/supplier/FlacSupplier.cpp
+++ b/source/audio/supplier/FlacSupplier.cpp
@@ -36,10 +36,10 @@ FLAC__StreamDecoderWriteStatus FlacSupplier::write_callback(const FLAC__Frame *f
 	const size_t blocksize = frame->header.blocksize;
 
 	AwaitBufferSpace();
-	static vector<sample_t> samples;
+	vector<sample_t> samples;
 	for(size_t i = 0; i < blocksize; ++i)
 		for(size_t ch = 0; ch < channels; ++ch)
-			samples.push_back(static_cast<sample_t>(buffer[ch][i]));
+			samples.emplace_back(static_cast<sample_t>(buffer[ch][i]));
 
 	AddBufferData(samples);
 	/// Allow looping back to the beginning of the file on the next read.

--- a/source/audio/supplier/FlacSupplier.cpp
+++ b/source/audio/supplier/FlacSupplier.cpp
@@ -26,6 +26,7 @@ using namespace std;
 FlacSupplier::FlacSupplier(shared_ptr<iostream> data, bool looping)
 	: AsyncAudioSupplier(std::move(data), looping)
 {
+	Start();
 }
 
 

--- a/source/audio/supplier/FlacSupplier.h
+++ b/source/audio/supplier/FlacSupplier.h
@@ -27,6 +27,7 @@ class FlacSupplier : protected FLAC::Decoder::Stream, public AsyncAudioSupplier 
 // otherwise the FLAC::Decoder::Stream may free the resources with the decoder thread running.
 public:
 	explicit FlacSupplier(std::shared_ptr<std::iostream> data, bool looping = false);
+	~FlacSupplier() override;
 
 
 private:

--- a/source/audio/supplier/Mp3Supplier.cpp
+++ b/source/audio/supplier/Mp3Supplier.cpp
@@ -29,6 +29,7 @@ using namespace std;
 Mp3Supplier::Mp3Supplier(shared_ptr<iostream> data, bool looping)
 	: AsyncAudioSupplier(std::move(data), looping)
 {
+	Start();
 }
 
 

--- a/source/audio/supplier/Mp3Supplier.cpp
+++ b/source/audio/supplier/Mp3Supplier.cpp
@@ -33,6 +33,13 @@ Mp3Supplier::Mp3Supplier(shared_ptr<iostream> data, bool looping)
 
 
 
+Mp3Supplier::~Mp3Supplier()
+{
+	Stop();
+}
+
+
+
 void Mp3Supplier::Decode()
 {
 	// This vector will store the input from the file.

--- a/source/audio/supplier/Mp3Supplier.h
+++ b/source/audio/supplier/Mp3Supplier.h
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 class Mp3Supplier : public AsyncAudioSupplier {
 public:
 	explicit Mp3Supplier(std::shared_ptr<std::iostream> data, bool looping = false);
+	~Mp3Supplier() override;
 
 
 private:

--- a/source/audio/supplier/SilenceSupplier.cpp
+++ b/source/audio/supplier/SilenceSupplier.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 
 
-SilenceSupplier::SilenceSupplier(double seconds) : seconds(seconds)
+SilenceSupplier::SilenceSupplier(double seconds, bool loop) : AudioSupplier(false, loop), seconds(seconds)
 {
 }
 
@@ -29,6 +29,8 @@ SilenceSupplier::SilenceSupplier(double seconds) : seconds(seconds)
 
 size_t SilenceSupplier::MaxChunks() const
 {
+	if(isLooping)
+		return 3;
 	return ceil(seconds / (static_cast<double>(OUTPUT_CHUNK) / SAMPLE_RATE / 2.)) - consumedBuffers;
 }
 

--- a/source/audio/supplier/SilenceSupplier.cpp
+++ b/source/audio/supplier/SilenceSupplier.cpp
@@ -1,0 +1,48 @@
+/* SilenceSupplier.cpp
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "SilenceSupplier.h"
+
+#include <cmath>
+
+using namespace std;
+
+
+
+SilenceSupplier::SilenceSupplier(double seconds) : seconds(seconds)
+{
+}
+
+
+
+size_t SilenceSupplier::MaxChunks() const
+{
+	return ceil(seconds / (static_cast<double>(OUTPUT_CHUNK) / SAMPLE_RATE / 2.)) - consumedBuffers;
+}
+
+
+
+size_t SilenceSupplier::AvailableChunks() const
+{
+	return MaxChunks();
+}
+
+
+
+vector<AudioSupplier::sample_t> SilenceSupplier::NextDataChunk()
+{
+	++consumedBuffers;
+	return vector<sample_t>(OUTPUT_CHUNK);
+}

--- a/source/audio/supplier/SilenceSupplier.h
+++ b/source/audio/supplier/SilenceSupplier.h
@@ -21,7 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class SilenceSupplier : public AudioSupplier {
 public:
-	explicit SilenceSupplier(double seconds);
+	explicit SilenceSupplier(double seconds, bool loop);
 
 	// Inherited pure virtual methods
 	size_t MaxChunks() const override;

--- a/source/audio/supplier/SilenceSupplier.h
+++ b/source/audio/supplier/SilenceSupplier.h
@@ -1,0 +1,34 @@
+/* SilenceSupplier.h
+Copyright (c) 2025 by tibetiroka
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "AudioSupplier.h"
+
+
+
+class SilenceSupplier : public AudioSupplier {
+public:
+	explicit SilenceSupplier(double seconds);
+
+	// Inherited pure virtual methods
+	size_t MaxChunks() const override;
+	size_t AvailableChunks() const override;
+	std::vector<sample_t> NextDataChunk() override;
+
+
+private:
+	double seconds;
+};

--- a/source/audio/supplier/WavSupplier.cpp
+++ b/source/audio/supplier/WavSupplier.cpp
@@ -56,6 +56,7 @@ vector<AudioSupplier::sample_t> WavSupplier::NextDataChunk()
 	// If we are at the beginning of the buffer and it was already played, this is a loop.
 	if(!currentSample && wasStarted && !isLooping)
 		return samples;
+	++consumedBuffers;
 
 	size_t currentSampleCount = 0;
 	do {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -428,7 +428,7 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 				}
 			}
 
-			Audio::Step(isFastForward);
+			Audio::Step(isFastForward, player);
 
 			// Events in this frame may have cleared out the menu, in which case
 			// we should draw the game panels instead:
@@ -492,7 +492,7 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 
 			if(!isHeadless)
 			{
-				Audio::Step(isFastForward);
+				Audio::Step(isFastForward, player);
 
 				// Events in this frame may have cleared out the menu, in which case
 				// we should draw the game panels instead:


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #6293 (closes #6293)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
See https://github.com/endless-sky/rfcs/pull/7

This pretty much implements the RFC, with some minor changes:
- switching between variants will still be cross-faded
- the `track` generated for a sound file can be overwritten in the data
- the heuristics for switching tracks (especially around takeoff and `GameAction`) are a bit different

Misc changes:
- Fade now always fades in as well as out
- AudioSupplier now keeps track of how many chunks it supplied (so they can be synchronized with each other)
- FlacSupplier no longer uses a static buffer
- The AsyncAudioSupplier constructors destructors are now even more paranoid, to avoid issues with the way the vtable is set up

## Usage examples
Music?

## Testing Done
Tested that planet music works, it works together with playlists, playlists work, variant switching works, looping works, fading works, foreground layers work, layer synchronization works, and probably a bunch of other stuff.

## Save File
This save file can be used to test these changes: 
[Omnis Omnis.txt](https://github.com/user-attachments/files/22185720/Omnis.Omnis.txt)

Use this plugin: 
[music test.zip](https://github.com/user-attachments/files/22185728/music.test.zip)

You are starting on a station with the station background music. That music will loop while you are landed there.

When you take off, the music will continue as there is a playlist covering that system with the same track. After the station track, there is also another track where you check the foreground tracks and the silence tracks working.

Jump to an adjacent system and come back. The music will continue playing. If you remain in the other system for longer, it will switch to a new playlist.

If you have Omnis, make your way to the Omnis system through Gamma Corvi, and wait there to hear another playlist. This shows how playlists can be redefined with additional conditions.

## Wiki Update
Soon.

## Performance Impact
Somewhat more expensive when we actually have music, as it's now checking playlist conditions globally.