### PR TITLE
Added third button to dialog, implemented focus model

### DIFF
--- a/source/Dialog.h
+++ b/source/Dialog.h
@@ -37,10 +37,10 @@ class TextArea;
 // callback function can be given to receive the player's response.
 class Dialog : public Panel {
 public:
-	// An OK / Cancel dialog where Cancel can be disabled. The okIsActive lets
+	// An OK / Cancel dialog where Cancel can be disabled. The activeButton == 1 lets
 	// you select whether "OK" (true) or "Cancel" (false) are selected as the default option.
 	Dialog(std::function<void()> okFunction, const std::string &message, Truncate truncate,
-		bool canCancel, bool okIsActive);
+		bool canCancel, int activeButton);
 	// Dialog that has no callback (information only). In this form, there is
 	// only an "ok" button, not a "cancel" button.
 	explicit Dialog(const std::string &text, Truncate truncate = Truncate::NONE, bool allowsFastForward = false);
@@ -59,6 +59,7 @@ public:
 	Dialog(T *t, void (T::*fun)(int), const std::string &text, int initialValue,
 		Truncate truncate = Truncate::NONE, bool allowsFastForward = false);
 
+	// Request string, 2 buttons
 	template<class T>
 	Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text, std::string initialValue = "",
 		Truncate truncate = Truncate::NONE, bool allowsFastForward = false);
@@ -104,6 +105,8 @@ private:
 	void DoCallback(bool isOk = true) const;
 	// The width of the dialog, excluding margins.
 	int Width() const;
+	// Function associated with the third button.
+	virtual bool ThirdButtonFun(std::string &);
 
 
 protected:
@@ -118,7 +121,7 @@ protected:
 	std::function<bool(const std::string &)> validateFun;
 
 	bool canCancel;
-	bool okIsActive;
+	int activeButton;
 	bool isMission;
 	bool isOkDisabled = false;
 	bool allowsFastForward = false;
@@ -128,6 +131,13 @@ protected:
 
 	Point okPos;
 	Point cancelPos;
+	Point thirdPos;
+
+	// Third button, always the left-most button:
+	std::string thirdButtonLabel;
+	SDL_Keycode thirdButtonKey;
+
+	int numButtons;
 
 	const System *system = nullptr;
 	PlayerInfo *player = nullptr;
@@ -168,6 +178,7 @@ Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &tex
 
 
 
+// Three buttons, string input with validation.
 template<class T>
 Dialog::Dialog(T *t, void (T::*fun)(const std::string &), const std::string &text,
 	std::function<bool(const std::string &)> validate, std::string initialValue, Truncate truncate, bool allowsFastForward)

--- a/source/ShipNameDialog.cpp
+++ b/source/ShipNameDialog.cpp
@@ -15,45 +15,18 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "ShipNameDialog.h"
 
-#include "Color.h"
-#include "text/Font.h"
-#include "text/FontSet.h"
 #include "GameData.h"
 #include "Phrase.h"
-#include "image/SpriteSet.h"
-#include "shader/SpriteShader.h"
 
-#include <cmath>
+#include "ShipyardPanel.h"
 
 using namespace std;
 
 
 
-void ShipNameDialog::Draw()
+bool ShipNameDialog::ThirdButtonFun(string &input)
 {
-	Dialog::Draw();
-
-	randomPos = cancelPos - Point(100., 0.);
-	SpriteShader::Draw(SpriteSet::Get("ui/dialog cancel"), randomPos);
-
-	const Font &font = FontSet::Get(14);
-	static const string RANDOM = "Random";
-	Point labelPos = randomPos - .5 * Point(font.Width(RANDOM), font.Height());
-	font.Draw(RANDOM, labelPos, *GameData::Colors().Get("medium"));
-}
-
-
-
-bool ShipNameDialog::Click(int x, int y, MouseButton button, int clicks)
-{
-	if(button != MouseButton::LEFT)
-		return Dialog::Click(x, y, button, clicks);
-	Point off = Point(x, y) - randomPos;
-	if(fabs(off.X()) < 40. && fabs(off.Y()) < 20.)
-	{
-		// TODO: always chooses human names even for alien ships
-		input = GameData::Phrases().Get("civilian")->Get();
-		return true;
-	}
-	return Dialog::Click(x, y, button, clicks);
+	input = GameData::Phrases().Get("civilian")->Get();
+	// False means to keep the dialog box open.
+	return false;
 }

--- a/source/ShipNameDialog.h
+++ b/source/ShipNameDialog.h
@@ -17,8 +17,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Dialog.h"
 
-#include "Point.h"
-
 #include <string>
 
 
@@ -33,15 +31,9 @@ public:
 	ShipNameDialog(T *panel, void (T::*fun)(const std::string &),
 		const std::string &message, std::string initialValue = "");
 
-	virtual void Draw() override;
-
-
-protected:
-	virtual bool Click(int x, int y, MouseButton button, int clicks) override;
-
 
 private:
-	Point randomPos;
+	virtual bool ThirdButtonFun(std::string &) override;
 };
 
 
@@ -51,4 +43,6 @@ ShipNameDialog::ShipNameDialog(T *panel, void (T::*fun)(const std::string &),
 		const std::string &message, std::string initialValue)
 	: Dialog(panel, fun, message, initialValue)
 {
+	thirdButtonLabel = "Random";
+	numButtons = 3;
 }


### PR DESCRIPTION
**Feature**
**Refactor**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added third button to dialog, implemented focus model.
Updated ShipNameDialog to use this new model.

This PR is going to be used by the updates to the controls that are in the works -- a third dialog option is needed.  Here it is in the context of the only 3-button dialog that exists in the game so far: Naming/Renaming a ship has a "Random" button.

Later this will be in the context of "Discard", "Cancel", "Save" -- updates related to that will be in a later PR.

## Screenshots

| Old | New |
| --- | --- |
| <img width="294" height="200" alt="image" src="https://github.com/user-attachments/assets/995a893c-9fcb-4aad-8064-3ff4b6d303ea" /> | <img width="294" height="200" alt="image" src="https://github.com/user-attachments/assets/284d3518-decc-4a1d-a33c-fa3aa55229e7" /> |

## Testing Done
Only tested in shipyard and player info ship rename contexts.

## Artwork Checklist
Used existing "ui/wide button"