### PR TITLE
Fix Remnant Research Expedition jobs again

### DIFF
--- a/data/map beyond patir.txt
+++ b/data/map beyond patir.txt
@@ -18,6 +18,7 @@ galaxy "Patir Cluster"
 system Athiri
 	pos 10225.5 -432.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-chanai
 	habitable 1400
 	belt 1074
@@ -45,6 +46,7 @@ system Athiri
 system Balnii
 	pos 10268.3 -359.3
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-sarifa
 	arrival 1100
 	habitable 360
@@ -63,6 +65,7 @@ system Balnii
 system Chanai
 	pos 9883.5 -34.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-chanai
 	habitable 1250
 	belt 1887
@@ -86,6 +89,7 @@ system Chanai
 system Ghila
 	pos 9820.5 -100.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-ghila
 	habitable 1715
 	belt 1165
@@ -115,6 +119,7 @@ system Ghila
 system Lathia
 	pos 10107.5 -332.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-lathia
 	habitable 1715
 	belt 1815
@@ -135,6 +140,7 @@ system Lathia
 system Maithi
 	pos 10092.5 -489.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-maithi
 	habitable 425.92
 	belt 1379
@@ -158,6 +164,7 @@ system Maithi
 system Mitera
 	pos 9957.5 -92.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-mitera
 	habitable 3645
 	belt 1464
@@ -181,6 +188,7 @@ system Mitera
 system Sarifa
 	pos 10136.5 -406.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-sarifa
 	habitable 5486.68
 	belt 1757
@@ -204,6 +212,7 @@ system Sarifa
 system Thepa
 	pos 9975.5 -2.5
 	government Uninhabited
+	attributes "beyond patir"
 	haze _menu/haze-maithi
 	habitable 320
 	belt 1793

--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -122,6 +122,7 @@ mission "Remnant: Expanded Horizons Astral job"
 		not attributes "tangled shroud"
 		not attributes "twilight"
 		not attributes "outer limits"
+		not attributes "beyond patir"
 	to offer
 		has "Remnant: Expanded Horizons Astral 2: done"
 		random < 50


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in the Discord server

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
As in https://github.com/endless-sky/endless-sky/issues/7702, https://github.com/endless-sky/endless-sky/issues/8543, and https://github.com/endless-sky/endless-sky/pull/10960, the Research Expedition has a new unintended location - the Patir 2 cluster, currently unreachable by the player after the mission chain in question. This fixes it by adding a set of attributes to the relevant systems and excluding it from the location filter.

## Testing Done
None.