### PR TITLE
fix(bug): Lost Racer bug fix

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6661,6 +6661,9 @@ mission "Lost Racer 2 - Continued"
 	on enter Kugel
 		dialog
 			"As soon as you enter the Kugel system, your sensors begin to pick up a weak radio signal coming from the second planet, this time matching exactly the frequency of Artemis Renard's transponder. It seems you have arrived in the correct system."
+	on visit
+		dialog
+			"Either not all of your passengers are in the system, or you need to fly through Acamar before landing here."
 
 mission "Lost Racer 2 - Failed"
 	entering
@@ -6697,7 +6700,7 @@ mission "Lost Racer 3"
 	destination "Glory"
 	passengers 2
 	to offer
-		has "Lost Racer 2: done"
+		has "Lost Racer 2 - Continued: done"
 	on offer
 		conversation
 			`Upon reaching the planet, you pinpoint the radio signal to a valley in the southern hemisphere. You descend through a raging sandstorm; you have to rely entirely on instruments as the view from the <ship>'s bridge is almost entirely obscured. Soon, your scanners report that the source of the signal is less than a kilometer out, and after a few moments more, you begin to discern the vague shape of a crashed Flivver through the haze of dust. You land the <ship> next to the wreck, and both you and Mr. Renard go to exit the ship.`


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1417209523315281982)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixed a bug in the Lost Racer mission chain where LR3 wouldn't offer.
Added an `on visit` node to LR2C so that people with JD who skipped Acamar would know what was going on.

## Testing Done
No.
