### PR TITLE
Process(code) Added function to support checking order of class declarations

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -568,7 +568,7 @@ def check_include(sanitized_lines, original_lines, file):
 	return errors, warnings
 
 
-# Checks the class forward declarations at the beginning of header files. Parameters:
+# Checks the class forward declarations within the specified file. Parameters:
 # sanitized_lines: the lines of the file, without the line separators and the contents of strings and comments
 # original_lines: the lines of the file, without the terminating line separators
 # file: the path to the file


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses catching out of order class forward declarations.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Save warp from teaching me the alphabet.

## Usage examples
` python3 ./utils/check_code_style.py`

## Testing Done
Made a mistake on purpose, and ran the util.  Util worked.