### PR TITLE
[feature] Allow control of Interface Element::HOVER via Information objects (not just the mouse)

### DIFF
--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -348,7 +348,7 @@ void Interface::Element::Draw(const Information &info, Panel *panel) const
 	// Check if this element is active.
 	int state = info.HasCondition(activeIf);
 	// Check if the mouse is hovering over this element.
-	state += (state && (box.Contains(UI::GetMouse()) || info.HasCondition(hoverIf)));
+	state += (state && (box.Contains(UI::GetMouse()) || (!hoverIf.empty() && info.HasCondition(hoverIf))));
 	// Place buttons even if they are inactive, in case the UI wants to show a
 	// message explaining why the button is inactive.
 	if(panel)
@@ -370,8 +370,7 @@ void Interface::Element::SetConditions(const string &visible, const string &acti
 {
 	visibleIf = visible;
 	activeIf = active;
-	if(hover != "")
-		hoverIf = hover;
+	hoverIf = hover;
 }
 
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -96,7 +96,7 @@ private:
 
 		// Set the conditions that control when this element is visible and active.
 		// An empty string means it is always visible or active.
-		void SetConditions(const std::string &visible, const std::string &active, const std::string &hover = "");
+		void SetConditions(const std::string &visible, const std::string &active, const std::string &hover);
 
 		// Get the bounding rectangle, given the current screen dimensions.
 		Rectangle Bounds() const;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Add support for controlling the hover effect of interface elements via info tags; Used to assist with focus model elements.

Purpose: Needed a mechanism to allow for setting hover state (in focus) via the keyboard -- see ModalListDialog for use.

### Dependency graph
```mermaid
graph TD;
    A[<a href='https://github.com/endless-sky/endless-sky/pull/11755'>PR 11755 Dialog 3rd Button</a>]-->B[<a href='https://github.com/endless-sky/endless-sky/pull/11765'>PR 11765 ModalListDialog</a>]
    C[<a href='https://github.com/endless-sky/endless-sky/pull/11767'>PR 11767 Interface SDL_Keycode</a>]-->B;
    D[<a href='https://github.com/endless-sky/endless-sky/pull/11766'>PR 11766 Interface Hover</a>]-->B;
    B-->E[<a href='https://github.com/endless-sky/endless-sky/pull/11764'>PR 11764 Controls Profiles</a>];
    style D fill:#dfd,stroke:#0a3,stroke-width:2px
```

## Usage examples
See PR #11765 (which is then used in #11764)

## Testing Done
See #11764