### PR TITLE
code checker catch bad structured bindings

### DIFF
--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -73,7 +73,7 @@ segment_include = {re.compile(regex): description for regex, description in {
 	# Matches any commas that are not followed by whitespace characters.
 	",\\S": "commas should be followed by whitespaces",
 	# Matches incorrect structured bindings
-	r"\s&\s+\[": "structured bindings should not contain a space after the ampersand: &[first, second]",
+	"&\\s+\\[": "structured bindings should not contain a space after the ampersand: &[first, second]",
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a single word.
 # Also contains the error description for the patterns.

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -73,7 +73,7 @@ segment_include = {re.compile(regex): description for regex, description in {
 	# Matches any commas that are not followed by whitespace characters.
 	",\\S": "commas should be followed by whitespaces",
 	# Matches incorrect structured bindings
-	"&\\s+\\[": "structured bindings should not contain a space after the ampersand: &[first, second]",
+	"&\\s+\\[": "structured bindings should not contain whitespace after the ampersand",
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a single word.
 # Also contains the error description for the patterns.

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -73,7 +73,7 @@ segment_include = {re.compile(regex): description for regex, description in {
 	# Matches any commas that are not followed by whitespace characters.
 	",\\S": "commas should be followed by whitespaces",
 	# Matches incorrect structured bindings
-	r"\s&\s+\[": "structured binding should be no space after ampersand: &[first, second]",
+	r"\s&\s+\[": "structured bindings should not contain a space after the ampersand: &[first, second]",
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a single word.
 # Also contains the error description for the patterns.

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -71,7 +71,9 @@ segment_include = {re.compile(regex): description for regex, description in {
 	# Matches any tabulator characters.
 	"\t": "tabulators should only be used for indentation",
 	# Matches any commas that are not followed by whitespace characters.
-	",\\S": "commas should be followed by whitespaces"
+	",\\S": "commas should be followed by whitespaces",
+	# Matches incorrect structured bindings
+	r"\s&\s+\[": "structured binding should be no space after ampersand: &[first, second]",
 }.items()}
 # Dict of patterns for selecting potential formatting issues in a single word.
 # Also contains the error description for the patterns.


### PR DESCRIPTION
**CI/CD/Testing**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This change to the `check_code_style.py` script to add a check for an ampersand followed by a space preceding a left square bracket by adding the following two lines to the existing checks:

```
	# Matches incorrect structured bindings
	r"\s&\s+\[": "structured bindings should not contain a space after the ampersand: &[first, second]",
```

Addresses: https://github.com/endless-sky/endless-sky/pull/11736#issuecomment-3315376155
