### PR TITLE
fix(mechanics): Make it possible to clear "hold position" orders by pressing the key again

### DIFF
--- a/source/orders/OrderSet.cpp
+++ b/source/orders/OrderSet.cpp
@@ -81,6 +81,11 @@ bool OrderSet::Empty() const noexcept
 
 void OrderSet::Add(const OrderSingle &newOrder, bool *hasMismatch, bool *alreadyHarvesting)
 {
+	// HOLD_ACTIVE cannot be given as manual order, but is used internally by ship AI.
+	// Set HOLD_POSITION here, so that it's possible for the player to unset the order.
+	if(Has(Types::HOLD_ACTIVE))
+		Set(Types::HOLD_POSITION);
+
 	shared_ptr<Ship> newTargetShip = newOrder.GetTargetShip();
 	bool newTargetShipRelevant = HAS_TARGET_SHIP[static_cast<size_t>(newOrder.type)]
 		|| HAS_TARGET_SHIP_OR_ASTEROID[static_cast<size_t>(newOrder.type)];


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Although there's one "hold position" order type the player can issue, AI internally uses another, "hold active", to differentiate between ships moving to the target position, and those that actually are stopped.
Unsetting orders (via pressing the same key a second time) relies on the ships having the same order type that is being unset. So, the type needs to be set to "hold position" when reading player input, and to "hold active" when needed by the AI. While switching between "hold position" and "hold active" is implemented for some cases in OrderSet::Update, the unification of these orders for player input purposes is still required (but was mistakenly removed in #10843).

Perhaps solving this by removing "hold active" completely would be cleaner, but it would require a larger refactor, and this PR just reimplements the behavior from before #10843, as it was originally placed in AI::IssueOrders.

## Testing Done
yes™.

## Performance Impact
N/A
