### PR TITLE
feat(content): Increase connectivity of Alpha Centauri

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -4907,6 +4907,7 @@ system "Alpha Centauri"
 	habitable 1190
 	belt 1116
 	haze _menu/haze-67
+	link Muphrid
 	link Sol
 	asteroids "small rock" 1 1.944
 	asteroids "medium rock" 2 5.04

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -28491,6 +28491,7 @@ system Muphrid
 	arrival 1570
 	habitable 1570
 	belt 1759
+	link "Alpha Centauri"
 	link Menkent
 	link Porrima
 	asteroids "small rock" 10 4.7348


### PR DESCRIPTION
## Making Alpha Centauri Connected Again

This PR has its root in the observation, that in each of my many runs, whether for fun or for testing, I barely enter Alpha Centauri. At the best I need to visit Alpha Centauri for that one Quarg mission to fetch building material, and that's it. Neither by hyperdrive nor by jump drive I ever traverse this system, let alone land on Chiron ever again. And as I crisscross the ES galaxy constantly from one edge to the other from and to any direction, that means something. At that I regularily visit Sol.

Now you may ask -- So what, that's your problem, why bother the community? Thing is, that Chiron should be a prosperous world according to its description. But that needs connectivity, and Alpha Centauri is actually a logistic dead end, with no indication of abundant mineral resources. Yes, some hundred years ago, Chiron was the first settled world etc. pp, but it defies any logic or economic law, why it should be one of the centers of mankind and be the second-most populated planet. For an university world alone, one wouldn't need "many sprawling cities and a burgeoning pollution problem".

Hence, this PR suggests to connect Alpha Centauri a bit better by linking it to Muphrid.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Performance Impact
Reasonability increased by 1%.