### PR TITLE
fix(mechanics): Correctly check blindspots on special weapons

### DIFF
--- a/source/Hardpoint.cpp
+++ b/source/Hardpoint.cpp
@@ -192,7 +192,7 @@ bool Hardpoint::CanAim(const Ship &ship) const
 // Check if this weapon is ready to fire.
 bool Hardpoint::IsReady() const
 {
-	return outfit && burstReload <= 0. && burstCount && !IsBlind();
+	return outfit && burstReload <= 0. && burstCount && (!IsBlind() || IsSpecial());
 }
 
 
@@ -433,7 +433,7 @@ bool Hardpoint::FireSpecialSystem(Ship &ship, const Body &body, std::vector<Visu
 	if(offset.Length() > range)
 		return false;
 
-	// Check if the target is within the arc of fire.
+	// Check if the target is within the arc of fire and isn't blocked by a blindspot.
 	Angle aim(offset);
 	if(!isOmnidirectional)
 	{
@@ -442,12 +442,14 @@ bool Hardpoint::FireSpecialSystem(Ship &ship, const Body &body, std::vector<Visu
 		if(!aim.IsInRange(minArc, maxArc))
 			return false;
 	}
+	angle = aim - facing;
+	if(IsBlind())
+		return false;
 
 	// Precompute the number of visuals that will be added.
 	visuals.reserve(visuals.size() + outfit->FireEffects().size()
 		+ outfit->HitEffects().size() + outfit->DieEffects().size());
 
-	angle = aim - facing;
 	start += aim.Rotate(outfit->HardpointOffset());
 	CreateEffects(outfit->FireEffects(), start, ship.Velocity(), aim, visuals);
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1420819056671588494).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, all weapons check the blindspot as part of the function that tells if the weapon is ready to fire. While it works well for normal weapons, special systems that can rotate instantly (anti-missile systems and tractor beams) are ready even if currently facing a blindspot, as they can still reaim before firing.
This PR changes it so that those systems now check the blindspots directly before firing.

## Testing Done
yes™.

## Performance Impact
N/A
