### PR TITLE
fix(ui): Focus map zoom animation on the mouse pointer

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -597,15 +597,16 @@ bool MapPanel::Scroll(double dx, double dy)
 {
 	// The mouse should be pointing to the same map position before and after zooming.
 	Point mouse = UI::GetMouse();
-	Point anchor = mouse / Zoom() - center;
+	Point anchor = mouse / TargetZoom() - center;
 	if(dy > 0.)
 		IncrementZoom();
 	else if(dy < 0.)
 		DecrementZoom();
 
-	// Now, Zoom() has changed (unless at one of the limits). But, we still want
+	// Now, the target zoom has changed (unless at one of the limits). But, we still want
 	// anchor to be the same, so:
-	center = mouse / Zoom() - anchor;
+	recenterVector = mouse / TargetZoom() - anchor - center;
+	recentering = RECENTER_TIME;
 	return true;
 }
 
@@ -816,6 +817,13 @@ void MapPanel::Find(const string &name)
 double MapPanel::Zoom() const
 {
 	return pow(1.5, zoom.AnimatedValue());
+}
+
+
+
+double MapPanel::TargetZoom() const
+{
+	return pow(1.5, zoom.Value());
 }
 
 

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -115,6 +115,7 @@ protected:
 	void Find(const std::string &name);
 
 	double Zoom() const;
+	double TargetZoom() const;
 
 	// Check whether the NPC and waypoint conditions of the given mission have
 	// been satisfied.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1420789874721685574).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When changing map zoom via mouse scroll, the map should recenter so that the mouse pointer is at the same point of the map before and after the zoom change. It worked like this before the smooth animation was introduced, but was broken with #11659.

## Testing Done
yes™.

## Performance Impact
N/A
