### PR TITLE
fix: Don't move the background if the player is dead

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -571,7 +571,7 @@ void Engine::Step(bool isActive)
 		}
 
 		// Step the background to account for the current velocity and zoom.
-		GameData::StepBackground(timePaused ? Point() : camera.Velocity(), zoom);
+		GameData::StepBackground(timePaused || !flagship ? Point() : camera.Velocity(), zoom);
 	}
 
 	outlines.clear();


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11775 (closes #11775).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When the player doesn't have a flagship (for example because the pilot is dead), the starfield in the background shouldn't move. This doesn't affect the menu background animation, only the engine.

## Testing Done
yes™.

## Performance Impact
N/A
