### PR TITLE
Fix the map not recentring about the mouse pointer when zooming by scrolling

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -298,7 +298,21 @@ void MapPanel::Step()
 		--recentering;
 	}
 
+	// The mouse should be pointing to the same map position before and after zooming.
+	bool needsRecenter = !zoom.IsAnimationDone();
+	Point mouse, anchor;
+	if(needsRecenter)
+	{
+		mouse = UI::GetMouse();
+		anchor = mouse / Zoom() - center;
+	}
+
 	zoom.Step();
+
+	// Now, Zoom() has changed (unless at one of the limits). But, we still want
+	// anchor to be the same, so:
+	if(needsRecenter)
+		center = mouse / Zoom() - anchor;
 }
 
 
@@ -580,17 +594,11 @@ bool MapPanel::Drag(double dx, double dy)
 
 bool MapPanel::Scroll(double dx, double dy)
 {
-	// The mouse should be pointing to the same map position before and after zooming.
-	Point mouse = UI::GetMouse();
-	Point anchor = mouse / Zoom() - center;
 	if(dy > 0.)
 		IncrementZoom();
 	else if(dy < 0.)
 		DecrementZoom();
 
-	// Now, Zoom() has changed (unless at one of the limits). But, we still want
-	// anchor to be the same, so:
-	center = mouse / Zoom() - anchor;
 	return true;
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1420789874721685574)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Previously, when zooming the map by scrolling, it would zoom centred around the mouse pointer. That is, the point in the map below the mouse pointer would remain the same before and after the  change in zoom level.
The addition of smooth zooming breaks this because the actual zoom value is no longer changed immediately, so the code that recentred the map to keep the map from moving under the mouse pointer doesn't work since it expects to be able to do it instantly. As a result, the map always zooms around the centre of the screen.
This PR fixes this by continuously recentring the map every step while the zoom animation is occurring.

## Screenshots
N/A - I can make a video tomorrow or something if someone really wants to see.

## Usage examples
N/A

## Testing Done
Open map panel.
Zoom in and out with the scroll wheel on my mouse.

## Save File
This save file can be used to test these changes:
N/A - any save, even a brand new one, ought to be adequate.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
`MapPanel::Step` does considerably more work while zooming, but I expect the difference to be very small compared to the cost of `MapPanel::Draw` and some other methods around there.
