### PR TITLE
feat(ui): Use Windows DWM attributes preferred by the player

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1575,7 +1575,7 @@ tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
 
 tip "Title bar theme"
-	`Choose the theme of the title bar, or leave "default" to use system settings. (Available on Windows 10 or newer.)`
+	`Choose the theme of the title bar, or leave "system default" to use system settings. (Available on Windows 10 or newer.)`
 
 tip "Window rounding"
 	`Control the appearance of window corners. (Available on Windows 11.)`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1575,7 +1575,7 @@ tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
 
 tip "Title bar theme"
-	`Choose the theme of the title bar, or leave "default" to use system settings.`
+	`Choose the theme of the title bar, or leave "default" to use system settings. (Available on Windows 10 or newer.)`
 
 tip "Window rounding"
-	`Control the appearance of window corners.`
+	`Control the appearance of window corners. (Available on Windows 11.)`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1573,3 +1573,9 @@ tip "Show parenthesis"
 
 tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
+
+tip "Title bar theme"
+	`Choose the theme of the title bar, or leave "default" to use system settings.`
+
+tip "Window rounding"
+	`Control the appearance of window corners.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1575,7 +1575,7 @@ tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
 
 tip "Title bar theme"
-	`Choose the theme of the title bar, or leave "system default" to use system settings. (Available on Windows 10 or newer.)`
+	`Choose the theme of the title bar, or leave "system default" to use system settings. (Available on Windows 10 or newer; on Windows 10, the game window must be resized or restarted in order for the change to take effect)`
 
 tip "Window rounding"
 	`Control the appearance of window corners. (Available on Windows 11.)`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1575,7 +1575,7 @@ tip "Notify on destination"
 	`If you enter a system with a planet you must land on for a mission, plays a notification sound.`
 
 tip "Title bar theme"
-	`Choose the theme of the title bar, or leave "system default" to use system settings. (Available on Windows 10 or newer; on Windows 10, the game window must be resized or restarted in order for the change to take effect)`
+	`Choose the theme of the title bar, or leave "system default" to use system settings. (Available on Windows 10 or newer; on Windows 10, the game window must be resized or restarted in order for the change to take effect.)`
 
 tip "Window rounding"
 	`Control the appearance of window corners. (Available on Windows 11.)`

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -442,5 +442,7 @@ if(WIN32)
 	target_sources(EndlessSkyLib PRIVATE
 		windows/TimerResolutionGuard.cpp
 		windows/TimerResolutionGuard.h
+		windows/WinVersion.cpp
+		windows/WinVersion.h
 	)
 endif()

--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -26,6 +26,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 
 #ifdef _WIN32
+#include "windows/WinVersion.h"
+
 #include <windows.h>
 
 #include <dwmapi.h>
@@ -251,27 +253,8 @@ bool GameWindow::Init(bool headless)
 	AdjustViewport();
 
 #ifdef _WIN32
-	// Set up a dark title bar on Windows versions that support it
-	// without having to draw it manually.
-	HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
-	auto rtlGetVersion = reinterpret_cast<NTSTATUS (*)(PRTL_OSVERSIONINFOW)>(GetProcAddress(ntdll, "RtlGetVersion"));
-	RTL_OSVERSIONINFOW versionInfo = {};
-	if(rtlGetVersion)
-		rtlGetVersion(&versionInfo);
-	FreeLibrary(ntdll);
-	if(versionInfo.dwBuildNumber >= 19041)
-	{
-		SDL_SysWMinfo windowInfo;
-		SDL_VERSION(&windowInfo.version);
-		SDL_GetWindowWMInfo(mainWindow, &windowInfo);
-		BOOL value = 1;
-
-		HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
-		auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
-			GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
-		dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
-		FreeLibrary(dwmapi);
-	}
+	UpdateTitleBarTheme();
+	UpdateWindowRounding();
 #endif
 
 	return true;
@@ -466,3 +449,67 @@ void GameWindow::ExitWithError(const string &message, bool doPopUp)
 
 	GameWindow::Quit();
 }
+
+
+
+#ifdef _WIN32
+void GameWindow::UpdateTitleBarTheme()
+{
+	if(!WinVersion::SupportsDarkTheme())
+		return;
+
+	SDL_SysWMinfo windowInfo;
+	SDL_VERSION(&windowInfo.version);
+	SDL_GetWindowWMInfo(mainWindow, &windowInfo);
+
+	BOOL value;
+	Preferences::TitleBarTheme themePreference = Preferences::GetTitleBarTheme();
+	// If the default option is selected, check the system-wide preference.
+	if(themePreference == Preferences::TitleBarTheme::DEFAULT)
+	{
+		HKEY systemPreference;
+		if(RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+			0, KEY_READ, &systemPreference) == ERROR_SUCCESS)
+		{
+			DWORD size = sizeof(value);
+			if(RegQueryValueExW(systemPreference, L"AppsUseLightTheme", 0, nullptr,
+					reinterpret_cast<LPBYTE>(&value), &size) == ERROR_SUCCESS)
+				// The key says about light theme, while DWM expects information about dark theme.
+				value = !value;
+			else
+				value = 1;
+			RegCloseKey(systemPreference);
+		}
+		else
+			value = 1;
+	}
+	else
+		value = themePreference == Preferences::TitleBarTheme::DARK;
+
+	HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
+	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
+		GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
+	dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
+	FreeLibrary(dwmapi);
+}
+
+
+
+void GameWindow::UpdateWindowRounding()
+{
+	if(!WinVersion::SupportsWindowRounding())
+		return;
+
+	SDL_SysWMinfo windowInfo;
+	SDL_VERSION(&windowInfo.version);
+	SDL_GetWindowWMInfo(mainWindow, &windowInfo);
+
+	auto value = static_cast<DWM_WINDOW_CORNER_PREFERENCE>(Preferences::GetWindowRounding());
+
+	HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
+	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
+		GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
+	dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_WINDOW_CORNER_PREFERENCE, &value, sizeof(value));
+	FreeLibrary(dwmapi);
+}
+#endif

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -50,4 +50,9 @@ public:
 	// Print the error message in the terminal, error file, and message box.
 	// Checks for video system errors and records those as well.
 	static void ExitWithError(const std::string &message, bool doPopUp = true);
+
+#ifdef _WIN32
+	static void UpdateTitleBarTheme();
+	static void UpdateWindowRounding();
+#endif
 };

--- a/source/GameWindow.h
+++ b/source/GameWindow.h
@@ -52,6 +52,7 @@ public:
 	static void ExitWithError(const std::string &message, bool doPopUp = true);
 
 #ifdef _WIN32
+	// Set attributes of the main window according to the current preferences.
 	static void UpdateTitleBarTheme();
 	static void UpdateWindowRounding();
 #endif

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -26,6 +26,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Logger.h"
 #include "Screen.h"
 
+#ifdef _WIN32
+#include "windows/WinVersion.h"
+#endif
+
 #include <algorithm>
 #include <cstddef>
 #include <map>
@@ -342,8 +346,10 @@ void Preferences::Save()
 	out.Write("Prioritize flagship use", flagshipSpacePriorityIndex);
 	out.Write("previous saves", previousSaveCount);
 #ifdef _WIN32
-	out.Write("Title bar theme", titleBarThemeIndex);
-	out.Write("Window rounding", windowRoundingIndex);
+	if(WinVersion::SupportsDarkTheme())
+		out.Write("Title bar theme", titleBarThemeIndex);
+	if(WinVersion::SupportsWindowRounding())
+		out.Write("Window rounding", windowRoundingIndex);
 #endif
 
 	for(const auto &it : settings)

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -177,10 +177,10 @@ namespace {
 	int previousSaveCount = 3;
 
 #ifdef _WIN32
-	const vector<string> TITLE_BAR_THEME_SETTINGS = {"default", "light", "dark"};
+	const vector<string> TITLE_BAR_THEME_SETTINGS = {"system default", "light", "dark"};
 	int titleBarThemeIndex = 0;
 
-	const vector<string> WINDOW_ROUNDING_SETTINGS = {"default", "off", "large", "small"};
+	const vector<string> WINDOW_ROUNDING_SETTINGS = {"system default", "off", "large", "small"};
 	int windowRoundingIndex = 0;
 #endif
 }

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -171,6 +171,14 @@ namespace {
 	int flagshipSpacePriorityIndex = 1;
 
 	int previousSaveCount = 3;
+
+#ifdef _WIN32
+	const vector<string> TITLE_BAR_THEME_SETTINGS = {"default", "light", "dark"};
+	int titleBarThemeIndex = 0;
+
+	const vector<string> WINDOW_ROUNDING_SETTINGS = {"default", "off", "large", "small"};
+	int windowRoundingIndex = 0;
+#endif
 }
 
 
@@ -260,6 +268,12 @@ void Preferences::Load()
 			settings["Control ship with mouse"] = (!hasValue || node.Value(1));
 		else if(key == "notification settings")
 			notifOptionsIndex = max<int>(0, min<int>(node.Value(1), NOTIF_OPTIONS.size() - 1));
+#ifdef _WIN32
+		else if(key == "Title bar theme")
+			titleBarThemeIndex = clamp<int>(node.Value(1), 0, TITLE_BAR_THEME_SETTINGS.size() - 1);
+		else if(key == "Window rounding")
+			windowRoundingIndex = clamp<int>(node.Value(1), 0, WINDOW_ROUNDING_SETTINGS.size() - 1);
+#endif
 		else
 			settings[key] = (node.Size() == 1 || node.Value(1));
 	}
@@ -327,6 +341,10 @@ void Preferences::Save()
 	out.Write("Show mini-map", minimapDisplayIndex);
 	out.Write("Prioritize flagship use", flagshipSpacePriorityIndex);
 	out.Write("previous saves", previousSaveCount);
+#ifdef _WIN32
+	out.Write("Title bar theme", titleBarThemeIndex);
+	out.Write("Window rounding", windowRoundingIndex);
+#endif
 
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);
@@ -862,3 +880,51 @@ const string &Preferences::FlagshipSpacePrioritySetting()
 {
 	return FLAGSHIP_SPACE_PRIORITY_SETTINGS[flagshipSpacePriorityIndex];
 }
+
+
+
+#ifdef _WIN32
+void Preferences::ToggleTitleBarTheme()
+{
+	if(++titleBarThemeIndex >= static_cast<int>(TITLE_BAR_THEME_SETTINGS.size()))
+		titleBarThemeIndex = 0;
+	GameWindow::UpdateTitleBarTheme();
+}
+
+
+
+Preferences::TitleBarTheme Preferences::GetTitleBarTheme()
+{
+	return static_cast<TitleBarTheme>(titleBarThemeIndex);
+}
+
+
+
+const string &Preferences::TitleBarThemeSetting()
+{
+	return TITLE_BAR_THEME_SETTINGS[titleBarThemeIndex];
+}
+
+
+
+void Preferences::ToggleWindowRounding()
+{
+	if(++windowRoundingIndex >= static_cast<int>(WINDOW_ROUNDING_SETTINGS.size()))
+		windowRoundingIndex = 0;
+	GameWindow::UpdateWindowRounding();
+}
+
+
+
+Preferences::WindowRounding Preferences::GetWindowRounding()
+{
+	return static_cast<WindowRounding>(windowRoundingIndex);
+}
+
+
+
+const string &Preferences::WindowRoundingSetting()
+{
+	return WINDOW_ROUNDING_SETTINGS[windowRoundingIndex];
+}
+#endif

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -127,6 +127,21 @@ public:
 		BOTH
 	};
 
+#ifdef _WIN32
+	enum class TitleBarTheme : int_fast8_t {
+		DEFAULT,
+		LIGHT,
+		DARK
+	};
+
+	enum class WindowRounding : int_fast8_t {
+		DEFAULT,
+		OFF,
+		LARGE,
+		SMALL
+	};
+#endif
+
 
 public:
 	static void Load();
@@ -230,4 +245,14 @@ public:
 	static const std::string &FlagshipSpacePrioritySetting();
 
 	static int GetPreviousSaveCount();
+
+#ifdef _WIN32
+	static void ToggleTitleBarTheme();
+	static TitleBarTheme GetTitleBarTheme();
+	static const std::string &TitleBarThemeSetting();
+
+	static void ToggleWindowRounding();
+	static WindowRounding GetWindowRounding();
+	static const std::string &WindowRoundingSetting();
+#endif
 };

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -796,7 +796,7 @@ void PreferencesPanel::DrawSettings()
 		NOTIFY_ON_DEST
 #ifdef _WIN32
 		, "",
-		"System-specific",
+		"Windows Options",
 		TITLE_BAR_THEME,
 		WINDOW_ROUNDING
 #endif

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -41,6 +41,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "UI.h"
 #include "text/WrappedText.h"
 
+#ifdef _WIN32
+#include "windows/WinVersion.h"
+#endif
+
 #include "opengl.h"
 
 #include <algorithm>
@@ -85,6 +89,10 @@ namespace {
 	const string ALERT_INDICATOR = "Alert indicator";
 	const string MINIMAP_DISPLAY = "Show mini-map";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
+#ifdef _WIN32
+	const string TITLE_BAR_THEME = "Title bar theme";
+	const string WINDOW_ROUNDING = "Window rounding";
+#endif
 
 	// How many pages of controls and settings there are.
 	const int CONTROLS_PAGE_COUNT = 2;
@@ -786,6 +794,12 @@ void PreferencesPanel::DrawSettings()
 		DATE_FORMAT,
 		"Show parenthesis",
 		NOTIFY_ON_DEST
+#ifdef _WIN32
+		, "",
+		"System-specific",
+		TITLE_BAR_THEME,
+		WINDOW_ROUNDING
+#endif
 	};
 
 	bool isCategory = true;
@@ -1014,6 +1028,18 @@ void PreferencesPanel::DrawSettings()
 			isOn = Preferences::GetMinimapDisplay() != Preferences::MinimapDisplay::OFF;
 			text = Preferences::MinimapSetting();
 		}
+#ifdef _WIN32
+		else if(setting == TITLE_BAR_THEME)
+		{
+			isOn = WinVersion::SupportsDarkTheme();
+			text = isOn ? Preferences::TitleBarThemeSetting() : "N/A";
+		}
+		else if(setting == WINDOW_ROUNDING)
+		{
+			isOn = WinVersion::SupportsWindowRounding();
+			text = isOn ? Preferences::WindowRoundingSetting() : "N/A";
+		}
+#endif
 		else
 			text = isOn ? "on" : "off";
 
@@ -1350,6 +1376,12 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleAlert();
 	else if(str == MINIMAP_DISPLAY)
 		Preferences::ToggleMinimapDisplay();
+#ifdef _WIN32
+	else if(str == TITLE_BAR_THEME)
+		Preferences::ToggleTitleBarTheme();
+	else if(str == WINDOW_ROUNDING)
+		Preferences::ToggleWindowRounding();
+#endif
 	// All other options are handled by just toggling the boolean state.
 	else
 		Preferences::Set(str, !Preferences::Has(str));

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -45,6 +45,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #ifdef _WIN32
 #include "windows/TimerResolutionGuard.h"
+#include "windows/WinVersion.h"
 #endif
 
 #include <chrono>
@@ -79,8 +80,9 @@ void InitConsole();
 // Entry point for the EndlessSky executable
 int main(int argc, char *argv[])
 {
-	// Handle command-line arguments
 #ifdef _WIN32
+	WinVersion::Init();
+	// Handle command-line arguments
 	if(argc > 1)
 		InitConsole();
 #endif

--- a/source/windows/WinVersion.cpp
+++ b/source/windows/WinVersion.cpp
@@ -1,0 +1,51 @@
+/* WinVersion.cpp
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "WinVersion.h"
+
+#include <windows.h>
+
+namespace {
+	bool supportsDarkTheme = false;
+	bool supportsWindowRounding = false;
+}
+
+
+
+void WinVersion::Init()
+{
+	HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
+	auto rtlGetVersion = reinterpret_cast<NTSTATUS (*)(PRTL_OSVERSIONINFOW)>(GetProcAddress(ntdll, "RtlGetVersion"));
+	RTL_OSVERSIONINFOW versionInfo = {};
+	rtlGetVersion(&versionInfo);
+	FreeLibrary(ntdll);
+
+	supportsDarkTheme = versionInfo.dwBuildNumber >= 19041;
+	supportsWindowRounding = versionInfo.dwBuildNumber >= 22000;
+}
+
+
+
+bool WinVersion::SupportsDarkTheme()
+{
+	return supportsDarkTheme;
+}
+
+
+
+bool WinVersion::SupportsWindowRounding()
+{
+	return supportsWindowRounding;
+}

--- a/source/windows/WinVersion.h
+++ b/source/windows/WinVersion.h
@@ -1,0 +1,28 @@
+/* WinVersion.h
+Copyright (c) 2025 by TomGoodIdea
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+
+
+// A wrapper class that queries the version of Windows that is running the game,
+// and provides information on support for various features.
+class WinVersion {
+public:
+	static void Init();
+
+	static bool SupportsDarkTheme();
+	static bool SupportsWindowRounding();
+};


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Instead of hardcoding the title bar theme to dark, there's now a preference allowing to choose between the default option (read from the registry) and force-enabling dark or light.

As window corner rounding on Windows 11 is controlled in the same way (must be done by programs themselves, and there's no documented global setting), it now also has an in-game preference controlling it.

## Screenshots
Preferences on Windows XP:
<img width="390" height="220" alt="dwmprefs" src="https://github.com/user-attachments/assets/3c36ef69-e0dd-4aed-9913-93187710ade9" />

on Windows 11:
<img width="319" height="132" alt="image" src="https://github.com/user-attachments/assets/f0103cd4-7a40-48e8-89de-f1fc20a68c0a" />

On systems other than Windows, they are ifdefed out, so they don't appear at all.

## Testing Done
Tested both settings on Windows 11.

## Performance Impact
N/A
