### PR TITLE
fix(mechanics): Take maximum velocity into account when approaching a moving target

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2499,7 +2499,8 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 
 	bool canMatchVelocityForward = ship.MaxVelocity() * ship.MaxVelocity() >= targetVelocity.LengthSquared();
 	bool canMatchVelocityReverse = ship.MaxReverseVelocity() * ship.MaxReverseVelocity() >= targetVelocity.LengthSquared();
-	if(canMatchVelocityReverse && (reverseTime < forwardTime || !canMatchVelocityForward))
+	if((canMatchVelocityReverse && (reverseTime < forwardTime || !canMatchVelocityForward))
+			|| (!canMatchVelocityReverse && !canMatchVelocityForward && reverseTime < forwardTime))
 		command.SetTurn(TurnToward(ship, -wantedAcceleration));
 	else
 		command.SetTurn(TurnToward(ship, wantedAcceleration));

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2497,7 +2497,9 @@ bool AI::MoveTo(const Ship &ship, Command &command, const Point &targetPosition,
 	bool facingAgainstTarget = angle.Unit().Dot(-wantedAcceleration.Unit()) > .9;
 	bool hasCruiseSpeed = (cruiseSpeed > 0.);
 
-	if(reverseTime < forwardTime)
+	bool canMatchVelocityForward = ship.MaxVelocity() * ship.MaxVelocity() >= targetVelocity.LengthSquared();
+	bool canMatchVelocityReverse = ship.MaxReverseVelocity() * ship.MaxReverseVelocity() >= targetVelocity.LengthSquared();
+	if(canMatchVelocityReverse && (reverseTime < forwardTime || !canMatchVelocityForward))
 		command.SetTurn(TurnToward(ship, -wantedAcceleration));
 	else
 		command.SetTurn(TurnToward(ship, wantedAcceleration));


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on discord and in the reverse thrust pr.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
If a ship has little steering and tries to catch up to a moving target behind it, it would sometimes get stuck using the reverse thrusters only. I added a check for the maximum velocity to see if it could ever catch up using the forward or reverse thrusters.

## Testing Done
I tested with a ranoerek and a hurricane as described on discord, with the gather order active. When my velocity was too great, the ship switched to its best engine.