### PR TITLE
feat(content): Give Hand-to-hand outfits to Bunrodean ships

### DIFF
--- a/data/bunrodea/bunrodea ships.txt
+++ b/data/bunrodea/bunrodea ships.txt
@@ -34,6 +34,7 @@ ship "Kaiken"
 			"hit force" 600
 	outfits
 		"Locust Blaster" 3
+		"Lasher Pistol"
 		
 		"Solar Battery"
 		"Solar Cell" 27
@@ -89,6 +90,7 @@ ship "Sasumata"
 		"Swarm Missile" 1000
 		"Swarm Clip"
 		"Buzzer Anti-Missile" 2
+		"Lasher Pistol" 41
 		
 		"Quark Reactor"
 		"Reactor Overclocker" 2
@@ -148,6 +150,7 @@ ship "Tanto"
 			"hit force" 1800
 	outfits
 		"Buzzer Anti-Missile" 2
+		"Lasher Pistol" 5
 		
 		"Solar Battery" 2
 		"Solar Cell" 42
@@ -201,6 +204,7 @@ ship "Ararebo"
 	outfits
 		"Locust Turret" 2
 		"Buzzer Anti-Missile" 2
+		"Lasher Pistol" 29
 		
 		"Dark Reactor"
 		"Reactor Overclocker" 8
@@ -269,6 +273,7 @@ ship "Tekkan"
 		"Locust Blaster" 2
 		"Locust Turret"
 		"Buzzer Anti-Missile" 2
+		"Lasher Pistol" 8
 		
 		"Quark Reactor"
 		"Solar Battery"
@@ -324,6 +329,7 @@ ship "Kunai"
 	outfits
 		"Mandible Cannon" 4
 		"Locust Blaster" 2
+		"Lasher Pistol" 26
 		
 		"Quark Reactor"
 		"Solar Battery" 2
@@ -383,6 +389,7 @@ ship "Kama"
 		"Mandible Cannon" 4
 		"Swarm Pod" 6
 		"Swarm Missile" 2400
+		"Lasher Pistol" 41
 		
 		"Electroweak Reactor"
 		"Reactor Overclocker" 2
@@ -451,6 +458,7 @@ ship "Chigiriki"
 		"Locust Blaster" 6
 		"Swarm Pod" 10
 		"Swarm Missile" 4000
+		"Lasher Pistol" 59
 		
 		"Dark Reactor"
 		"Reactor Limiter" 3


### PR DESCRIPTION
## Bunrodean Call to Arms

This PR addresses the observation described [on Discord](https://discord.com/channels/251118043411775489/308902312741568512/1421743494086529064) by Koalabog, which is simply, that the Bunrodeans don't carry H2H weapons on their ships.

This may be due to the Bunrodeans being work in progress, however it's common gameplay to farm them for ships, and not equipping their crew with H2H weapons makes boarding unnecessarily easy.

Hence, this PR adds to all ships Lasher Pistols according the following formula to match the average crew size to be expected:
```
#h2h = required crew + 0.5 * (bunks - required crew)
```

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.