### PR TITLE
ui: Add a message category that allows duplicates

### DIFF
--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -49,7 +49,7 @@ void Messages::Add(const string &message, Importance importance, bool force)
 // also on the main panel, use Add instead.
 void Messages::AddLog(const string &message, Importance importance, bool force)
 {
-	if(force || logged.empty() || message != logged.front().first)
+	if(force || logged.empty() || message != logged.front().first || importance == Importance::Duplicating)
 	{
 		logged.emplace_front(message, importance);
 		if(logged.size() > MAX_LOG)
@@ -103,7 +103,7 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 			// For each incoming message, if it exactly matches an existing message,
 			// replace that one with this new one by scheduling the old one for removal.
 			if(importance != Importance::Low && importance != Importance::HighestNoRepeat
-					&& it.message == message && it.deathStep < 0)
+					&& importance != Importance::Duplicating && it.message == message && it.deathStep < 0)
 				it.deathStep = step + animationDuration;
 		}
 		recent.emplace_back(step, message, importance);
@@ -140,6 +140,7 @@ const Color *Messages::GetColor(Importance importance, bool isLogPanel)
 	{
 		case Messages::Importance::Highest:
 		case Messages::Importance::HighestNoRepeat:
+		case Messages::Importance::Duplicating:
 			return GameData::Colors().Get(prefix + "highest");
 		case Messages::Importance::High:
 			return GameData::Colors().Get(prefix + "high");

--- a/source/Messages.cpp
+++ b/source/Messages.cpp
@@ -49,7 +49,7 @@ void Messages::Add(const string &message, Importance importance, bool force)
 // also on the main panel, use Add instead.
 void Messages::AddLog(const string &message, Importance importance, bool force)
 {
-	if(force || logged.empty() || message != logged.front().first || importance == Importance::Duplicating)
+	if(force || logged.empty() || message != logged.front().first || importance == Importance::HighestDuplicating)
 	{
 		logged.emplace_front(message, importance);
 		if(logged.size() > MAX_LOG)
@@ -103,7 +103,7 @@ const vector<Messages::Entry> &Messages::Get(int step, int animationDuration)
 			// For each incoming message, if it exactly matches an existing message,
 			// replace that one with this new one by scheduling the old one for removal.
 			if(importance != Importance::Low && importance != Importance::HighestNoRepeat
-					&& importance != Importance::Duplicating && it.message == message && it.deathStep < 0)
+					&& importance != Importance::HighestDuplicating && it.message == message && it.deathStep < 0)
 				it.deathStep = step + animationDuration;
 		}
 		recent.emplace_back(step, message, importance);
@@ -140,7 +140,7 @@ const Color *Messages::GetColor(Importance importance, bool isLogPanel)
 	{
 		case Messages::Importance::Highest:
 		case Messages::Importance::HighestNoRepeat:
-		case Messages::Importance::Duplicating:
+		case Messages::Importance::HighestDuplicating:
 			return GameData::Colors().Get(prefix + "highest");
 		case Messages::Importance::High:
 			return GameData::Colors().Get(prefix + "high");

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -39,7 +39,7 @@ public:
 		Daily,
 		Low,
 		HighestNoRepeat,
-		Duplicating
+		HighestDuplicating
 	};
 
 	class Entry {

--- a/source/Messages.h
+++ b/source/Messages.h
@@ -38,7 +38,8 @@ public:
 		Info,
 		Daily,
 		Low,
-		HighestNoRepeat
+		HighestNoRepeat,
+		Duplicating
 	};
 
 	class Entry {

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3270,7 +3270,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 
 		if(IsYours())
 			Messages::Add("Your " + DisplayModelName() +
-				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Highest);
+				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Duplicating);
 	}
 
 	// Inflicted heat damage may also disable a ship, but does not trigger a "DISABLE" event.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3270,7 +3270,7 @@ int Ship::TakeDamage(vector<Visual> &visuals, const DamageDealt &damage, const G
 
 		if(IsYours())
 			Messages::Add("Your " + DisplayModelName() +
-				" \"" + Name() + "\" has been destroyed.", Messages::Importance::Duplicating);
+				" \"" + Name() + "\" has been destroyed.", Messages::Importance::HighestDuplicating);
 	}
 
 	// Inflicted heat damage may also disable a ship, but does not trigger a "DISABLE" event.


### PR DESCRIPTION
**Feature**

This PR addresses the behavior reported [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1421837228182605835).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently if you have multiple ships with the same name, and they get destroyed in a short time, the duplicate messages get removed. This PR adds a new importance level that allows duplicates in both the main list and the log, and uses it for these messages.

## Screenshots
<img width="488" height="97" alt="image" src="https://github.com/user-attachments/assets/205ddc09-4257-4cc2-bcdb-5d176a6486f8" />
<img width="602" height="160" alt="image" src="https://github.com/user-attachments/assets/52ef2d98-da94-48d7-9dca-08a69ab5d54e" />

## Testing Done
See the above screenshots.

## Performance Impact
N/A
