### PR TITLE
ui: Don't show fleet's cargo capacity in the shipyard

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -859,7 +859,7 @@ void ShopPanel::DrawShipsSidebar()
 		const int detailHeight = DrawPlayerShipInfo(point + offset);
 		point.Y() += detailHeight + SHIP_SIZE / 2;
 	}
-	else if(player.Cargo().Size())
+	else if(isOutfitter && player.Cargo().Size())
 	{
 		point.X() = Screen::Right() - SIDEBAR_WIDTH + 10;
 		font.Draw("cargo space:", point, medium);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11784 (closes #11784).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, cargo space is shown on the fleet sidebar of shop panels when you don't have any of your ships selected, but is only useful in the outfitter, where by deselecting your ships you can put outfits into cargo.
Now that the ShopPanel's code can know if it's a shipyard or an outfitter, we can hide the cargo space info on the shipyard panel.

## Screenshots
Outfitter:
<img width="250" height="151" alt="{BFE77E6D-F50E-4461-BFC2-C03D5B1071E3}" src="https://github.com/user-attachments/assets/f6835ff5-a5c9-4dc0-ad2e-07ffea9d11b1" />

Shipyard:
<img width="241" height="186" alt="{C7B938DD-9D6A-43D6-90B3-15264E7E00F7}" src="https://github.com/user-attachments/assets/f73c1086-47c0-4b3b-b3a6-8451139da687" />

## Testing Done
See above.

## Performance Impact
N/A
