### PR TITLE
(bugfix) Prevent Coalition Yottrite missions from offering on Gas Giants

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -243,6 +243,7 @@ mission "Coalition Yottrite 1"
 		has "Coalition Yottrite 2: offered"
 	source
 		near "Bloptab" 1 100
+		not government "Uninhabited"
 	destination "Bloptab's Furnace"
 	on offer
 		conversation

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -243,7 +243,7 @@ mission "Coalition Yottrite 1"
 		has "Coalition Yottrite 2: offered"
 	source
 		near "Bloptab" 1 100
-		not government "Uninhabited"
+		government "Coalition" "Heliarch"
 	destination "Bloptab's Furnace"
 	on offer
 		conversation


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in [this Steam post](https://steamcommunity.com/app/404410/discussions/1/591783706467849836/) by user hellminister.

## Acknowledgement

- [ x ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Just adds a line to prevent the mission from offering on a gas giant (Uninhabited).
