### PR TITLE
fix(sound): Fix planet ambient music playback

### DIFF
--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -91,9 +91,6 @@ MenuPanel::MenuPanel(PlayerInfo &player, UI &gamePanels)
 		gamePanels.StepAll();
 	}
 
-	if(player.GetPlanet())
-		Audio::PlayMusic(player.GetPlanet()->MusicName());
-
 	if(!scrollSpeed)
 		scrollSpeed = 1;
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -1501,10 +1501,8 @@ void PlayerInfo::Land(UI *ui)
 		return;
 
 	if(!freshlyLoaded)
-	{
 		Audio::Play(Audio::Get("landing"), SoundCategory::ENGINE);
-		Audio::PlayMusic(planet->MusicName());
-	}
+	Audio::PlayMusic(planet->MusicName());
 
 	// Mark this planet as visited.
 	Visit(*planet);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11150 (closes #11150).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Moved the code responsible for playing planet music to a single place. It's now independent of opening the menu panel, and only started when landing or loading a save.

## Testing Done
yes™.

## Performance Impact
N/A