### PR TITLE
fix(mechanics): Correctly apply fighter repair heat and fuel

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4142,10 +4142,10 @@ void Ship::DoGeneration()
 				Ship &ship = *it.second;
 				if(!hullDelay)
 					DoRepair(ship.hull, hullRemaining, ship.MaxHull(),
-						energy, hullEnergy, heat, hullHeat, fuel, hullFuel);
+						energy, hullEnergy, fuel, hullFuel, heat, hullHeat);
 				if(!shieldDelay)
 					DoRepair(ship.shields, shieldsRemaining, ship.MaxShields(),
-						energy, shieldsEnergy, heat, shieldsHeat, fuel, shieldsFuel);
+						energy, shieldsEnergy, fuel, shieldsFuel, heat, shieldsHeat);
 			}
 
 			// Now that there is no more need to use energy for hull and shield


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Some calls to DoRepair on carried ships have heat and fuel mixed up (which this PR fixes). As you can see, the signature matches
https://github.com/endless-sky/endless-sky/blob/ea826d4427277f0625bca012abb89325b7d86daa/source/Ship.cpp#L111-L112
so the compiler has no problems when the values are in a wrong order where the function is used.

## Testing Done
None.

## Performance Impact
N/A