### PR TITLE
Fixes needed to get this to compile on my debian box

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,15 +90,15 @@ find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INS
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
 
 if(UNIX AND NOT APPLE AND NOT ES_USE_VCPKG)
-   # Many linux distros use the autotools build of flac, which does not 
-   # package the flac-config.cmake. Use PkgConfig instead.
-   find_package(PkgConfig REQUIRED)
-   pkg_check_modules(flac++ REQUIRED IMPORTED_TARGET flac++)
-   add_library(FLAC::FLAC++ ALIAS PkgConfig::flac++)
+	# Many linux distros use the autotools build of flac, which does not
+	# package the flac-config.cmake. Use PkgConfig instead.
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(flac++ REQUIRED IMPORTED_TARGET flac++)
+	add_library(FLAC::FLAC++ ALIAS PkgConfig::flac++)
 else()
-   # FLAC's config is missing find_dependency(Threads), so include it here.
-   find_package(Threads REQUIRED)
-   find_package(FLAC CONFIG REQUIRED)
+	# FLAC's config is missing find_dependency(Threads), so include it here.
+	find_package(Threads REQUIRED)
+	find_package(FLAC CONFIG REQUIRED)
 endif()
 
 # Find the zip-reading component of zlib.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,15 +89,18 @@ find_path(LIBMAD_INCLUDE_DIR mad.h)
 find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
 
+# FLAC's config is missing find_dependency(Threads), so include it here.
+find_package(Threads REQUIRED)
 if(UNIX AND NOT APPLE AND NOT ES_USE_VCPKG)
-	# Many linux distros use the autotools build of flac, which does not
-	# package the flac-config.cmake. Use PkgConfig instead.
-	find_package(PkgConfig REQUIRED)
-	pkg_check_modules(flac++ REQUIRED IMPORTED_TARGET flac++)
-	add_library(FLAC::FLAC++ ALIAS PkgConfig::flac++)
+	find_package(FLAC CONFIG QUIET)
+	if(NOT FLAC_FOUND)
+		# Many linux distros use the autotools build of flac, which does not
+		# package the flac-config.cmake. Use PkgConfig instead.
+		find_package(PkgConfig REQUIRED)
+		pkg_check_modules(flac++ REQUIRED IMPORTED_TARGET flac++)
+		add_library(FLAC::FLAC++ ALIAS PkgConfig::flac++)
+	endif()
 else()
-	# FLAC's config is missing find_dependency(Threads), so include it here.
-	find_package(Threads REQUIRED)
 	find_package(FLAC CONFIG REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,17 @@ find_path(LIBMAD_INCLUDE_DIR mad.h)
 find_library(LIBMAD_LIB_DEBUG NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
 find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
 
-# FLAC's config is missing find_dependency(Threads), so include it here.
-find_package(Threads REQUIRED)
-find_package(FLAC CONFIG REQUIRED)
+if(UNIX AND NOT APPLE AND NOT ES_USE_VCPKG)
+   # Many linux distros use the autotools build of flac, which does not 
+   # package the flac-config.cmake. Use PkgConfig instead.
+   find_package(PkgConfig REQUIRED)
+   pkg_check_modules(flac++ REQUIRED IMPORTED_TARGET flac++)
+   add_library(FLAC::FLAC++ ALIAS PkgConfig::flac++)
+else()
+   # FLAC's config is missing find_dependency(Threads), so include it here.
+   find_package(Threads REQUIRED)
+   find_package(FLAC CONFIG REQUIRED)
+endif()
 
 # Find the zip-reading component of zlib.
 find_package(ZLIB REQUIRED)

--- a/source/audio/supplier/AudioSupplier.h
+++ b/source/audio/supplier/AudioSupplier.h
@@ -17,6 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <AL/al.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 

--- a/tests/unit/src/test_weightedList.cpp
+++ b/tests/unit/src/test_weightedList.cpp
@@ -349,7 +349,9 @@ SCENARIO( "Obtaining a random value", "[WeightedList][Usage]" ) {
 			THEN( "an informative runtime exception is thrown" ) {
 				CHECK_THROWS_AS( list.Get(), std::runtime_error );
 #ifndef __APPLE__
+#if CATCH_VERSION_MAJOR >= 3
 				CHECK_THROWS_WITH( list.Get(), Catch::Matchers::ContainsSubstring("empty weighted list") );
+#endif
 #endif
 			}
 		}


### PR DESCRIPTION
**Build fix**

This PR addresses the bug/feature described in issue #11760

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adjusts flac on linux targets to pull in flac via pkg-config instead of relying on a potentially non-existent `flac-config.cmake`. 
Adds a missing header that defines size_t in `AudioSupplier.h`
Conditionally skips a test that relies on catch2 v3, which is not available on debian stable. 

## Testing Done
Compiled, flew around. 

## Performance Impact
None