### PR TITLE
refactor(ui): Optimize the startup animation

### DIFF
--- a/source/MenuAnimationPanel.cpp
+++ b/source/MenuAnimationPanel.cpp
@@ -47,10 +47,12 @@ void MenuAnimationPanel::Draw()
 	// Draw the shrinking loading circle.
 	Angle da(6.);
 	Angle a(0.);
+	Color color(.5f * alpha, 0.f);
+	PointerShader::Bind();
 	for(int i = 0; i < 60; ++i)
 	{
-		Color color(.5f * alpha, 0.f);
-		PointerShader::Draw(Point(), a.Unit(), 8.f, 20.f, 140.f * alpha, color);
+		PointerShader::Add(Point(), a.Unit(), 8.f, 20.f, 140.f * alpha, color);
 		a += da;
 	}
+	PointerShader::Unbind();
 }


### PR DESCRIPTION
**Refactor**, I guess

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When testing the game on low(est)-end hardware, I noticed that the animation happening after all data is loaded is relatively heavy, considering its visual simplicity.
This PR makes use of the Bind/Add/Unbind functions available in PointerShader instead of binding and unbinding with each Draw call.

## Testing Done
The game still works and the animation looks like before.

## Performance Impact
Unnoticeable on most devices.