### PR TITLE
Add label to STOP command

### DIFF
--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -89,7 +89,7 @@ const Command Command::AUTOSTEER(ONE << 36, "Auto steer");
 // assigned to them, but may have descriptions as needed to facilitate
 // assignments in downstream ports like endless-mobile.
 const Command Command::WAIT(ONE << 37, "");
-const Command Command::STOP(ONE << 38, "Stop Ship");
+const Command Command::STOP(ONE << 38, "Stop your ship");
 const Command Command::SHIFT(ONE << 39, "");
 
 

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -85,7 +85,7 @@ const Command Command::HARVEST(ONE << 34, "Fleet: Harvest flotsam");
 const Command Command::AMMO(ONE << 35, "Fleet: Toggle ammo usage");
 const Command Command::AUTOSTEER(ONE << 36, "Auto steer");
 const Command Command::WAIT(ONE << 37, "");
-const Command Command::STOP(ONE << 38, "");
+const Command Command::STOP(ONE << 38, "Stop Ship");
 const Command Command::SHIFT(ONE << 39, "");
 
 

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -84,6 +84,10 @@ const Command Command::HOLD_POSITION(ONE << 33, "Fleet: Hold position");
 const Command Command::HARVEST(ONE << 34, "Fleet: Harvest flotsam");
 const Command Command::AMMO(ONE << 35, "Fleet: Toggle ammo usage");
 const Command Command::AUTOSTEER(ONE << 36, "Auto steer");
+
+// These commands are not in the preferences panel, and do not have keys
+// assigned to them, but may have descriptions as needed to facilitate
+// assignments in downstream ports like endless-mobile.
 const Command Command::WAIT(ONE << 37, "");
 const Command Command::STOP(ONE << 38, "Stop Ship");
 const Command Command::SHIFT(ONE << 39, "");


### PR DESCRIPTION
The downstream fork endless-mobile uses the command name to link to interface buttons. Normally I wouldn't bother with an upstream merge as I can just add the label in endless-mobile, but this particular command keeps being a source of merge conflicts.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
I just added a label to Command::STOP.

## Testing Done
Verified that that the stop command still works as expected.

## Performance Impact
N/A
