### PR TITLE
Acorn Delights: fix repeatable options

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -2157,29 +2157,45 @@ mission "Acorn Delights: Part 1"
 			choice
 				`	"Three tons of cookies!?"`
 					goto tons
+					to display
+							not "acorn delights: three tons"
 				`	"She's gone?"`
 					goto gone
+					to display
+							not "acorn delights: gone"
 				`	"Why don't you ask the authorities for help?"`
 					goto authorities
+					to display
+							not "acorn delights: authorities"
 				`	"Can't your friends help you find her?"`
 					goto friends
+					to display
+							not "acorn delights: friends"
 				`	"Let's go find her!"`
 					goto accept
 				`	"I have other places to be."`
 					decline
 			label tons
+			action
+				set "acorn delights: three tons"
 			`	"Well, I... I don't know... I cook when I'm worried, and Anoo has been missing for three months! I've sealed all three tons of cookies. They should last a year or two. Maybe she'll share them with her friends? She has many friends! Tons of friends! They all miss her, but none are willing to help...`
 				goto questions
 			label gone
+			action
+				set "acorn delights: gone"
 			`	"Anoo passed medical school on the Frostmark four months ago, near the top of her class! A famous hospital on the Hai-home needed a new trauma surgeon and said she would be perfect for the job. She accepted the position and said she would be on vacation for a few weeks.`
 			`	"A month later, she told them she won't be coming, and nobody has heard from her since.`
 				goto questions
 			label authorities
+			action
+				set "acorn delights: authorities"
 			`	"I talked to the Central Medical Bureau, and they told me she got approval for practicing medicine anywhere in Hai space or beyond. They've heard nothing from her since she got approval. She has to register new medicines with the Bureau, so they should have heard from her.`
 			`	"The police told me that several other people have reported Anoo missing, but they refused to tell me anything else. They said I had to talk to military, but they won't tell me anything.`
 			`	"Maybe she's involved in something secret? Or illegal? No, she'd never do that. Where is she?`
 				goto questions
 			label friends
+			action
+				set "acorn delights: friends"
 			`	"I have few friends, and none of them are interested in finding a missing Hai who could be anywhere. None of my customers want to help either, and her family is all dead.`
 				goto questions
 			label accept


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1424447969457078394)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added `to display` nodes to each option in Acorn Delights: Part 1 so that it is not possible to repeatedly pick the same option.
