### PR TITLE
fix(mechanics): Fix landing logic with custom `"landing speed"`

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4645,7 +4645,7 @@ bool Ship::DoLandingLogic()
 		if(GetTargetStellar())
 			position = .97 * position + .03 * GetTargetStellar()->Position();
 		zoom -= landingSpeed;
-		if(zoom < 0.f)
+		if(zoom <= 0.f)
 		{
 			// If this is not a special ship, it ceases to exist when it
 			// lands on a true planet. If this is a wormhole, the ship is


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1425137296512127057).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
If a ship's zoom becomes exactly 0 when landing on a wormhole, certain portion of important code is skipped, possibly resulting in all kinds of bugs, including visual glitches, or even corrupting/locking save files by permanently landing on the wormhole as if it was a normal planet, but refusing to launch the ship after loading such save.

## Testing Done
Tested both custom `"landing speed"` set to 1, and the default 0.02.

## Performance Impact
N/A
