### PR TITLE
Bump macos runners to 14

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -129,7 +129,7 @@ jobs:
 
   cd_macos_x64:
     name: MacOS
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       OUTPUT: EndlessSky-macOS-continuous.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -193,7 +193,7 @@ jobs:
 
   release_macos_x64:
     name: MacOS x64
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -243,7 +243,7 @@ jobs:
 
   release_macos_arm:
     name: MacOS ARM
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -293,7 +293,7 @@ jobs:
 
   release_macos:
     name: MacOS Universal
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [release_macos_arm, release_macos_x64]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
     name: MacOS
     needs: changed
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.ci_config == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
**CI/CD/Testing**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Most of our MacOS based GitHub Actions jobs run on the `macos-13` GitHub hosted runner. This runner is deprecated and will be removed by the end of the year, with planned outages in November.
This PR updates those jobs to use the `macos-14` runner, which I assume will be around for another year.
Moving to `macos-15` would require either raising our minimum target MacOS version from 10.7 to 10.15, or possibly changing the compiler we use for MacOS (currently Apple Clang) because the version on the `macos-15` runners claims `std::filesystem::path` is only available on 10.15 and later, even though the `macos-13` and `macos-14` versions of the compiler are happy to compile the same code targeting 10.7.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
It'll test itself. See the workflows on this PR.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
