### PR TITLE
Fix "Dangerous Games 1" on visit

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4974,7 +4974,7 @@ mission "Dangerous Games 1"
 			`	You're treated to some jeering and rude looks as you leave the bar.`
 				decline
 	on visit
-		dialog `You land on <planet>, but realize that your escort carrying the passengers hasn't entered this system yet. Better depart and wait for it.`
+		dialog phrase "generic missing stopover or passengers"
 	on stopover
 		conversation
 			`Karengo directs you down through the atmosphere of Skymoot, steering clear of the usual tourist areas and, you realize, of the local law enforcement. As you're putting down in a clearing halfway up a mountain, you hear an otherworldly screech as your ship lurches violently to one side. You would have been thrown to the floor if you hadn't been strapped in.`


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11751

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The mission "Dangerous Games 1" involves taking some passengers on a round trip to Skymoot, which is a stopover.
The "on visist" text currently only suggests that the player has arrived at the destination without the passengers, but it is also possible to get that message if you have arrived at the destination with all the passengers but not visited the stopover, but this possibility is not accounted for.
This PR updates the mission to use the "generic missing stopover or passengers" phrase which looks like:
> You have reached \<planet\>, but you're missing something! Either you haven't visited <stopovers>, or not all the passengers are in the system.

Which means that "on visit" message will now always be correct.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
None yet.

## Save File
This save file can be used to test these changes:
Maybe later.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
