### PR TITLE
Use unique_ptrs in Interface

### DIFF
--- a/source/Interface.cpp
+++ b/source/Interface.cpp
@@ -65,15 +65,6 @@ namespace {
 
 
 
-// Destructor, which frees the memory used by the polymorphic list of elements.
-Interface::~Interface()
-{
-	for(Element *element : elements)
-		delete element;
-}
-
-
-
 // Load an interface.
 void Interface::Load(const DataNode &node)
 {
@@ -125,18 +116,18 @@ void Interface::Load(const DataNode &node)
 		{
 			// Check if this node specifies a known element type.
 			if(key == "sprite" || key == "image" || key == "outline")
-				elements.push_back(new ImageElement(child, anchor));
+				elements.push_back(make_unique<ImageElement>(child, anchor));
 			else if(key == "label" || key == "string" || key == "button" || key == "dynamic button")
-				elements.push_back(new BasicTextElement(child, anchor));
+				elements.push_back(make_unique<BasicTextElement>(child, anchor));
 			else if(key == "wrapped label" || key == "wrapped string"
 					|| key == "wrapped button" || key == "wrapped dynamic button")
-				elements.push_back(new WrappedTextElement(child, anchor));
+				elements.push_back(make_unique<WrappedTextElement>(child, anchor));
 			else if(key == "bar" || key == "ring")
-				elements.push_back(new BarElement(child, anchor));
+				elements.push_back(make_unique<BarElement>(child, anchor));
 			else if(key == "pointer")
-				elements.push_back(new PointerElement(child, anchor));
+				elements.push_back(make_unique<PointerElement>(child, anchor));
 			else if(key == "line")
-				elements.push_back(new LineElement(child, anchor));
+				elements.push_back(make_unique<LineElement>(child, anchor));
 			else
 			{
 				child.PrintTrace("Skipping unrecognized element:");
@@ -154,7 +145,7 @@ void Interface::Load(const DataNode &node)
 // Draw this interface.
 void Interface::Draw(const Information &info, Panel *panel) const
 {
-	for(const Element *element : elements)
+	for(const unique_ptr<Element> &element : elements)
 		element->Draw(info, panel);
 }
 

--- a/source/Interface.h
+++ b/source/Interface.h
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/WrappedText.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -37,10 +38,6 @@ class Sprite;
 // the contents of an Information object.
 class Interface {
 public:
-	// A destructor is needed to clean up the polymorphic list of elements.
-	Interface() = default;
-	~Interface();
-
 	void Load(const DataNode &node);
 
 	// Draw this interface. If the given panel is not null, also register any
@@ -274,7 +271,7 @@ private:
 
 
 private:
-	std::vector<Element *> elements;
+	std::vector<std::unique_ptr<Element>> elements;
 	std::map<std::string, Element> points;
 	std::map<std::string, double> values;
 	std::map<std::string, std::vector<double>> lists;


### PR DESCRIPTION
**Bug fix/Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The `Interface` class currently contains an `std::vector` of raw pointers to `Interface::Element`s. This is a polymorphic list of the elements the interface contains. The `Element` objects are stored in dynamically allocated memory, created with the `new` keyword when the interface definition is loaded. The memory allocated to these objects therefore needs to be freed when we are done with them, using the `delete` keyword. `Interface` defines a destructor which does this. However, it does not define a copy constructor or copy assignment operator, which means, assignment is performed on an `Interface`, the `Elements` already owned by that `Interface` will become leaked memory.
Additionally, when loading an interface definition, `Interface::Load` clears the collection of `Element` pointers, discarding the addresses without deleting the objects and freeing the memory. This is also a memory leak.

Fortunately, `Interface`s are not copied, and overriding an interface definition is only going to leak a small, finite amount of memory, so this doesn't result in noticeable problems, but we should still fix it.

This PR changes the way `Interface` stores its `Element`s from an `std::vector<Element *>` to an `std::vector<std::unique_ptr<Element>>`.
`std::unique_ptr` is a smart pointer that owns and manages a dynamically allocated object. When the `unique_ptr` reaches the end of its lifetime, its destructor will free the memory its object occupied.

I also removed the explicit defaulting of the constructor of `Interface` because it is not necessary.
And removed the explicitly defined destructor because the autogenerated destructor will be correct (it will destroy the `std::vector`, which will destroy each of its `unique_ptr` elements, which will free the memory used by their managed objects).

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Launch game. Look at various panels (planet, map, shops, player infor). They all look correct.

## Save File
This save file can be used to test these changes:
Any save will do. Make your own.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
None expected, except that overriding an interface will now involve properly deleting the existing `Element`s, which should have been done anyway.
