### PR TITLE
[Bugfix] Make Tiny and Small VLS launchers count for Nettle resupplying

### DIFF
--- a/data/avgi/avgi weapons.txt
+++ b/data/avgi/avgi weapons.txt
@@ -765,6 +765,8 @@ effect "fleck impact"
 outfitter "Nettle Restock"
 	to sell
 		or
+			has "outfit: Tiny VLS"
+			has "outfit: Small VLS"
 			has "outfit: Medium VLS"
 	location
 		attributes "outfitter"


### PR DESCRIPTION

**Bug fix**

This PR addresses the bug/feature described on discord

## Acknowledgement

- [ ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Does the thing in the title.

## Screenshots
No.

## Testing Done
Literally none

## Performance Impact
Very significant. Trust me.
