### PR TITLE
Variants inherit installed weapon layouts in some cases

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -659,12 +659,18 @@ void Ship::FinishLoading(bool isNewInstance)
 		}
 		if(finalExplosions.empty())
 			finalExplosions = base->finalExplosions;
-		if(outfits.empty())
+		const bool inheritsOutfits = outfits.empty();
+		if(inheritsOutfits)
 			outfits = base->outfits;
 		if(description.IsEmpty())
 			description = base->description;
 
 		bool hasHardpoints = false;
+		if(inheritsOutfits && armament.Get().empty())
+		{
+			hasHardpoints = true;
+			armament = base->armament;
+		}
 		for(const Hardpoint &hardpoint : armament.Get())
 			if(hardpoint.GetPoint())
 				hasHardpoints = true;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When loading a variant ship definition, if the variant does not define locations for its weapon hardpoints, the hardpoints of hte base ship will be used, with the installed weapon layout defined in the variant.
If the variant does not define an installed weapon layout, the weapons will be automatically assigned to the hardpoints. The installed weapon layout from the base ship will not be used. This results in some variants, such as the "Aberrant Chomper (Disable-able)", having different installed weapon layouts to the base ship. In cases such as this, where the installed outfits and weapon hardpoints are inherited from the base ship, we can easily just coyp the whole `Aremament` from the base ship, since the hardpoint layout was going to be copied anyway, this also gives us hte same installed weapon layout.
This is what this PR does: if a variant is inheriting both the installed outfit list and hardpoint layout from the base ship, it will copy the entire `Armament`, inheriting the installed weapon layout as well.

## Screenshots
N/A

## Usage examples
```
ship "a ship"
    outfits
        "a gun" 2
        "another gun"
    gun -10 10 "a gun"
    gun 0 10 "another gun"
    gun 10 10 "a gun"

ship "a ship" "a variant"
```
Without this PR, the variant "a variant" would end up with "another gun" in either the left or rightmost gun hardpoint, instead of in the centre as it is in the base "a ship".
With this PR, the variant "a variant" will have the same weapon layout as the base "a ship", with "another gun" in the central gun hardpoint.

## Testing Done
Load the attached save.
Go to the shipyard.
Buy one each of the Chomper ships.
Leave the shipyard.
Open the player info panel.
Open the ship info panel.
Move between the ship info panels for the two ships.

Without this PR, they do not have the same installed weapon layout: the Nucleolysis Beam will be in the central gun hardpoint on one ship, and in one of the others in the other ship (probably either the front leftmost or back rightmost).
With this PR, the Nucleolysis Beam is in the central hardpoint on both ships.

## Save File
This save file can be used to test these changes:
[test test 4.txt](https://github.com/user-attachments/files/22805266/test.test.4.txt)

## Artwork Checklist
N/A

## Wiki Update
I don't think one is needed here.

## Performance Impact
Minimal.
