### PR TITLE
refactor: Timestamp formatting cleanup

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -26,6 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "shader/FillShader.h"
 #include "text/Font.h"
 #include "text/FontSet.h"
+#include "text/Format.h"
 #include "GameData.h"
 #include "Information.h"
 #include "Interface.h"
@@ -49,44 +50,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// Return a pair containing settings to use for time formatting.
-	pair<const char*, const char*> TimestampFormatString(Preferences::DateFormat format)
-	{
-		// pair<string, string>: Linux (1st) and Windows (2nd) format strings.
-		switch(format)
-		{
-			case Preferences::DateFormat::YMD:
-				return make_pair("%F %T", "%F %T");
-			case Preferences::DateFormat::MDY:
-				return make_pair("%-I:%M %p on %b %-d, %Y", "%#I:%M %p on %b %#d, %Y");
-			case Preferences::DateFormat::DMY:
-			default:
-				return make_pair("%-I:%M %p on %-d %b %Y", "%#I:%M %p on %#d %b %Y");
-		}
-	}
-
-	// Convert a file_time_type to a human-readable time and date.
-	string TimestampString(filesystem::file_time_type time)
-	{
-		// TODO: Replace with chrono formatting when it is properly supported.
-		auto sctp = time_point_cast<chrono::system_clock::duration>(time - filesystem::file_time_type::clock::now()
-				+ chrono::system_clock::now());
-		time_t timestamp = chrono::system_clock::to_time_t(sctp);
-
-		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
-		static const size_t BUF_SIZE = 25;
-		char str[BUF_SIZE];
-
-#ifdef _WIN32
-		tm date;
-		localtime_s(&date, &timestamp);
-		return string(str, std::strftime(str, BUF_SIZE, format.second, &date));
-#else
-		const tm *date = localtime(&timestamp);
-		return string(str, std::strftime(str, BUF_SIZE, format.first, date));
-#endif
-	}
-
 	// Extract the date from this pilot's most recent save.
 	string FileDate(const filesystem::path &filename)
 	{
@@ -243,7 +206,7 @@ void LoadPanel::Draw()
 				tooltip.IncrementCount();
 				if(tooltip.ShouldDraw())
 				{
-					tooltip.SetText(TimestampString(it.second), true);
+					tooltip.SetText(Format::TimestampString(it.second), true);
 					tooltip.SetZone(zone);
 				}
 			}

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -15,6 +15,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Format.h"
 
+#include "../Preferences.h"
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -266,6 +268,29 @@ namespace {
 			// "number" or unsupported format
 			result.append(Format::Number(value));
 	}
+
+	// Return a string containing the setting to use for time formatting.
+	const char *TimestampFormatString()
+	{
+		switch(Preferences::GetDateFormat())
+		{
+			case Preferences::DateFormat::YMD:
+				return "%F %T";
+			case Preferences::DateFormat::MDY:
+#ifdef _WIN32
+				return "%#I:%M:%S %p on %b %#d, %Y";
+#else
+				return "%-I:%M:%S %p on %b %-d, %Y";
+#endif
+			case Preferences::DateFormat::DMY:
+			default:
+#ifdef _WIN32
+				return "%#I:%M:%S %p on %#d %b %Y";
+#else
+				return "%-I:%M:%S %p on %-d %b %Y";
+#endif
+		}
+	}
 }
 
 
@@ -394,6 +419,37 @@ string Format::PlayTime(double timeVal)
 
 	reverse(result.begin(), result.end());
 	return result;
+}
+
+
+
+string Format::TimestampString(chrono::time_point<chrono::system_clock> time)
+{
+	// TODO: Replace with chrono formatting when it is properly supported.
+	time_t timestamp = chrono::system_clock::to_time_t(time);
+
+	const char *format = TimestampFormatString();
+	static const size_t BUF_SIZE = 28;
+	char str[BUF_SIZE];
+
+#ifdef _MSC_VER
+	// Use the "safe" function with MSVC.
+	tm date;
+	localtime_s(&date, &timestamp);
+	return string(str, std::strftime(str, BUF_SIZE, format, &date));
+#else
+	const tm *date = localtime(&timestamp);
+	return string(str, std::strftime(str, BUF_SIZE, format, date));
+#endif
+}
+
+
+
+string Format::TimestampString(filesystem::file_time_type time)
+{
+	auto sctp = time_point_cast<chrono::system_clock::duration>(time - filesystem::file_time_type::clock::now()
+		+ chrono::system_clock::now());
+	return TimestampString(sctp);
 }
 
 

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -15,7 +15,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <map>
 #include <string>
@@ -51,6 +53,9 @@ public:
 	static std::string StepsToSeconds(size_t steps);
 	// Convert a time in seconds to years/days/hours/minutes/seconds
 	static std::string PlayTime(double timeVal);
+	// Convert a time point to a human-readable time and date.
+	static std::string TimestampString(std::chrono::time_point<std::chrono::system_clock> time);
+	static std::string TimestampString(std::filesystem::file_time_type time);
 	// Convert an ammo count into a short string for use in the ammo display.
 	// Only the absolute value of a negative number is considered.
 	static std::string AmmoCount(int64_t value);


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
1. Removed (replaced with proper ifdefs) the pointless behavior of TimestampFormatString returning a pair of strings, one of which is guaranteed to be unused.
2. Changed the localtime_s ifdef from Win32 to MSVC, as that is the reason why it replaces localtime.
3. Fixed date formats that were missing seconds (and increased the buffer size to account for that).
4. Moved the functions to Format.

## Testing Done
Tested on Windows.

## Performance Impact
N/A
