### PR TITLE
revert(content): Revert change to final Expanding Business mission from #4952

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -918,7 +918,6 @@ mission "Expanding Business: shipyard complete"
 		has "event: shipyard on greenwater"
 	on offer
 		"salary: Turner Incorporated" = 4000
-		dialog "On receipt of a new and unexpected deposit, you realize that the shipyard on Greenwater must now be operational."
 		fail
 
 


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR closes #11601.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Removes the dialog in "Expanding Business: shipyard complete". This dialog was not originally part of this mission, and was added by #4952.

https://github.com/endless-sky/endless-sky/blob/2e56b30fc2f46b68455ece9f51e4f69644c346fa/data/hai/hai%20missions.txt#L1072-L1079

While this dialog does guarantee that the completion of the shipyard is brought to the player's attention, the original intention was that you'd just notice the salary bump and know that it's done.

There's a similar mission for when the outfitter is completed that wasn't given a dialog, so this really just brings the second mission back in line with the first.

https://github.com/endless-sky/endless-sky/blob/ff68df2a1202a691d5d27d03b0e18faa429ab494/data/hai/hai%20missions.txt#L707-L715

## Testing Done

What is there to test?
