### PR TITLE
feat(mechanics): Planetary security no longer scans parked ships

### DIFF
--- a/source/Politics.cpp
+++ b/source/Politics.cpp
@@ -252,9 +252,11 @@ string Politics::Fine(PlayerInfo &player, const Government *gov, int scan, const
 			continue;
 		if(ship->GetSystem() != player.GetSystem())
 			continue;
-		// Skip parked ships. The spaceport authorities are only scanning the ships you just landed with.
 		const Planet *planet = player.GetPlanet();
-		if((planet && ship->GetPlanet() != planet) || ship->IsParked())
+		if(planet && ship->GetPlanet() != planet)
+			continue;
+		// Skip parked ships. The spaceport authorities are only scanning the ships you just landed with.
+		if(ship->IsParked())
 			continue;
 
 		int failedMissions = 0;


### PR DESCRIPTION
**Feature**

Closes #5090.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In Politics::Fine, which is run when you land on a planet, the loop that goes over your ships now skips over parked ships. The idea here is that spaceport authorities only run security on the ships you just landed with, as parked ships already previously went through inspection.

## Testing Done
Naw, I just eyeballed it.

## Save File
Do you want one?
