### PR TITLE
fix: Recognize shader-only plugins

### DIFF
--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -320,7 +320,8 @@ bool Plugins::IsPlugin(const filesystem::path &path)
 {
 	// A folder is a valid plugin if it contains one (or more) of the assets folders.
 	// (They can be empty too).
-	return Files::Exists(path / "data") || Files::Exists(path / "images") || Files::Exists(path / "sounds");
+	return Files::Exists(path / "data") || Files::Exists(path / "images")
+		|| Files::Exists(path / "shaders") || Files::Exists(path / "sounds");
 }
 
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
If a plugin contains no data, sounds, or images, it's not recognized on master. However, since plugins can also modify shaders, including only shaders as the plugin contents should still be considered valid.

## Testing Done
yes™.

## Wiki Update
N/A

## Performance Impact
N/A
