### PR TITLE
Fix "Care Package to South 1" choosing inappropriate destinations

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6362,9 +6362,9 @@ mission "Care Package to South 1"
 		not attributes "station"
 	destination
 		attributes "rim" "south"
-		not government "Pirate"
-		not system "Alniyat" "Atria" "Han"
-		not planet "Glaze"
+		not attributes "station"
+		government "Republic" "Independent"
+		not planet "Glaze" "Harmony"
 	to offer
 		not "event: war begins"
 		random < 65


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1428923537661366354) by @Rob59er.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The mission "Care Package to South 1" involves delivering a care package to someone at a militia base in the South. It takes place before the event "war begins" when Geminus and Martini are bombed and the Free Worlds is formed.
As noted in the report, it doesn't make sense for a place like Humanika to have a militia base, since this is a Quarg world, and they guard it against pirates.
I have modified the destination location filter to only select planets with either the "Republic" or "Independent" government, this avoids selecting Humanika. There is no need to include "Free Worlds" in this filter because the mission is only available prior to their formation, so no planet has that government. The planets that gain that government are currently "Republic".
I've also excluded Harmony, because it also shouldn't have a militia base, probably.
I've also excluded stations, because it probably doesn't make sense to select one of those, either.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Used the "--matches" command line argument and gave it the old and new location filters:
<details><summary>Planets that can be selected by the old filter:</summary>

Arachne Station
Bourne
Charon Station
Clink
Cornucopia
Dancer
Deep
Dune
Flood
Harmony
Humanika
Longjump
Mere
Oasis
Poisonwood
Poseidos
Rust
Shorebreak
Skymoot
Solace
Starcross
Sundrinker
Thunder
Trinket
Typhon Station
Wayfarer
Winter
Wyvern Station
Zug

</details>

<details><summary>Planets that can be selected by the new filter:</summary>

Bourne
Clink
Cornucopia
Dancer
Darkstone
Deep
Dune
Flood
Lichen
Longjump
Mere
Oasis
Poisonwood
Poseidos
Rust
Shorebreak
Skymoot
Solace
Starcross
Sundrinker
Thunder
Trinket
Twinstar
Wayfarer
Winter
Zug

</details>

## Save File
Not from me.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
