### PR TITLE
fix(mechanics): Restore the Person ships individually after resetting the set

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -435,6 +435,8 @@ void GameData::Revert()
 	objects.substitutions.Revert(defaultSubstitutions);
 	objects.wormholes.Revert(defaultWormholes);
 	objects.persons.Revert(defaultPersons);
+	for(auto &it : objects.persons)
+		it.second.Restore();
 
 	politics.Reset();
 	purchases.clear();


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1429233268468875436).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When resetting the universe on save file load, we're restoring the set of persons to its original state, saved when the data loading finishes. Apparently, we also need to manually restore the ships to prevent some plugin-defined persons from being incorrectly marked as destroyed.

## Testing Done
warp tested it.

## Performance Impact
N/A
