### PR TITLE
ui: Animate UI elements of the Engine regardless of fast-forward

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1112,7 +1112,6 @@ void Engine::Go()
 {
 	if(!timePaused)
 		++step;
-	++uiStep;
 	currentCalcBuffer = currentCalcBuffer ? 0 : 1;
 	queue.Run([this] { CalculateStep(); });
 }
@@ -1147,6 +1146,8 @@ list<ShipEvent> &Engine::Events()
 // Draw a frame.
 void Engine::Draw() const
 {
+	++uiStep;
+
 	Point motionBlur = camera.Velocity();
 	double baseBlur = Preferences::Has("Render motion blur") ? 1. : 0.;
 

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -277,7 +277,7 @@ private:
 
 	int step = 0;
 	// Count steps for UI elements separately, because they shouldn't be affected by pausing.
-	int uiStep = 0;
+	mutable int uiStep = 0;
 	bool timePaused = false;
 
 	std::list<ShipEvent> eventQueue;


### PR DESCRIPTION
This PR addresses the bug/feature described in issue #7943 (closes #7943).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
HUD elements defined in the Engine class will no longer change the speed of their animations when fast-forward is active. I marked the UI step counter as mutable, because I believe it's better than removing const from the whole Engine::Draw.
When writing #11790, for some reason I thought this feature would be more difficult to implement, but I realized it's just a matter of moving the place of assignment for one variable.

## Testing Done
yes™.

## Performance Impact
N/A
