### PR TITLE
fix: Detect adaptive VSync at runtime if possible

### DIFF
--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -23,6 +23,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #endif
 #endif
 
+#include <cstring>
+
 #if defined(ES_GLES) || defined(_WIN32)
 namespace {
 	bool HasOpenGLExtension(const char *name)


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11801 (closes #11801).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, the detection of the *_swap_control_tear OpenGL extensions is short-circuited on Windows, and completely omitted on Linux. For the reasons mentioned in the issue we shouldn't try enabling adaptive VSync when unsupported, especially with older video drivers.
For Windows, I replaced the compile-time macro with a proper feature check, in addition to the existing standard extensions check.
For Linux, I don't see any way to implement 100% accurate detection. I tested the mixed method on my Intel HD 4000, and glew saw the extension only on Windows, while obviously the hardware has the same capabilities on Linux. I guess it's acceptable to continue assuming that the feature is supported, since the potential problems mainly affect older drivers and Linux instances are easily kept up to date even on old hardware. To make this clear, I replaced the confusing compile-time macro with a simple boolean truth value.
Additionally cleaned up some unused code in the standard extension detection function.

## Testing Done
yes™.

## Performance Impact
N/A
