### PR TITLE
refactor: Load ntdll statically on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG
 
 # Link the needed OS-specific dependencies, if any.
 if(WIN32)
-	target_link_libraries(ExternalLibraries INTERFACE rpcrt4 Winmm)
+	target_link_libraries(ExternalLibraries INTERFACE rpcrt4 winmm ntdll)
 elseif(ES_LINK_LIBATOMIC)
 	target_link_libraries(ExternalLibraries INTERFACE pthread atomic)
 else()

--- a/source/windows/WinVersion.cpp
+++ b/source/windows/WinVersion.cpp
@@ -17,6 +17,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <windows.h>
 
+// Declare RtlGetVersion here so that we don't need DDK headers.
+extern "C" NTSTATUS RtlGetVersion(PRTL_OSVERSIONINFOW);
+
 namespace {
 	bool supportsDarkTheme = false;
 	bool supportsWindowRounding = false;
@@ -26,11 +29,8 @@ namespace {
 
 void WinVersion::Init()
 {
-	HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
-	auto rtlGetVersion = reinterpret_cast<NTSTATUS (*)(PRTL_OSVERSIONINFOW)>(GetProcAddress(ntdll, "RtlGetVersion"));
 	RTL_OSVERSIONINFOW versionInfo = {};
-	rtlGetVersion(&versionInfo);
-	FreeLibrary(ntdll);
+	RtlGetVersion(&versionInfo);
 
 	supportsDarkTheme = versionInfo.dwBuildNumber >= 19041;
 	supportsWindowRounding = versionInfo.dwBuildNumber >= 22000;


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
We can load ntdll statically without requiring the compiler to have DDK headers by forward-declaring the function we need from it. While this method looks ugly in code, it's no better than the dynamic load with a reinterpret cast.

Now you're probably wondering if it matters, and the answer is: in general it doesn't. However, I need RtlGetVersion moved from the code to the import table for easier patching, as recent discoveries (#11867) opened some new possibilities.

## Testing Done
Launched the game.

## Performance Impact
Literally none as ntdll is loaded all the time anyway.