### PR TITLE
Fix beyond Patir event condition setting

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -1268,7 +1268,7 @@ event "Patir moves"
 	system Patir
 		pos 10059.5 10.5
 		remove haze
-		set "ka'het: beyond Patir"
+	set "ka'het: beyond Patir"
 
 event "Patir spaceport"
 	planet "Builder Settlement"
@@ -1997,7 +1997,7 @@ event "Patir returns"
 	system Patir
 		pos -38 553
 		haze _menu/haze-red
-		clear "ka'het: beyond Patir"
+	clear "ka'het: beyond Patir"
 
 
 conversation "end of Patir 2 - on enter"


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This problem was mentioned in #11870, though it is not related to the main point of that issue.
There are two events in the "beyond Patir" mission chain that modify the system "Patir", and attempt to set and clear a condition, respectively. However, the "set" and "clear" lines are written as children of the "system" node so they are passed to the `System` class to parse, instead of being interpretted by the event as condition assignments and treated accordingly.
This PR removes one level of indentation from those two lines so they are direct children of the `event` node, not children of the `system` node so they are handled correctly.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
None.

## Save File
No.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
