### PR TITLE
feat: Parse events at game startup

### DIFF
--- a/source/Fleet.cpp
+++ b/source/Fleet.cpp
@@ -51,14 +51,14 @@ namespace {
 
 
 // Construct and Load() at the same time.
-Fleet::Fleet(const DataNode &node)
+Fleet::Fleet(const DataNode &node, bool dryRun)
 {
-	Load(node);
+	Load(node, dryRun);
 }
 
 
 
-void Fleet::Load(const DataNode &node)
+void Fleet::Load(const DataNode &node, bool dryRun)
 {
 	if(node.Size() >= 2)
 		fleetName = node.Token(1);
@@ -127,7 +127,7 @@ void Fleet::Load(const DataNode &node)
 			// If given a full definition of one of this fleet's variant members, remove the variant.
 			Variant toRemove(child);
 			int count = erase(variants, toRemove);
-			if(!count)
+			if(!count && !dryRun)
 				child.PrintTrace("Warning: Did not find matching variant for specified operation:");
 		}
 		else

--- a/source/Fleet.h
+++ b/source/Fleet.h
@@ -48,9 +48,9 @@ class Fleet {
 public:
 	Fleet() = default;
 	// Construct and Load() at the same time.
-	Fleet(const DataNode &node);
+	Fleet(const DataNode &node, bool dryRun);
 
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, bool dryRun);
 
 	// Determine if this fleet template uses well-defined data.
 	bool IsValid(bool requireGovernment = true) const;

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -268,9 +268,15 @@ void GameData::FinishLoading()
 
 
 
-void GameData::CheckReferences()
+void GameData::CheckReferences(bool audioParseOnly)
 {
+	if(!IsLoaded())
+		return;
+	// Run the check on objects first to add undefined sprites and sounds
+	// from events to the sets.
 	objects.CheckReferences();
+	SpriteSet::CheckReferences();
+	Audio::CheckReferences(audioParseOnly);
 }
 
 

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -84,7 +84,7 @@ public:
 		bool onlyLoadData, bool debugMode, bool preventUpload);
 	static void FinishLoading();
 	// Check for objects that are referred to but never defined.
-	static void CheckReferences();
+	static void CheckReferences(bool audioParseOnly = false);
 	static void LoadSettings();
 	static void LoadShaders();
 	static double GetProgress();

--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -28,7 +28,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Point.h"
 #include "shader/PointerShader.h"
 #include "Ship.h"
-#include "image/SpriteSet.h"
 #include "shader/StarField.h"
 #include "System.h"
 #include "TaskQueue.h"
@@ -55,10 +54,6 @@ void GameLoadingPanel::Step()
 	queue.ProcessSyncTasks();
 	if(GameData::IsLoaded())
 	{
-		// Now that we have finished loading all the basic sprites and sounds, we can look for invalid file paths,
-		// e.g. due to capitalization errors or other typos.
-		SpriteSet::CheckReferences();
-		Audio::CheckReferences();
 		// Set the game's initial internal state.
 		GameData::FinishLoading();
 

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -100,7 +100,7 @@ Government::Government()
 
 // Load a government's definition from a file.
 void Government::Load(const DataNode &node, const set<const System *> *visitedSystems,
-	const set<const Planet *> *visitedPlanets)
+	const set<const Planet *> *visitedPlanets, bool dryRun)
 {
 	if(node.Size() >= 2)
 	{
@@ -295,10 +295,10 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 				{
 					if(grand.Token(1) == "ship" && grand.Size() >= 3)
 					{
-						if(!illegalShips.erase(grand.Token(2)))
+						if(!illegalShips.erase(grand.Token(2)) && !dryRun)
 							grand.PrintTrace("Invalid remove, ship not found in existing illegals:");
 					}
-					else if(!illegalOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
+					else if(!illegalOutfits.erase(GameData::Outfits().Get(grand.Token(1))) && !dryRun)
 						grand.PrintTrace("Invalid remove, outfit not found in existing illegals:");
 				}
 				else if(grandKey == "ignore")
@@ -330,10 +330,10 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 				{
 					if(grand.Token(1) == "ship" && grand.Size() >= 3)
 					{
-						if(!atrocityShips.erase(grand.Token(2)))
+						if(!atrocityShips.erase(grand.Token(2)) && !dryRun)
 							grand.PrintTrace("Invalid remove, ship not found in existing atrocities:");
 					}
-					else if(!atrocityOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
+					else if(!atrocityOutfits.erase(GameData::Outfits().Get(grand.Token(1))) && !dryRun)
 						grand.PrintTrace("Invalid remove, outfit not found in existing atrocities:");
 				}
 				else if(grandKey == "ignore")

--- a/source/Government.h
+++ b/source/Government.h
@@ -53,7 +53,7 @@ public:
 
 	// Load a government's definition from a file.
 	void Load(const DataNode &node, const std::set<const System *> *visitedSystems,
-		const std::set<const Planet *> *visitedPlanets);
+		const std::set<const Planet *> *visitedPlanets, bool dryRun);
 
 	// Get the display name of this government.
 	const std::string &DisplayName() const;

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -243,7 +243,8 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions,
 		{
 			if(child.HasChildren())
 			{
-				fleets.emplace_back(ExclusiveItem<Fleet>(Fleet(child)));
+				// NPCs cannot be included in event changes, so we can assume the fleet load won't be a dry run.
+				fleets.emplace_back(ExclusiveItem<Fleet>(Fleet(child, false)));
 				if(hasValue)
 				{
 					// Copy the custom fleet in lieu of reparsing the same DataNode.

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 
 void News::Load(const DataNode &node, const ConditionsStore *playerConditions,
-	const set<const System *> *visitedSystems, const set<const Planet *> *visitedPlanets)
+	const set<const System *> *visitedSystems, const set<const Planet *> *visitedPlanets, bool dryRun)
 {
 	for(const DataNode &child : node)
 	{
@@ -46,7 +46,10 @@ void News::Load(const DataNode &node, const ConditionsStore *playerConditions,
 		if(tag == "location")
 		{
 			if(add && !location.IsEmpty())
-				child.PrintTrace("Error: Cannot \"add\" to an existing location filter:");
+			{
+				if(!dryRun)
+					child.PrintTrace("Error: Cannot \"add\" to an existing location filter:");
+			}
 			else if(remove)
 			{
 				location = LocationFilter{};
@@ -105,7 +108,10 @@ void News::Load(const DataNode &node, const ConditionsStore *playerConditions,
 		else if(tag == "to" && hasValue && child.Token(valueIndex) == "show")
 		{
 			if(add && !toShow.IsEmpty())
-				child.PrintTrace("Error: Cannot \"add\" to an existing condition set:");
+			{
+				if(!dryRun)
+					child.PrintTrace("Error: Cannot \"add\" to an existing condition set:");
+			}
 			else if(remove)
 			{
 				toShow = ConditionSet{};

--- a/source/News.h
+++ b/source/News.h
@@ -35,7 +35,7 @@ class System;
 class News {
 public:
 	void Load(const DataNode &node, const ConditionsStore *playerConditions,
-		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets);
+		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets, bool dryRun);
 
 	// Check whether this news item has anything to say.
 	bool IsEmpty() const;

--- a/source/Shop.h
+++ b/source/Shop.h
@@ -37,10 +37,10 @@ class Shop {
 public:
 	Shop();
 	Shop(const DataNode &node, const Set<Item> &items, const ConditionsStore *playerConditions,
-		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets);
+		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets, bool dryRun);
 
 	void Load(const DataNode &node, const Set<Item> &items, const ConditionsStore *playerConditions,
-		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets);
+		const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets, bool dryRun);
 
 	// This shop's name.
 	const std::string &Name() const;
@@ -71,16 +71,16 @@ Shop<Item>::Shop()
 
 template<class Item>
 Shop<Item>::Shop(const DataNode &node, const Set<Item> &items, const ConditionsStore *playerConditions,
-	const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets)
+	const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets, bool dryRun)
 {
-	Load(node, items, playerConditions, visitedSystems, visitedPlanets);
+	Load(node, items, playerConditions, visitedSystems, visitedPlanets, dryRun);
 }
 
 
 
 template<class Item>
 void Shop<Item>::Load(const DataNode &node, const Set<Item> &items, const ConditionsStore *playerConditions,
-	const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets)
+	const std::set<const System *> *visitedSystems, const std::set<const Planet *> *visitedPlanets, bool dryRun)
 {
 	name = node.Token(1);
 	// If an event or second definition updates this shop, clear the stock
@@ -99,7 +99,10 @@ void Shop<Item>::Load(const DataNode &node, const Set<Item> &items, const Condit
 		if(key == "to" && hasValue && child.Token(valueIndex) == "sell")
 		{
 			if(add && !toSell.IsEmpty())
-				child.PrintTrace("Error: Cannot \"add\" to an existing condition set:");
+			{
+				if(!dryRun)
+					child.PrintTrace("Error: Cannot \"add\" to an existing condition set:");
+			}
 			else if(remove)
 			{
 				toSell = ConditionSet{};
@@ -112,7 +115,10 @@ void Shop<Item>::Load(const DataNode &node, const Set<Item> &items, const Condit
 		else if(key == "location")
 		{
 			if(add && !location.IsEmpty())
-				child.PrintTrace("Error: Cannot \"add\" to an existing location filter:");
+			{
+				if(!dryRun)
+					child.PrintTrace("Error: Cannot \"add\" to an existing location filter:");
+			}
 			else if(remove)
 			{
 				location = LocationFilter{};

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -91,7 +91,7 @@ double System::Asteroid::Energy() const
 
 
 // Load a system's description.
-void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsStore *playerConditions)
+void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsStore *playerConditions, bool dryRun)
 {
 	if(node.Size() < 2)
 		return;
@@ -350,7 +350,8 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 
 				if(removeIt == objects.end())
 				{
-					child.PrintTrace("Warning: Did not find matching object for specified operation:");
+					if(!dryRun)
+						child.PrintTrace("Warning: Did not find matching object for specified operation:");
 					continue;
 				}
 

--- a/source/System.h
+++ b/source/System.h
@@ -75,7 +75,7 @@ public:
 
 public:
 	// Load a system's description.
-	void Load(const DataNode &node, Set<Planet> &planets, const ConditionsStore *playerConditions);
+	void Load(const DataNode &node, Set<Planet> &planets, const ConditionsStore *playerConditions, bool dryRun);
 	// Update any information about the system that may have changed due to events,
 	// e.g. neighbors, solar wind and power, or if the system is inhabited.
 	void UpdateSystem(const Set<System> &systems, const std::set<double> &neighborDistances);

--- a/source/UniverseObjects.h
+++ b/source/UniverseObjects.h
@@ -82,7 +82,7 @@ public:
 	void FinishLoading();
 
 	// Apply the given change to the universe.
-	void Change(const DataNode &node, const PlayerInfo &player);
+	void Change(const DataNode &node, const PlayerInfo &player, bool dryRun = false);
 	// Update the neighbor lists and other information for all the systems.
 	// (This must be done any time a GameEvent creates or moves a system.)
 	void UpdateSystems();

--- a/source/Wormhole.cpp
+++ b/source/Wormhole.cpp
@@ -39,7 +39,7 @@ Wormhole::Wormhole()
 
 
 // Load a wormhole's description from a file.
-void Wormhole::Load(const DataNode &node)
+void Wormhole::Load(const DataNode &node, bool dryRun)
 {
 	if(node.Size() < 2)
 		return;
@@ -92,7 +92,7 @@ void Wormhole::Load(const DataNode &node)
 				auto it = links.find(from);
 				if(it != links.end() && it->second == to)
 					links.erase(from);
-				else
+				else if(!dryRun)
 					child.PrintTrace("Unable to remove non-existent link:");
 			}
 			else

--- a/source/Wormhole.h
+++ b/source/Wormhole.h
@@ -33,7 +33,7 @@ public:
 	// Define the constructor to set "linkColor" to the desired default color.
 	Wormhole();
 	// Load a wormhole's description from a file.
-	void Load(const DataNode &node);
+	void Load(const DataNode &node, bool dryRun);
 	// Load a wormhole from a given planet.
 	void LoadFromPlanet(const Planet &planet);
 	// Check if this wormhole has been defined.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -182,13 +182,6 @@ int main(int argc, char *argv[])
 					queue.ProcessSyncTasks();
 					std::this_thread::yield();
 				}
-				if(GameData::IsLoaded())
-				{
-					// Now that we have finished loading all the basic sprites and sounds, we can look for invalid file paths,
-					// e.g. due to capitalization errors or other typos.
-					SpriteSet::CheckReferences();
-					Audio::CheckReferences(true);
-				}
 			}
 
 			// Set the game's initial internal state.
@@ -197,7 +190,7 @@ int main(int argc, char *argv[])
 			// Reference check the universe, as known to the player. If no player found,
 			// then check the default state of the universe.
 			if(!player.LoadRecent())
-				GameData::CheckReferences();
+				GameData::CheckReferences(checkAssets);
 			cout << "Parse completed with " << (hasErrors ? "at least one" : "no") << " error(s)." << endl;
 			if(checkAssets)
 				Audio::Quit();


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, events are loaded as raw data nodes that are loaded when the event is applied. This means any errors in that data are logged only if the player triggers the event.
With this PR, all events are temporarily applied at once before the data reference check to make sure every definition included in event changes is correct. As we're potentially applying the events out of their intended order, we can't be sure about some problems we detect (for example, removal of an element that wasn't already present), so some warnings are silenced when loading certain nodes for this purpose.
Additionally, I moved the reference checks for sprites and sounds so they are executed after the event check, to cover all data.

## Testing Done
Launched the game and checked errors.txt on a fresh pilot. Without #11874, the data CI is expected to fail.

## Performance Impact
In the reference check we now need to make a copy of the state of data without the temporary event changes to be able to revert it later.