### PR TITLE
Fix "Lost Racer 2   Continued" offering

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6556,6 +6556,7 @@ mission "Lost Racer 2 - Continued"
 	deadline
 	to offer
 		has "Lost Racer 1: done"
+		not "abandoned lost racer"
 	to accept
 		has "Lost Racer 2 - Ended: declined"
 		not "abandoned lost racer"


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The mission "Lost Racer 2 - Continued" is supposed to offer from the spaceport after a particular outcome of the mission "Lost Racer 2 - Ended" offer conversation, which offers on landing upon completion of "Lost Racer 1". That outcome involved declining that mission.
However, currently, "Lost Racer 2 - Continued" will only offer after making the appropriate choice in the "Lost Racer 2 - Ended" offer conversation and then taking off and landing again. This is because the "to offer" conditions of the "Continued" mission requires that the "Ended" mission has been declined already. However, new missions to be offered are all created at once, and so at the time that the game considers if the "Continued" mission should be offered, it decides not to because the "to offer" conditions are not met. That mission is therefore not available at this time, even after declining the "Ended" mission. Taking off and landing again creates new missions, and this time the game sees that the "to offer" conditions of the "Continued" mission are met, and so it creates that mission.

This PR modifies the "to offer" conditions of the "Continued" mission to match those of the "Ended" mission. This means that they will be available at the same time. I have then moved the previous contents of its "to offer" conditions to a "to accept" node, meaning that the mission will be "blocked" unless the appropriate choices have been made in the "Ended" mission.
I also added an additional "to offer" condition to make sure that the mission will not offer if a different choice is made in the "Ended" mission. It will still be available but blocked until taking off after making such a choice in the "Ended" mission, but this prevents it from being available but blocked on all subsequent visits to Sunracer.

I also fixed an incorrect substitution in the "on offer" conversation of the "Ended" mission. That mission offers on Sunracer, and the text at this point is referring to the player's current location. The `<planet>` substitution refers to the destination of the mission, which in this case is Glory, `<origin>` refers to the planet that this mission is being offered from.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
None.

## Save File
This save file can be used to test these changes:
[warp core lost racer test~original.txt](https://github.com/user-attachments/files/23196597/warp.core.lost.racer.test.original.txt)
Follow the currently planned route to Kursa then continue towards and through the waypointed systems to the destination.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
