### PR TITLE
git: Add desktop.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ docs/api/
 # OS-specific generated files
 .DS_Store
 *.db
+desktop.ini
 
 # IDEs (no support implied)
 .cache


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Because I want my custom folder icon.

## Testing Done
If you don't see any desktop.ini added to the repo, it works.