### PR TITLE
refactor: Use freopen_s only with MSVC

### DIFF
--- a/source/windows/WinConsole.cpp
+++ b/source/windows/WinConsole.cpp
@@ -39,6 +39,8 @@ void WinConsole::Init()
 		return;
 
 	// Perform console redirection.
+#ifdef _MSC_VER
+	// Use the "safe" function with MSVC.
 	if(redirectStdout)
 	{
 		FILE *fstdout = nullptr;
@@ -60,4 +62,12 @@ void WinConsole::Init()
 		if(fstdin)
 			setvbuf(stdin, nullptr, _IONBF, 0);
 	}
+#else
+	if(redirectStdout && freopen("CONOUT$", "w", stdout))
+		setvbuf(stdout, nullptr, _IOFBF, 4096);
+	if(redirectStderr && freopen("CONOUT$", "w", stderr))
+		setvbuf(stderr, nullptr, _IOLBF, 1024);
+	if(redirectStdin && freopen("CONIN$", "r", stdin))
+		setvbuf(stdin, nullptr, _IONBF, 0);
+#endif
 }


### PR DESCRIPTION
**Refactor**

A better attempt at #10570.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
It seems that freopen has better compatibility with MSVCRT than freopen_s. While the official releases of the game are currently linked against UCRT (where both functions are equally compatible), not MSVCRT, we support other compilers, such as MSVC.

Similarly to #11834, added ifdefs that replace freopen with freopen_s only when compiling with MSVC, which requires it for ["security"](https://learn.microsoft.com/en-us/cpp/c-runtime-library/security-features-in-the-crt). This means we don't need to silence the warnings for MSVC (as I understand it, that was the main issue with #10570).

## Testing Done
Compiled and launched the game. Verified that the exe has no freopen_s imports when built with mingw.

## Performance Impact
Unnoticeably shorter load time on mingw builds.