### PR TITLE
fix(content): Adjust Weapon Kestrel's hardpoints

### DIFF
--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -425,10 +425,10 @@ ship "Kestrel" "Kestrel (More Weapons)"
 	gun 76.5 49
 	gun -73.5 46 "Torpedo Launcher"
 	gun 73.5 46 "Torpedo Launcher"
-	gun -51 49.5 "Particle Cannon"
-	gun 51 49.5 "Particle Cannon"
 	gun -55.5 52.5
 	gun 55.5 52.5
+	gun -51 49.5 "Particle Cannon"
+	gun 51 49.5 "Particle Cannon"
 	gun -33 55
 	gun 33 55
 	gun -29.5 52 "Particle Cannon"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses a bug reported in Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The weapons variant Kestrel's turret hardpoints are slightly askew to the other Kestrel variants. This PR changes them to use the same positions as the other variants, as well as reorders the hardpoints in the ship definition to match the others (by having mirrored hardpoints listed next to each other instead of mixed up with others).

## Testing Done
Compared the adjusted hardpoints between the weapons Kestrel before and after in-game.

## Save File
I can make one, but it's pretty quick to get one in an all content plug-in. (Unfortunately this won't affect any already-instantiated Kestrels.)