### PR TITLE
fix(content): Shorten Betelgeuse stolen ship news to better fit UI

### DIFF
--- a/data/human/news.txt
+++ b/data/human/news.txt
@@ -2870,14 +2870,14 @@ news "betelgeuse stolen ship advisory"
 		word
 			"? "
 		word
-			"Ensure that when buying new you do so from a reputable dealer"
-			"Buy your ships direct from a Betelgeuse-affiliated shipyard"
-			"Give yourself peace of mind by purchasing your Betelgeuse ship from a reputable shipyard"
-			"Request the certificate of authenticity from the seller with your purchase"
+			"Buy new from a reputable dealer"
+			"Buy from a Betelgeuse-affiliated shipyard"
+			"Purchase from a reputable shipyard"
+			"Confirm authenticity with your purchase"
 		word
 			". "
 		word
-			"These simple precautions will ensure that"
+			"These precautions will ensure that"
 		word
 			" you're not "
 		word
@@ -2885,8 +2885,7 @@ news "betelgeuse stolen ship advisory"
 			"conned with a counterfeit"
 			"purchasing a"
 		word
-			" ship assembled from refuse by "
-			" ship assembled with inferior materials by "
+			" ship assembled by "
 			" stolen ship from "
 			" hijacked ship from "
 			" patchy ship from "
@@ -2894,7 +2893,7 @@ news "betelgeuse stolen ship advisory"
 			"a gang of "
 			"a bunch of "
 			"some unsavory "
-			"some untrustworthy "
+			"untrustworthy "
 		word
 			"pirates. "
 			"bootleggers. "


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The entries for "betelgeuse stolen ship advisory" news often touch the bottom of the panel, rather than fit snuggly above it. This PR simplifies several of these news lines to shorten their possibilities and ensure that they fit the panel correctly. 

Alternatives are welcome, although as the replacements/removals are, it is still cutting close and making longer ones will likely lead to more clipping.

## Screenshots

### Examples of before:
![sb3](https://github.com/user-attachments/assets/c0eece73-9d4e-4a75-953a-a19b8ec2b634)
![sb5](https://github.com/user-attachments/assets/2fa87882-dded-4ba9-a386-4c88504f240e)

### After:
![sb fixed 1](https://github.com/user-attachments/assets/11913c5c-420b-4152-9b27-50113070fed0)

## Testing Done
Rotated through the news before and after many times. Have yet to come across them poking the bottom of the box again.

## Save File
N/A - just fly to Betelgeuse and spam the spaceport.
