### PR TITLE
fix(content): Remove offer requirements of "You Are (Not) Alone"

### DIFF
--- a/data/rulei/rulei.txt
+++ b/data/rulei/rulei.txt
@@ -95,8 +95,6 @@ mission "Rulei: You Are (Not) Alone"
 	landing
 	to complete
 		never
-	to offer
-		has "First Contact: Rulei: offered"
 	on enter "L-118"
 		log `Discovered a region of emptiness east of the core, where systems are shrouded by a vast, eerie darkness. Other than dim stars and a few planets, nothing exists.`
 		conversation


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
As a consequence of #11416 and the way the tutorial is set up, `"Rulei: You Are (Not) Alone"` usually offers immediately after completing the tutorial, preventing Pookie Part 1 from offering on Hestia. This PR lets that mission offer on pilot creation instead, freeing Pookie.

## Testing Done
0
