### PR TITLE
Reduce cost of High Velocity Spike Rack

### DIFF
--- a/data/successors/successor weapons.txt
+++ b/data/successors/successor weapons.txt
@@ -381,7 +381,7 @@ outfit "High-Velocity Spike Rack"
 	category "Ammunition"
 	series "Ammunition"
 	index 11020
-	cost 350000
+	cost 50000
 	licenses
 		"High Houses"
 	thumbnail "outfit/hv spike rack"


### PR DESCRIPTION
**Balance**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The High-Velocity Spike Rack currently costs 350k credits. This makes it the most expensive ammunition storage outfit in the game, despite not being particularly remarkable in any respect. This PR **reduces its cost to 50k credits**, putting it between the costs of the Thunderhead Storage Array (36k) and Finisher Storage Tube (58.8k). This keeps it a bit pricey for its size and complexity, like most Successor outfits, but no longer an outlier.

## Testing Done
Everything shows up just fine.