### PR TITLE
Mark the systems occupied by the scattered remnant

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -2702,19 +2702,74 @@ mission "Wanderers: Sestor: Kill Southern Remnant"
 		has "Wanderers: Sestor: Bomb Zenith 2: done"
 	to complete
 		has "Wanderers: Sestor: Scattered Remnant: done"
-	waypoint "Alnitak"
-	waypoint "Betelgeuse"
-	waypoint "Canopus"
-	waypoint "Capella"
-	waypoint "Castor"
-	waypoint "Kursa"
-	waypoint "Mebsuta"
-	waypoint "Miaplacidus"
-	waypoint "Rigel"
-	waypoint "Saiph"
-	waypoint "Wazn"
+	mark "Alnitak"
+	mark "Betelgeuse"
+	mark "Canopus"
+	mark "Capella"
+	mark "Castor"
+	mark "Kursa"
+	mark "Mebsuta"
+	mark "Miaplacidus"
+	mark "Rigel"
+	mark "Saiph"
+	mark "Wazn"
 	on offer
 		conversation
+			branch "skip unmark alnitak"
+				not "wanderers: scattered remnant: alnitak clear"
+			action
+				unmark "Alnitak"
+			label "skip unmark alnitak"
+			branch "skip unmark betelgeuse"
+				not "wanderers: scattered remnant: betelgeuse clear"
+			action
+				unmark "Betelgeuse"
+			label "skip unmark betelgeuse"
+			branch "skip unmark canopus"
+				not "wanderers: scattered remnant: canopus clear"
+			action
+				unmark "Canopus"
+			label "skip unmark canopus"
+			branch "skip unmark capella"
+				not "wanderers: scattered remnant: capella clear"
+			action
+				unmark "Capella"
+			label "skip unmark capella"
+			branch "skip unmark castor"
+				not "wanderers: scattered remnant: castor clear"
+			action
+				unmark "Castor"
+			label "skip unmark castor"
+			branch "skip unmark kursa"
+				not "wanderers: scattered remnant: kursa clear"
+			action
+				unmark "Kursa"
+			label "skip unmark kursa"
+			branch "skip unmark mebsuta"
+				not "wanderers: scattered remnant: mebsuta clear"
+			action
+				unmark "Mebsuta"
+			label "skip unmark mebsuta"
+			branch "skip unmark miaplacidus"
+				not "wanderers: scattered remnant: miaplacidus clear"
+			action
+				unmark "Miaplacidus"
+			label "skip unmark miaplacidus"
+			branch "skip unmark rigel"
+				not "wanderers: scattered remnant: rigel clear"
+			action
+				unmark "Rigel"
+			label "skip unmark rigel"
+			branch "skip unmark saiph"
+				not "wanderers: scattered remnant: saiph clear"
+			action
+				unmark "Saiph"
+			label "skip unmark saiph"
+			branch "skip unmark wazn"
+				not "wanderers: scattered remnant: wazn clear"
+			action
+				unmark "Wazn"
+			label "skip unmark wazn"
 			`The base on <planet> appears to have survived the attack, despite the Kor Sestor drones that were overhead. You meet with Danforth and tell him that you destroyed the Alpha base using the weapon he gave you.`
 			`	He says, "When you destroyed the base, the Sestor drones suddenly stopped acting as a unified fleet. A few stayed here, but most of them have spread throughout this sector of space, and we are receiving reports that they are attacking Navy and civilian ships indiscriminately. My own fleet is too damaged to do anything to stop them, but other Navy bases are sending in reinforcements. Can you join them to help eliminate the drones?"`
 			choice


### PR DESCRIPTION
**Content (Missions change)**

This PR addresses the bug/feature described in issue #4327

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The mission "Wanderers: Sestor: Scattered Remnant" is given to the player when they bomb Zenith. This mission spawns the Kor Sestor ships throughout the north of human space, which the player has to go kill. This mission is invisible.
Upon returning to Farpoint, the mission "Wanderers: Sestor: Kill Southern Remnant" is given. This mission is visible, and instructs the player to go murder the aforementioned Kor Sestor ships, waypointing the systems they are in.
The problem (from the linked issue) is that the waypoints disappear once you enter the system, even though there may still be Kor Sestor ships that have not been destroyed there.
This PR, along with #11896, alleviates this through the following steps:
- The Scattered Remnant mission will set a condition for each system upon the elimination of all target ships in that system.
- It will also unmark that system in teh Kill Southern Remnant mission.
- The Kill Southern Remnant mission now marks the systems the Kor Sestor ships are in, instead of waypointing them.
- In its on offer conversation, the Kill Southern Remnant mission uses a branch-action-label tower to unmark systems where the Kor Sestor ships have already been destroyed, based on conditions set by the other mission.

I think this last part is fairly questionable. I'm wondering if conditional marking would be useful:
```
mission "Wanderers: Sestor: Kill Southern Remnant"
	mark "Castor"
		to mark
			not "wanderers: scattered remnant: castor clear"
```
But I think there might be too much complexity, ambiguity, and confusion about when/how often conditions are evaluated and the changes applied. We could do something like how "to spawn" conditions work, that is, only on take off, but that would still require the linked feature PR to make changes while in space.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Used the branch at https://github.com/warp-core/endless-sky/pull/78.
Used the attached save file.
Proceeded through the missions until the Scattered Remnant was created.
Destroyed the ships in Saiph before visiting Farpoint to receive the Kill Southern Remnant mission.
See that Saiph is not marked by the mission, but the other systems are.
Destroy the Sestor ships in Alnitak.
See that the mark is removed from Alnitak (though it is still the mission destination).

## Save File
This save file can be used to test these changes:
[warped core sestor remnant marking test~original.txt](https://github.com/user-attachments/files/23286684/warped.core.sestor.remnant.marking.test.original.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
