### PR TITLE
Option to disable "shrouded"

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -821,7 +821,8 @@ void PreferencesPanel::DrawSettings()
 		TOOLTIP_ACTIVATION,
 		DATE_FORMAT,
 		"Show parenthesis",
-		NOTIFY_ON_DEST
+		NOTIFY_ON_DEST,
+		"Ignore 'shrouded' property"
 #ifdef _WIN32
 		, "",
 		"Windows Options",

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Hazard.h"
 #include "Minable.h"
 #include "Planet.h"
+#include "Preferences.h"
 #include "Random.h"
 #include "image/SpriteSet.h"
 
@@ -691,7 +692,7 @@ bool System::Hidden() const
 // Defines whether a system can be remembered when out of view.
 bool System::Shrouded() const
 {
-	return shrouded;
+	return shrouded && !Preferences::Has("Ignore 'shrouded' property");
 }
 
 


### PR DESCRIPTION
**Feature**

This PR addresses the discussion intensity in issue #10949. Maybe it could get some heads to cool off.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a checkbox to the settings. When turned on, the map is displayed as if the shrouded property had never been invented. It doesn't modify any pilot data - when you turn it back off it's as if you never turned it on.

(I'm open for suggestions for a better wording. Or to move it to "map"?)

## Screenshots
<img width="540" height="400" alt="image" src="https://github.com/user-attachments/assets/1a25105f-a329-4839-a9ff-2a0b812c5bc4" />

Option ON:
<img width="540" height="304" alt="image" src="https://github.com/user-attachments/assets/605b01fa-74bb-40dc-a87b-4884128fdc49" />

Option OFF:
<img width="540" height="304" alt="image" src="https://github.com/user-attachments/assets/7c0b8ee7-f95f-4c82-8749-ea641c255059" />

## Testing Done
I've had this in my play branch for months, through several playthroughs.

## Performance Impact
Low to negligible - `System::Shrouded()` isn't called in any render loop. Not noticeable in any way in my tests.
