### PR TITLE
fix(mechanics): Player ships no longer launch after dying in a conversation

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -85,6 +85,8 @@ void PlanetPanel::Step()
 	if(player.IsDead())
 	{
 		player.SetPlanet(nullptr);
+		if(callback)
+			callback();
 		if(selectedPanel)
 			GetUI()->Pop(selectedPanel);
 		GetUI()->Pop(this);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -658,7 +658,12 @@ void PlayerInfo::Die(int response, const shared_ptr<Ship> &capturer)
 	isDead = true;
 	// The player loses access to all their ships if they die on a planet.
 	if(GetPlanet() || !flagship)
+	{
+		// Zero out the flagship's velocity to prevent camera drift.
+		if(flagship)
+			flagship.get()->SetVelocity(Point());
 		ships.clear();
+	}
 	// If the flagship should explode due to choices made in a mission's
 	// conversation, it should still appear in the player's ship list (but
 	// will be red, because it is dead). The player's escorts will scatter


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, if you die in a conversation and you aren't on a freshly-loaded save, all your ships will take off after closing the panel. This PR fixes that bug by sending a callback to the main panel, properly resetting the system and clearing the player's ship.

## Testing Done
Tested dying in a conversation in both a freshly-loaded save and after taking off and landing, and saw expected behaviour.

## Save File
This save file can be used to test these changes:
[Rin Satsuki~Death Test.txt](https://github.com/user-attachments/files/23304447/Rin.Satsuki.Death.Test.txt)

## Performance Impact
N/A
