### PR TITLE
fix(segfault): Re-add the call to Resize in PreferencesPanel::KeyDown when changing pages

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -251,7 +251,7 @@ bool PreferencesPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &comma
 		hoverItem.clear();
 		selected = 0;
 
-		// Reset the render buffers in case the UI scale has changed.
+		// Make sure the render buffers are initialized and are aware of the current UI scale.
 		Resize();
 	}
 	else if(key == 'o' && page == 'p')


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug introduced by #11887.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Title.

## Testing Done

Yes.