### PR TITLE
fix(content): You are now only lost in the Coalition if you do not have any means of escape

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -159,8 +159,8 @@ mission "lost in coalition"
 		government "Coalition" "Heliarch"
 	to offer
 		has "license: Coalition"
+		not "ship attribute: jump drive"
 	on offer
-		require "Jump Drive" 0
 		event "lost in coalition" 14
 		fail
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #9308 (sort of).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

#10787 updated several missions to check if you have the ability to jump without hyperlanes rather than checking for the Jump Drive itself. However, lost in coalition was never updated. The reasons given for not updating FW Pug 2C do not apply here, because you will only see lost in coalition if you have no means of escape, which means you by definition will have no vanilla Jump Drive, as the mission explains.

## Screenshots
Lost in coalition

## Testing Done
Lost in coalition

## Save File
Lost in coalition