### PR TITLE
feat(ui): When using jump/tab to jump target systems on the map, use the selected system if it is not at the end of the travel plan

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -224,7 +224,7 @@ bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command
 		// If a system is selected that is not at the end of the travel plan, then the player selected it
 		// by either using the Find function, or by ctrl+clicking on it. If the player then hits jump while this
 		// other system is selected, it should be added to the travel plan.
-		if((plan.empty() && selectedSystem != player.GetSystem()) || (!plan.empty() && selectedSystem != plan.front()))
+		if(selectedSystem != (plan.empty() ? player.GetSystem() : plan.front()))
 		{
 			Select(selectedSystem);
 			return true;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

I've been using keyboard shortcuts to get around a lot lately while playing the game. Something I tried to do recently (as in like 15 minutes ago) is pull up the map, use the find function to select a distant system, and then hit the jump key to target it. Turns out, that doesn't work. Hitting the jump key on the map just targets a nearby system.

This PR changes it so that if you have a system selected that is not your current system and is not at the end of your travel plan (which can occur when using the find function or when ctrl+clicking on a system), hitting the jump key either adds that system to your travel plan (when shift is held), or replaces your travel plan with the shortest route to the selected system. This makes it so that you can very quickly select distance systems without needing to use the mouse.

## Testing Done

Yes