### PR TITLE
fix(mechanics): Default turret placement to "over"

### DIFF
--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -50,7 +50,7 @@ public:
 		// An omnidirectional turret can rotate infinitely.
 		bool isOmnidirectional;
 		// Whether the hardpoint should be drawn over the ship, under it, or not at all.
-		Side side;
+		Side side = Side::OVER;
 		// Range over which the turret can turn, from leftmost position to rightmost position.
 		// (directional turret only)
 		Angle minArc;


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a gun is defined, the ship constructor changes the value of the hardpoint placement to under. But when a turret is defined, the default value is used, which before this PR was uninitialized, leading to potential errors in placement of the turret.

## Testing Done
None.

## Performance Impact
N/A
