### PR TITLE
fix: Fix crash when rendering ship status effects

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -5203,7 +5203,8 @@ void Ship::CreateSparks(vector<Visual> &visuals, const Effect *effect, double am
 		return;
 
 	// Limit the number of sparks, depending on the size of the sprite.
-	amount = min(amount, Width() * Height() * .0006);
+	// The limit needs to be the first argument in case amount is NaN.
+	amount = min(Width() * Height() * .0006, amount);
 	// Preallocate capacity, in case we're adding a non-trivial number of sparks.
 	visuals.reserve(visuals.size() + static_cast<size_t>(amount));
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described [on Discord](https://discord.com/channels/251118043411775489/431496424992014347/1436767976635498627).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When using negative numbers for memory size calculations, strange things tend to happen.
This PR adds a check to Ship::CreateSparks to make sure the amount of generated sparks will be positive. Also now that we know that the amount is positive, we can use size_t instead of int to calculate the required element count.

## Testing Done
None.

## Performance Impact
N/A
