### PR TITLE
(bugfix) Prevent Heliarch Investigation missions from offering if one joined the Lunarium

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -300,6 +300,8 @@ mission "Heliarch Investigation 2 - Shifting Sand"
 	destination "Shifting Sand"
 	to offer
 		has "Heliarch Investigation 1: done"
+		not "joined the lunarium"
+		not "assisting lunarium"
 	to fail
 		or
 			has "Heliarch Investigation 2: declined"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described by [xSeito on the Discord](https://discord.com/channels/251118043411775489/747839420115189801/1436891066883375155)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The missions did not have the conditions preventing them from offering if one was currently helping the Lunarium or had joined them, so if someone did the Investigation 1 mission, left, then later came back, they wouldn't pick up Investigation 2, but would pick up all the other missions.
