### PR TITLE
fix(bug): fix the Star Tail Storage and High-Velocity Spike Rack not having ammo nodes

### DIFF
--- a/data/incipias/incipias outfits.txt
+++ b/data/incipias/incipias outfits.txt
@@ -183,6 +183,7 @@ outfit "Star Tail Storage"
 	"mass" 10
 	"outfit space" -10
 	"star tail capacity" 20
+	ammo "Star Tail Cell"
 	licenses
 		"Hicemus Conflict"
 	description "Because Star Tail Cells are highly volatile, they need a robust storage system. This radial design is able to withstand minor explosions by using a variant of a shield that can be deployed temporarily."

--- a/data/successors/successor weapons.txt
+++ b/data/successors/successor weapons.txt
@@ -389,6 +389,7 @@ outfit "High-Velocity Spike Rack"
 	"outfit space" -12
 	"energy capacity" 800
 	"spike capacity" 16
+	ammo "High-Velocity Spike"
 	description `Though the built-in ammunition reserves of the Sjeja Kinetic Lance are sufficient for all but the most protracted engagements, the High Houses do manufacture this additional storage unit for use on their largest warships. The rack includes a small set of batteries to help support the high power costs of the Sjeja.`
 
 outfitter "Kinetic Lance Restock"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1436808928515195001)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a missing `ammo` node to both the "Star Tail Storage" and "High-Velocity Spike Rack" outfits.
