### PR TITLE
Set "First Contact: <species name>" automatically

### DIFF
--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -231,6 +231,15 @@ mission "Avgi: First Contact"
 		set "discovered avgi"
 		event "outer limits label"
 
+mission "First Contact: Avgi"
+	landing
+	invisible
+	to offer
+		has "Avgi: First Contact: done"
+	on offer
+		set "First Contact: Avgi: done"
+		fail
+
 
 
 mission "Avgi: Humans From the Deep"

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -103,6 +103,15 @@ event "label coalition space"
 	galaxy "label arachi"
 		sprite "label/arachi"
 
+mission "First Contact: Coalition"
+	landing
+	invisible
+	to offer
+		has "Coalition: First Contact: done"
+	on offer
+		set "First Contact: Coalition: done"
+		fail
+
 
 
 mission "Coalition: Contributor"

--- a/data/incipias/incipias first contact.txt
+++ b/data/incipias/incipias first contact.txt
@@ -103,6 +103,15 @@ mission "Incipias: First Contact"
 				to display
 					has "Visit Quarg in Incipias Space: offered"
 
+mission "First Contact: Incipias"
+	landing
+	invisible
+	to offer
+		has "Incipias: First Contact: done"
+	on offer
+		set "First Contact: Incipias: done"
+		fail
+
 
 
 mission "Visit Quarg in Incipias Space"


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Some species' first contact missions are `"First Contact: <species name>"`, while some are `"<species name>: First Contact"`.
Ideally, this would be standardized in the mission names themselves, but that is a more gamebreaking change and probably should wait for the next major release.
Instead, I've added three new missions which automatically set `"First Contact: <species name>: done"` once the `"<species name>: First Contact"` is done.
~~This will also fix a bug with the Struggling Author mission chain; apparently the testing save file had an extra condition that you can't get in vanilla.~~
