### PR TITLE
Revert "Set "First Contact: <species name>" automatically"

### DIFF
--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -231,15 +231,6 @@ mission "Avgi: First Contact"
 		set "discovered avgi"
 		event "outer limits label"
 
-mission "First Contact: Avgi"
-	landing
-	invisible
-	to offer
-		has "Avgi: First Contact: done"
-	on offer
-		set "First Contact: Avgi: done"
-		fail
-
 
 
 mission "Avgi: Humans From the Deep"

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -103,15 +103,6 @@ event "label coalition space"
 	galaxy "label arachi"
 		sprite "label/arachi"
 
-mission "First Contact: Coalition"
-	landing
-	invisible
-	to offer
-		has "Coalition: First Contact: done"
-	on offer
-		set "First Contact: Coalition: done"
-		fail
-
 
 
 mission "Coalition: Contributor"

--- a/data/incipias/incipias first contact.txt
+++ b/data/incipias/incipias first contact.txt
@@ -103,15 +103,6 @@ mission "Incipias: First Contact"
 				to display
 					has "Visit Quarg in Incipias Space: offered"
 
-mission "First Contact: Incipias"
-	landing
-	invisible
-	to offer
-		has "Incipias: First Contact: done"
-	on offer
-		set "First Contact: Incipias: done"
-		fail
-
 
 
 mission "Visit Quarg in Incipias Space"


### PR DESCRIPTION
Reverts endless-sky/endless-sky#11930, which I think was prematurely merged.

I don't think this format is desirable or consistent. The first contact missions are parts of a series for each species, they aren't part of a First Contact series. Even the older Remnant and Wanderer missions that do use the First Contact: Remnant/Wanderers format are immediately followed up by missions using the Remnant/Wanderers: XYZ naming format.