### PR TITLE
fix: Add a conversation for the "no bunks!" flight check

### DIFF
--- a/data/_ui/flight checks.txt
+++ b/data/_ui/flight checks.txt
@@ -33,6 +33,6 @@ conversation "flight check: overheating!"
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
 
 conversation "flight check: no bunks!"
-	scene "scene/engine"
+	scene "outfit/bunk room"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of the <ship> warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	It is all going smoothly, but suddenly a manual confirmation prompt appears on the diagnostics screen. You hail the crew of the <ship>... and you realize, much to your embarrassment, that you do not have any bunks installed. Time to head back to the outfitter and fix that!`


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
_You've heard enough horror stories about the sort of accidents that happen when the game malfunctions to be completely convinced of the necessity of a pre-commit safety check. As you listen to the complex symphony of hums, rattles, and clicks of #11819 warming up, you run through a mental checklist. CI: check. Code review: check.
It is all going smoothly until you decide to test another pull request. You try to depart... and you realize, much to your embarrassment, that you do not have the flight check conversation loaded and the panel is empty. Time to head back to Github and fix that!_

## Testing Done
yes™.