### PR TITLE
fix(crash): Handle invalid syntax in plugin.txt

### DIFF
--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -221,26 +221,26 @@ const Plugin *Plugins::Load(const filesystem::path &path)
 			aboutText += child.Token(1) + '\n';
 		else if(key == "version" && hasValue)
 			version = child.Token(1);
-		else if(key == "authors" && child.HasChildren())
+		else if(key == "authors")
 			for(const DataNode &grand : child)
 				authors.insert(grand.Token(0));
-		else if(key == "tags" && child.HasChildren())
+		else if(key == "tags")
 			for(const DataNode &grand : child)
 				tags.insert(grand.Token(0));
-		else if(key == "dependencies" && child.HasChildren())
+		else if(key == "dependencies")
 		{
 			for(const DataNode &grand : child)
 			{
 				const string &grandKey = grand.Token(0);
-				if(grandKey == "game version")
+				if(grandKey == "game version" && hasValue)
 					dependencies.gameVersion = grand.Token(1);
-				else if(grandKey == "requires" && grand.HasChildren())
+				else if(grandKey == "requires")
 					for(const DataNode &great : grand)
 						dependencies.required.insert(great.Token(0));
-				else if(grandKey == "optional" && grand.HasChildren())
+				else if(grandKey == "optional")
 					for(const DataNode &great : grand)
 						dependencies.optional.insert(great.Token(0));
-				else if(grandKey == "conflicts" && grand.HasChildren())
+				else if(grandKey == "conflicts")
 					for(const DataNode &great : grand)
 						dependencies.conflicted.insert(great.Token(0));
 				else


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1439521106754142258).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a missing hasValue check to prevent the game from crashing when it encounters a malformed "game version" dependency.
Also removed a few instances of HasChildren, because the loops simply don't run if they don't have any range even without these checks.

## Testing Done
yes™.