### PR TITLE
fix(bug): don't auto-decline the second Successor First Contact mission

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -319,7 +319,7 @@ mission "Successors: First Contact 2"
 			`	As you exit, the door closes behind you, reforming into solid metal.`
 				flee
 			label end
-				decline
+				accept
 
 mission "Successors: First Contact 3"
 	name "Capture an animal for House Sioeora"


### PR DESCRIPTION
**Bug fix**

Fixes #11934 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Somehow, if the player chooses the choice that should accept the Successors First Contact 2 mission, it is instead declined. This PR changes the `decline` to an `accept`.
I couldn't find the commit where this issue was introduced. It worked at some point, I'm pretty sure.

## Testing Done
Not yet. Needs to be done, since a `label` with an endpoint may not work without text.

## Save File
This save file can be used to test these changes:
[Jude.Bertt.txt](https://github.com/user-attachments/files/23567795/Jude.Bertt.txt) should work.
