### PR TITLE
feat(content): Make Wanderers: Mereti Observation use a timer

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -643,7 +643,7 @@ mission "Wanderers: Mereti Observation"
 	timer 3600 3600
 		"pause when inactive"
 		"activation requirements"
-			system Mesuket
+			system "Mesuket"
 		on timeup
 			dialog `The Wanderer recording device chirps at you to let you know that it has collected enough data. Time to return to <planet>.`
 	on visit


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #4475 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In #4475, Amazinite suggested that Wanderers: Mereti Observation should be changed to use a timer. Now that timers are a thing, this updates the mission so that you have to wait a minute or two rather than wait for a specific ship to become disabled.

## Testing Done
Waited one minute without the game open

## Save File
This save file can be used to test these changes: 
[Test Pilot~broken wanderer.txt](https://github.com/user-attachments/files/23596110/Test.Pilot.broken.wanderer.txt)

Take off and land. Like Pug Magic, the mission will offer.

## Performance Impact
Does not improve performance because there are not less ships starting in Mesuket