### PR TITLE
fix: Correctly check whether a plugin's "game version" node has a value

### DIFF
--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -232,8 +232,8 @@ const Plugin *Plugins::Load(const filesystem::path &path)
 			for(const DataNode &grand : child)
 			{
 				const string &grandKey = grand.Token(0);
-				bool hasGrandValue = grand.Size() >= 2;
-				if(grandKey == "game version" && hasGrandValue)
+				bool grandHasValue = grand.Size() >= 2;
+				if(grandKey == "game version" && grandHasValue)
 					dependencies.gameVersion = grand.Token(1);
 				else if(grandKey == "requires")
 					for(const DataNode &great : grand)


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
#11937 added a hasValue guard to the "game version" node of a plugin's metadata. Problem is that the hasValue variable is checking if the child node has a value, while "game version" is a grandchild node.

## Testing Done
Trust me, bro.