### PR TITLE
(Feat) Adds GoTo support for conversation nodes

### DIFF
--- a/source/Conversation.cpp
+++ b/source/Conversation.cpp
@@ -182,7 +182,7 @@ void Conversation::Load(const DataNode &node, const ConditionsStore *playerCondi
 				}
 			}
 		}
-		else if(key == "goto")
+		else if(key == "goto" && hasValue)
 		{
 			// Goto the label with the specified name, even if that name matches an endpoint.
 			nodes.emplace_back();


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #11946

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
In a conversation, a branch with no condition can be used to unconditionally go to a label. On issue #11946, @Amazinite suggested that `goto` could function as an alias for that:
> I wonder if for the sake of clarity, we should allow `goto` to be a direct child node of a conversation. Since a branch with no conditions has the same behavior, we could just internally treat them the same.

This PR attempts to achieve that.

## Usage examples
A simple diverge and then gather can be implemented like so:
```
conversation
		choice
			"	Tacos"
				goto tacos
			"	Cookies"		
		action
			set "prefers cookies"
		goto gather
		label tacos
		action
			set "prefers tacos"	
		label gather
		"	Your food preferences are now known to the galaxy."
			decline
```

## Testing Done
Confirmed no new errors appear in `errors.txt`
Ran through the FW story including `FW Southern Recon 1B`, triggering the `branch end` path in that mission.
Changed the data file to instead use `goto end`, and then rolled back and replayed that mission. Both behaved the same way.
Edit:
Verified various behaviors (goto earlier label, goto later label, goto endpoint) confirming the behavior exactly matches how unconditional branch behaves in the same situation (using plugin [testing-goto-11949.zip](https://github.com/user-attachments/files/23618150/testing-goto-11949.zip) )

## Save File
This save was used for the `Testing Done` step:
[Issue 11946~FW-Recon-1.txt](https://github.com/user-attachments/files/23616920/Issue.11946.FW-Recon-1.txt)

## Wiki Update
Edit: [Link to wiki update](https://github.com/endless-sky/endless-sky-wiki/pull/188)

## Performance Impact
None observed.