### PR TITLE
fix(content): Don't mention the Tempest in the Heavy Gust's description, as it may not exist yet

### DIFF
--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -313,7 +313,7 @@ ship "Heavy Gust"
 	explode "medium explosion" 45
 	explode "large explosion" 22
 	"final explode" "final explosion medium"
-	description "The Heavy Gust is a further modification of the Strong Wind, adjusted even more heavily for combat purposes at the expense of much of its precursor's peacetime utility. With these modifications, the Heavy Gust becomes both faster and deadlier, pushing the frame of the original civilian design to its limits."
+	description "The Heavy Gust is a further modification of the Strong Wind, adjusted even more heavily for combat purposes at the expense of much of its precursor's peacetime utility. With these modifications, the Heavy Gust becomes both faster and deadlier, pushing the original civilian frame to its limits."
 
 ship "Heavy Gust" "Heavy Gust (Moonbeam)"
 	outfits


### PR DESCRIPTION
This PR addresses the bug/feature described by Cracked Emerald on the discord

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Instead of mentioning the Tempest - which does not exist at the point at which the Heavy Gust first appears, and hence should not be explicitly mentioned yet, this description hints at its imminent arrival in an indirect manner, by outlining the Wanderers' need for a purpose-built warship rather than further conversions of their existing civilian designs.

