### PR TITLE
fix(bug): add a blocked message to Remnant: Cognizance 33

### DIFF
--- a/data/remnant/remnant 2 cognizance.txt
+++ b/data/remnant/remnant 2 cognizance.txt
@@ -1498,6 +1498,7 @@ mission "Remnant: Cognizance 33"
 	destination "Ssil Vida"
 	cargo "refined fuel" 58
 	deadline 19
+	blocked "For the next mission in the Remnant campaign, you must have at least 58 cargo space free."
 	to offer
 		has "Remnant: Cognizance 32: done"
 	on offer


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on [Discord](https://discord.com/channels/251118043411775489/308902312741568512/1442368350037479425)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a "blocked" message to `Remnant: Cognizance 33` so that players don't get stuck without knowing what to do.

## Testing Done
Unfortunately, the user who reported the bug had already overwritten their save by the time I asked for it, and I do not have a save that has done Cognizance.