### PR TITLE
Fix null pointer dereference in FillShader::Init()

### DIFF
--- a/source/shader/FillShader.cpp
+++ b/source/shader/FillShader.cpp
@@ -40,7 +40,7 @@ namespace {
 
 void FillShader::Init()
 {
-	shader = GameData::Shaders().Find("fill");
+	shader = GameData::Shaders().Get("fill");
 	if(!shader->Object())
 		throw runtime_error("Could not find fill shader!");
 	scaleI = shader->Uniform("scale");


### PR DESCRIPTION
If the fill shader isn't defined, then `Find()` will return a null, where `Get()` will return an uninitialized shader, which is what the code seems to expect. 

If we are going to crash, we might as well do it on purpose.

**Bug fix**

This is just a bug seen by code inspection after going through some stack traces provided to me on discord

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Change shader from `Find()` to `Get()` to match the expectation of the followup validation check, and to match what the rest of the shaders are doing.

## Testing Done
It compiles and runs, the shader still works. 

## Performance Impact
No performance impact expected. 