### PR TITLE
fix(bug): Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ find_library(LIBMAD_LIB_RELEASE NAMES mad libmad NAMES_PER_DIR PATHS "${_VCPKG_I
 
 # FLAC's config is missing find_dependency(Threads), so include it here.
 find_package(Threads REQUIRED)
-if(UNIX)
+if(UNIX AND NOT ES_USE_VCPKG)
 	find_package(FLAC CONFIG QUIET)
 	if(NOT FLAC_FOUND)
 		# Many linux distros use the autotools build of flac, which does not


### PR DESCRIPTION
**Bug fix**
This PR addresses the bug described in issue #11432

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removed `AND NOT APPLE` as it was not recognising my installation of FLAC on my Mac. Removing this does not solve my problem entirely as it also won't recognise my installation of minizip (as described in #11432) but by following [these instructions](https://github.com/endless-sky/endless-sky/issues/11432#issuecomment-2926010060) I was able to work around it.

## Testing Done
It builds?