### PR TITLE
feat(conditions): Add a condition for checking the previous system's government

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4074,6 +4074,11 @@ void PlayerInfo::RegisterDerivedConditions()
 		if(!previousSystem)
 			return false;
 		return !ce.NameWithoutPrefix().compare(previousSystem->TrueName()); });
+	conditions["previous system government: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
+		if(!previousSystem || !previousSystem->GetGovernment())
+			return false;
+		return !ce.NameWithoutPrefix().compare(previousSystem->GetGovernment()->TrueName());
+	});
 
 	// Conditions to determine if flagship is in a system and on a planet.
 	conditions["flagship system: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in https://github.com/endless-sky/endless-sky/pull/11964#discussion_r2570447367.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds the following autocondition:
* `"previous system government: <government>"`: is 1 if the name provided is the government of the system you were previously in before your current one, 0 otherwise.

## Usage Example + Testing
```
mission "Message Buoy: Testing New Condition"
	entering
	repeat
	destination "Earth"
	invisible
	to offer
		not "previous system government: Republic"
		not "entered system by: takeoff"
	source
		government "Republic"
	on offer
		message
			text "You just entered Navy-patrolled space."
		fail
```

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/192
