### PR TITLE
Increase timeouts for integration tests to 2 minutes

### DIFF
--- a/tests/integration/IntegrationTests.cmake
+++ b/tests/integration/IntegrationTests.cmake
@@ -27,7 +27,7 @@ foreach(test ${INTEGRATION_TESTS_LIST})
 		set(SET_TEST_PROPS
 	"set_tests_properties([==[${test}]==] PROPERTIES
 		WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
-		TIMEOUT 30
+		TIMEOUT 120
 		LABELS integration)")
 
 	# Launches the integration tests in debug mode, so that they can be followed.


### PR DESCRIPTION
@tibetiroka Commit 7481629 was too aggressive in reducing the timeout, the Debian riscv64 buildds are rather slow and after this fix the output for 0.10.16 is:
```
      Start  1: Abort Take Off On Excess Outfits In Cargo Warning
 1/45 Test  #1: Abort Take Off On Excess Outfits In Cargo Warning ...   Passed   38.52 sec
      Start  3: Afterburner-flight - Simple depart land
 2/45 Test  #3: Afterburner-flight - Simple depart land .............   Passed   38.07 sec
      Start  5: Atrocity Test - New Atrocity
 3/45 Test  #5: Atrocity Test - New Atrocity ........................   Passed   36.49 sec
      Start  7: Capture Uncapturable With Capturable Override
 4/45 Test  #7: Capture Uncapturable With Capturable Override .......   Passed   35.99 sec
      Start  9: Checking For A Gifted Ship
 5/45 Test  #9: Checking For A Gifted Ship ..........................   Passed   38.27 sec
      Start 11: Clear flagship model condition
 6/45 Test #11: Clear flagship model condition ......................   Passed   37.63 sec
      Start 13: Conditional Test
 7/45 Test #13: Conditional Test ....................................   Passed   36.89 sec
      Start 15: Conditional Test Goto
 8/45 Test #15: Conditional Test Goto ...............................   Passed   39.05 sec
      Start 17: Conditional Test Out of Bound
 9/45 Test #17: Conditional Test Out of Bound .......................   Passed   38.35 sec
      Start 19: Ember Wastes Navigation
10/45 Test #19: Ember Wastes Navigation .............................   Passed   44.30 sec
      Start 21: Enter Name in Conversation
11/45 Test #21: Enter Name in Conversation ..........................   Passed   36.80 sec
      Start 23: Flagship Attribute Autoconditions
12/45 Test #23: Flagship Attribute Autoconditions ...................   Passed   37.04 sec
      Start 25: Flagship Planet Attribute Test
13/45 Test #25: Flagship Planet Attribute Test ......................   Passed   36.13 sec
      Start 27: Hyperjumps To Autocondition
14/45 Test #27: Hyperjumps To Autocondition .........................   Passed   36.46 sec
      Start 29: Illegal Test - Ignore and New Illegal
15/45 Test #29: Illegal Test - Ignore and New Illegal ...............   Passed   36.94 sec
      Start 31: Job Board During Mission Test
16/45 Test #31: Job Board During Mission Test .......................   Passed   41.07 sec
      Start 33: Job Board Mission From Map Test
17/45 Test #33: Job Board Mission From Map Test .....................   Passed   36.20 sec
      Start 35: Job Board Mission From Planet Test
18/45 Test #35: Job Board Mission From Planet Test ..................   Passed   37.62 sec
      Start 37: Landing in a system with multiple planets
19/45 Test #37: Landing in a system with multiple planets ...........   Passed   38.41 sec
      Start 39: Loading and Reloading
20/45 Test #39: Loading and Reloading ...............................   Passed   38.10 sec
      Start 41: Loading and Saving
21/45 Test #41: Loading and Saving ..................................   Passed   40.91 sec
      Start 43: Outfitter Mission Test
22/45 Test #43: Outfitter Mission Test ..............................   Passed   36.20 sec
      Start 45: Plugin Installed Autocondition
23/45 Test #45: Plugin Installed Autocondition ......................   Passed   36.41 sec
      Start 47: Save To Default Snapshot
24/45 Test #47: Save To Default Snapshot ............................   Passed   41.37 sec
      Start 49: Saving during conversation
25/45 Test #49: Saving during conversation ..........................   Passed   37.16 sec
      Start 51: Sell 0 ships
26/45 Test #51: Sell 0 ships ........................................   Passed   36.53 sec
      Start 53: Sell 1 ship
27/45 Test #53: Sell 1 ship .........................................   Passed   35.68 sec
      Start 55: Sell 2 ships
28/45 Test #55: Sell 2 ships ........................................   Passed   36.52 sec
      Start 57: Sell 3 ships
29/45 Test #57: Sell 3 ships ........................................   Passed   36.52 sec
      Start 59: Sell Outfit On Take Off
30/45 Test #59: Sell Outfit On Take Off .............................   Passed   37.30 sec
      Start 61: Shipyard Mission Test
31/45 Test #61: Shipyard Mission Test ...............................   Passed   36.72 sec
      Start 63: Store Outfit On Take Off
32/45 Test #63: Store Outfit On Take Off ............................   Passed   42.41 sec
      Start 65: Taking Ship With Outfits And Unconstrained
33/45 Test #65: Taking Ship With Outfits And Unconstrained ..........   Passed   36.72 sec
      Start 67: Test-Framework - Calling other functions
34/45 Test #67: Test-Framework - Calling other functions ............   Passed   37.91 sec
      Start 69: Test-Framework - Conditions Arithmetic and Loops
35/45 Test #69: Test-Framework - Conditions Arithmetic and Loops ....   Passed   36.22 sec
      Start 71: Test-Framework - Empty Test Sequence
36/45 Test #71: Test-Framework - Empty Test Sequence ................   Passed   36.68 sec
      Start 73: Test-Framework - Empty Testcase
37/45 Test #73: Test-Framework - Empty Testcase .....................   Passed   36.26 sec
      Start 75: Test-Framework - Load Depart Land
38/45 Test #75: Test-Framework - Load Depart Land ...................   Passed   37.64 sec
      Start 77: Test-Framework - Mission Injection
39/45 Test #77: Test-Framework - Mission Injection ..................   Passed   36.91 sec
      Start 79: Test-Framework - Navigate
40/45 Test #79: Test-Framework - Navigate ...........................   Passed   44.97 sec
      Start 81: Test-Framework - Recursive Calling
41/45 Test #81: Test-Framework - Recursive Calling ..................   Passed   36.31 sec
      Start 83: Test-Framework - UI Keyboard controls
42/45 Test #83: Test-Framework - UI Keyboard controls ...............   Passed   36.25 sec
      Start 85: To Accept Blocks Accepts When Conditions Fail
43/45 Test #85: To Accept Blocks Accepts When Conditions Fail .......   Passed   36.68 sec
      Start 87: Wormhole Navigation
44/45 Test #87: Wormhole Navigation .................................   Passed   41.57 sec
      Start 89: unit
45/45 Test #89: unit ................................................   Passed    3.07 sec

100% tests passed, 0 tests failed out of 45

Label Time Summary:
integration    = 1666.17 sec*proc (44 tests)
unit           =   3.07 sec*proc (1 test)

Total Test time (real) = 1669.40 sec
```

2 minutes gives some buffer if a test takes longer in a future release.

This does make the tests take longer in the (rare) case of actual hangs, the timeout does not matter when a test passes or fails.