### PR TITLE
**Bug fix** - Adds clearance tag to 5 HR missions which require you to land on hai-home

### DIFF
--- a/data/hai/hai reveal 4 middle.txt
+++ b/data/hai/hai reveal 4 middle.txt
@@ -60,6 +60,7 @@ mission "Hai Reveal [A02] Symbol Identification"
 	description "Fly to <destination> and ask Alondo if he can help in some way."
 	source Darkwaste
 	destination Hai-home
+	clearance
 	to offer
 		has "Hai Reveal [A01] Visit Darkwaste: done"
 	on offer
@@ -749,6 +750,7 @@ mission "Hai Reveal [A05] Take Teeneep to Hai-home"
 	description `Take Teeneep to Hai-home so she can investigate the Elders arming pirates with Hai weapons.`
 	source Darkwaste
 	destination Hai-home
+	clearance
 	passengers 1
 	blocked `It's probably not advisable to bring so many unnecessary people to a secret location on Darkwaste. You should return when your spare bunks are unoccupied.`
 	to offer
@@ -1034,6 +1036,7 @@ mission "Hai Reveal [A08] Symbol Identification"
 	description "Return to <destination> with Batu Cegeen and your new information."
 	source Earth
 	destination Hai-home
+	clearance
 	passengers 1
 	to offer
 		has "Hai Reveal [A07] Deliver the Relays: done"
@@ -1353,6 +1356,7 @@ mission "Hai Reveal [A10] Demanding Satisfaction"
 	description "Fly to <destination> and deliver Teeneep and her ultimatum to the Elders."
 	source "Darkcloak"
 	destination "Hai-home"
+	clearance
 	passengers 1
 	to offer
 		has "Hai Reveal [A09] History of Appeasement: done"
@@ -1699,6 +1703,7 @@ mission "Hai Reveal [A12] Into the Lion's Den"
 	description "Travel back to <planet> and ensure the diplomats are safe."
 	source "Mountaintop"
 	destination "Hai-home"
+	clearance
 	to offer
 		has "Hai Reveal [A11] Sound the Alarm: done"
 	on offer


### PR DESCRIPTION

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

several hai reveal mission require you to land on hai-home, however, some of them lack clearance tag, this PR adds it


## Testing Done
~~this is a bug fix~~ Checked all mission with destination "Hai-home" or destination Hai-home , check for clearance tag, if absent, checked if its applicable

## Save File (unsure how this works for this pr but oh well)
This save file can be used to test these changes:
(used a roundabout way and made duplicate missions without the offer conditions)
save file - 
[s c.txt](https://github.com/user-attachments/files/23902023/s.c.txt)
plugin used/containing the duplicate missions without offer conditions - 
[test.txt](https://github.com/user-attachments/files/23902043/test.txt) \

all the edited 5 missions should be active, and none of them have clearance tag to let you land on hai home

## Performance Impact

N/A
