### PR TITLE
fix(ui): Use display names when sorting ships and outfits

### DIFF
--- a/source/comparators/BySeriesAndIndex.h
+++ b/source/comparators/BySeriesAndIndex.h
@@ -45,9 +45,9 @@ class BySeriesAndIndex<Ship> {
 public:
 	bool operator()(const std::string &nameA, const std::string &nameB) const
 	{
-		const Outfit &shipA = GameData::Ships().Get(nameA)->Attributes();
-		const Outfit &shipB = GameData::Ships().Get(nameB)->Attributes();
-		return Helper(shipA, shipB, nameA, nameB);
+		const Ship &shipA = *GameData::Ships().Get(nameA);
+		const Ship &shipB = *GameData::Ships().Get(nameB);
+		return Helper(shipA.Attributes(), shipB.Attributes(), shipA.DisplayModelName(), shipB.DisplayModelName());
 	}
 };
 
@@ -56,8 +56,8 @@ class BySeriesAndIndex<Outfit> {
 public:
 	bool operator()(const std::string &nameA, const std::string &nameB) const
 	{
-		const Outfit *outfitA = GameData::Outfits().Get(nameA);
-		const Outfit *outfitB = GameData::Outfits().Get(nameB);
-		return Helper(*outfitA, *outfitB, nameA, nameB);
+		const Outfit &outfitA = *GameData::Outfits().Get(nameA);
+		const Outfit &outfitB = *GameData::Outfits().Get(nameB);
+		return Helper(outfitA, outfitB, outfitA.DisplayName(), outfitB.DisplayName());
 	}
 };


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported [on Discord](https://discord.com/channels/251118043411775489/431496424992014347/1445443033800904836).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Sorting is something visible in the UI, so it should look at display names instead of the internal true names.

## Testing Done
None.

## Performance Impact
N/A
