### PR TITLE
refactor: Use more compatible strftime format

### DIFF
--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -269,7 +269,7 @@ namespace {
 			result.append(Format::Number(value));
 	}
 
-	const char *DEFAULT_TIMESTAMP_FORMAT = "%F %T";
+	const char *DEFAULT_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S";
 
 	// Return a string containing the setting to use for time formatting.
 	const char *TimestampFormatString()


### PR DESCRIPTION
**Bug Fix**/**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Apparently Microsoft hates C99 and the default C runtime provided in Windows doesn't support newer strftime expansion formats, resulting in an empty timestamp string. This PR replaces `%F` and `%T` with their pre-C99 equivalents, (see https://en.cppreference.com/w/c/chrono/strftime.html).

## Testing Done
Tested on Windows 11.

## Performance Impact
N/A
