### PR TITLE
feat(balance): Make `prospecting` more effective on higher-value mineables rather than less

### DIFF
--- a/data/harvesting.txt
+++ b/data/harvesting.txt
@@ -445,7 +445,7 @@ minable "small water droplet"
 	hull 180
 	"random hull" 180
 	payload "Voidfish" 3
-		"toughness" 540
+		"toughness" 1260
 	explode "droplet burst" 3
 
 minable "medium water droplet"
@@ -459,7 +459,7 @@ minable "medium water droplet"
 	hull 600
 	"random hull" 600
 	payload "Voidfish" 15
-		"toughness" 1800
+		"toughness" 4200
 	explode "droplet burst" 6
 
 minable "large water droplet"
@@ -473,7 +473,7 @@ minable "large water droplet"
 	hull 1800
 	"random hull" 1800
 	payload "Voidfish" 45
-		"toughness" 4500
+		"toughness" 12600
 	explode "droplet burst" 12
 
 minable "huge water droplet"
@@ -487,7 +487,7 @@ minable "huge water droplet"
 	hull 3600
 	"random hull" 3600
 	payload "Voidfish" 120
-		"toughness" 10800
+		"toughness" 25200
 	explode "droplet burst" 36
 
 outfit "Voidfish"


### PR DESCRIPTION
**Balance**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Reworks the scaling of `toughness` on mineables, making it lower relative to hull on higher-value mineables and higher relative to hull on lower-value mineables. This makes specialised mining equipment (that is, equipment with `prospecting`) more effective, proportionally, when mining higher-value mineables like gold and platinum.

This is also, effectively, a significant buff to `prospecting`, but I think the effect size of the benefit from it was too small previously, so that's also a problem that I'm addressing.

Before:
<img width="307" height="295" alt="520530100-b72422b5-32c5-4a31-bdcb-3b6810399917" src="https://github.com/user-attachments/assets/45a8be2a-45e3-4bc5-8684-776f5e89426e" />

After:
<img width="304" height="317" alt="521994971-c60685e8-45aa-4d10-a4ca-990e3bc53f85" src="https://github.com/user-attachments/assets/426c39d9-78a2-4da9-98be-7e875f320e70" />


## Testing Done
None

## Save File
Any save file can be used to test these changes. Grab a mining laser, digger mining beam, or MCS and go for it.