### PR TITLE
fix(build): Correctly link RtlGetVersion on Win32

### DIFF
--- a/source/windows/WinVersion.cpp
+++ b/source/windows/WinVersion.cpp
@@ -20,7 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <windows.h>
 
 // Declare RtlGetVersion here so that we don't need DDK headers.
-extern "C" NTSTATUS RtlGetVersion(PRTL_OSVERSIONINFOW);
+extern "C" NTSTATUS NTAPI RtlGetVersion(PRTL_OSVERSIONINFOW);
 
 using namespace std;
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Apparently the linker in 32-bit mingw-w64 expects that functions we use from standard system libraries on Windows are formatted as stdcalls, which causes a name mismatch with an undecorated `RtlGetVersion`.
This PR adds an `NTDLL` specifier (usually resolved to `__stdcall`) to `RtlGetVersion` that marks it as stdcall, which fixes the problem. This change doesn't matter at all on Win64 as there's only one calling convention there, so this specifier is ignored.
## Testing Done
Compiled locally with both 32- and 64-bit mingw-w64.

## Performance Impact
N/A