### PR TITLE
feat(issue template): Ask for errors.txt in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -49,7 +49,7 @@ body:
         (If you are reporting a visual bug, a screenshot is effectively required!)
   - type: textarea
     attributes:
-      label: Link to save file
+      label: Save File
       description: You can either upload your save here, or to e.g. hastebin / GitHub Gists
       placeholder: |
         Windows: %APPDATA%\endless-sky\saves


### PR DESCRIPTION
**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a field for errors.txt to the "bug report" issue template as it's often helpful for identifying problems and debugging.