### PR TITLE
Add decline to Remnant: S-970 Regenerator mission

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1940,7 +1940,6 @@ mission "Remnant: S-970 Regenerator"
 		conversation
 			`You recall that Taely was interested in seeing instances of new human technology, and the S-970 Regenerator is definitely a recent development. Would you like to show her?`
 			choice
-						not "event: syndicate tech available"
 				`	(Not now.)`
 					defer
 				`	(Yes.)`


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in the Discord server by me.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
I added `decline` to `Remnant: S-970 Regenerator`. This is because it's possible that S-970 Regenerators are not purchaseable, and that you don't want to *ever* give them to the Remnant.

## Testing Done
No.

## Save File
This save file can be used to test these changes:
[Tessa Salmagard.txt](https://github.com/user-attachments/files/24170325/Tessa.Salmagard.txt)

## Performance Impact
Yes.
