### PR TITLE
feat(content): Notify players when they reach the end of available content for a (major) faction

### DIFF
--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -1094,5 +1094,7 @@ mission "Avgi: Twilight Escape 3"
 			`	She bursts out laughing. "I wouldn't believe it if anyone else had told me. I mean, men come up with all sorts of excuses for coming home late, but this is something else!" Her tone suddenly turns serious. "It'll be a headache, working all this out with the government. They gave me the money for this place as recompense for your supposed 'death,' no matter how much I insisted you were still alive."`
 			`	"We'll work it out. They owe me backpay anyway," jokes Darius, still in Katrina's arms.`
 			`	As the pair move to the door, you say your goodbyes, and Darius promises he will keep in touch with you about the Avgi. Neither of you have forgotten the aliens fighting to survive at the edge of the galaxy, and now that you know of a safe way in and out of their space, you can go back without fear of becoming trapped.`
+			``
+			`[This is the end of Avgi content currently in the game. Stay tuned for more in a future update!]`
 	on visit
 		dialog `You land on <planet>, but realize that your escort carrying Darius hasn't entered the system yet. Better depart and wait for it to arrive.`

--- a/data/bunrodea/bunrodea missions.txt
+++ b/data/bunrodea/bunrodea missions.txt
@@ -217,4 +217,6 @@ mission "First Contact: Bunrodea (Hostile)"
 			
 			label end
 			`	You're escorted out of the throne room and told by the small creature to leave as soon as you reach your ship. You exit the palace, and realize that you must once again face the stairs. You take a deep breath, and prepare yourself for the long journey down.`
+			``
+			`[This is the end of Bunrodea content currently in the game. Stay tuned for more in a future update!]`
 				launch

--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -2138,6 +2138,8 @@ mission "Heliarch License 2"
 			`	When you're done, the two Heliarchs explain some more. "As of a lower rank you are, permit you access to everything and everywhere, your circlet will not. Not yet, at least. But, as mentioned, come to some of the restricted sections, you now many. On many of our worlds, find you will Heliarch outfitters, where now available some of our equipment will be. Permit you to take on some jobs we put up for Heliarch agents here in the restricted sections, the circlet also will."`
 			`	They commend you for having joined up, and bid you farewell, having the guards now bring you back to your ship. The three Heliarch consuls who greeted you are waiting for you when you arrive, and hand you a small box which you soon realize is a translation device. "One of us you now are, Captain," the Saryd says. "Trust you we do to uphold the Coalition's values and laws."`
 			`	The trio congratulates you once again and wishes you safe travels.`
+			``
+			`[This is the end of Coalition content currently in the game. Stay tuned for more in a future update!]`
 				decline
 
 event "first heliarch unlock"

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -2057,6 +2057,8 @@ mission "Lunarium: Join"
 			`	You say your goodbyes, and you're escorted out of the complex and back to your ship. The Kimek who brought you there enter the ship with you briefly, and inform you that they've sent word across their major bases in the Coalition about your joining up. You're told that you'll find some new outfits available in their secretive outfitters. "In separate portions of the cities, sometimes in other cities entirely, our shops are, but safe from Heliarch patrols, they so far have proven." They give you a short list of the planets where you'll find their outfitters, and coordinates and instructions as to how to get to and access each of them.`
 			`	When they leave, you start tinkering with the translation device, figuring out how to configure it to translate each of the languages. After testing it using local transmissions and broadcasts for half an hour or so, you're decently fast with it, to the point where you can change what language it translates to or from a few times in a second.`
 			`	It may be a long time still before the Lunarium is ready to take up arms against the Heliarchs, so for now you figure you could help by looking into what minor jobs they may have for you.`
+			``
+			`[This is the end of Coalition content currently in the game. Stay tuned for more in a future update!]`
 	on fail
 		"assisting lunarium" --
 

--- a/data/gegno/gegno I corroboration.txt
+++ b/data/gegno/gegno I corroboration.txt
@@ -1267,3 +1267,5 @@ mission "Gegno Asteroid Mining Prologue"
 		conversation
 			`You dock with the station at the facility's port, rather than on the other side of it. Waiting for you is a large group of Gegno workers, all in rusted or damaged gear. After a few moments of staring and discussion among one another, they unload the minerals from your ship, then go about their business as if nothing happened. Another approaches you, and to your surprise, pays you a sum of <payment> for your work. It seems that the Gegno value and reward effort no matter who does it, even a member of another species.`
 			`	For the time being, the station remains accessible to you, as well as these small odd jobs for mining. Hopefully someday the Gegno will recognize that you're worth more than whatever they've labeled you for.`
+			``
+			`[This is the end of Gegno content currently in the game. Stay tuned for more in a future update!]`

--- a/data/hai/hai reveal 0 prologue.txt
+++ b/data/hai/hai reveal 0 prologue.txt
@@ -768,5 +768,7 @@ mission "Hai Reveal: Meet the Team: Sayari 2"
 			`	Sayari smiles. "How humble. Although I suppose you're wondering what do to next.`
 			label more
 			`	"For now, there are no immediate tasks for you. The others will continue working on the plan to manage the situation, and we will call upon you once you are needed. I suggest you explore our systems while you wait and gain a better understanding of the Hai people. It will do us well for you to have this knowledge."`
+			``
+			`[This is the end of Hai content currently in the game. Stay tuned for more in a future update!]`
 
 event "hr: exploration period"

--- a/data/incipias/incipias first contact.txt
+++ b/data/incipias/incipias first contact.txt
@@ -408,3 +408,5 @@ mission "Incipias: Help The Stranded 2"
 				decline
 			label "end no time"
 			`	"We are understanding-sad. Safe travels, captain." You notice a slight blue tone in the representative's communication as one of the Incipias guides you back to your ship.`
+			``
+			`[This is the end of Incipias content currently in the game. Stay tuned for more in a future update!]`

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -2389,6 +2389,8 @@ mission "Ka'het: Voice From The Past 6"
 				`	"The location you gave me did not seem to have been inhabited."`
 			`	You give her a brief summary of your mission, and of your findings. "I am afraid the people you were supposed to deliver this data to have left together with the satellite," she replies, perplexed. "It has been busy for all of us recently, and some steps were skipped to accelerate the process.`
 			`	"If you leave the datapad here, I promise I will make sure it gets into the right hands. I am sure they will contact you themselves after things have calmed down a bit." You hand her the tablet with the info you recorded, hopeful it will reach its destination.`
+			``
+			`[This is the end of Ember Waste content currently in the game. Stay tuned for more in a future update!]`
 
 event "ka'het: quarantine site"
 

--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -1026,3 +1026,5 @@ mission "Successors: Trusted"
 				clear "Successors: explain"
 				clear "Successors: sioeora"
 			`	With your meeting resolved here, you head back to the monorail station and catch the next train back to the spaceport.`
+			``
+			`[This is the end of Successors content currently in the game. Stay tuned for more in a future update!]`

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -3549,6 +3549,8 @@ mission "Wanderers: Sestor: Final: Patched"
 			`You inform the Wanderers that the Korath exiles are now producing war drones. "This is [unfortunate, regrettable]," says Sobari Tele'ek. "Clearly they [anticipate, expect] further conflict in the future."`
 			`	Tema'a Iriket says, "Perhaps they are [afraid of, threatened by] us and seek only to have the means to [defend, protect] themselves. The important thing is that the drones in this [territory, area] have been [neutralized, pacified] and we can now focus on our true work."`
 			`	From there, the conversation shifts to an excited discussion about what worlds they will settle on next and what their next steps should be in building relationships with the Kor Efret and the Kor Mereti collective. The exiles may become a threat some time in the future, but for now the Wanderers are eager to pursue their peacetime calling in this new territory that the Eye has led them to.`
+			``
+			`[This is the end of Wanderers content currently in the game. Stay tuned for more in a future update!]`
 
 # This patch mission is necessary for people who got the older version of the "Sestor: Final" mission without the patches integrated.
 mission "Wanderers: Sestor: Combined Patch 1"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the many suggestions we've had over the years requesting clarification of the end of available content (for major stories). Additionally, it follows the same suit as https://github.com/endless-sky/endless-sky/pull/11699, adding notes to the game's content for clarification purposes.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds notes at the end of every major faction's current in-game story, telling the player that there will be more to come in the future. (It does not add notes to smaller mission stories, and I don't believe those necessarily need notes.)

This has been requested many times over the years, and generally we've believed it's unnecessary to add because the game is publicly known to be in-progress and constantly receiving updates. As a volunteer project, anyone writing for the stories in the game does so on their own time. There also has been discussion that adding acknowledgement like this in the game seems a bit too from the 4th wall.

That said, the argument against this is that these notes would always be temporary while waiting for progress on the content, and affixed at the end of every new chunk/until a story meets its end. To match them same manner in which MZ wrote the 4th wall note telling the player to be careful with their ships in Reconciliation, these notes use braces and are indented a line down.

I am not sold on the phrasing. If we do end up merging this (I expect this PR to be a contention point/discussion to happen) we can change the phrasing as needed.

### Sidenotes:

I gave the end of current in-game Ka'het content "Ember Waste" content, as that region involves both the Remnant and Ka'het. I think that's best for the time being. We could put "Graveyard" too, but the Ka'het and Remnant are both often referred to as part of the EW and less-so any specific Graveyard-only content.

I feel that notes for any non-major story factions, factions with an abstract end goal, or factions that currently serve as supportive story elements (Korath, Rulei, Drak, Pug, etc..) are unnecessary.

Note that the contents of this PR are based on factions as how they are currently represented in the game. Instead of leapfrog and predict changes that are not final/merged in the game, any adjustments can happen at a later point.

We could also consider logbook entries for this, but I think that would be excessive/finnicky? 

## Testing Done
None as of yet. If the formatting is fine (adding another line below existing lines), it should be fine?

## Save File
If necessary, I will procure one, but it will take a while as these stories are long.