### PR TITLE
One singular typo fix in coalition mission.txt

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -603,7 +603,7 @@ mission "Kimek Student 1"
 			`	"Lacking proper funds, I currently am," he says, speaking much slower than before. "Once paid by this new job I am, however, pay you I will. I promise."`
 			choice
 				`	"Ok, I'll take you there."`
-				`	I prefer not having to wait to get paid, sorry.`
+				`	"I prefer not having to wait to get paid, sorry."`
 					decline
 			label accept2
 			`	He thanks you and says to wait for him by your ship before you depart. You leave the restaurant shortly after, and head to your ship.`


### PR DESCRIPTION
(The lines in parentheses (like this one) are instructions for filling out this template. These lines can be deleted.)
(The lines in double curly brackets ({{}}) should be replaced as it describes.)
(You can open a PR to add to or improve this template, if you find it lacking!)

(Choose one heading, or add your own.)
**Content (Artwork / Missions / Jobs)**
**Balance**
**Feature**
**Bug fix**
**Typo fix**
**CI/CD/Testing**
**Refactor**
**Documentation**

This PR addresses the bug/feature described by user .dagroth on discord, in bug reporting [here](https://discord.com/channels/251118043411775489/536900466655887360/1450595301726359808)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Typo, that specific line is used twice, that specific choice lacked quotation (which is hopefully the correct fix instead of the other way around)

Edit - was referring to line 588
