### PR TITLE
**Typo fix** removing unnecessary quotation in human missions.txt

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -5960,7 +5960,7 @@ mission "Quicksilver Mixup 3"
 		dialog `You have reached <planet>, but your escort carrying the misposted mail has not arrived. Better depart and wait for your escorts to arrive in this star system.`
 	on complete
 		payment 100000
-		dialog `The same manager from before is waiting with the unloading crew, and thanks you for covering for the other pilot before handing you the credit chip for payment. It's nice to know that captains who get hired to deliver such wrongly-posted packages, like you once did, won't have to finish those deliveries themselves in the future."`
+		dialog `The same manager from before is waiting with the unloading crew, and thanks you for covering for the other pilot before handing you the credit chip for payment. It's nice to know that captains who get hired to deliver such wrongly-posted packages, like you once did, won't have to finish those deliveries themselves in the future.`
 
 
 


### PR DESCRIPTION
This PR addresses the bug/feature described on bug reporting channel by the114dragon [here](https://discord.com/channels/251118043411775489/536900466655887360/1452782081020006422)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removes a quotation, which I believe should be the edit instead of the other way around i.e, adding quotation instead


## Testing Done
Hopefully not required

