### PR TITLE
add dialogue option to admit to Ivan that the player wants to share his research

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1418,9 +1418,9 @@ mission "Remnant: Deep Surveillance"
 				`	"Understood."`
 					goto branches
 				`	"Actually, I was hoping to show it to someone else who's interested."`
-			`	Ivan stares at you for a moment. "I... see. Thanks for your honesty, but I can't give you a copy. That research is classified."`
 			action
 				set "remnant: honest about deep research"
+			`	Ivan stares at you for a moment. "I... see. Thanks for your honesty, but I can't give you a copy. That research is classified."`
 				goto leave
 			
 			label again2


### PR DESCRIPTION
**Content (Missions)**

This PR addresses the bug/feature described in issue #9691

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Add a dialogue option to "Remnant: Deep Surveillance", after Ivan tells the player that the information is for their eyes only, allowing them to be honest about their desire to share it (and have Ivan refuse). Add corresponding reaction at the Remnant end.
