### PR TITLE
feat(enhancement): Allow plugins to fully overwrite any vanilla objects

### DIFF
--- a/source/CategoryList.cpp
+++ b/source/CategoryList.cpp
@@ -55,6 +55,14 @@ void CategoryList::Load(const DataNode &node)
 
 
 
+void CategoryList::Clear()
+{
+	list.clear();
+	currentPrecedence = 0;
+}
+
+
+
 // Sort the CategoryList. Categories are sorted by precedence. If multiple categories
 // share the same precedence then they are sorted alphabetically.
 void CategoryList::Sort()

--- a/source/CategoryList.h
+++ b/source/CategoryList.h
@@ -55,6 +55,7 @@ public:
 	CategoryList() = default;
 
 	void Load(const DataNode &node);
+	void Clear();
 
 	// Sort the CategoryList. Categories are sorted by precedence. If multiple Categories
 	// share the same precedence then they are sorted alphabetically.

--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -644,7 +644,7 @@ void UniverseObjects::LoadFile(const filesystem::path &path, const PlayerInfo &p
 			{
 				CategoryList &list = categories[it->second];
 				if(overwrite)
-					list = CategoryList();
+					list.Clear();
 				list.Load(node);
 			}
 		}


### PR DESCRIPTION
**Feature**

Resolves https://github.com/endless-sky/endless-sky/issues/1764
Resolves https://github.com/endless-sky/endless-sky/issues/4487

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR adds a new root node:
- `overwrite`: If present, the next node in the file that gets loaded will be completely overwritten, resetting all previous values back to their defaults before loading the next node. If you want to overwrite multiple nodes, then this node should be present above each of them.

This allows plugins to completely overwrite outfits, ships, missions, and various other objects that they currently can't. This is done by having UniverseObjects::LoadFile use an `overwrite` boolean that gets set to true if the above node is encountered. Then, for whichever root node is encountered next, if `overwrite` is true, use the default constructor of the object to replace the value at the pointer prior to calling the Load function. By overwriting in this way, all previous pointers to the object remain valid.

## Usage examples + Testing Done

The following example creates a mission and a fleet, then overwrites both. If you land on any planet, the second iteration of the mission gets offered, and it spawns the correct ship as an NPC.
```
mission "test mission"
	landing
	repeat
	on offer
		conversation
			`This is a testing mission that has not been overwritten.`
				decline

fleet "test fleet"
	government "Merchant"
	variant
		"Sparrow"

overwrite
mission "test mission"
	landing
	repeat
	on offer
		conversation
			`This mission has been overwritten. It should spawn an NPC from the "test fleet" Fleet, which should be a single Fury.`
				accept
	npc
		personality staying
		government Merchant
		fleet "test fleet"

overwrite
fleet "test fleet"
	government "Merchant"
	variant
		"Fury"
```

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/200
