### PR TITLE
fix(build): Automatically choose the CMake target for GLEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,12 @@ else()
 		target_compile_definitions(EndlessSkyLib PUBLIC GL_SILENCE_DEPRECATION)
 	else()
 		# GLEW is only needed on Linux and Windows.
-		target_link_libraries(ExternalLibraries INTERFACE GLEW::glew)
+		if(TARGET GLEW::GLEW)
+			set(GLEW_TARGET_NAME GLEW::GLEW)
+		else()
+			set(GLEW_TARGET_NAME GLEW::glew)
+		endif()
+		target_link_libraries(ExternalLibraries INTERFACE ${GLEW_TARGET_NAME})
 	endif()
 endif()
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10519 (closes #10519).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Does what the title says, because some systems expect `GLEW::GLEW`, while others want `GLEW::glew`.

## Testing Done
Tested locally.

## Performance Impact
N/A
