### PR TITLE
fix(ai): Fix odd edge-case escort behaviors

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1520,7 +1520,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		}
 	}
 	if(!maxRange)
-		return FindNonHostileTarget(ship);
+		return isYours ? target : FindNonHostileTarget(ship);
 
 	const Personality &person = ship.GetPersonality();
 	shared_ptr<Ship> oldTarget = ship.GetTargetShip();


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

While testing #11817, I ran into a bug where my escorts would jump away from me if they had a dev drive from World Forge and I told them to stop focus firing on a friendly target (without the target being provoked). This behavior stems from #8860, which moved a `return` statement that resulted in escorts with no orders and a friendly target while not having scanners equipped to fall into independent movement, leading to them choosing a random system to jump to. This seemingly isn't noticeable without a dev drive, because on the next frame the escorts realize they shouldn't be jumping away and decide to stick around instead, but with the dev drive they're ready to jump away the moment they decide to jump, and so go through with jumping to another system.

After fixing that issue, I realized that if I did have scanners on my escorts, they would decide to try and get near their target to "scan" it, even though they don't actually have that capability. Confusingly though, they would seemingly pick ships at random in the system to behave like this toward, as opposed to huddling around the ship I just told them to target. The reason for this is that the ships I was using didn't actually have any weapons, only scanners, which caused AI::FindTarget to find a non-hostile target to move toward, which only occurs for ships with scanners. I've fixed this by adding an extra `isYours` check to AI:FindTarget around this area.

## Testing Done

Yes.
