### PR TITLE
fix potential conversation loop

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -6751,18 +6751,26 @@ mission "Lost Racer 3"
 				`	"I'll leave the questions to your father."`
 					goto noquestions
 			label crash
+			action
+				set "asked artemis about crash"
 			`	"I really do not know. We checked everything before launch, everything, and yet during the jump the Moonfox's hyperdrive malfunctioned, knocking me out. When I woke up, I was in the wrong system and the Flivver was hurtling away from the star. Luckily, the engines hadn't been harmed too much, so I was able to turn around and thrust in the direction of <origin>, but then the batteries gave out and the generator stopped working. So I ended up stranded on a planet with no way of calling for help - the flares had triggered when I crashed, being unable to slow down without thrusters. Well, now you know. Is there anything else?"`
 			`	August asks, "Do you think someone could have sabotaged the hyperdrive? Any suspicious Syndicate employees hanging around? Any anything out of the ordinary?"`
 			`	"Not that I remember," replies Artemis. "This rarely happens in spaceship racing, but it's still happened. A one-in-a-million chance, perhaps. I wouldn't worry about it too much."`
 			choice
 				`	"That was a beautiful ship you had there. I've never seen a Flivver quite like that."`
+					to display
+						not "asked artemis about flivver"
 				`	"Alright."`
 					goto noquestions
 			label beautiful
+			action
+				set "asked artemis about flivver"
 			`	"You have good taste, Captain. It's modified for racing: lighter hull plating, no weapon mounts, ample engines, of course. We've got a dozen for all the different races, but that one was a personal favorite."`
 			choice
 				`	"Why did you crash?`
 					goto crash
+					to display
+						not "asked artemis about crash"
 				`	"I have no more questions."`
 			label noquestions
 			`	Artemis nods. "Well, could we head back to <planet> now? It'll be nice to get home after all this commotion and discomfort."`


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12039 

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Disable dialogue options that the player has already taken.
