### PR TITLE
fix(save): Properly update systems according to event changes when reloading a save

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -642,20 +642,8 @@ void PlayerInfo::AddChanges(list<DataNode> &changes, bool instantChanges)
 		// Date nodes do not represent a change.
 		if(key == "date")
 			continue;
-		if(key == "event")
-		{
-			for(const DataNode &child : change)
-			{
-				const string &childKey = child.Token(0);
-				changedPlanets |= (childKey == "planet" || childKey == "wormhole");
-				changedSystems |= (childKey == "system" || childKey == "link" || childKey == "unlink");
-			}
-		}
-		else
-		{
-			changedPlanets |= (key == "planet" || key == "wormhole");
-			changedSystems |= (key == "system" || key == "link" || key == "unlink");
-		}
+		changedPlanets |= (key == "planet" || key == "wormhole");
+		changedSystems |= (key == "system" || key == "link" || key == "unlink");
 		GameData::Change(change, *this);
 	}
 	if(changedPlanets)
@@ -3461,6 +3449,7 @@ void PlayerInfo::ApplyChanges()
 		it.first->SetReputation(it.second);
 	reputationChanges.clear();
 	AddChanges(dataChanges);
+	GameData::UpdateSystems();
 	GameData::ReadEconomy(economy);
 	economy = DataNode();
 


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug reported on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1456132026263670967).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When events are loaded from the save file, they go through PlayerInfo::AddChanges as "event" nodes and get recursively loaded by UniverseObjects::Change. PlayerInfo::AddChanges is currently looking at the root node of every change to determine if the systems need updated. This only works for events that are triggered after the save file has been loaded, though, as that is when the actual event body is given to this function. Therefore, events that change systems are loaded, but the GameData::UpdateSystems function is never being called to actually tell the game what those changes are.

This PR updates PlayerInfo::ApplyChanges to always call GameData::UpdateSystems after the events from the save file have been loaded. An alternative approach would have been to get the events from GameData and check their changes within PlayerInfo::AddChanges, but odds are any save file that's been around for more than 2 seconds is going to be guaranteed to have to call UpdateSystems anyway.

This was a bug with #11324.

## Testing Done

Yeah.

## Save File

[Sona Elysium.txt](https://github.com/user-attachments/files/24402790/Sona.Elysium.txt)

