### PR TITLE
feat(content): Allow Karengo to land back on his origin world without a bribe.

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -4935,6 +4935,7 @@ mission "Dangerous Games 1"
 	source
 		attributes "frontier" "pirate"
 		near "Hadar" 1 100
+	clearance "Karengo grabs the intercom and gives the traffic controllers a piece of his mind. They grovel in apology, claiming not to know he was aboard, and grant you landing clearance."
 	stopover "Skymoot"
 	to offer
 		random < 15


### PR DESCRIPTION
**Content (Mission)**

This PR addresses the bug/feature described in issue #12058

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Implements my desired solution, with some text I wrote.

## Screenshots
Not really needed, it works as expected.

## Testing Done
I added this line to a save game with the Dragonriders mission active, AFTER I had already landed on the stopover world and was returning. I did not test whether the `clearance` text also gets shown if you are at war with the stopover world and hail them.

## Save File
This save file can be used to test these changes:
[Myfanwy Angharad~karengo.txt](https://github.com/user-attachments/files/24415113/Myfanwy.Angharad.karengo.txt)

## Performance Impact
n/a