### PR TITLE
Move sell outfits btn 2026

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2039,24 +2039,30 @@ interface "trade"
 	
 	active if "can buy"
 	sprite "ui/dialog cancel"
-		center 100 355
+		center 120 355
 	button u "B_uy All"
-		center 100 355
+		center 120 355
 		dimensions 70 30
 	
-	sprite "ui/wide button"
-		center 190 355
-	
 	active if "can sell"
-	visible if "!can sell outfits"
+	sprite "ui/dialog cancel"
+		center 200 355
 	button e "S_ell All"
-		center 190 355
-		dimensions 90 30
+		center 200 355
+		dimensions 70 30
 	
+	active if "can sell minerals"
+	sprite "ui/wide button"
+		center -90 355
+	button n "Sell Mi_nerals"
+		center -90 355
+		dimensions 90 30
+
 	active if "can sell outfits"
-	visible if "can sell outfits"
-	button e "S_ell Outfits"
-		center 190 355
+	sprite "ui/wide button"
+		center -190 355
+	button f "Sell Out_fits"
+		center -190 355
 		dimensions 90 30
 
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2071,24 +2071,30 @@ interface "trade (small screen)"
 	
 	active if "can buy"
 	sprite "ui/dialog cancel"
-		center 40 355
+		center 60 355
 	button u "B_uy All"
-		center 40 355
+		center 60 355
 		dimensions 70 30
-	
-	sprite "ui/wide button"
-		center 130 355
-	
+
+	sprite "ui/dialog cancel"
+		center 140 355
 	active if "can sell"
-	visible if "!can sell outfits"
 	button e "S_ell All"
-		center 130 355
+		center 140 355
+		dimensions 70 30
+
+	sprite "ui/wide button"
+		center -150 355
+	active if "can sell minerals"
+	button n "Sell Mi_nerals"
+		center -150 355
 		dimensions 90 30
-	
+
+	sprite "ui/wide button"
+		center -250 355
 	active if "can sell outfits"
-	visible if "can sell outfits"
-	button e "S_ell Outfits"
-		center 130 355
+	button f "Sell Out_fits"
+		center -250 355
 		dimensions 90 30
 
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -124,20 +124,18 @@ void TradingPanel::Draw()
 	font.Draw("free:", Point(MIN_X + SELL_X + 5, lastY), selected);
 	font.Draw(to_string(player.Cargo().Free()), Point(MIN_X + HOLD_X, lastY), selected);
 
+	bool hasOutfits = false;
+	bool hasMinables = false;
 	int outfits = player.Cargo().OutfitsSize();
 	int missionCargo = player.Cargo().MissionCargoSize();
-	sellOutfits = false;
 	if(player.Cargo().HasOutfits() || missionCargo)
 	{
-		bool hasOutfits = false;
-		bool hasMinables = false;
 		for(const auto &it : player.Cargo().Outfits())
 			if(it.second)
 			{
 				bool isMinable = it.first->Get("minable");
 				(isMinable ? hasMinables : hasOutfits) = true;
 			}
-		sellOutfits = (hasOutfits && !hasMinables);
 
 		string str = Format::MassString(outfits + missionCargo) + " of ";
 		if(hasMinables && missionCargo)
@@ -145,11 +143,11 @@ void TradingPanel::Draw()
 		else if(hasOutfits && missionCargo)
 			str += "outfits and mission cargo.";
 		else if(hasOutfits && hasMinables)
-			str += "outfits and special commodities.";
+			str += "outfits and minerals.";
 		else if(hasOutfits)
 			str += "outfits.";
 		else if(hasMinables)
-			str += "special commodities.";
+			str += "minerals.";
 		else
 			str += "mission cargo.";
 		font.Draw(str, Point(MIN_X + NAME_X, lastY), unselected);
@@ -201,7 +199,6 @@ void TradingPanel::Draw()
 
 		if(hold)
 		{
-			sellOutfits = false;
 			canSell |= (price != 0);
 			font.Draw(to_string(hold), Point(MIN_X + HOLD_X, y), selected);
 		}
@@ -211,9 +208,11 @@ void TradingPanel::Draw()
 		font.Draw("Profit", Point(MIN_X + PROFIT_X, FIRST_Y), selected);
 
 	Information info;
-	if(sellOutfits)
+	if(hasOutfits)
 		info.SetCondition("can sell outfits");
-	else if(player.Cargo().HasOutfits() || canSell)
+	if(hasMinables)
+		info.SetCondition("can sell minerals");
+	if(canSell)
 		info.SetCondition("can sell");
 	if(player.Cargo().Free() > 0 && canBuy)
 		info.SetCondition("can buy");
@@ -256,14 +255,35 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			player.Accounts().AddCredits(amount * price);
 			player.Cargo().Remove(commodity, amount);
 		}
+	}
+	else if(key == 'n' || key == 'M' || (key == 'm' && (mod & KMOD_SHIFT)))
+	{
+		for(const auto &it : player.Cargo().Outfits())
+		{
+			const Outfit * const outfit = it.first;
+			if(outfit->Get("minable") <= 0.) // only sell minerals
+				continue;
+
+			const int64_t &amount = it.second;
+			int64_t value = amount * outfit->Cost();
+			profit += value;
+			tonsSold += static_cast<int>(amount * outfit->Mass());
+
+			player.AddStock(outfit, amount);
+			player.Accounts().AddCredits(value);
+			player.Cargo().Remove(outfit, amount);
+		}
+	}
+	else if(key == 'f' || key == 'O' || (key == 'o' && (mod & KMOD_SHIFT)))
+	{
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
 			const Outfit * const outfit = it.first;
-			const int64_t &amount = it.second;
-			if(outfit->Get("minable") <= 0. && !sellOutfits)
+			if(outfit->Get("minable") > 0) // don't sell minerals
 				continue;
 
+			const int64_t &amount = it.second;
 			int64_t value = player.FleetDepreciation().Value(outfit, day, amount);
 			profit += value;
 			tonsSold += static_cast<int>(amount * outfit->Mass());

--- a/source/TradingPanel.h
+++ b/source/TradingPanel.h
@@ -50,10 +50,6 @@ private:
 	const System &system;
 	const int COMMODITY_COUNT;
 
-	// Remember whether the "sell all" button will sell all outfits, or sell
-	// everything except outfits.
-	bool sellOutfits = false;
-
 	// Keep track of how much we sold and how much profit was made.
 	int tonsSold = 0;
 	int64_t profit = 0;


### PR DESCRIPTION
**Feature**

This is a resurrection of a branch for 18 months ago that didn't get merged. I am trying again. I have updated it for the latest master and the new wide-screen trade panel.

This PR also circumvents the bug described in issue #11754

As the Player Info button was recently added, I think this is a good time to add these too.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
* Move the "Sell Outfits" button out from underneath the Sell All (commodities) button so that it is not accidentally clicked.
* Treat minables as separate from installable outfits, and give them their own Sell button.
* Reword "special commodities" to "minerals". (I know Voidfish etc are not minerals but the do appear under the Minerals heading in the Outfitters map, and are a mid-to-late game item, so I think this is OK.)

## Screenshots
<img width="596" height="382" alt="Screenshot 2026-01-03 at 15 22 33" src="https://github.com/user-attachments/assets/5b185a62-5120-4212-a3aa-fed030a8d6a9" />

## Testing Done
* Bought and sold commodities, outfits and minerals.
* Made window wide and narrow.

## Save File
Any save file will do.

## Artwork Checklist
No new art used.

## Wiki Update
_may need wiki update — I am not familiar with the wiki contents_

## Performance Impact
n/a
