### PR TITLE
Check available stock when buying outfits into cargo

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -748,6 +748,8 @@ ShopPanel::TransactionResult OutfitterPanel::MoveOutfit(OutfitLocation fromLocat
 		}
 		else if(toLocation == OutfitLocation::Cargo)
 		{
+			if(!outfitter.Has(selectedOutfit))
+				howManyPer = min(howManyPer, player.Stock(selectedOutfit));
 			// Buy up to <modifier> of the selected outfit and place them in fleet cargo.
 			double mass = selectedOutfit->Mass();
 			if(mass)


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported by solarshade [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1456918364197883975).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When buying outfits into cargo, the amount of available stock is not checked beyond ensuring that at least one unit of the outfit is available (either because this location sells this outfit generally, or currently has at least one unit in stock from the player selling it). As a result, if the outfit is not generally sold but is in stock, it is possible to buy many more than are actually available by applying a modifier (shift, control, and alt keys) to buy many at once. For example, there may only be one outfit in stock, but you could  buy 500 into cargo by holding down the alt key when performing the operation (assuming you have sufficient cargo space, otherwise you would buy as many as you have space for).

This PR fixes this by setting the number of outfits to be purchased to the number available in stock if the outfitter does not generally sell the outfit and the number in stock is less than the number the player is requesting to buy.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Landed on Earth.
Sold a Quantum Keystone.
Tried to buy five hundred into cargo. (I have enough money and cargo space to do this.)
Without this PR, I now have 500 Quantum Keystones in cargo.
With this PR, I only have 1 Quantum Keystone in cargo.

## Save File
No.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Immeasurable
