### PR TITLE
fix(performance): Fix large escort selections causing lag

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -667,14 +667,14 @@ void Engine::Step(bool isActive)
 				const System *system = it->GetSystem();
 				escorts.Add(it, system == currentSystem, player.KnowsName(*system), fleetIsJumping, isSelected);
 			}
-	set<const Ship *> selected;
+	set<shared_ptr<Ship>> selected;
 	for(const weak_ptr<Ship> &ptr : player.SelectedEscorts())
-		selected.insert(ptr.lock().get());
+		selected.insert(ptr.lock());
 	for(const shared_ptr<Ship> &escort : player.Ships())
 		if(!escort->IsParked() && escort != flagship && !escort->IsDestroyed())
 		{
 			// Check if this escort is selected.
-			bool isSelected = selected.contains(escort.get());
+			bool isSelected = selected.contains(escort);
 			const System *system = escort->GetSystem();
 			escorts.Add(escort, system == currentSystem, system && player.KnowsName(*system), fleetIsJumping, isSelected);
 		}


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Considering this more of a bug fix than a refactor because of how stupid this was. Right now when you select an escort, Engine iterates over all of your escorts, then iterates over all of your selected ships to see if that particular escort is selected. This is an O(n^2) operation, and when you have a lot of escorts with a big selection, this slows the game down considerably. This PR changes it so that we put the selected escorts into a set, then check against that set when iterating over all of your escorts.

## Testing Done + Screenshots

Selecting 2,500 Flivvers.

Vanilla:
<img width="1113" height="700" alt="image" src="https://github.com/user-attachments/assets/1313da98-f261-40b8-996c-f34c2b33f80c" />

This PR:
<img width="910" height="704" alt="image" src="https://github.com/user-attachments/assets/38bfb317-e58d-4102-bdfe-1fc7ff7ed336" />

## Performance Impact

Greatly improved performance when you are selecting all of your escorts at once, especially if you have a lot of them. (See the screenshots for proof.)
