### PR TITLE
fix(mechanics): Fix a crash caused by missions that take ships from the player while in the shop

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -131,6 +131,7 @@ void OutfitterPanel::Step()
 	CheckRefill();
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::OUTFITTER);
+	ShopPanel::ValidateSelectedShips();
 	if(GetUI().IsTop(this) && !checkedHelp)
 		// Use short-circuiting to only display one of them at a time.
 		// (The first valid condition encountered will make us skip the others.)

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -69,6 +69,7 @@ void ShipyardPanel::Step()
 {
 	ShopPanel::Step();
 	ShopPanel::CheckForMissions(Mission::SHIPYARD);
+	ShopPanel::ValidateSelectedShips();
 	if(GetUI().IsTop(this))
 		DoHelp("shipyard");
 }

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -103,32 +103,6 @@ ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
 
 void ShopPanel::Step()
 {
-	// Verify that the player's selection is still valid.
-	// A mission action may have taken a ship away from the player,
-	// therefore invalidating its pointer.
-	set<Ship *> shipPtrs;
-	for(const shared_ptr<Ship> &ship : player.Ships())
-		shipPtrs.insert(ship.get());
-	set<Ship *> stillValid;
-	ranges::set_intersection(shipPtrs, playerShips, inserter(stillValid, stillValid.begin()));
-	playerShips = stillValid;
-	if(playerShip && !playerShips.contains(playerShip))
-	{
-		playerShip = nullptr;
-		if(!playerShips.empty())
-			playerShip = *playerShips.begin();
-		else
-		{
-			for(const shared_ptr<Ship> &ship : player.Ships())
-				if(CanShowInSidebar(*ship, player.GetPlanet()))
-				{
-					playerShip = ship.get();
-					playerShips.insert(playerShip);
-					break;
-				}
-		}
-	}
-
 	if(!checkedHelp && GetUI().IsTop(this) && player.Ships().size() > 1)
 	{
 		if(DoHelp("multiple ships"))
@@ -267,6 +241,37 @@ void ShopPanel::CheckForMissions(Mission::Location location) const
 		mission->Do(Mission::OFFER, player, &GetUI());
 	else
 		player.HandleBlockedMissions(location, GetUI());
+}
+
+
+
+void ShopPanel::ValidateSelectedShips()
+{
+	// Verify that the player's selection is still valid.
+	// A mission action may have taken a ship away from the player,
+	// therefore invalidating its pointer.
+	set<Ship *> shipPtrs;
+	for(const shared_ptr<Ship> &ship : player.Ships())
+		shipPtrs.insert(ship.get());
+	set<Ship *> stillValid;
+	ranges::set_intersection(shipPtrs, playerShips, inserter(stillValid, stillValid.begin()));
+	playerShips = stillValid;
+	if(playerShip && !playerShips.contains(playerShip))
+	{
+		playerShip = nullptr;
+		if(!playerShips.empty())
+			playerShip = *playerShips.begin();
+		else
+		{
+			for(const shared_ptr<Ship> &ship : player.Ships())
+				if(CanShowInSidebar(*ship, player.GetPlanet()))
+				{
+					playerShip = ship.get();
+					playerShips.insert(playerShip);
+					break;
+				}
+		}
+	}
 }
 
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -79,6 +79,7 @@ protected:
 	void DrawShip(const Ship &ship, const Point &center, bool isSelected);
 
 	void CheckForMissions(Mission::Location location) const;
+	void ValidateSelectedShips();
 
 	// These are for the individual shop panels to override.
 	virtual int TileSize() const = 0;


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Fixes #12074.

## Testing Done

Yes.

## Save File

See the issue.
