### PR TITLE
feat(controls): Make `Command::SHIFT` user-assignable.

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1320,7 +1320,7 @@ tip "Turn right"
 
 tip "Reverse"
 	`Turn your flagship opposite its current direction of flight. If reverse thrusters are installed, accelerate backwards.`
-	`With <shift>, stop your ship.`
+	`With <Secondary action>, stop your ship.`
 
 tip "Fire afterburner"
 	`Fire your flagship's afterburner, if one is installed.`
@@ -1333,7 +1333,10 @@ tip "Land on planet / station"
 
 tip "Initiate hyperspace jump"
 	`Initiate a hyperspace jump to follow your current travel plan. If you have no travel plan, initiates a jump nearest to your current facing angle. When held, commands your escorts to get ready to jump and only initiates the jump when released.`
-	`With <shift>, your fleet will not jump until every ship in the fleet is ready for every system in the travel plan instead of needing to hold the key at each system.`
+	`With <Secondary action>, your fleet will not jump until every ship in the fleet is ready for every system in the travel plan instead of needing to hold the key at each system.`
+
+tip "Secondary action"
+	`Hold down this key whilst pressing another to perform that key's secondary action, if it has one.`
 
 tip "View star map"
 	`Open the star map panel.`
@@ -1343,19 +1346,19 @@ tip "View player info"
 
 tip "Select nearest hostile ship"
 	`Select the nearest hostile ship.`
-	`With <shift>, select the nearest ship regardless of hostility.`
+	`With <Secondary action>, select the nearest ship regardless of hostility.`
 
 tip "Select next ship"
 	`Select the next non-escort ship in the system, cycling through all ships.`
-	`With <shift>, cycle through escorts.`
+	`With <Secondary action>, cycle through escorts.`
 
 tip "Talk to selected ship"
 	`Hail the selected ship or planet. If both a ship and planet are selected, hails the ship.`
-	`With <shift>, hails the planet.`
+	`With <Secondary action>, hails the planet.`
 
 tip "Board selected ship"
 	`Board the selected ship. If no boardable ship is selected, selects a ship to board based on the "Boarding target priority" setting.`
-	`With <shift>, selects an escort to board.`
+	`With <Secondary action>, selects an escort to board.`
 
 tip "Select nearest asteroid"
 	`Select the nearest asteroid based on the "Target asteroid based on" setting.`
@@ -1416,7 +1419,7 @@ tip "Fleet: Toggle hold fire"
 
 tip "Fleet: Gather around me"
 	`Command your fleet to gather around your flagship. If only some escorts are selected, only sends the command to those escorts. You can also command escorts to gather around another ship by right clicking on a friendly ship.`
-	`With <shift>, change the formation pattern in your fleet.`
+	`With <Secondary action>, change the formation pattern in your fleet.`
 
 tip "Fleet: Hold position"
 	`Command your fleet to hold its current position. If only some escorts are selected, only sends the command to those escorts. This command can also be sent by right clicking on empty space.`

--- a/keys.txt
+++ b/keys.txt
@@ -32,4 +32,5 @@
 "Fleet: Hold position" 104
 "Fleet: Toggle ammo usage" 117
 "Fleet: Harvest flotsam" 122
+"Secondary action" 1073742049
 "Mouse turning (hold)" 1073742050

--- a/source/Command.cpp
+++ b/source/Command.cpp
@@ -85,13 +85,13 @@ const Command Command::HOLD_POSITION(ONE << 34, "Fleet: Hold position");
 const Command Command::HARVEST(ONE << 35, "Fleet: Harvest flotsam");
 const Command Command::AMMO(ONE << 36, "Fleet: Toggle ammo usage");
 const Command Command::AUTOSTEER(ONE << 37, "Auto steer");
+const Command Command::SHIFT(ONE << 38, "Secondary action");
 
 // These commands are not in the preferences panel, and do not have keys
 // assigned to them, but may have descriptions as needed to facilitate
 // assignments in downstream ports like endless-mobile.
-const Command Command::WAIT(ONE << 38, "");
-const Command Command::STOP(ONE << 39, "Stop your ship");
-const Command Command::SHIFT(ONE << 40, "");
+const Command Command::WAIT(ONE << 39, "");
+const Command Command::STOP(ONE << 40, "Stop your ship");
 
 
 
@@ -130,10 +130,6 @@ void Command::ReadKeyboard()
 	for(const auto &it : keycodeForCommand)
 		if(keyDown[SDL_GetScancodeFromKey(it.second)])
 			*this |= it.first;
-
-	// Check whether the `Shift` modifier key was pressed for this step.
-	if(SDL_GetModState() & KMOD_SHIFT)
-		*this |= SHIFT;
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Alignment.h"
 #include "audio/Audio.h"
 #include "Color.h"
+#include "Command.h"
 #include "DialogPanel.h"
 #include "Files.h"
 #include "shader/FillShader.h"
@@ -598,6 +599,7 @@ void PreferencesPanel::DrawControls()
 		Command::AUTOSTEER,
 		Command::LAND,
 		Command::JUMP,
+		Command::SHIFT,
 		Command::NONE,
 		Command::DEPLOY,
 		Command::FIGHT,
@@ -1295,7 +1297,7 @@ void PreferencesPanel::DrawTooltips()
 		return;
 
 	if(!tooltip.HasText())
-		tooltip.SetText(GameData::Tooltip(hoverItem));
+		tooltip.SetText(Command::ReplaceNamesWithKeys(GameData::Tooltip(hoverItem)));
 
 	tooltip.Draw();
 }


### PR DESCRIPTION
**Feature**
This allows players to use the Shift keys for another purpose (e.g. primary fire).

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

With this change, users can reassign the Left or Right Shift keys (or both) to other functions that would normally require the key to be held down whilst performing other combat manoeuvers, such as shooting and ordering your fleet to come to you, without them assuming a formation, or shooting and ordering your fleet to attack the selected ship without instructing them to FINISH_OFF the target!

However, since it no longer uses `SDL_GetModState()`, the Left and Right Shift keys are not treated as the same for Command::SHIFT. The default is set to Left Shift. Players used to using the Right Shift key for this action will have to reassign it in the prefs. I am assuming very few players will use both Shift keys interchangably for the secondary actions.

The term "secondary action" is something I just picked out of the air and open to change.

## Background
In 1995, when the original Escape Velocity was released, one limitation of either the Macintosh operating system or hardware of the era was that it could only recognise two non-modifier keys being pressed simultaneously. Thus the default key bindings for EV were for Shift to fire the primary (unlimited ammo) weapons, and Space to fire the secondary (and much more limited ammo) weapons. Shift could thus be held down indefinetly during combat—EV has no energy or heat—while up to two other combat actions were performed, such as turning and thrusting, using non-modifier keys. These original key bindings are what my brain reverts to whenever the action in Endless Sky gets intense and I promptly do the wrong thing and often die.
With this PR, I can fly the ship using the key bindings I am predisposed to use (see screenshot).

## Screenshots
<img width="1728" height="1117" alt="Screenshot 2026-01-07 at 15 37 17" src="https://github.com/user-attachments/assets/9185d2a3-c21b-48a3-b9cb-921977a2ed59" />

## Usage examples
n/a

## Testing Done
Tried assigning several modifier keys on my 2023 MacBook Pro, and comparing them to the current `master` branch. I discovered that the "fn"/Globe key is not recognised by SDL, and it interprets the Control key, which is on the left of the keyboard, as Right Control in the Preferences pane (there is no Control key on the right hand side — that space is used by the half-height arrow keys), but when a function is assigned to that key, it is not recognised during play. As such neither of these keys are usable in the game. This PR does not affect that positivly nor negativly.

## Save File
n/a

## Artwork Checklist
n/a

## Wiki Update
The [default key bindings](https://github.com/endless-sky/endless-sky/wiki/PlayersManual#key-bindings-and-shortcuts) will need to be updated to specify Left Shift.

## Performance Impact
n/a