### PR TITLE
Add non-blocking to Hai Reveal: Secret Leaks

### DIFF
--- a/data/hai/hai reveal 0 prologue.txt
+++ b/data/hai/hai reveal 0 prologue.txt
@@ -14,6 +14,7 @@
 mission "Hai Reveal: Secret Leaks"
 	landing
 	invisible
+	non-blocking
 	to offer
 		has "main plot completed date"
 		"days since start" - "main plot completed date" > 230


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported in the Discord server by Arachi.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added `non-blocking` to `Hai Reveal: Secret Leaks`.

## Testing Done
Too lazy. With the attached save file, before this change Expanding Business would not offer due to Hai Reveal: Secret Leaks offering first. With this change, they should both offer.

## Save File
Arachi's save file can be used to test these changes:
[Yorick Spring.txt](https://github.com/user-attachments/files/24486571/Yorick.Spring.txt)

## Performance Impact
Of course.