### PR TITLE
fix(ui): Correctly synchronize fast-forward when reloading dead pilots

### DIFF
--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -191,6 +191,10 @@ bool MenuPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 	}
 	else if(key == 'r' && player.IsLoaded() && player.IsDead())
 	{
+		// First, make sure the previous MainPanel has been deleted.
+		gamePanels.Reset();
+		gamePanels.CanSave(true);
+
 		player.Reload();
 
 		GetUI().PopThrough(GetUI().Root().get());


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12090 (closes #12090).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When you reload a pilot from the load panel, the game deletes the old MainPanel and replaces it with a new one. However, when you reload via the new button that shows up on the main menu when the pilot is dead, the game doesn't clean up the old panel, and just adds a new one. This breaks fast-forward, and potentially many other things.
This PR copies the missing two lines of cleanup code from LoadPanel.cpp to MenuPanel.cpp.

## Testing Done
yes™.

## Performance Impact
N/A
