### PR TITLE
ui: Make performance info panel more consistent with the rest of UI

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -33,6 +33,7 @@ color "dead" .4 0. 0. 0.
 # Colors used for certain UI elements. These elements generally have a variable
 # size (e.g. they may fit to the current screen dimensions).
 color "panel background" .1 .1 .1 1.
+color "performance info background" .1 .1 .1 .7
 color "dialog backdrop" 0. 0. 0. .7
 color "conversation background" .125 .125 .125 1.
 color "map side panel background" .125 .125 .125 1.
@@ -222,32 +223,32 @@ color "plugin reload required" .75 .1 .1 0.
 interface "performance info"
 	anchor top left
 	fill
-		from 400 5 to 560 55
-		color "panel background"
+		from 560 5 to 720 55
+		color "performance info background"
 	visible if "ready"
 	string "cpu"
-		from 410 16
+		from 570 16
 		color "medium"
 		align left
 	string "gpu"
-		from 410 30
+		from 570 30
 		color "medium"
 		align left
 	string "mem"
-		from 410 44
+		from 570 44
 		color "medium"
 		align left
 	visible if "!ready"
 	label "CPU: calculating..."
-		from 410 16
+		from 570 16
 		color "medium"
 		align left
 	label "GPU: calculating..."
-		from 410 30
+		from 570 30
 		color "medium"
 		align left
 	label "MEM: calculating..."
-		from 410 44
+		from 570 44
 		color "medium"
 		align left
 


### PR DESCRIPTION
**User Interface**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Based on the feedback from https://discord.com/channels/251118043411775489/536900466655887360/1459001817013817479 and https://github.com/endless-sky/endless-sky/pull/11817#issuecomment-3714865388, this PR moves the performance info overlay 160 px to the right to avoid overlapping with the conversation panel, and adds a bit of transparency to match other elements of the in-flight HUD, while still being readable.

## Screenshots
Before:
<img width="280" height="138" alt="{1194487B-C387-4C76-9628-47C420402D8C}" src="https://github.com/user-attachments/assets/410c4823-94e8-4b00-88d0-4f47f74e7677" />
After:
<img width="353" height="186" alt="{F52659FB-65BE-4F23-86F2-E93DA2169968}" src="https://github.com/user-attachments/assets/e81ed6e5-94d0-40d5-9ae1-9de8e88ed52f" />

## Testing Done
See above.

## Performance Impact
N/A
