### PR TITLE
feature(small) Where did I land again?

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -771,7 +771,6 @@ void Engine::Step(bool isActive)
 	info.SetString("credits",
 		Format::CreditString(player.Accounts().Credits()));
 	bool isJumping = flagship && (flagship->Commands().Has(Command::JUMP) || flagship->IsEnteringHyperspace());
-
 	if(object)
 	{
 		info.SetString("navigation mode", "Landed on:");


### PR DESCRIPTION
**Bug fix** / **Feature** / **Quality of life**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This is a quality of life fix for something that has bothered me for a while.  Presently we don't reliably show the planet/station that was landed on.  This fixes that.  Most notable when starting from a save, as most of the rest of the time the navigation panel shows "Landing on" but this will ensure that the status is updated when the planet panel is displayed.

## Screenshots
<img width="1016" height="768" alt="image" src="https://github.com/user-attachments/assets/5e7f3c86-0363-4461-8feb-c0f9f5e9b5ac" />

The upper left "Navigation" pane is what I updated -- however, I have long thought that it might fit nicely to have the name of the station/planet centered in the other area that I show in this screenshot.

## Testing Done
Yes:
 - Load
 - Land
 - Navigate to and land
 - Many times
