### PR TITLE
feat(balance): Reduce spawn rates of Korath raiders in human space

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -4451,8 +4451,8 @@ system Almach
 	fleet "Small Core Pirates" 500
 	fleet "Large Core Pirates" 1400
 	fleet "Large Syndicate" 6000
-	fleet "Korath Large Raid" 50000
-	fleet "Korath Miners" 25000
+	fleet "Korath Large Raid" 60000
+	fleet "Korath Miners" 30000
 	object
 		sprite star/k8
 		period 10
@@ -7167,7 +7167,7 @@ system Atik
 	fleet "Small Core Pirates" 10000
 	fleet "Large Core Pirates" 18000
 	fleet "Human Miners" 5000
-	fleet "Korath Miners" 15000
+	fleet "Korath Miners" 25000
 	fleet "Derelict Pirate" 10000
 	object
 		sprite star/b-giant
@@ -13566,8 +13566,8 @@ system Durax
 	fleet "Small Core Pirates" 600
 	fleet "Large Core Pirates" 900
 	fleet "Large Syndicate" 2500
-	fleet "Korath Raid" 7000
-	fleet "Korath Miners" 17000
+	fleet "Korath Raid" 35000
+	fleet "Korath Miners" 45000
 	fleet "Derelict Pirate" 30000
 	object
 		sprite star/g0-old
@@ -27960,11 +27960,11 @@ system Misam
 	trade Plastic 368
 	fleet "Small Core Pirates" 750
 	fleet "Large Core Pirates" 2000
-	fleet "Korath Raid" 5000
-	fleet "Korath Large Raid" 11000
+	fleet "Korath Raid" 65000
+	fleet "Korath Large Raid" 40000
 	fleet "Human Miners" 10000
 	fleet "Large Syndicate" 20000
-	fleet "Korath Miners" 15000
+	fleet "Korath Miners" 70000
 	object
 		sprite star/f5-old
 		distance 50
@@ -36220,7 +36220,7 @@ system Sheratan
 	fleet "Large Core Merchants" 1800
 	fleet "Small Core Pirates" 3000
 	fleet "Large Core Pirates" 5000
-	fleet "Korath Large Raid" 40000
+	fleet "Korath Large Raid" 60000
 	object
 		sprite star/f5
 		distance 21.0246


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
[Back in 2016](https://github.com/endless-sky/endless-sky/commit/8abfab293dd517476ffde73706734f7b12ee57a3), MZ increased the period of Korath Raid fleets in Durax from 20000 to 5000, with the justification that hunting Exiles for an early jump drive was too time consuming.

This isn't necessary anymore. That commit was made before the introduction of the Ember Wastes and the Remnant, who provide easy, reliable access to an early jump drive through their missions. When the Korath Revamp was merged, it primarily based the spawn rates of its new systems on the inflated rates of Durax. It also turned Durax from a dead-end system with little value outside of the Korath spawns to a connection leading to a pirate world and a mining system. With more to do in those systems, the likelihood that a new player will stumble onto a Palavret and its jump drive before finding the Free Worlds campaign is much higher than before.

This PR reduces the spawn rates of Korath Raid fleets.
- Almach used to spawn Korath roughly every 5 and a half minutes, but the new fleets spawn Korath roughly 20% more frequently. The periods of the new fleets have been increased to compensate.
- Atik was added by the Korath Revamp, and its spawn rates have been reduced to around where they might've been if Durax still had its 20000 Korath Raid fleet frequency.
- Durax's new fleets from the revamp were roughly equivalent to MZ's spawn rates, spawning Korath every minute and 20 seconds on average. This PR raises their periods to match the old spawn rate of one every 5 and a half minutes.
- Misam spawns a Korath every 45 seconds, with a 10% chance that a Korath ship will already be in the system when you enter it. The spawn rate in Misam has been reduced substantially, down to one Korath fleet every 5 minutes. This is still the highest Korath appearance rate in human space.
- Unlike many other Korath-spawning systems like Alpha Hydri or Polaris, Sheratan isn't a dead-end system. To reflect that players will be passing by the system far more frequently relative to other Korath systems, the Korath Raid fleet period in the system has been increased.