### PR TITLE
Hide empty orbit & key panel on Stars map.

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -384,8 +384,11 @@ bool MapDetailPanel::Click(int x, int y, MouseButton button, int clicks)
 
 	if(button == MouseButton::RIGHT)
 	{
-		if(!Preferences::Has("System map sends move orders") || (commodity == SHOW_STARS && !player.CanView(*selectedSystem)))
+		if(!Preferences::Has("System map sends move orders"))
 			return true;
+		if(commodity == SHOW_STARS && !player.CanView(*selectedSystem))
+			return true;
+
 		// TODO: rewrite the map panels to be driven from interfaces.txt so these XY
 		// positions aren't hard-coded.
 		else if(x >= Screen::Right() - 240 && y >= Screen::Top() + 10 && y <= Screen::Top() + 270)


### PR DESCRIPTION
**Feature / Bug fix**


## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Hide the empty ui/orbit-and-key sprite on the Stars map, until such a time as we have something to put there (#12079 will have to be changed to remove "unknown" from the key)

## Screenshots
Before:
<img width="1728" height="1117" alt="Screenshot 2026-01-17 at 01 15 29" src="https://github.com/user-attachments/assets/11b13d9c-9443-4432-92d8-5ef291a7c6b8" />
After:
<img width="1728" height="1117" alt="Screenshot 2026-01-17 at 01 12 57" src="https://github.com/user-attachments/assets/614b3e37-0ea7-48ad-8ae5-882a1a920037" />

## Usage examples
n/a

## Testing Done
Not much to test here.

## Save File
Any new pilot.

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
Slight boost for Stars map view due to drawing less per frame.
