### PR TITLE
Add support for custom spaceport / bar image.

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1687,12 +1687,16 @@ interface "planet (small screen)"
 interface "spaceport"
 	box "content"
 		from -240 80 to 240 320
+	image "port"
+		center 0 -140
 
 
 
 interface "spaceport (small screen)"
 	box "content"
 		from -300 80 to 180 320
+	image "port"
+		center -60 -140
 
 
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1689,6 +1689,7 @@ interface "spaceport"
 		from -240 80 to 240 320
 	image "port"
 		center 0 -140
+		dimensions 720 360
 
 
 
@@ -1697,6 +1698,7 @@ interface "spaceport (small screen)"
 		from -300 80 to 180 320
 	image "port"
 		center -60 -140
+		dimensions 720 360
 
 
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1689,7 +1689,6 @@ interface "spaceport"
 		from -240 80 to 240 320
 	image "port"
 		center 0 -140
-		dimensions 720 360
 
 
 
@@ -1698,7 +1697,6 @@ interface "spaceport (small screen)"
 		from -300 80 to 180 320
 	image "port"
 		center -60 -140
-		dimensions 720 360
 
 
 

--- a/source/Port.cpp
+++ b/source/Port.cpp
@@ -112,6 +112,8 @@ void Port::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			if(displayName.empty())
 				displayName = SPACEPORT;
 		}
+		else if(key == "landscape" && hasValue)
+			landscape = SpriteSet::Get(child.Token(1));
 		else if(key == "to" && child.Size() >= 2)
 		{
 			const string &conditional = child.Token(1);
@@ -236,6 +238,13 @@ const string &Port::DisplayName() const
 const Paragraphs &Port::Description() const
 {
 	return description;
+}
+
+
+
+const Sprite *Port::Landscape() const
+{
+	return landscape;
 }
 
 

--- a/source/Port.h
+++ b/source/Port.h
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 class ConditionsStore;
 class DataNode;
+class Sprite;
 
 
 
@@ -75,6 +76,7 @@ public:
 
 	const std::string &DisplayName() const;
 	const Paragraphs &Description() const;
+	const Sprite *Landscape() const;
 
 	// Whether the player is required to bribe before landing due to their conditions.
 	bool RequiresBribe() const;
@@ -101,9 +103,10 @@ private:
 	// The name of this port.
 	std::string displayName;
 
-	// The description of this port. Shown when clicking on the
-	// port button on the planet panel.
+	// The description and graphic for this port. Shown when
+	// clicking on the Spaceport button on the planet panel.
 	Paragraphs description;
+	const Sprite *landscape = nullptr;
 
 	// What is recharged when landing on this port.
 	int recharge = RechargeType::None;

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -105,6 +105,15 @@ void SpaceportPanel::Draw()
 	// in the meantime, for example if the player accepts a mission on the Job Board.
 	description->SetText(port.Description().ToString());
 
+	if(port.Landscape())
+	{
+		Information info;
+		info.SetSprite("port", port.Landscape());
+		const Interface *ui = GameData::Interfaces().Get(Screen::Width() < 1280 ?
+			"spaceport (small screen)" : "spaceport");
+		ui->Draw(info);
+	}
+
 	if(hasNews)
 	{
 		const Interface *newsUi = GameData::Interfaces().Get(Screen::Width() < 1280 ?


### PR DESCRIPTION
**Feature**

This PR adds setting a custom image to go with the custom Spaceport description text.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Add an image in the `port` section of a planet to go with your port description.

## Screenshots
<img width="1022" height="715" alt="Screenshot 2026-01-17 at 02 49 45" src="https://github.com/user-attachments/assets/89f14e96-bf93-42a1-9e05-8f9c0bb3994f" />

Obviously it would look better with a correctly sized port image and no news in the way.

## Usage examples
```
planet
	port
		landscape <sprite>
```

For example:
```
planet Shangri-La
	attributes core frontier rich urban
	landscape land/sea6
	description `Named after a mythical paradise, Shangri-La is an almost ideal planet, with a mixture of advanced, developed cities and uninhabited mountains. It is a rich and prosperous world, and nearly self-sufficient, but the cost of living here is prohibitively high for anyone from off-world. Because Polaris is on the very fringe of human space, and because of the wealth of its economy, piracy is a constant threat. Although recently the Syndicate has provided good protection, in past centuries it was not unheard of for raiding parties of starships to attack major port cities here, carrying off valuable cargo and sometimes also human slaves.`
	port "Seedy Bar"
		recharges all
		services all
		news
		landscape scene/hroar
		description `The spaceport is state-of-the-art. So are the laser turrets and missile silos spaced out along its periphery. But somehow, instead of making you feel more secure, the defenses only serve to remind you of how far on the fringes of civilization you are, and of how rich this planet is compared to some of its neighbors. Everyone walking through the port is moving at a brisk, purposeful pace; loitering and sightseeing are not encouraged here.`
	shipyard "Syndicate Basics"
	shipyard "Megaparsec Basics"
	outfitter "Syndicate Advanced"
	...
```

## Testing Done
See screenshot.

## Save File
add "landscape foo" under a port in "map planets.txt"

## Artwork Checklist
n/a

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/217

## Performance Impact
One extra sprite will be drawn per frame when in the spaceport.
