### PR TITLE
feat(balance): Tone down the frequency of Navy Surveillance spawns inside FW space.

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -865,7 +865,7 @@ event "initial deployment 4"
 		fleet "Large Southern Pirates" 5000
 		fleet "Small Free Worlds" 1000
 		fleet "Large Free Worlds" 1500
-		fleet "Navy Surveillance" 800
+		fleet "Navy Surveillance" 2000
 	system "Dschubba"
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 2600
@@ -873,7 +873,7 @@ event "initial deployment 4"
 		fleet "Large Southern Pirates" 6000
 		fleet "Small Free Worlds" 2000
 		fleet "Large Free Worlds" 3000
-		fleet "Navy Surveillance" 800
+		fleet "Navy Surveillance" 2000
 	system "Lesath"
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1600
@@ -882,7 +882,7 @@ event "initial deployment 4"
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1100
 		fleet "Derelict Southern" 30000
-		fleet "Navy Surveillance" 800
+		fleet "Navy Surveillance" 2000
 	system "Atria"
 		fleet "Small Southern Merchants" 700
 		fleet "Large Southern Merchants" 2600
@@ -940,13 +940,13 @@ event "initial deployment 4"
 		fleet "Large Southern Pirates" 8000
 		fleet "Small Republic" 900
 		fleet "Large Republic" 700
-		fleet "Navy Surveillance" 1200
+		fleet "Navy Surveillance" 3000
 	system "Sabik"
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 800
 		fleet "Small Free Worlds" 800
 		fleet "Large Free Worlds" 1200
-		fleet "Navy Surveillance" 800
+		fleet "Navy Surveillance" 2000
 	system "Aldhibain"
 		fleet "Small Southern Merchants" 600
 		fleet "Large Southern Merchants" 800
@@ -954,14 +954,14 @@ event "initial deployment 4"
 		fleet "Large Free Worlds" 600
 		fleet "Small Southern Pirates" 1400
 		fleet "Large Southern Pirates" 3000
-		fleet "Navy Surveillance" 800
+		fleet "Navy Surveillance" 2000
 	system "Kornephoros"
 		fleet "Small Southern Merchants" 800
 		fleet "Large Southern Merchants" 1000
 		fleet "Small Southern Pirates" 5000
 		fleet "Small Free Worlds" 900
 		fleet "Large Free Worlds" 1700
-		fleet "Navy Surveillance" 800
+		fleet "Navy Surveillance" 2000
 		fleet "Human Miners" 3000
 
 


### PR DESCRIPTION
**Balance**

This PR addresses the bug/feature described by me just now

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The Navy should not be throwing this many cruisers and gunboats into FW space in surveillance fleets. That would be an invasion, not a surveillance. It makes sense that they'd want to do _some_ monitoring of these FW systems, but sending in fleets in numbers that outnumber the FW's own fleets seems excessive.

## Testing Done
None

## Save File
This save file can be used to test these changes:
[Annie Leonhart~Ready to join FW.txt](https://github.com/user-attachments/files/24688863/Annie.Leonhart.Ready.to.join.FW.txt)


## Performance Impact
Performance will be very slightly improved when you are in the systems affected due to lower numbers of ships.