### PR TITLE
fix(typo): Correct "Vimnal" to "Viminal" in Kumkapi description

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -3166,7 +3166,7 @@ planet Kuj-Sol-Nnesa
 planet Kumkapi
 	attributes moon uninhabited
 	landscape land/mars0
-	description `While this moon's minerals aren't particularly rare or exotic, its closeness to Viminal has made it the subject of many mining projects over the centuries - efforts to find traces of the valuable Key Stones which permit travel through this region of space. None of them were successful, and most Remnant scientists believe that Kumkapi formed somewhere else and was captured by Vimnal's gravitational pull at some time during its formation.`
+	description `While this moon's minerals aren't particularly rare or exotic, its closeness to Viminal has made it the subject of many mining projects over the centuries - efforts to find traces of the valuable Key Stones which permit travel through this region of space. None of them were successful, and most Remnant scientists believe that Kumkapi formed somewhere else and was captured by Viminal's gravitational pull at some time during its formation.`
 	description `	When the absence of Key Stones became clear, most scientific and mining interests faded away, and today the surface is scattered with abandoned outposts whose somber tunnels are thousand-kilometer labyrinths.`
 	government Uninhabited
 	security 0


### PR DESCRIPTION
**Typo fix**

This PR addresses the bug/feature described in issue #12132

## Acknowledgement

- [ ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Corrects typo of "Vimnal" in the description of planet Kumkapi to "Viminal".
