### PR TITLE
Give female pilots a "heroine's welcome".

### DIFF
--- a/data/avgi/avgi 0 first contact.txt
+++ b/data/avgi/avgi 0 first contact.txt
@@ -848,6 +848,11 @@ mission "Avgi: Dissonance Outreach 0.5"
 	on offer
 		conversation
 			`You receive a hero's welcome back on the Feo Platform from the Twilight Guards stationed there. After a short celebration and many expressions of praise toward you, an alien stranger, you find Darius and Sora waiting by the <ship> to speak with you.`
+				to display
+					not "gender: female"
+			`You receive a heroine's welcome back on the Feo Platform from the Twilight Guards stationed there. After a short celebration and many expressions of praise toward you, an alien stranger, you find Darius and Sora waiting by the <ship> to speak with you.`
+				to display
+					has "gender: female"
 			`	"<first>, I think we have a golden opportunity," Darius says. "I was just talking to an Assemblyman, Hriso, who's worried about the political situation in the eastern branch of the Tangled Shroud."`
 			`	"A bunch of selfish cowards, they are," says Sora disdainfully.`
 			`	"Something about the miners grumbling about price controls on nickel-iron," Darius says after a moment, "but he wants to know if you could use your jump drive to take him there for some outreach to the miners without needing to spend weeks wandering through the mess of twisted hyperlanes. It's the perfect chance to meet my friend and ask him some questions. We'll need to head to Peripheria to pick up Hriso and get this trip sorted out."`

--- a/data/human/free worlds 1 start.txt
+++ b/data/human/free worlds 1 start.txt
@@ -1658,6 +1658,11 @@ mission "FW Pirates: Diplomacy 4"
 		event "fw suppressed Greenrock"
 		conversation
 			`You arrive back on Longjump to a hero's welcome. People have heard of the battle you fought on Thule and the deal that was forged with the locals there. JJ and Freya greet you too, and congratulate you. But then Freya says, "We need to talk in private."`
+				to display
+					not "gender: female"
+			`You arrive back on Longjump to a heroine's welcome. People have heard of the battle you fought on Thule and the deal that was forged with the locals there. JJ and Freya greet you too, and congratulate you. But then Freya says, "We need to talk in private."`
+				to display
+					has "gender: female"
 			`	You lead them into your ship, where Freya explains, "Soon after you left for Thule, Tomek took off on his own and raised a fleet for an attack on Greenrock. He thought the Senate's plan of making a deal with the pirate worlds was too cowardly, and that we needed a show of strength instead. Surprisingly, his stunt succeeded; Greenrock is now nominally under Free Worlds control."`
 			`	"This puts us in a rather difficult position," says JJ. "Much of Tomek's fleet didn't survive the assault, and those ships didn't come out of thin air; they were intended for defensive purposes in case the Navy attacks again. Word of this has spread quickly. Thule is already second guessing their deal with us, and if Thule has heard of this then there's no doubt in my mind that the Republic has as well."`
 			`	"And regardless of his success, an invasion of Greenrock was not approved by the Senate," says Freya. "Tomek was detained on Greenrock by some of our officers on order of the Senate, and he's currently being transported to Bourne for a hearing."`

--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -2622,6 +2622,11 @@ mission "FW Syndicate Extremists 1C"
 		set "free worlds reconciliation"
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
+				to display
+					not "gender: female"
+			`On Earth, you return to something of a heroine's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a heroine rather than a criminal.`
+				to display
+					has "gender: female"
 			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a reward of five million credits "to cover any of your expenses from fighting the aliens."`
 			`	As you walk out, you find Alondo, JJ, and Katya sitting in the courtyard of Parliament. When they spot you walking towards them, JJ waves and says, "<first> and Freya! Am I glad to see the two of you still in one piece! What brings you to Earth?"`
 			choice


### PR DESCRIPTION
**Content (grammar fix)**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
"Hero" is very male word in the English langauge, and heroine is the female counterpart. Use it in a few places I've found. This PR serves as both a grammatical fix and an example usage of the new feature from #12136.

In other news, yay! I've completed the FW storyline. :)

## Screenshots
Not included as text change only.

## Usage examples
n/a

## Testing Done
1. Merge #12136 and this onto a test branch.
2. Load pilot file. Go to Earth.
3. Edit pilot file to change gender to "m". Go to Earth.

## Save File
[Myfanwy Angharad.txt](https://github.com/user-attachments/files/24696662/Myfanwy.Angharad.txt)

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
None.
