### PR TITLE
Fix divide-by-zero in Projectile.

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -188,77 +188,80 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 		CheckLock(*target);
 		CheckConfused(*target);
 	}
-	// Update the confusion direction after the projectile turns about
-	// 180 degrees away from its target.
-	if(!Random::Int(ceil(180 / turn)))
-		confusionDirection = Random::Int(2) ? -1 : 1;
-	if(target && homing)
-	{
-		// Vector d is the direction we want to turn towards.
-		Point d = target->Position() - position;
-		bool isFacingAway = d.Dot(angle.Unit()) < 0.;
-
-		// The very dumbest of homing missiles lose their target if pointed
-		// away from it.
-		if(isFacingAway && weapon->HasBlindspot())
-			targetShip.reset();
-		else if(hasLock)
-		{
-			Point unit = d.Unit();
-			double drag = weapon->Drag();
-			double trueVelocity = drag ? accel / drag : velocity.Length();
-			double stepsToReach = d.Length() / trueVelocity;
-			// At the highest homing level, compensate for target motion.
-			if(weapon->Leading())
-			{
-				if(unit.Dot(target->Velocity()) < 0.)
-				{
-					// If the target is moving toward this projectile, the intercept
-					// course is where the target and the projectile have the same
-					// velocity normal to the distance between them.
-					Point normal(unit.Y(), -unit.X());
-					double vN = normal.Dot(target->Velocity());
-					double vT = sqrt(max(0., trueVelocity * trueVelocity - vN * vN));
-					d = vT * unit + vN * normal;
-				}
-				else
-				{
-					// Adjust the target's position based on where it will be when we
-					// reach it (assuming we're pointed right towards it).
-					d += stepsToReach * target->Velocity();
-					stepsToReach = d.Length() / trueVelocity;
-				}
-				unit = d.Unit();
-			}
-
-			double cross = angle.Unit().Cross(unit);
-
-			double desiredTurn = TO_DEG * asin(cross);
-			if(fabs(desiredTurn) > turn)
-				turn = copysign(turn, desiredTurn);
-			else
-				turn = desiredTurn;
-
-			// Levels 3 and 4 stop accelerating when facing away.
-			if(weapon->ThrottleControl())
-			{
-				double stepsToFace = desiredTurn / turn;
-
-				// If you are facing away from the target, stop accelerating.
-				if(stepsToFace * 1.5 > stepsToReach)
-					accel = 0.;
-			}
-		}
-		// Turn in a random direction if this weapon is confused.
-		else if(isConfused)
-			turn *= confusionDirection;
-	}
-	// If a weapon is homing but has no target, do not turn it.
-	else if(homing)
-		turn = 0.;
-
 	if(turn)
-		angle += Angle(turn);
+	{
+		// Update the confusion direction after the projectile turns about
+		// 180 degrees away from its target.
+		if(!Random::Int(ceil(180 / turn)))
+			confusionDirection = Random::Int(2) ? -1 : 1;
+		if(target && homing)
+		{
+			// Vector d is the direction we want to turn towards.
+			Point d = target->Position() - position;
+			bool isFacingAway = d.Dot(angle.Unit()) < 0.;
+
+			// The very dumbest of homing missiles lose their target if pointed
+			// away from it.
+			if(isFacingAway && weapon->HasBlindspot())
+				targetShip.reset();
+			else if(hasLock)
+			{
+				Point unit = d.Unit();
+				double drag = weapon->Drag();
+				double trueVelocity = drag ? accel / drag : velocity.Length();
+				double stepsToReach = d.Length() / trueVelocity;
+				// At the highest homing level, compensate for target motion.
+				if(weapon->Leading())
+				{
+					if(unit.Dot(target->Velocity()) < 0.)
+					{
+						// If the target is moving toward this projectile, the intercept
+						// course is where the target and the projectile have the same
+						// velocity normal to the distance between them.
+						Point normal(unit.Y(), -unit.X());
+						double vN = normal.Dot(target->Velocity());
+						double vT = sqrt(max(0., trueVelocity * trueVelocity - vN * vN));
+						d = vT * unit + vN * normal;
+					}
+					else
+					{
+						// Adjust the target's position based on where it will be when we
+						// reach it (assuming we're pointed right towards it).
+						d += stepsToReach * target->Velocity();
+						stepsToReach = d.Length() / trueVelocity;
+					}
+					unit = d.Unit();
+				}
+
+				double cross = angle.Unit().Cross(unit);
+
+				double desiredTurn = TO_DEG * asin(cross);
+				if(fabs(desiredTurn) > turn)
+					turn = copysign(turn, desiredTurn);
+				else
+					turn = desiredTurn;
+
+				// Levels 3 and 4 stop accelerating when facing away.
+				if(weapon->ThrottleControl())
+				{
+					double stepsToFace = desiredTurn / turn;
+
+					// If you are facing away from the target, stop accelerating.
+					if(stepsToFace * 1.5 > stepsToReach)
+						accel = 0.;
+				}
+			}
+			// Turn in a random direction if this weapon is confused.
+			else if(isConfused)
+				turn *= confusionDirection;
+		}
+		// If a weapon is homing but has no target, do not turn it.
+		else if(homing)
+			turn = 0.;
+
+		if(turn)
+			angle += Angle(turn);
+	}
 
 	if(accel)
 	{


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixes this log message that appears every time the game runs:
```
/Users/*/.../endless-sky/source/Projectile.cpp:185:18: runtime error: inf is outside the range of representable values of type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/*/.../endless-sky/source/Projectile.cpp:185:18 in 
```

## Screenshots
n/a

## Usage examples
n/a

## Testing Done
Played the game. It used to appear once (presumably further instances get suppressed), 100% of the time I played (probably ther first time a projectile was ever shot).

## Save File
n/a

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
n/a
