### PR TITLE
Grant a basic Navy licence at the end of the Free Worlds campaign.

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -2620,9 +2620,10 @@ mission "FW Syndicate Extremists 1C"
 		set "main plot completed"
 		set "free worlds plot completed"
 		set "free worlds reconciliation"
+		set "license: Navy"
 		conversation
 			`On Earth, you return to something of a hero's welcome, far different from the first time you were here on a diplomatic mission. A crowd of locals gathers in the spaceport to watch your ship land. With the Free Worlds having been instrumental in defeating the aliens, and absolved of any guilt in the terrorist attacks, it seems that most people here are ready to see you as a hero rather than a criminal.`
-			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a reward of five million credits "to cover any of your expenses from fighting the aliens."`
+			`	Your meeting with Parliament is long and grueling, as they press you and Freya for every detail you can give them about the enigmatic Pug and their apparent motivation in invading human space. The questions about the Syndicate are equally hard to answer. But at the end of the session, one of the members of Parliament informs you that they have authorized an official commendation for you, along with a Navy license, and a reward of five million credits "to cover any of your expenses from fighting the aliens."`
 			`	As you walk out, you find Alondo, JJ, and Katya sitting in the courtyard of Parliament. When they spot you walking towards them, JJ waves and says, "<first> and Freya! Am I glad to see the two of you still in one piece! What brings you to Earth?"`
 			choice
 				`	"I received a commendation from Parliament."`


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the bug/feature described in issue #12147

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Grant a basic Navy licence at the end of the Free Worlds campaign.

Alternate text suggestions welcome.

## Screenshots
n/a

## Usage examples
n/a

## Testing Done
None

## Save File
I don't have one from before that mission is offered.

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
n/a
