### PR TITLE
refactor: Replace various shared_from_this calls with weak_from_this

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -925,7 +925,7 @@ void AI::Step(Command &activeCommands)
 					it->SetTargetShip(nullptr);
 				}
 				shipToAssist.reset();
-				it->SetShipToAssist(nullptr);
+				it->SetShipToAssist(weak_ptr<Ship>());
 			}
 			else if(!it->IsBoarding())
 			{
@@ -1422,8 +1422,8 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 		if(!hasEnemy && !canHelp.empty())
 		{
 			Ship *helper = canHelp[Random::Int(canHelp.size())];
-			helper->SetShipToAssist((&ship)->shared_from_this());
-			helperList[&ship] = helper->shared_from_this();
+			helper->SetShipToAssist(ship.weak_from_this());
+			helperList[&ship] = helper->weak_from_this();
 			isStranded = true;
 		}
 		else
@@ -1590,7 +1590,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 
 		// Ships which only disable never target already-disabled ships.
 		if((person.Disables() || (!person.IsNemesis() && foe != oldTarget.get()))
-				&& foe->IsDisabled() && (!canPlunder || Has(ship, foe->shared_from_this(), ShipEvent::BOARD)))
+				&& foe->IsDisabled() && (!canPlunder || Has(ship, foe->weak_from_this(), ShipEvent::BOARD)))
 			continue;
 
 		// Ships that don't (or can't) plunder strongly prefer active targets.
@@ -1602,7 +1602,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 			if(any_of(boarders.begin(), boarders.end(), [&ship, &foe](auto &it)
 					{ return it.first != &ship && it.second == foe; }))
 				continue;
-			range += 2000. * (2 * foe->IsDisabled() - !Has(ship, foe->shared_from_this(), ShipEvent::BOARD));
+			range += 2000. * (2 * foe->IsDisabled() - !Has(ship, foe->weak_from_this(), ShipEvent::BOARD));
 		}
 
 		// Prefer to go after armed targets, especially if you're not a pirate.
@@ -1700,7 +1700,7 @@ shared_ptr<Ship> AI::FindNonHostileTarget(const Ship &ship) const
 			for(const auto &it : GetShipsList(ship, false))
 				if(it->GetGovernment() != gov)
 				{
-					auto ptr = it->shared_from_this();
+					shared_ptr<Ship> ptr = it->shared_from_this();
 					// Scan friendly ships that are as-yet unscanned by this ship's government.
 					if((!cargoScan || Has(gov, ptr, ShipEvent::SCAN_CARGO))
 							&& (!outfitScan || Has(gov, ptr, ShipEvent::SCAN_OUTFITS)))
@@ -3174,7 +3174,7 @@ void AI::DoSurveillance(Ship &ship, Command &command, shared_ptr<Ship> &target)
 			for(const auto &it : GetShipsList(ship, false))
 				if(it->GetGovernment() != gov)
 				{
-					auto ptr = it->shared_from_this();
+					weak_ptr<Ship> ptr = it->weak_from_this();
 					if((!cargoScan || Has(gov, ptr, ShipEvent::SCAN_CARGO))
 							&& (!outfitScan || Has(gov, ptr, ShipEvent::SCAN_OUTFITS)))
 						continue;
@@ -3553,7 +3553,7 @@ bool AI::DoSecretive(Ship &ship, Command &command) const
 	for(auto &otherShip : GetShipsList(ship, false))
 		if(!ship.GetGovernment()->Trusts(otherShip->GetGovernment()) &&
 				otherShip->Commands().Has(Command::SCAN) &&
-				otherShip->GetTargetShip() == ship.shared_from_this() &&
+				otherShip->GetTargetShip().get() == &ship &&
 				!otherShip->IsDisabled() && !otherShip->IsDestroyed())
 			scanningShip = make_shared<Ship>(*otherShip);
 
@@ -4048,7 +4048,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		for(const auto &target : enemies)
 		{
 			// NPCs shoot ships that they just plundered.
-			bool hasBoarded = !ship.IsYours() && Has(ship, target->shared_from_this(), ShipEvent::BOARD);
+			bool hasBoarded = !ship.IsYours() && Has(ship, target->weak_from_this(), ShipEvent::BOARD);
 			if(target->IsDisabled() && (disables || (plunders && !hasBoarded)) && !disabledOverride)
 				continue;
 			// Merciful ships let fleeing ships go.
@@ -4421,13 +4421,13 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 						return [this, &ship](const Ship &other) noexcept -> double
 						{
 							// Use the exact cost if the ship was scanned, otherwise use an estimation.
-							return this->Has(ship, other.shared_from_this(), ShipEvent::SCAN_OUTFITS) ?
+							return this->Has(ship, other.weak_from_this(), ShipEvent::SCAN_OUTFITS) ?
 								other.Cost() : (other.ChassisCost() * 2.);
 						};
 					case Preferences::BoardingPriority::MIXED:
 						return [this, &ship, current](const Ship &other) noexcept -> double
 						{
-							double cost = this->Has(ship, other.shared_from_this(), ShipEvent::SCAN_OUTFITS) ?
+							double cost = this->Has(ship, other.weak_from_this(), ShipEvent::SCAN_OUTFITS) ?
 								other.Cost() : (other.ChassisCost() * 2.);
 							// Even if we divide by 0, doubles can contain and handle infinity,
 							// and we should definitely board that one then.
@@ -4904,7 +4904,7 @@ void AI::DisengageAutopilot()
 
 bool AI::Has(const Ship &ship, const weak_ptr<const Ship> &other, int type) const
 {
-	auto sit = actions.find(ship.shared_from_this());
+	auto sit = actions.find(ship.weak_from_this());
 	if(sit == actions.end())
 		return false;
 
@@ -4936,7 +4936,7 @@ bool AI::Has(const Government *government, const weak_ptr<const Ship> &other, in
 // example, if the player boarded any ship belonging to that government.
 bool AI::Has(const Ship &ship, const Government *government, int type) const
 {
-	auto sit = notoriety.find(ship.shared_from_this());
+	auto sit = notoriety.find(ship.weak_from_this());
 	if(sit == notoriety.end())
 		return false;
 

--- a/source/FormationPositioner.cpp
+++ b/source/FormationPositioner.cpp
@@ -87,7 +87,7 @@ Point FormationPositioner::Position(const Ship *ship)
 		shipPositions[ship] = make_pair(relPos, tickTock);
 
 		// Add the ship to the ring.
-		shipsInFormation.push_back(ship->shared_from_this());
+		shipsInFormation.push_back(ship->weak_from_this());
 
 		// Trigger immediate re-generation of the formation positions (to
 		// ensure that this new ship also gets a valid position).

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1850,7 +1850,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 	// Board a friendly ship, to repair or refuel it.
 	if(!government->IsEnemy(victim->GetGovernment()))
 	{
-		SetShipToAssist(shared_ptr<Ship>());
+		SetShipToAssist(weak_ptr<Ship>());
 		SetTargetShip(shared_ptr<Ship>());
 		bool helped = victim->isDisabled;
 		victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->MaxHull());
@@ -3415,10 +3415,10 @@ bool Ship::CanCarry(const Ship &ship) const
 
 	for(const auto &it : escorts)
 	{
-		auto escort = it.lock();
+		shared_ptr<Ship> escort = it.lock();
 		if(!escort)
 			continue;
-		if(escort == ship.shared_from_this())
+		if(escort.get() == &ship)
 			break;
 		if(escort->attributes.Category() == category && !escort->IsDestroyed() &&
 				(!IsYours() || (IsYours() && escort->IsYours())))
@@ -3862,7 +3862,7 @@ void Ship::SetTargetShip(const shared_ptr<Ship> &ship)
 
 
 
-void Ship::SetShipToAssist(const shared_ptr<Ship> &ship)
+void Ship::SetShipToAssist(const weak_ptr<Ship> &ship)
 {
 	shipToAssist = ship;
 }
@@ -5111,7 +5111,7 @@ void Ship::DoEngineVisuals(vector<Visual> &visuals, bool isUsingAfterburner)
 // cues and try to stay with it when it lands or goes into hyperspace.
 void Ship::AddEscort(Ship &ship)
 {
-	escorts.push_back(ship.shared_from_this());
+	escorts.push_back(ship.weak_from_this());
 }
 
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -519,7 +519,7 @@ public:
 
 	// Set this ship's targets.
 	void SetTargetShip(const std::shared_ptr<Ship> &ship);
-	void SetShipToAssist(const std::shared_ptr<Ship> &ship);
+	void SetShipToAssist(const std::weak_ptr<Ship> &ship);
 	void SetTargetStellar(const StellarObject *object);
 	// Set ship's target system (it should always be one jump / wormhole pass away).
 	void SetTargetSystem(const System *system);


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Turns out that weak_from_this is a thing that exists, and we have various shared_from_this calls that serve only to create a shared pointer that immediately gets implicitly converted into a weak pointer. This PR replaces any such shared_from_this call with a weak_from_this call. 

This also replaces a couple unnecessary shared_from_this calls used only for comparisons against other shared pointers with comparisons against raw pointers instead (which is what is typically done).

I've also updated Ship::SetShipToAssist to accept a weak pointer instead of a shared pointer, since all it does is store the given variable into a weak pointer. Other Ship functions that accept shared pointers do actually make use of the shared pointer in a way that it wouldn't make sense for them to accept a weak pointer.

## Testing Done

The game compiles and runs. Didn't notice any issues when engaging in combat.

## Performance Impact

This is presumably a performance increase since shared_from_this is more taxing a function than weak_from_this, but I didn't bother checking if it's a noticeable increase.
