### PR TITLE
feat(balance): Missiles check for a lock when fired

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -74,8 +74,12 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 		lifetime += Random::Int(weapon->RandomLifetime() + 1);
 
 	// Set an initial confusion turn direction.
-	if(weapon->Homing())
+	if(weapon->Homing() && cachedTarget)
+	{
 		confusionDirection = Random::Int(2) ? -1 : 1;
+		CheckLock(*cachedTarget);
+		CheckConfused(*cachedTarget);
+	}
 }
 
 
@@ -104,8 +108,12 @@ Projectile::Projectile(const Projectile &parent, const Point &offset, const Angl
 		lifetime += Random::Int(weapon->RandomLifetime() + 1);
 
 	// Set an initial confusion turn direction.
-	if(weapon->Homing())
+	if(weapon->Homing() && cachedTarget)
+	{
 		confusionDirection = Random::Int(2) ? -1 : 1;
+		CheckLock(*cachedTarget);
+		CheckConfused(*cachedTarget);
+	}
 }
 
 


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR makes it so that missiles check for a lock when they are fired. This makes the effects of low tracking and jamming more pronounced at close ranges, as you no longer have to wait until locks are checked for a missile to lose its lock or go haywire.

## Performance Impact
Minimal.
