### PR TITLE
feat(mechanics): Haywire missiles with `blindspot` will lose their target

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -184,46 +184,47 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 	// 180 degrees away from its target.
 	if(!Random::Int(ceil(180 / turn)))
 		confusionDirection = Random::Int(2) ? -1 : 1;
-	if(target && homing && hasLock)
+	if(target && homing)
 	{
 		// Vector d is the direction we want to turn towards.
 		Point d = target->Position() - position;
-		Point unit = d.Unit();
-		double drag = weapon->Drag();
-		double trueVelocity = drag ? accel / drag : velocity.Length();
-		double stepsToReach = d.Length() / trueVelocity;
 		bool isFacingAway = d.Dot(angle.Unit()) < 0.;
-		// At the highest homing level, compensate for target motion.
-		if(weapon->Leading())
-		{
-			if(unit.Dot(target->Velocity()) < 0.)
-			{
-				// If the target is moving toward this projectile, the intercept
-				// course is where the target and the projectile have the same
-				// velocity normal to the distance between them.
-				Point normal(unit.Y(), -unit.X());
-				double vN = normal.Dot(target->Velocity());
-				double vT = sqrt(max(0., trueVelocity * trueVelocity - vN * vN));
-				d = vT * unit + vN * normal;
-			}
-			else
-			{
-				// Adjust the target's position based on where it will be when we
-				// reach it (assuming we're pointed right towards it).
-				d += stepsToReach * target->Velocity();
-				stepsToReach = d.Length() / trueVelocity;
-			}
-			unit = d.Unit();
-		}
-
-		double cross = angle.Unit().Cross(unit);
 
 		// The very dumbest of homing missiles lose their target if pointed
 		// away from it.
 		if(isFacingAway && weapon->HasBlindspot())
 			targetShip.reset();
-		else
+		else if(hasLock)
 		{
+			Point unit = d.Unit();
+			double drag = weapon->Drag();
+			double trueVelocity = drag ? accel / drag : velocity.Length();
+			double stepsToReach = d.Length() / trueVelocity;
+			// At the highest homing level, compensate for target motion.
+			if(weapon->Leading())
+			{
+				if(unit.Dot(target->Velocity()) < 0.)
+				{
+					// If the target is moving toward this projectile, the intercept
+					// course is where the target and the projectile have the same
+					// velocity normal to the distance between them.
+					Point normal(unit.Y(), -unit.X());
+					double vN = normal.Dot(target->Velocity());
+					double vT = sqrt(max(0., trueVelocity * trueVelocity - vN * vN));
+					d = vT * unit + vN * normal;
+				}
+				else
+				{
+					// Adjust the target's position based on where it will be when we
+					// reach it (assuming we're pointed right towards it).
+					d += stepsToReach * target->Velocity();
+					stepsToReach = d.Length() / trueVelocity;
+				}
+				unit = d.Unit();
+			}
+
+			double cross = angle.Unit().Cross(unit);
+
 			double desiredTurn = TO_DEG * asin(cross);
 			if(fabs(desiredTurn) > turn)
 				turn = copysign(turn, desiredTurn);
@@ -240,10 +241,10 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 					accel = 0.;
 			}
 		}
+		// Turn in a random direction if this weapon is confused.
+		else if(isConfused)
+			turn *= confusionDirection;
 	}
-	// Turn in a random direction if this weapon is confused.
-	else if(target && homing && isConfused)
-		turn *= confusionDirection;
 	// If a weapon is homing but has no target, do not turn it.
 	else if(homing)
 		turn = 0.;


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, the check that determines whether a missile with a blindspot is facing away from its target is within an `if` statement requiring that the missile has a lock. This means that, if a missile with `blindspot` loses its lock, turns away from its target, then turns to face it again, it can still regain its lock. This is especially troublesome with haywire missiles, who turn unpredictably and can easily end up facing the player when the haywire state ends.

This PR makes any missile that faces away from its target lose its lock, locked or unlocked.

## Performance Impact
None.
