### PR TITLE
feat(mechanics): Add autocondition for attributes of the previous system

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4263,7 +4263,12 @@ void PlayerInfo::RegisterDerivedConditions()
 	conditions["previous system government: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		if(!previousSystem || !previousSystem->GetGovernment())
 			return false;
-		return !ce.NameWithoutPrefix().compare(previousSystem->GetGovernment()->TrueName());
+		return !ce.NameWithoutPrefix().compare(previousSystem->GetGovernment()->TrueName()); });
+	conditions["previous system attribute: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
+		if(!previousSystem)
+			return false;
+		string attribute = ce.NameWithoutPrefix();
+		return previousSystem->Attributes().contains(attribute);
 	});
 
 	// Conditions to determine if flagship is in a system and on a planet.


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds an autocondition to check the attributes of the previous system. This would be useful for creating message buoys for specific regions within a single government, like the Republic.

## Usage examples
```
mission "Message Buoy: Testing New Condition"
	entering
	repeat
	destination "Earth"
	invisible
	to offer
		not "previous system attribute: paradise"
		not "entered system by: takeoff"
	source
		attributes paradise
	on offer
		message
			text "You just entered the Paradise Worlds."
		fail
```

## Wiki Update
(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)
