### PR TITLE
Always write sprite frame rate.

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -277,8 +277,7 @@ void Body::SaveSprite(DataWriter &out, const string &tag) const
 	out.Write(tag, sprite->Name());
 	out.BeginChild();
 	{
-		if(frameRate != static_cast<float>(2. / 60.))
-			out.Write("frame rate", frameRate * 60.);
+		out.Write("frame rate", frameRate * 60.);
 		if(delay)
 			out.Write("delay", delay);
 		if(scale != Point(1., 1.))


### PR DESCRIPTION
**Bug fix**

This PR avoids a potential floating-point issue.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Whilst working on splitting Body into two, I noticed an equality comparison using floats. You cannot reliably do this in C (well, on any hardware that uses IEEE 754 number representations, which is ~100% of them), and the correct code would look something like this:

```diff
diff --git a/source/Body.cpp b/source/Body.cpp
index 13ca27532..8c14cc76a 100644
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -277,7 +277,7 @@ void Body::SaveSprite(DataWriter &out, const string &tag) const
        out.Write(tag, sprite->Name());
        out.BeginChild();
        {
-               if(frameRate != static_cast<float>(2. / 60.))
+               if(abs(frameRate - 1.f/30.f) > __FLT_EPSILON__)
                        out.Write("frame rate", frameRate * 60.);
                if(delay)
                        out.Write("delay", delay);
```

However in this instance, the code came from 10-year-old commit 9ce110a8e260e8b0274edb57a46e89e67096b341 with the description "Made animation default to 2 FPS instead of 60 FPS, so that if I add running-light graphics for ships it will look reasonable even for ships from old saved games where ships have no frame rate specified."

Given this context, the lack of running lights added in the past 10 years, and the non-extant use of sprites with a frame rate of 2fps (even the red alert icon is done with a conditional toggle), I decided it would be best to simply remove the check and always write out the frame rate value when saving a sprite (which is only called when writing out a Ship with flares).

There are no other instances of `==` or `!=` followed by `static_cast<float|double>`.

## Screenshots
n/a

## Usage examples
n/a

## Testing Done
n/a

## Save File
Not sure what ships have flares.

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
Miniscule improvement to pilot file saving, in some cases.