### PR TITLE
fix(ui): Allow maps and licenses to be purchased without having a ship selected

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -103,7 +103,7 @@ namespace {
 			case OutfitterPanel::OutfitLocation::Storage:
 				return "storage";
 			default:
-				throw "unreachable";
+				throw runtime_error("unreachable");
 		}
 	}
 }
@@ -364,9 +364,9 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 
 	// Prevent coding up bad combinations.
 	if(fromLocation == toLocation)
-		throw "unreachable; to and from are the same";
+		throw runtime_error("unreachable; to and from are the same");
 	if(fromLocation == OutfitLocation::Shop && toLocation == OutfitLocation::Storage)
-		throw "unreachable; unsupported to/from combination";
+		throw runtime_error("unreachable; unsupported to/from combination");
 
 	// Handle special cases such as maps and licenses.
 	int mapSize = selectedOutfit->Get("map");
@@ -538,7 +538,7 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 			break;
 		}
 		default:
-			throw "unreachable";
+			throw runtime_error("unreachable");
 	}
 
 	// Collect relevant errors.
@@ -664,7 +664,7 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 			break;
 		}
 		default:
-			throw "unreachable";
+			throw runtime_error("unreachable");
 	}
 
 	return canSource && canPlace;

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -59,19 +59,19 @@ protected:
 	virtual bool HasItem(const std::string &name) const override;
 	virtual void DrawItem(const std::string &name, const Point &point) override;
 	virtual double DrawDetails(const Point &center) override;
-	virtual TransactionResult CanMoveOutfit(OutfitLocation fromLocation, OutfitLocation toLocation,
+	TransactionResult CanMoveOutfit(OutfitLocation fromLocation, OutfitLocation toLocation,
 		const std::string &actionName = "no action specified") const;
-	virtual TransactionResult MoveOutfit(OutfitLocation fromLocation, OutfitLocation toLocation,
+	TransactionResult MoveOutfit(OutfitLocation fromLocation, OutfitLocation toLocation,
 		const std::string &actionName = "no action specified") const;
-	virtual bool ButtonActive(char key, bool shipRelatedOnly = false);
+	bool ButtonActive(char key, bool shipRelatedOnly = false);
 	virtual bool ShouldHighlight(const Ship *ship) override;
 	virtual void DrawKey() override;
 
 	// Toggles for the display filters.
-	virtual void ToggleForSale();
-	virtual void ToggleInstalled();
-	virtual void ToggleStorage();
-	virtual void ToggleCargo();
+	void ToggleForSale();
+	void ToggleInstalled();
+	void ToggleStorage();
+	void ToggleCargo();
 
 	virtual int FindItem(const std::string &text) const override;
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12149.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Title.

## Testing Done

Started a new save file. Left the shipyard without purchasing a ship and went to the outfitter. I was able to buy a map.