### PR TITLE
The left edge of the large-screen trading panel was 10px off.

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2056,7 +2056,7 @@ interface "hiring (small screen)"
 
 interface "trade"
 	box "content"
-		from -240 80 to 250 355
+		from -250 80 to 250 355
 	
 	fill
 		center 0 95

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -100,7 +100,7 @@ void TradingPanel::Draw()
 	int selectedRow = player.MapColoring();
 	if(selectedRow >= 0 && selectedRow < COMMODITY_COUNT)
 	{
-		const Point center(MIN_X + box.Width() / 2, FIRST_Y + 20 * selectedRow + 33);
+		const Point center(box.Center().X(), FIRST_Y + 20 * selectedRow + 33);
 		const Point dimensions(box.Width() - 20., 20.);
 		FillShader::Fill(center, dimensions, back);
 	}


### PR DESCRIPTION
**Bug fix**

See screenshots.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
For some reason the columns on the larger-screen trade panel were 10px right-shifted compared to the smaller-screen panel, resulting in 30px of left-padding and 10px of right padding. The header underline was not affected as it was independently defined in the interfaces file.

## Screenshots
Before:
<img width="501" height="261" alt="Screenshot 2026-01-28 at 18 41 09" src="https://github.com/user-attachments/assets/c5d82135-9fca-4d26-940c-4f99e01d5987" />
After:
<img width="508" height="267" alt="Screenshot 2026-01-28 at 19 05 57" src="https://github.com/user-attachments/assets/b4c9fc21-a8b4-4e8e-8b00-708e1792f512" />
Small-screen panel (unaffected by PR):
<img width="508" height="267" alt="Screenshot 2026-01-28 at 19 06 09" src="https://github.com/user-attachments/assets/2a2280fc-9ca1-4c1a-b5f2-b9ae628eef43" />
This is now identical to the big screen except (as you can see from the star positions underneath) that the whole planet panel is shifted.

## Usage examples
n/a

## Testing Done
None besides screenshots.

## Save File
n/a

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
n/a