### PR TITLE
feat(ui): Allow canceling map move orders

### DIFF
--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -75,6 +75,7 @@ help "map advanced"
 help "map advanced ports"
 	`The ports panel shows you where systems with spaceports are, as well as a plethora of other information. Clicking on the name of the system, the government of the system, the lines under the name of each planet, or any trade commodity will color the map differently, the key to which can be seen on the right side of the screen.`
 	`Clicking the name of a planet, or clicking on a planet in the orbit map on the right side of the screen, will show that planet's description if you have visited it already. Clicking a planet on the orbit map will also tell your autopilot to land on that planet after you have arrived at that system at the end of your jump path.`
+	`Right-clicking on a location in the orbit map will send your escorts to that location in the selected system.`
 
 help "map advanced shops"
 	`The shipyard and outfitter map panels respectively display the ships and outfits sold on any planets that you have seen. Ships and outfits are displayed in categories which can be collapsed by clicking on the category name. Using Shift+click on a category name will collapse or uncollapse all the categories at once.`

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -255,6 +255,7 @@ interface "performance info"
 
 
 interface "map detail panel"
+	anchor top right
 	value "min planet panel height" 195
 	value "max planet panel height" 2022
 	value "starting X" 100
@@ -267,6 +268,12 @@ interface "map detail panel"
 	value "description x offset" 240
 	value "description width" 500
 	value "description height" 240
+	visible if "has escort destination"
+	sprite "ui/wide button"
+		center -256 56
+	button c "Cancel order"
+		center -256 56
+		dimensions 90 30
 
 
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1583,9 +1583,6 @@ tip "Show escort systems on map"
 tip "Show stored outfits on map"
 	`If you have outfits stored on a planet, marks systems with stored outfits on the star map.`
 
-tip "System map sends move orders"
-	`Right-click on a location in the system mini-map on the galaxy map to send your escorts to that location in the selected system.`
-
 tip "Always underline shortcuts"
 	`Always underline the shortcut key for any buttons. Holding the alt key in any panel will also underline the button shortcut keys if this setting is off.`
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/FontSet.h"
 #include "GameData.h"
 #include "Government.h"
+#include "Information.h"
 #include "Interface.h"
 #include "text/Layout.h"
 #include "MapOutfitterPanel.h"
@@ -144,8 +145,8 @@ void MapDetailPanel::Draw()
 
 	clickZones.clear();
 
-	DrawInfo();
 	DrawOrbits();
+	DrawInfo();
 	DrawKey();
 	FinishDrawing(isStars ? "is stars" : "is ports");
 }
@@ -369,6 +370,8 @@ bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command
 			}
 		}
 	}
+	else if(key == 'c')
+		player.SetEscortDestination();
 	else
 		return MapPanel::KeyDown(key, mod, command, isNewPress);
 
@@ -384,8 +387,6 @@ bool MapDetailPanel::Click(int x, int y, MouseButton button, int clicks)
 
 	if(button == MouseButton::RIGHT)
 	{
-		if(!Preferences::Has("System map sends move orders"))
-			return true;
 		if(commodity == SHOW_STARS && !player.CanView(*selectedSystem))
 			return true;
 
@@ -963,6 +964,11 @@ void MapDetailPanel::DrawInfo()
 		RemoveChild(description.get());
 		descriptionVisible = false;
 	}
+
+	Information mapInterfaceInfo;
+	if(player.HasEscortDestination())
+		mapInterfaceInfo.SetCondition("has escort destination");
+	mapInterface->Draw(mapInterfaceInfo, this);
 }
 
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -806,7 +806,6 @@ void PreferencesPanel::DrawSettings()
 		"Hide unexplored map regions",
 		"Show escort systems on map",
 		"Show stored outfits on map",
-		"System map sends move orders",
 		"",
 		"Other",
 		"Always underline shortcuts",


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When you prepare a move order via the orbit map, a button removing the order appears (see screenshot below). Since it's now possible to cancel the order, accidental right clicks on the panel are not as dangerous and confusing as they could be before. With the guarding preference no longer needed, the information about this feature has been moved from the tooltip of the now-removed setting to one of the help messages displayed on the map.

## Screenshots
<img width="234" height="174" alt="{4F47CE6C-DA72-4121-9CE6-012FC24BD8F3}" src="https://github.com/user-attachments/assets/535da42f-eeb1-44f2-9768-55ec060173b6" />

## Testing Done
yes™.

## Performance Impact
N/A
