### PR TITLE
fix(ui): Correct dimensions of the "Open Saves" button

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -506,7 +506,7 @@ interface "load menu"
 	active
 	button o "_Open Saves"
 		center -435 195
-		dimensions 120 30
+		dimensions 90 30
 	
 	active if "pilot alive"
 	button a "_Add Snapshot"


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Every interface element using the "wide button" sprite has the clickable zone 90 pixels wide, except for the "Open Saves" button, which for some reason has 120 px.

## Testing Done
yes.

## Performance Impact
N/A