### PR TITLE
fix(mechanics): Properly set `turn` to zero if a missile has lost its lock

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -194,17 +194,22 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 		// 180 degrees away from its target.
 		if(!Random::Int(ceil(180 / turn)))
 			confusionDirection = Random::Int(2) ? -1 : 1;
-		if(target && homing)
+		if(homing)
 		{
 			// Vector d is the direction we want to turn towards.
-			Point d = target->Position() - position;
-			bool isFacingAway = d.Dot(angle.Unit()) < 0.;
+			Point d;
+			bool isFacingAway = false;
+			if(target)
+			{
+				d = target->Position() - position;
+				isFacingAway = d.Dot(angle.Unit()) < 0.;
+			}
 
 			// The very dumbest of homing missiles lose their target if pointed
 			// away from it.
 			if(isFacingAway && weapon->HasBlindspot())
 				targetShip.reset();
-			else if(hasLock)
+			else if(target && hasLock)
 			{
 				Point unit = d.Unit();
 				double drag = weapon->Drag();
@@ -254,10 +259,10 @@ void Projectile::Move(vector<Visual> &visuals, vector<Projectile> &projectiles)
 			// Turn in a random direction if this weapon is confused.
 			else if(isConfused)
 				turn *= confusionDirection;
+			// If a weapon is homing but has no target, do not turn it.
+			else
+				turn = 0.;
 		}
-		// If a weapon is homing but has no target, do not turn it.
-		else if(homing)
-			turn = 0.;
 
 		if(turn)
 			angle += Angle(turn);


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Due to a bug introduced by #12155, missiles that have lost their lock, but not their target, would not have their turn set to zero, causing them to turn. This PR fixes that.

## Testing Done
Yes.