### PR TITLE
fix(mechanics): Prevent weapons with `trigger radius` from triggering off of disabled fighters if the "disabled fighters avoid projectiles" gamerule is active

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2407,8 +2407,9 @@ void Engine::DoCollisions(Projectile &projectile)
 			for(const Body *body : inRadius)
 			{
 				const Ship *ship = reinterpret_cast<const Ship *>(body);
+				// Don't trigger off of carried ships that are disabled and not directly targeted.
 				if(body == projectile.Target() || (gov->IsEnemy(body->GetGovernment())
-						&& !ship->IsCloaked()))
+						&& !ship->IsCloaked() && FighterHitHelper::IsValidTarget(ship)))
 				{
 					collisions.emplace_back(nullptr, CollisionType::NONE, 0.);
 					break;


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Collisions with the blast radius of a weapon with `trigger radius` are counted as `CollisionType::NONE`. However, the check for whether a disabled fighter should be able to be hit or not relies on the collision type being `SHIP`. This PR pre-emptively checks if a body within a projectile's trigger radius is a disabled fighter while the "disabled fighters avoid projectiles" gamerule is active, preventing it from counting as a collision if so.

## Testing Done
Yes.
