### PR TITLE
feat(ui): Move the Player Info button on the Planet Panel up to between the Job Board and Bank

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -1510,9 +1510,50 @@ interface "planet"
 	box "content"
 		from -240 80 to 240 320
 	
+	visible if "has trade"
+	sprite "ui/planet dialog button"
+		center -340 90
+	button t "_Trading"
+		center -340 90
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible if "has job board"
+	sprite "ui/planet dialog button"
+		center -340 145
+	button j "_Job Board"
+		center -340 145
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible
+	sprite "ui/planet dialog button"
+		center -340 200
+	button i "Player _Info"
+		center -340 200
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible if "has bank"
+	sprite "ui/planet dialog button"
+		center -340 255
+	button b "_Bank"
+		center -340 255
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible if "has port"
 	sprite "ui/planet dialog button"
 		center -340 310
-	button i "Player _Info"
+	"dynamic button" p "port name"
 		center -340 310
 		dimensions 140 40
 		size 18
@@ -1539,15 +1580,6 @@ interface "planet"
 		align right
 		pad 10 0
 	
-	visible if "has job board"
-	sprite "ui/planet dialog button"
-		center -340 145
-	button j "_Job Board"
-		center -340 145
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
 	visible if "can hire crew"
 	sprite "ui/planet dialog button"
 		center 340 200
@@ -1558,37 +1590,7 @@ interface "planet"
 		align right
 		pad 10 0
 	
-	visible if "has trade"
-	sprite "ui/planet dialog button"
-		center -340 90
-	button t "_Trading"
-		center -340 90
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
-	
-	visible if "has bank"
-	sprite "ui/planet dialog button"
-		center -340 200
-	button b "_Bank"
-		center -340 200
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
-	
-	visible if "has port"
-	sprite "ui/planet dialog button"
-		center -340 255
-	"dynamic button" p "port name"
-		center -340 255
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
 	visible
-	
 	active if "has ship"
 	sprite "ui/planet dialog button"
 		center 340 310
@@ -1613,9 +1615,50 @@ interface "planet (small screen)"
 	box "content"
 		from -300 80 to 180 320
 	
+	visible if "has trade"
+	sprite "ui/planet dialog button"
+		center -400 90
+	button t "_Trading"
+		center -400 90
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible if "has job board"
+	sprite "ui/planet dialog button"
+		center -400 145
+	button j "_Job Board"
+		center -400 145
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible
+	sprite "ui/planet dialog button"
+		center -400 200
+	button i "Player _Info"
+		center -400 200
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible if "has bank"
+	sprite "ui/planet dialog button"
+		center -400 255
+	button b "_Bank"
+		center -400 255
+		dimensions 140 40
+		size 18
+		align left
+		pad 10 0
+	
+	visible if "has port"
 	sprite "ui/planet dialog button"
 		center -400 310
-	button i "Player _Info"
+	"dynamic button" p "port name"
 		center -400 310
 		dimensions 140 40
 		size 18
@@ -1642,15 +1685,6 @@ interface "planet (small screen)"
 		align right
 		pad 10 0
 	
-	visible if "has job board"
-	sprite "ui/planet dialog button"
-		center -400 145
-	button j "_Job Board"
-		center -400 145
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
 	visible if "can hire crew"
 	sprite "ui/planet dialog button"
 		center 280 200
@@ -1661,37 +1695,7 @@ interface "planet (small screen)"
 		align right
 		pad 10 0
 	
-	visible if "has trade"
-	sprite "ui/planet dialog button"
-		center -400 90
-	button t "_Trading"
-		center -400 90
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
-	
-	visible if "has bank"
-	sprite "ui/planet dialog button"
-		center -400 200
-	button b "_Bank"
-		center -400 200
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
-	
-	visible if "has port"
-	sprite "ui/planet dialog button"
-		center -400 255
-	"dynamic button" p "port name"
-		center -400 255
-		dimensions 140 40
-		size 18
-		align left
-		pad 10 0
 	visible
-	
 	active if "has ship"
 	sprite "ui/planet dialog button"
 		center 280 310


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
I keep clicking on the Player Info button when I want to go to the Spaceport :(

This PR also moves around the planet panel definitions to reflect the order in which buttons appear on the panel, going from top-left to bottom-left, then to top-right to bottom-right.

## Screenshots
<img width="892" height="715" alt="image" src="https://github.com/user-attachments/assets/6b9ffd3c-ddc7-428d-8f20-6662e4fdb391" />
<img width="880" height="712" alt="image" src="https://github.com/user-attachments/assets/526d36c5-b600-4644-a184-846726926fba" />
<img width="899" height="718" alt="image" src="https://github.com/user-attachments/assets/349d558e-7d66-43a0-aa14-e06b8ee3ddf9" />
