### PR TITLE
fix(content): Buoys referring to bombings now only activate after the bombings

### DIFF
--- a/data/human/message buoys.txt
+++ b/data/human/message buoys.txt
@@ -289,7 +289,7 @@ mission "Message Buoy: Elnath"
 		"reputation: Republic" < 100
 	on offer
 		message
-			text "Message buoy to all ships: all inhabited installations in the Elnath system are restricted to employees of Lovelace Labs. Please refuel or repair in another system."
+			text "Message buoy to all ships: All inhabited installations in the Elnath system are restricted to employees of Lovelace Labs. Please refuel or repair in another system."
 		fail
 
 mission "Message Buoy: Occupied Greenrock"
@@ -329,7 +329,7 @@ mission "Message Buoy: beyond Farpoint"
 		has "previous system: Alnitak"
 	on offer
 		message
-			text "Message buoy to all ships: you have exited Republic-controlled space. Assistance from Navy vessels is limited beyond the system of Alnitak. It is recommended you return to Farpoint immediately."
+			text "Message buoy to all ships: You have exited Republic-controlled space. Assistance from Navy vessels is limited beyond the system of Alnitak. It is recommended you return to Farpoint immediately."
 		fail
 
 mission "Message Buoy: Megaparsec"


### PR DESCRIPTION
**Bug fix**
This PR addresses the bug described on discord

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Silly bene should have done more testing with his buoys PR. This should make the Geminus and Martini buoys work more accurately (i.e. not spoil the game for newcomers). Also modifies when they stop sending out hails and makes capitalisation after colons consistent.