### PR TITLE
Fix a crash when capturing mission NPCs

### DIFF
--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -455,7 +455,7 @@ bool NPC::Do(const ShipEvent &event, PlayerInfo &player, UI &ui, const Mission *
 			// displayed a second time below.
 			if(event.Type() & ShipEvent::CAPTURE)
 			{
-				shared_ptr copy = make_shared<Ship>(*ptr);
+				shared_ptr<Ship> copy = make_shared<Ship>(*ptr);
 				copy->SetUUID(ptr->UUID());
 				copy->Destroy();
 				shipEvents[copy.get()] = shipEvents[ptr.get()];


### PR DESCRIPTION
**Bug fix**

Thanks to @Saugia for discovering this.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a mission NPC ship is captured, a copy is made which the mission NPC object continues to own for the purposes of tracking events that have happened to it's ships. Previously, the copy was made as a raw pointer which was given to a shared pointer to manage after it had been marked as destroyed.
The recent change to enable more accurate attribution of kills involves created a shared pointer to a ship in `Ship::Destroy`, but this throws an exception if the object is already managed by a shared pointer. Since the copy has not been given to a shared pointer yet, this results in a crash when capturing a mission NPC.
This PR fixes this by ensuring that the `Ship` object is managed by a shared pointer for its whole life by creating it with `make_shared`.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Use the attached save file.
Take off.
Go to the Parakacha'a system (south-east).
Board a disabled Violin Spider (this should not be particularly difficult).
Attempt capture.
Attack.
Without this PR, crash.
With this PR, no crash.

## Save File
This save file can be used to test these changes (courtesy of @Saugia):
[Shin Tensus~original.txt](https://github.com/user-attachments/files/24996024/Shin.Tensus.original.txt)


## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Immeasurable
