### PR TITLE
Fix past-the-end dereference

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1508,7 +1508,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 	if(!gov || ship.GetPersonality().IsPacifist())
 		return FindNonHostileTarget(ship);
 
-	int64_t alliedStrength = allyStrength.find(ship.GetGovernment())->second;
+	int64_t alliedStrength = AllyStrength(ship.GetGovernment());
 
 	bool isYours = ship.IsYours();
 	if(isYours)


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When using `std::map::find`, if the requested key is not present in the map, the "past-the-end" iterator is returned. This iterator should not be dereferenced, and attempting to do so fails a debug assertion.
This PR fixes a case where this could happen by using an existing method for finding a particular item in the collection which already checks to ensure that the iterator can be dereferenced before dereferencing it, returning 0, otherwise.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Launch the game, use an executable built for Debug, not Release. (Only tested with clang.)
Load the attached save.
Take off.
Without this PR, debug assertion failed and crash.
With this PR, no problem.

## Save File
This save file can be used to test these changes (courtesy of @Saugia):
[Shin Tensus~original.txt](https://github.com/user-attachments/files/24996437/Shin.Tensus.original.txt)


## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
