### PR TITLE
feat(content): Raven tells the player to install a Scram Drive in FW Reconciliation 1B

### DIFF
--- a/data/human/free worlds 3 reconciliation.txt
+++ b/data/human/free worlds 3 reconciliation.txt
@@ -11,6 +11,22 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
+ship "Gunboat" "Gunboat (Raven)"
+	outfits
+		"Electron Beam" 2
+		"Electron Turret"
+		"Fission Reactor"
+		"Supercapacitor" 3
+		"D14-RN Shield Generator"
+		"Cooling Ducts"
+		"Fuel Pod" 3
+		"Outfits Expansion" 2
+		"A250 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Scram Drive"
+
+
+
 mission "FW Reconciliation 1"
 	name "Pick up Ijs from <planet>"
 	description "Bring Katya and Sawyer to <destination>, along with Raven's ship (the Eye of Horus), and pick up Ijs and his equipment for detecting atomic testing."
@@ -90,22 +106,6 @@ mission "FW Reconciliation 1"
 			`	You tell her that the last you heard, Ijs was helping to found a new university on <planet>. She says, "We should bring him with us. Raven, will you be traveling with us too?"`
 			`	"Yes," she says. "I'll tell my ship and crew to get ready."`
 				accept
-
-
-
-ship "Gunboat" "Gunboat (Raven)"
-	outfits
-		"Electron Beam" 2
-		"Electron Turret"
-		"Fission Reactor"
-		"Supercapacitor" 3
-		"D14-RN Shield Generator"
-		"Cooling Ducts"
-		"Fuel Pod" 3
-		"Outfits Expansion" 2
-		"A250 Atomic Thruster"
-		"A255 Atomic Steering"
-		"Scram Drive"
 
 
 


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
[It's the big 2026 and people still don't know what a scram drive is 😔](https://discord.com/channels/251118043411775489/308902312741568512/1467996824177741897)

More seriously, the FW Recon Mutiny missions are the first (and possibly only) time in the campaign where the scram drive goes from "really nice to have, but isn't mandatory" to "you will die a million times if you do not have it". Every other mission where you have to fly through enemy territory utilises at least some random spawning and have their fleets in the centre of the systems, meaning that, with enough tries, it's possible to eventually low-roll on enemy count and jump away at the edge of a system before an enemy can reach you.

FW Reconciliation 1C spawns four guaranteed fleets that follow the player through hyperjumps. Not only that, but you also have to escort Raven, preventing you from running away and taking out their faster and weaker ships before jumping.

This PR has Raven explicitly warn the player that they should install a scram drive before going to Mutiny if they don't already have a non-hyperdrive drive.

## Testing Done
It doesn't immediately break.

## Save File
This save file can be used to test these changes:
[An Archist~~previous-1.txt](https://github.com/user-attachments/files/25026561/An.Archist.previous-1.txt)