### PR TITLE
feat(mechanics): Have optical jamming affect a ship's effective mass instead of the raw lock chance

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -436,8 +436,8 @@ void Projectile::CheckLock(const Ship &target)
 			double rangeFraction = min(1., distance / jammingRange);
 			opticalJamming = (1. - rangeFraction) * opticalJamming;
 		}
-		double targetMass = target.Mass();
-		double weight = targetMass * targetMass * targetMass / 1e9 / (1. + opticalJamming);
+		double targetMass = target.Mass() / (1. + opticalJamming);
+		double weight = targetMass * targetMass * targetMass / 1e9;
 		double lockChance = weapon->OpticalTracking() * weight / (1. + weight);
 		double probability = lockChance / (RELOCK_RATE - (lockChance * RELOCK_RATE) + lockChance);
 		hasLock |= Check(probability, base);


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The optical tracking bonus for high-mass ships scales non-linearly: vessels that are around 1800 tons and above will all have similar tracking probabilities, since they're so close to 100% already. However, jamming works by directly reducing the raw tracking probability of a missile, meaning that, even though a ship like the Model 256 (~3200 tons) is twice as heavy as a Falcon (1800 tons), both will benefit nearly identical amounts from the same amount of jamming.

This PR makes optical jamming affect a ship's effective mass instead of it's raw lock chance. This means that super heavy ships will need more jamming than smaller, but still heavy ships, even if their lock chance before applying jamming is only a few percent apart.

## Testing Done
0