### PR TITLE
Professionalizing Human Miners

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -853,9 +853,12 @@ event "southern carriers 4"
 			"Lance (Gatling)" 4
 
 	fleet "Human Miners"
-		add variant 1
+		add variant 10
 			"Nest (Miner)"
 			"Barb (Miner)" 2
+		add variant 2
+			"Nest (Miner)" 2
+			"Barb (Miner)" 4
 
 event "initial deployment 4"
 	date 17 9 3014

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1011,6 +1011,14 @@ fleet "Human Miners"
 	personality
 		confusion 20
 		timid frugal mining harvests
+	variant 3
+		"Sparrow"
+	variant 2
+		"Fury"
+	variant 2
+		"Hawk"
+	variant 1
+		"Headhunter"
 	variant 5
 		"Sparrow (Miner)"
 	variant 5

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1011,48 +1011,37 @@ fleet "Human Miners"
 	personality
 		confusion 20
 		timid frugal mining harvests
-	variant 12
-		"Sparrow"
-	variant 7
-		"Sparrow (Miner)"
-	variant 1
-		"Fury"
-	variant 6
-		"Fury (Miner A)"
-	variant 3
-		"Fury (Miner B)"
-	variant 1
-		"Hawk"
-	variant 6
-		"Hawk (Miner A)"
-	variant 3
-		"Hawk (Miner B)"
-	variant 1
-		"Headhunter"
-	variant 3
-		"Headhunter (Miner A)"
-	variant 2
-		"Headhunter (Miner B)"
-	variant 3
-		"Star Barge (Miner)"
-	variant 2
-		"Freighter (Miner A)"
-	variant 2
-		"Freighter (Miner B)"
 	variant 5
+		"Sparrow (Miner)"
+	variant 5
+		"Fury (Miner)"
+	variant 5
+		"Hawk (Miner)"
+	variant 5
+		"Headhunter (Miner)"
+	variant 10
+		"Star Barge (Miner)"
+	variant 10
+		"Freighter (Miner)"
+	variant 10
 		"Sunder"
 		"Mining Drone" 2
-	variant 5
+	variant 10
 		"Sunder (Heavy)"
 		"Mining Drone" 2
-	variant
+	variant 10
 		"Aerie (Miner)"
-		"Dagger" 4
-	variant
-		"Aerie"
 		"Dagger (Miner)" 4
-	variant
+	variant 10
 		"Behemoth (Miner)"
+	variant 4
+		"Sunder" 2
+		"Mining Drone" 4
+	variant 2
+		"Aerie (Miner)" 2
+		"Dagger (Miner)" 8
+	variant 2
+		"Behemoth (Miner)" 2
 
 fleet "Small Free Worlds"
 	government "Free Worlds"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1609,26 +1609,7 @@ ship "Flivver" "Flivver (Racing)"
 
 
 
-ship "Freighter" "Freighter (Miner A)"
-	outfits
-		"Mining Laser Turret"
-		"Tractor Beam" 2
-
-		"Asteroid Scanner"
-		"nGVF-CC Fuel Cell"
-		"LP072a Battery Pack"
-		"D14-RN Shield Generator"
-
-		"Greyhound Plasma Thruster"
-		"Greyhound Plasma Steering"
-		"X1100 Ion Reverse Thruster"
-		"Scram Drive"
-	turret "Tractor Beam"
-	turret "Mining Laser Turret"
-	turret "Tractor Beam"
-
-
-ship "Freighter" "Freighter (Miner B)"
+ship "Freighter" "Freighter (Miner)"
 	outfits
 		"Mining Laser Turret" 2
 		"Tractor Beam"
@@ -1830,19 +1811,7 @@ ship "Fury" "Fury (Laser)"
 		"Hyperdrive"
 
 
-ship "Fury" "Fury (Miner A)"
-	outfits
-		"Heavy Laser" 2
-		"nGVF-CC Fuel Cell"
-		"Supercapacitor"
-		"D14-RN Shield Generator"
-		"Asteroid Scanner"
-		"X2700 Ion Thruster"
-		"X2200 Ion Steering"
-		"Hyperdrive"
-
-
-ship "Fury" "Fury (Miner B)"
+ship "Fury" "Fury (Miner)"
 	outfits
 		"Mining Laser" 2
 		"Energy Blaster" 2
@@ -1991,19 +1960,7 @@ ship "Hawk" "Hawk (Bomber)"
 		"Hyperdrive"
 
 
-ship "Hawk" "Hawk (Miner A)"
-	outfits
-		"Heavy Laser" 2
-		"S3 Thermionic"
-		"LP036a Battery Pack"
-		"D41-HY Shield Generator"
-		"Asteroid Scanner"
-		"A120 Atomic Thruster"
-		"A255 Atomic Steering"
-		"Hyperdrive"
-
-
-ship "Hawk" "Hawk (Miner B)"
+ship "Hawk" "Hawk (Miner)"
 	outfits
 		"Mining Laser" 2
 		
@@ -2065,19 +2022,7 @@ ship "Headhunter" "Headhunter (Hai)"
 		"Hyperdrive"
 
 
-ship "Headhunter" "Headhunter (Miner A)"
-	outfits
-		"Particle Cannon" 2
-		"NT-200 Nucleovoltaic"
-		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
-		"Asteroid Scanner"
-		"A250 Atomic Thruster"
-		"A375 Atomic Steering"
-		"Hyperdrive"
-
-
-ship "Headhunter" "Headhunter (Miner B)"
+ship "Headhunter" "Headhunter (Miner)"
 	outfits
 		"Mining Laser" 4
 		


### PR DESCRIPTION
# Making Human Miners More Professional

As of now the human miner fleet definition suggests, that space mining is done by a bunch of amateurs, which would be extremely unrealistic. Occasional miners, like many players at the beginning of their career, should represent only an insignificant part of mining operations. Instead, looking at the ship variants used in the `Human Miners` fleet definition and their relative frequency of appearance, only 50% of the miners are professionals (`Miner` and `Miner B` builds), 25% are semiprofessionals if at all (`Miner A`) with inadequate equipment, and 25% are amateurs (stock builds).

This PR shall professionalize the human miners by reducing the presence of amateurs/semiprofessionals which should not be as relevant as currently depicted. Hence, in a first step:
- All `Miner A` variants have been removed, and `Miner B` variants are made `Miner` variants in `data/human/variants.txt`
- The `Miner A` variants have been removed from the definition of `Human Miners` in `data/human/fleets.txt`.
- Stock variants occur at low frequency to take into account the amateurs.

Further, in `data/human/fleets.txt`:
- Amateurs occur at frequencies of 1 to 3, corresponding to their current frequency relative to each other.
- Interceptor professional miner variants should be rarer, hence they have been weighted with `5` each.
- Utility and freighter professional miner variants have been weighted with `10`.
- `Aerie + Digger (Miner)` and `Aerie (Miner) + Dagger` are united to `Aerie (Miner) + Digger (Miner)`
- Additionally miner pairs are introduced, being a fifth as frequent as their correspondent single miner brethren.

The `Nest (Miner) + Barb (Miner)` variant in `data/human/'campaign events.txt'` has been adjusted correspondingly.

(Also it helps plugin writers to add new miners more consistently.)

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Performance Impact
Removes objectively unnecessary variant definitions, and unifies the variant frequency definitions, so might save some tiny fraction of time even.