### PR TITLE
fix(ui): Correctly display travel plan during jump

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1099,10 +1099,7 @@ void MapPanel::DrawTravelPlan()
 				continue;
 			}
 
-			if(it->IsEnteringHyperspace())
-				fuel[it.get()] = it->FuelBeforeHyperspacing();
-			else
-				fuel[it.get()] = it->FuelLevel();
+			fuel[it.get()] = it->FuelLevel() + it->FuelUsedForHyperspacing();
 			hasEscort |= (it.get() != flagship);
 		}
 	stranded |= !hasEscort;

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1099,7 +1099,10 @@ void MapPanel::DrawTravelPlan()
 				continue;
 			}
 
-			fuel[it.get()] = it->Fuel() * it->Attributes().Get("fuel capacity");
+			if(it->IsEnteringHyperspace())
+				fuel[it.get()] = it->FuelBeforeHyperspacing();
+			else
+				fuel[it.get()] = it->FuelLevel();
 			hasEscort |= (it.get() != flagship);
 		}
 	stranded |= !hasEscort;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2421,9 +2421,10 @@ bool Ship::IsUsingJumpDrive() const
 	return (hyperspaceSystem || hyperspaceCount) && isUsingJumpDrive;
 }
 
-double Ship::FuelBeforeHyperspacing() const
+// Get the fuel already used for an ongoing hyperspace movement
+double Ship::FuelUsedForHyperspacing() const
 {
-	return fuelBeforeHyperspacing;
+	return hyperspaceFuelCost * Ship::GetHyperspacePercentage() / 100;
 }
 
 // Check if this ship is allowed to land on this planet, accounting for its personality.
@@ -4565,7 +4566,6 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 		SetSystem(hyperspaceSystem);
 		hyperspaceSystem = nullptr;
 		targetSystem = nullptr;
-		fuelBeforeHyperspacing = 0.;
 		// Check if the target planet is in the destination system or not.
 		const Planet *planet = (targetPlanet ? targetPlanet->GetPlanet() : nullptr);
 		if(!planet || planet->IsWormhole() || !planet->IsInSystem(currentSystem))
@@ -4767,7 +4767,6 @@ void Ship::DoInitializeMovement()
 		pair<JumpType, double> jumpUsed = navigation.GetCheapestJumpType(hyperspaceSystem);
 		isUsingJumpDrive = (jumpUsed.first == JumpType::JUMP_DRIVE);
 		hyperspaceFuelCost = jumpUsed.second;
-		fuelBeforeHyperspacing = fuel;
 	}
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2421,7 +2421,10 @@ bool Ship::IsUsingJumpDrive() const
 	return (hyperspaceSystem || hyperspaceCount) && isUsingJumpDrive;
 }
 
-
+double Ship::FuelBeforeHyperspacing() const
+{
+	return fuelBeforeHyperspacing;
+}
 
 // Check if this ship is allowed to land on this planet, accounting for its personality.
 bool Ship::IsRestrictedFrom(const Planet &planet) const
@@ -4562,6 +4565,7 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 		SetSystem(hyperspaceSystem);
 		hyperspaceSystem = nullptr;
 		targetSystem = nullptr;
+		fuelBeforeHyperspacing = 0.;
 		// Check if the target planet is in the destination system or not.
 		const Planet *planet = (targetPlanet ? targetPlanet->GetPlanet() : nullptr);
 		if(!planet || planet->IsWormhole() || !planet->IsInSystem(currentSystem))
@@ -4763,6 +4767,7 @@ void Ship::DoInitializeMovement()
 		pair<JumpType, double> jumpUsed = navigation.GetCheapestJumpType(hyperspaceSystem);
 		isUsingJumpDrive = (jumpUsed.first == JumpType::JUMP_DRIVE);
 		hyperspaceFuelCost = jumpUsed.second;
+		fuelBeforeHyperspacing = fuel;
 	}
 }
 

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -307,8 +307,8 @@ public:
 	int GetHyperspacePercentage() const;
 	// Check if this ship is hyperspacing, specifically via a jump drive.
 	bool IsUsingJumpDrive() const;
-	// Fuel level before hyperspacing: only well-defined while entering hyperspace
-	double FuelBeforeHyperspacing() const;
+	// Fuel already used for ongoing hyperspace movement
+	double FuelUsedForHyperspacing() const;
 	// Check if this ship is currently able to enter hyperspace to it target.
 	bool IsReadyToJump(bool waitingIsReady = false) const;
 	// Check if this ship is allowed to land on this planet, accounting for its personality.
@@ -737,7 +737,6 @@ private:
 	const System *hyperspaceSystem = nullptr;
 	bool isUsingJumpDrive = false;
 	double hyperspaceFuelCost = 0.;
-	double fuelBeforeHyperspacing = 0.;
 	Point hyperspaceOffset;
 
 	// The hull may spring a "leak" (venting atmosphere, flames, blood, etc.)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -307,6 +307,8 @@ public:
 	int GetHyperspacePercentage() const;
 	// Check if this ship is hyperspacing, specifically via a jump drive.
 	bool IsUsingJumpDrive() const;
+	// Fuel level before hyperspacing: only well-defined while entering hyperspace
+	double FuelBeforeHyperspacing() const;
 	// Check if this ship is currently able to enter hyperspace to it target.
 	bool IsReadyToJump(bool waitingIsReady = false) const;
 	// Check if this ship is allowed to land on this planet, accounting for its personality.
@@ -735,6 +737,7 @@ private:
 	const System *hyperspaceSystem = nullptr;
 	bool isUsingJumpDrive = false;
 	double hyperspaceFuelCost = 0.;
+	double fuelBeforeHyperspacing = 0.;
 	Point hyperspaceOffset;
 
 	// The hull may spring a "leak" (venting atmosphere, flames, blood, etc.)


### PR DESCRIPTION
closes #7904

**Bug fix**

This PR addresses the bug/feature described in issue #7904.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This corrects the potentially wrong (color) display of the travel plan during a jump.

This is done by `Ship` providing the fuel level before the jump during a jump and using this in that situation in `MapPanel`.

Without this, fuel will already start to be consumed while the system is not changed yet, resulting in potentially the wrong color for the last leg(s) of the plan when opening the `MapPanel` during the jump.

This change only affects visuals, and only the TravelPlan drawn in the MapPanel.

One alternative, as mentioned in the linked issue, would be to reconstruct the pre-jump fuel level in MapPanel. This would avoid a new variable and a new function. However, this would violate separation of concerns and might create problems if the internal fuel depletion mid-jump is ever changed.

An alternative avoiding a new variable would be to provide a function in `Ship` that would reconstruct the pre-jump fuel level from the current fuel level and mid-jump progress. However, I decided against that too, because it would also duplicate the existing fuel-depletion code (just reversed), and while better (inside `Ship` and not `MapPanel`) it would make the code unnecessarily complex.


## Testing Done
I tested this by opening the map panel mid-jump for various scenarios.

## Performance Impact
This adds one private `double` and one public function to obtain the value of that double to the `Ship` class. The impact on performance should be minimal.
