### PR TITLE
feat(balance): Reduce optical jamming values to a tenth of their current value

### DIFF
--- a/data/avgi/avgi outfits.txt
+++ b/data/avgi/avgi outfits.txt
@@ -42,7 +42,7 @@ outfit "Concealment Lamina"
 	"anchor point" -1
 	"scan interference" 6
 	"radar jamming" 12
-	"optical jamming" 12
+	"optical jamming" 1.2
 	"solar heat" 6
 	description "A specialized coating of quantum dot phased array antennas, grown molecule by molecule, forms a conformal film capable of interfering with and jamming any attempts to scan or detect a ship. Working in aggregate, the phased array can be used to jam the sensors of missiles from further away, or even blind them with a low-power beam. However, the density of quantum dots required to produce these effects considerably increases the amount of sunlight absorbed by a ship using Concealment Laminae, and such an advanced material does not come cheap."
 	description "	Laminae take advantage of special external hardpoints built into most Avgi ships, allowing them to be mounted without taking up any outfit space. However, they also tend to increase the amount of heat absorbed from the local star."

--- a/data/avgi/avgi weapons.txt
+++ b/data/avgi/avgi weapons.txt
@@ -182,7 +182,7 @@ outfit "Green Optical Laser"
 	"outfit space" -6
 	"weapon capacity" -6
 	"turret mounts" -1
-	"optical jamming" 6
+	"optical jamming" .6
 	"lasing power" -1
 	weapon
 		"hardpoint sprite" "hardpoint/green optical laser"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -517,7 +517,7 @@ outfit "Hai Cuttlefish Jammer"
 	thumbnail "outfit/hai jammer"
 	"mass" 10
 	"outfit space" -7
-	"optical jamming" 15
+	"optical jamming" 1.5
 	"energy consumption" .8
 	description "When the Hai first started fighting each other, the need for a counter to Trackers quickly became apparent. The Cuttlefish Jammer can noticeably disturb a Tracker's lock to the ship by presenting it with a seemingly better, albeit illusory, target. This jammer is most effective on larger ships that cannot field enough anti-missiles to effectively counter missiles from all directions."
 
@@ -529,7 +529,7 @@ outfit "Hai Octopus Jammer"
 	thumbnail "outfit/hai jammer overclocked"
 	"mass" 10
 	"outfit space" -7
-	"optical jamming" 20
+	"optical jamming" 2
 	"energy consumption" 1.2
 	description "The Octopus Jammer is a more aggressive adaptation of the Cuttlefish Jammer, intended for short raids by the Unfettered. With several safety circuits bypassed, it is able to more effectively deceive incoming Trackers, but the much higher associated energy cost makes any ship carrying this even more vulnerable to ion weaponry."
 

--- a/data/vyrmeid/vyrmeid.txt
+++ b/data/vyrmeid/vyrmeid.txt
@@ -117,7 +117,7 @@ outfit "Boomerang Organ"
 	"mass" 10
 	"outfit space" 10
 	"radar jamming" 30
-	"optical jamming" 20
+	"optical jamming" 2
 	"energy capacity" 100
 	"energy generation" 1
 	"heat generation" 0.5


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Optical jamming numbers are too high currently. The strength of jamming scales with range, linearly decreasing until it reaches max distance at `500. + sqrt(jamming) * 500.`. After accounting for distance, the effective mass of a ship is then divided by `(1. + opticalJamming)`. A Shield Beetle (2669 tons) with one (1) Hai Cuttlefish Jammer (15 optical jamming) at a range of 1200 would have its perceived mass reduced to around 11.7% percent, or 312 tons. (A Grasshopper is 305 tons.)

This PR divides all optical jamming numbers by 10. A single Cuttlefish Jammer at a range of 556 now reduces perceived mass to 57.1%, two Cuttlefish at range 683 reduce mass to 40% and three Cuttlefish at range 780 reduce it to 30.8%. Swapping those Cuttlefish out for Hai Octopus Jammers (originally 20 optical jamming, now 2) gets you down to 25% effective mass at range 862. A stock Difraktos (1968 tons) will have its raw optical tracking probability when facing an Aberrant Spiker at range 637 reduced from 79.6% to 37.6% thanks to optical jamming, as opposed to being reduced to 0.09% with the jamming values in the game currently.