### PR TITLE
fix(mechanics): Untie confusion probability from weapon range

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -48,8 +48,10 @@ namespace {
 		if(!jamming)
 			return Random::Real() > tracking;
 		else
+		{
 			jamming = sqrt(jamming) * RangeFraction(distance, jamming);
 			return Random::Real() > tracking / (1. + jamming);
+		}
 	}
 }
 


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, the function for calculating the chance of a missile going haywire when under the affects of jamming uses the range of the firing weapon:
```
return Random::Real() > (tracking * distance) / (sqrt(jamming) * weaponRange);
```
This breaks if the weapon in question has a range of zero, such as the activated stage of a Finisher or Orchid.

This PR makes the power of jamming in relation to confusing missiles scale the same way it does against tracking, removing weapon range from the equation entirely.

## Testing Done
Flew around and shot a bit.

## Performance Impact
Zero.
