### PR TITLE
feat(balance): Heavy Rocket Launchers fire in `stream` instead of `cluster` & other changes

### DIFF
--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -870,10 +870,10 @@ ship "Carrier" "Carrier (Mark II)"
 
 ship "Clipper" "Clipper (Heavy)"
 	outfits
-		"Heavy Rocket Pod" 2
-		"Heavy Rocket" 4
-		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Heavy Rocket Launcher" 2
+		"Heavy Rocket" 40
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 14
 		"RT-I Radiothermal"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
@@ -2031,11 +2031,11 @@ ship "Hawk" "Hawk (Plasma)"
 
 ship "Hawk" "Hawk (Rocket)"
 	outfits
-		"Heavy Rocket Pod" 2
-		"Heavy Rocket" 4
+		"Heavy Rocket Launcher" 2
+		"Heavy Rocket" 40
 		"RT-I Radiothermal"
 		"Supercapacitor" 2
-		"D41-HY Shield Generator"
+		"D14-RN Shield Generator"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1596,7 +1596,7 @@ outfit "Heavy Rocket Launcher"
 		"shield damage" 790
 		"hull damage" 670
 		"hit force" 900
-		"missile strength" 16
+		"missile strength" 24
 	description "Heavy Rockets are one of the most powerful missile weapons available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 	description "	Ammunition for this weapon can be restocked at any outfitter."
 		to display
@@ -1636,7 +1636,7 @@ outfit "Heavy Rocket Pod"
 		"shield damage" 790
 		"hull damage" 670
 		"hit force" 900
-		"missile strength" 16
+		"missile strength" 24
 	description "Heavy Rockets are one of the most powerful missile weapons available, but at a price: instead of having a homing system, they simply fire straight forward and rely on a proximity trigger to set them off. Once triggered, however, they damage all ships within their blast radius, making them highly effective against clusters of fighters."
 	description "	Pods enable fighters and other light craft to carry small quantities of rockets into battle while retaining enough space for other weapons. Large ships are better off with full-size launchers."
 	description "	Ammunition for this weapon can be restocked at any outfitter."


### PR DESCRIPTION
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
If the Heavy Rocket is meant to be an anti-fighter weapon, it would be more effective with `stream` instead of `cluster`. `cluster` is more useful when you need to maximise burst damage and push missiles through anti-missile, two things that are largely irrelevant for fighting low health, turretless fighters. Using `stream` also makes misses less punishing, because instead of wasting multiple rockets and needing to wait for the full reload, you only lose one rocket and can fire a second one shortly afterward.

The Heavy Rocket Pod has not been altered in this PR due to #1273.

Other changes:
- Increased the missile strength of Heavy Rockets to compensate for how they're easier to shoot down.
- Swapped double Heavy Rocket Pods on some ships to double Heavy Rocket Launchers. The addition of `stream` makes Heavy Rocket Launchers much less likely to cause an instant death compared to Heavy Rocket Pods, since you'll only be shot by a single rocket at a time.