### PR TITLE
fix(typo): Changed a plural to a singular & added a missing comma

### DIFF
--- a/data/coalition/heliarch intro.txt
+++ b/data/coalition/heliarch intro.txt
@@ -1534,7 +1534,7 @@ mission "Heliarch Containment 4-B"
 	on offer
 		conversation
 			`Hundreds of Heliarch agents pour out of the three Kimek transports, rushing in groups to separate parts of the city. They march in unison, weapons in hand. From the reactions of the locals, it's clear they were neither expecting such a thing, nor are they happy with the agents going about the city in that manner.`
-			`	When the last of the Heliarchs leave the transports, one of the Kimek captains informs you that you should now head to <destination> to meet with Consul Plortub, collect your payment of <payment>, and to "avoid getting caught in any potential retaliation."`
+			`	When the last of the Heliarchs leave the transports, one of the Kimek captains informs you that you should now head to <destination> to meet with Consul Plortub, collect your payment of <payment>, and "avoid getting caught in any potential retaliation."`
 				accept
 	on accept
 		"assisting heliarchy" ++


### PR DESCRIPTION
**Typo fixes**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixed a whopping two typos in the same sentence in the mission "Heliarch Containment 4-B".
"inform" -> "informs" (Because there is only one Kimek captain informing you.)
"meet with Consul Plortub" -> "meet with Consul Plortub," (Added a missing comma because it is part of a list of reasons to go to \<destination\> and should be seperated as such.)

## Testing Done
none
