### PR TITLE
fix(gamerules): Properly update gamerule changes applied to new pilots

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -257,6 +257,7 @@ void PlayerInfo::New(const StartConditions &start, const Gamerules &gamerules)
 	RegisterDerivedConditions();
 	start.GetConditions().Apply();
 	this->gamerules.Replace(gamerules);
+	GameData::SetGamerules(&this->gamerules);
 
 	// Generate missions that will be available on the first day.
 	CreateMissions();


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described by Terin on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When creating a new pilot, I wasn't giving GameData a pointer to the new pilot's gamerules, so changes to the gamerules wouldn't be applied until after the pilot was reloaded.

## Testing Done
Yes