### PR TITLE
refactor(code): Remove redundant default GameRules cached pointer

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -89,7 +89,6 @@ namespace {
 	Set<Person> defaultPersons;
 	TextReplacements defaultSubstitutions;
 
-	const Gamerules *defaultGamerules = nullptr;
 	const Gamerules *activeGamerules = nullptr;
 
 	Politics politics;
@@ -265,8 +264,7 @@ void GameData::FinishLoading()
 	defaultPersons = objects.persons;
 	defaultSubstitutions = objects.substitutions;
 
-	defaultGamerules = objects.gamerulesPresets.Get("Default");
-	activeGamerules = defaultGamerules;
+	activeGamerules = objects.gamerulesPresets.Get("Default");
 	playerGovernment = objects.governments.Get("Escort");
 
 	politics.Reset();
@@ -442,7 +440,8 @@ void GameData::Revert()
 	objects.wormholes.Revert(defaultWormholes);
 	objects.persons.Revert(defaultPersons);
 	objects.substitutions.Revert(defaultSubstitutions);
-	activeGamerules = defaultGamerules;
+
+	activeGamerules = objects.gamerulesPresets.Get("Default");
 
 	for(auto &it : objects.persons)
 		it.second.Restore();
@@ -1037,7 +1036,9 @@ const TextReplacements &GameData::GetTextReplacements()
 
 const Gamerules &GameData::GetGamerules()
 {
-	assert(activeGamerules != nullptr && "activeGamerules may not be nullptr");
+	if(!activeGamerules)
+		activeGamerules = objects.gamerulesPresets.Get("Default");
+
 	return *activeGamerules;
 }
 
@@ -1052,8 +1053,7 @@ void GameData::SetGamerules(const Gamerules *gamerules)
 
 const Gamerules &GameData::DefaultGamerules()
 {
-	assert(defaultGamerules != nullptr && "defaultGamerules may not be nullptr");
-	return *defaultGamerules;
+	return *(objects.gamerulesPresets.Get("Default"));
 }
 
 


### PR DESCRIPTION
**Refactor**

This PR removes an (apparent) redundant pointer for default gamerules that seemed to be introduced in #11630

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The pointer that was added didn't seem very different from the Default gamerules in the UniverseObjects, so if they both simply point to exactly the same data, then we can probably just use the UniverseObjects version anywhere we need such data.

(I don't have a lot of experience with the recent GameRules modifications, so if I overlooked something important around this pointer, then please feel free to provide that as review feedback on this PR.)

## Testing Done
Checked compilation and did a short test-flight.

## Save File
N/A

## Wiki Update
N/A

## Performance Impact
None expected. (Gamerules are not loaded often.)