### PR TITLE
feat(preference): Add a preference for controlling the ammo refill prompt in the outfitter

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1628,8 +1628,12 @@ tip "Save message log"
 tip "Block screen saver"
 	`Whether your monitor should be able to dim and turn off or change to the screen saver while the game is open.`
 
-tip "Auto refill ammo in outfitter"
-	`Controls the ammo refill behavior when you enter the outfitter. If "always," ammo will be automatically refilled if you have the credits for it. If "ask," you will be prompted to refill any missing ammunition upon entering the outfitter. If "never," you will have to manually refill your ammunition.`
+tip "Auto refill ammo"
+	`Controls the ammo refill behavior when you enter the outfitter.`
+	`- "always": ammo will be automatically refilled if you have the credits for it.`
+	`- "when free": ammo will be automatically refill only if it doesn't cost you anything, such as when you have spare ammo in cargo or storage.`
+	`- "ask": you will be prompted to refill any missing ammunition upon entering the outfitter.`
+	`- "never": you will have to manually refill your ammunition.`
 
 tip "Title bar theme"
 	`Choose the theme of the title bar, or leave "system default" to use system settings. (Available on Windows 10 or newer; on Windows 10, the game window must be resized or restarted in order for the change to take effect.)`

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -1158,7 +1158,7 @@ void OutfitterPanel::CheckRefill()
 	}
 	if(!needed.empty() && cost < player.Accounts().Credits())
 	{
-		if(refillPref == Preferences::AmmoRefill::ASK)
+		if(refillPref == Preferences::AmmoRefill::ASK || (cost && refillPref == Preferences::AmmoRefill::WHEN_FREE))
 		{
 			string message = "Do you want to reload all the ammunition for your ship";
 			message += (count == 1) ? "?" : "s?";

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -184,7 +184,7 @@ namespace {
 	const vector<string> TRIBUTE_CONFIRMATION_SETTINGS = {"off", "friendly only", "always"};
 	int tributeConfirmationIndex = 1;
 
-	const vector<string> AMMO_REFILL_SETTINGS = {"always", "ask", "never"};
+	const vector<string> AMMO_REFILL_SETTINGS = {"never", "ask", "when free", "always"};
 	int ammoRefillIndex = 1;
 
 	const string BLOCK_SCREEN_SAVER = "Block screen saver";

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -147,8 +147,9 @@ public:
 	};
 
 	enum class AmmoRefill : int_fast8_t {
-		NEVER,
+		NEVER = 0,
 		ASK,
+		WHEN_FREE,
 		ALWAYS
 	};
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -92,7 +92,7 @@ namespace {
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
 	const string BLOCK_SCREEN_SAVER = "Block screen saver";
 	const string TRIBUTE_CONFIRMATION = "Tribute confirmation";
-	const string AMMO_REFILL = "Auto refill ammo in outfitter";
+	const string AMMO_REFILL = "Auto refill ammo";
 #ifdef _WIN32
 	const string TITLE_BAR_THEME = "Title bar theme";
 	const string WINDOW_ROUNDING = "Window rounding";


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This resolves an issue discussed during today's campfire chat. Currently, the ammo refill dialog shows up whenever you have space for ammo and the credits to pay for it upon entering the outfitter. It was noted during the campfire chat that this behavior can be annoying.

This PR adds a new preference, "Ammo refill in outfitter", that controls the behavior of this dialog. It has the following options:
* `manual`: The prompt never appears upon entering the dialog.
* `ask`: The prompt appears if you have room for ammo and the credits to pay for it. (Default behavior, same as right now.)
* `auto`: If the prompt would have appeared, it automatically refills your ammo without asking.

## Testing Done

Yes.

<img width="930" height="590" alt="image" src="https://github.com/user-attachments/assets/9b74bcde-1d57-43e9-8779-9d078bcdfac0" />
