### PR TITLE
feat(ui): Display messages for transferred fuel and energy during boarding

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -463,7 +463,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 				if(!victim->JumpsRemaining() && you->CanRefuel(*victim))
 				{
 					double fuelTransferred = you->TransferFuel(victim->JumpFuelMissing(), &*victim);
-					if(fuelTransferred >= 1)
+					if(fuelTransferred >= 1.)
 						messages.push_back(Format::Number(fuelTransferred, 0) + " fuel has been transferred.");
 				}
 				player.AddShip(victim);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1859,7 +1859,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 		{
 			helped = true;
 			double fuelTransferred = TransferFuel(victim->JumpFuelMissing(), victim.get());
-			if(fuelTransferred >= 1)
+			if(fuelTransferred >= 1.)
 			{
 				if(isYours)
 					Messages::Add({Format::Number(fuelTransferred, 0) + " fuel transferred from your "
@@ -1877,7 +1877,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 			helped = true;
 			double toGive = max(attributes.Get("energy capacity") * 0.1, victim->Attributes().Get("energy capacity") * 0.2);
 			double energyTransferred = TransferEnergy(max(200., toGive), victim.get());
-			if(energyTransferred >= 1)
+			if(energyTransferred >= 1.)
 			{
 				if(isYours)
 					Messages::Add({Format::Number(energyTransferred, 0) + " energy transferred from your "
@@ -1902,7 +1902,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 	// If the boarding ship is the player, they will choose what to plunder.
 	// Always take fuel and energy if you can.
 	double fuelTransferred = victim->TransferFuel(victim->fuel, this);
-	if(fuelTransferred >= 1)
+	if(fuelTransferred >= 1.)
 	{
 		if(isYours)
 			Messages::Add({Format::Number(fuelTransferred, 0) + " fuel siphoned from the "
@@ -1914,7 +1914,7 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 				GameData::MessageCategories().Get("normal")});
 	}
 	double energyTransferred = victim->TransferEnergy(victim->energy, this);
-	if(energyTransferred >= 1)
+	if(energyTransferred >= 1.)
 	{
 		if(isYours)
 			Messages::Add({Format::Number(energyTransferred, 0) + " energy siphoned from the "


### PR DESCRIPTION
**UI**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This resolves an issue discussed during today's campfire chat. Someone asked for the ability to take fuel from ships when you board them. This is actually already something that occurs automatically, but it can be easy to miss if you aren't looking at your fuel gauge the moment you board a ship.

This PR changes it so that when fuel or energy are transferred during boarding, a message is displayed. This includes within the boarding panel when you successfully capture a ship and transfer fuel to your new ship.

## Testing Done

Yes.

Being assisted by a friendly:
<img width="457" height="56" alt="image" src="https://github.com/user-attachments/assets/d06a7729-5080-4764-b881-837f39152aa7" />

Boarding a hostile:
<img width="434" height="59" alt="image" src="https://github.com/user-attachments/assets/6845da22-d84a-4de9-a085-9f9e850eec44" />

Boarding panel after a successful capture:
<img width="764" height="472" alt="image" src="https://github.com/user-attachments/assets/c1faca97-af93-4f09-8c2c-713b420ce2b4" />
