### PR TITLE
feat(ui): Play sound effect when pausing

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2203,12 +2203,12 @@ void Engine::HandleKeyboardInputs()
 
 	if(keyDown.Has(Command::PAUSE))
 	{
-		UI::PlaySound(UI::UISound::NORMAL);
 		timePaused = !timePaused;
 		if(timePaused)
 			Audio::Pause();
 		else
 			Audio::Resume();
+		UI::PlaySound(UI::UISound::NORMAL);
 	}
 }
 


### PR DESCRIPTION

**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR plays the default click sound upon hitting the pause button. I've accidentally pressed it while flying around before, and if I didn't know about pausing, the lack of any feedback makes it feel like a hard freeze of the game.

Was considering a noticeable visual component of this as well, like a pulse effect on the side of the screen, but that might be a bit much and more difficult to implement, while the audio effect is already a big improvement.

## Testing Done
Paused multiple times while in flight, noticed the sound effect playing while pausing and unpausing, while hearing no difference in the other effects being interrupted.

## Performance Impact
N/A
