### PR TITLE
feat(ui): Don't blink the map marker for deadline missions that have already failed

### DIFF
--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -218,7 +218,7 @@ pair<bool, bool> MapPanel::BlinkMissionIndicator(const PlayerInfo &player, const
 {
 	bool blink = false;
 	int daysLeft = 1;
-	if(mission.Deadline())
+	if(mission.Deadline() && !mission.IsFailed())
 	{
 		daysLeft = player.RemainingDeadline(mission);
 		int blinkFactor = min(6, max(1, daysLeft));


### PR DESCRIPTION
**UI**

This PR addresses the issue described by alquimistablanco on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Currently, bounty missions "fail" after you destroy the target and immediately give you your payment. Bounty missions also have a deadline, meaning that the map marker for the mission blinks. A failed mission's map marker will remain on the map until you land to clear the mission.

Since the blinking map marker is intended to create a sense of urgency, but there is no urgency for a failed mission, this PR changes it so that failed missions with a deadline no longer blink their map marker.

(I think long term that bounties should use "complete anywhere" behavior instead of failing, but this change should happen regardless.)

## Testing Done

Yes.