### PR TITLE
style(code): Standardize style of const pointers

### DIFF
--- a/source/Files.cpp
+++ b/source/Files.cpp
@@ -94,11 +94,11 @@ namespace {
 
 
 
-void Files::Init(const char * const *argv)
+void Files::Init(const char *const *argv)
 {
 	// Parse the command line arguments to see if the user has specified
 	// different directories to use.
-	for(const char * const *it = argv + 1; *it; ++it)
+	for(const char *const *it = argv + 1; *it; ++it)
 	{
 		string arg = *it;
 		if((arg == "-r" || arg == "--resources") && *++it)

--- a/source/Files.h
+++ b/source/Files.h
@@ -28,7 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // be completely platform-agnostic.
 class Files {
 public:
-	static void Init(const char * const *argv);
+	static void Init(const char *const *argv);
 
 	// The game's installation directory, or whichever directory was passed on the command line via `--resources`
 	static const std::filesystem::path &Resources();

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -374,7 +374,7 @@ void GameData::Preload(TaskQueue &queue, const Sprite *sprite)
 	map<const Sprite *, int>::iterator pit = preloaded.find(sprite);
 	if(pit != preloaded.end())
 	{
-		for(pair<const Sprite * const, int> &it : preloaded)
+		for(pair<const Sprite *const, int> &it : preloaded)
 			if(it.second < pit->second)
 				++it.second;
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -259,7 +259,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 		int day = player.GetDate().DaysSinceEpoch();
 		for(const auto &it : player.Cargo().Outfits())
 		{
-			const Outfit * const outfit = it.first;
+			const Outfit *const outfit = it.first;
 			const int64_t &amount = it.second;
 			if(outfit->Get("minable") <= 0. && !sellOutfits)
 				continue;

--- a/source/shader/BatchDrawList.cpp
+++ b/source/shader/BatchDrawList.cpp
@@ -86,7 +86,7 @@ void BatchDrawList::Draw() const
 {
 	BatchShader::Bind();
 
-	for(const pair<const Sprite * const, vector<float>> &it : data)
+	for(const pair<const Sprite *const, vector<float>> &it : data)
 		BatchShader::Add(it.first, it.second);
 
 	BatchShader::Unbind();


### PR DESCRIPTION
**Style**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
If you want to have a const pointer (not a pointer to a const type, but one that is const itself), you can write either `*const` or `* const`. Currently we have examples of both styles: there are 38 uses of `*const`, and 6 of `* const`. This PR unifies the style so the more common form becomes the new standard.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/220