### PR TITLE
fix(crash): Fix crash caused by generating entering/transition missions when you have no active missions

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2470,12 +2470,12 @@ void PlayerInfo::CreateEnteringMissions()
 				availableEnteringMissions.pop_back();
 			else
 			{
-				hasPriorityMissions |= missions.back().HasPriority();
-				nonBlockingMissions += missions.back().IsNonBlocking();
+				hasPriorityMissions |= availableEnteringMissions.back().HasPriority();
+				nonBlockingMissions += availableEnteringMissions.back().IsNonBlocking();
 			}
 		}
 
-	SortMissions(availableMissions, hasPriorityMissions, nonBlockingMissions);
+	SortMissions(availableEnteringMissions, hasPriorityMissions, nonBlockingMissions);
 }
 
 
@@ -2494,12 +2494,12 @@ void PlayerInfo::CreateTransitionMissions()
 				availableTransitionMissions.pop_back();
 			else
 			{
-				hasPriorityMissions |= missions.back().HasPriority();
-				nonBlockingMissions += missions.back().IsNonBlocking();
+				hasPriorityMissions |= availableTransitionMissions.back().HasPriority();
+				nonBlockingMissions += availableTransitionMissions.back().IsNonBlocking();
 			}
 		}
 
-	SortMissions(availableMissions, hasPriorityMissions, nonBlockingMissions);
+	SortMissions(availableTransitionMissions, hasPriorityMissions, nonBlockingMissions);
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12242.

This one's a bit of a doozy.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The functions for generating entering or transition missions are looking at the wrong list when determining if the freshly added mission is priority or non-blocking. This means that if you do not have any active missions and the next mission that gets offered is an `entering` or `transition` mission, your game will crash.

## Testing Done

This change gives good vibes. I don't need to test it.