### PR TITLE
fix: Update the help message about help messages

### DIFF
--- a/data/_ui/messages.txt
+++ b/data/_ui/messages.txt
@@ -129,7 +129,7 @@ message "basics 2"
 	text `For the main menu, press <Show main menu>. The control key bindings can be viewed and changed in the preferences.`
 
 message "basics 3"
-	text `To see a help message again, press <Show help>. To see all help messages again, go to the main menu, select Preferences, then go to Settings. Navigate to page three, then select "Reactivate first-time help."`
+	text `To see a help message again, press <Show help>. To see all help messages again, go to the main menu, select Preferences, go to Settings, then locate and select "Reactivate first-time help."`
 
 message "map received"
 	text "You received a map of nearby systems."


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
#12042 moved the help reset option to the third page of preferences, but the help message telling the player about this option wasn't updated there.