### PR TITLE
Turn off hyperspace flash, camera acceleratio, nand landing zoom by default

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -206,7 +206,6 @@ void Preferences::Load()
 	settings["Show stored outfits on map"] = true;
 	settings["Show planet labels"] = true;
 	settings["Show asteroid scanner overlay"] = true;
-	settings["Show hyperspace flash"] = true;
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
 	settings["Animate main menu background"] = true;


### PR DESCRIPTION
**Change**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Camera acceleration and landing zoom are currently on by default.
This is terrible.
No one will start the playing the game and be put off by the lack of these features. People will be put off by the presence of these features.
It may be easy enough to turn them off, but the list of settings is kind of long, it may not be obvious to a new player what settings they need to change, and someone who is looking for a low friction experience may not even bother looking. The default settings should be acceptable to as many users as possible, and again, no one, or at least, not many people, will find these settings being off unacceptable, but many more people will find them being on to be unacceptable.
I haven't looked at the PRs that added the features recently, but at least part of the argument for having them on by default was that people who might like them may not find them to turn them off, and people who dislike them can turn them off. As I mentioned before, people who dislike them may just close the game forever.

Also turns the hyperspace flash off by default. Does anyone who knows it can be turned off leave it on?

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
None.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
