### PR TITLE
feat(refactor): add command line prng seed

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -50,6 +50,9 @@ prints (to STDOUT) a list of available tests, usable for automatic test runs. Th
 .IP \fB\-\-nomute
 prevents muting the game when running tests.
 
+.IP \fB\-c,\ \-\-rngseed\ <number>
+seeds the pseudo random number generators with the given seed. This should only be used for debugging and profiling and is meant to increase repeatability during those activities. This will likely not help repeatability in between different systems and environments, and thus, not help reproducing someone else's bug.
+
 .IP \fB\-s,\ \-\-ships
 prints (to STDOUT) a table of ship stats (just the base stats, not considering any stored outfits). This option prevents the game from launching.
 .RS

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -50,8 +50,8 @@ prints (to STDOUT) a list of available tests, usable for automatic test runs. Th
 .IP \fB\-\-nomute
 prevents muting the game when running tests.
 
-.IP \fB\-c,\ \-\-rngseed\ <number>
-seeds the pseudo random number generators with the given seed. This should only be used for debugging and profiling and is meant to increase repeatability during those activities. This will likely not help repeatability in between different systems and environments, and thus, not help reproducing someone else's bug.
+.IP \fB\-c,\ \-\-rngseed\ <seed>
+every time the pseudo-random number generator is seeded, it will be given this value.
 
 .IP \fB\-s,\ \-\-ships
 prints (to STDOUT) a table of ship stats (just the base stats, not considering any stored outfits). This option prevents the game from launching.

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -39,7 +39,9 @@ namespace {
 #endif
 }
 
-
+// Initialize the seed override to false: only use this if explicitly enabled
+bool Random::useFixedSeed = false;
+uint64_t Random::fixedSeed = 0;
 
 // Seed the generator (e.g. to make it produce exactly the same random
 // numbers it produced previously).
@@ -48,7 +50,15 @@ void Random::Seed(uint64_t seed)
 #ifndef __linux__
 	lock_guard<mutex> lock(workaroundMutex);
 #endif
-	gen.seed(seed);
+	gen.seed(useFixedSeed ? fixedSeed : seed);
+}
+
+
+
+Random::Random()
+{
+	if(useFixedSeed)
+		Seed(fixedSeed);
 }
 
 

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -37,11 +37,10 @@ namespace {
 	thread_local uniform_real_distribution<double> real;
 	thread_local normal_distribution<double> normal;
 #endif
-}
 
-// Initialize the seed override to false: only use this if explicitly enabled
-bool useFixedSeed = false;
-uint64_t fixedSeed = 0;
+	bool useFixedSeed = false;
+	uint64_t fixedSeed = 0;
+}
 
 void Random::SetFixedSeed(uint64_t seed)
 {

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -40,8 +40,14 @@ namespace {
 }
 
 // Initialize the seed override to false: only use this if explicitly enabled
-bool Random::useFixedSeed = false;
-uint64_t Random::fixedSeed = 0;
+bool useFixedSeed = false;
+uint64_t fixedSeed = 0;
+
+void Random::SetFixedSeed(uint64_t seed)
+{
+	useFixedSeed = true;
+	fixedSeed = seed;
+}
 
 // Seed the generator (e.g. to make it produce exactly the same random
 // numbers it produced previously).

--- a/source/Random.cpp
+++ b/source/Random.cpp
@@ -42,11 +42,7 @@ namespace {
 	uint64_t fixedSeed = 0;
 }
 
-void Random::SetFixedSeed(uint64_t seed)
-{
-	useFixedSeed = true;
-	fixedSeed = seed;
-}
+
 
 // Seed the generator (e.g. to make it produce exactly the same random
 // numbers it produced previously).
@@ -60,10 +56,10 @@ void Random::Seed(uint64_t seed)
 
 
 
-Random::Random()
+void Random::SetFixedSeed(uint64_t seed)
 {
-	if(useFixedSeed)
-		Seed(fixedSeed);
+	useFixedSeed = true;
+	fixedSeed = seed;
 }
 
 

--- a/source/Random.h
+++ b/source/Random.h
@@ -26,8 +26,7 @@ class Random {
 public:
 	// Used to override any seed, especially also to always set a seed;
 	// to make runs reproducible (always get the same random numbers)
-	static bool useFixedSeed;
-	static uint64_t fixedSeed;
+	static void SetFixedSeed(uint64_t seed);
 	// Seed the generator (e.g. to make it produce exactly the same random
 	// numbers it produced previously).
 	static void Seed(uint64_t seed);

--- a/source/Random.h
+++ b/source/Random.h
@@ -24,10 +24,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // random number generation is not thread-safe.)
 class Random {
 public:
-  // Used to override any seed, especially also to always set a seed;
-  // to make runs reproducible (always get the same random numbers)
-  static bool useFixedSeed;
-  static uint64_t fixedSeed;
+	// Used to override any seed, especially also to always set a seed;
+	// to make runs reproducible (always get the same random numbers)
+	static bool useFixedSeed;
+	static uint64_t fixedSeed;
 	// Seed the generator (e.g. to make it produce exactly the same random
 	// numbers it produced previously).
 	static void Seed(uint64_t seed);

--- a/source/Random.h
+++ b/source/Random.h
@@ -24,9 +24,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // random number generation is not thread-safe.)
 class Random {
 public:
+  // Used to override any seed, especially also to always set a seed;
+  // to make runs reproducible (always get the same random numbers)
+  static bool useFixedSeed;
+  static uint64_t fixedSeed;
 	// Seed the generator (e.g. to make it produce exactly the same random
 	// numbers it produced previously).
 	static void Seed(uint64_t seed);
+	Random();
 
 	static uint32_t Int();
 	static uint32_t Int(uint32_t modulus);

--- a/source/Random.h
+++ b/source/Random.h
@@ -24,13 +24,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // random number generation is not thread-safe.)
 class Random {
 public:
-	// Used to override any seed, especially also to always set a seed;
-	// to make runs reproducible (always get the same random numbers)
+	// After this method runs, Seed will discard its argument and reseed the prng with the value given here.
 	static void SetFixedSeed(uint64_t seed);
 	// Seed the generator (e.g. to make it produce exactly the same random
 	// numbers it produced previously).
 	static void Seed(uint64_t seed);
-	Random();
 
 	static uint32_t Int();
 	static uint32_t Int(uint32_t modulus);

--- a/source/Random.h
+++ b/source/Random.h
@@ -24,11 +24,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // random number generation is not thread-safe.)
 class Random {
 public:
-	// After this method runs, Seed will discard its argument and reseed the prng with the value given here.
-	static void SetFixedSeed(uint64_t seed);
 	// Seed the generator (e.g. to make it produce exactly the same random
 	// numbers it produced previously).
 	static void Seed(uint64_t seed);
+	// After this method runs, Seed will discard its argument and reseed the prng with the value given here.
+	static void SetFixedSeed(uint64_t seed);
 
 	static uint32_t Int();
 	static uint32_t Int(uint32_t modulus);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "Random.h"
 #include "audio/Audio.h"
 #include "Command.h"
 #include "Conversation.h"
@@ -146,6 +147,11 @@ int main(int argc, char *argv[])
 			printTests = true;
 		else if(arg == "--nomute")
 			noTestMute = true;
+		else if(arg == "--rngseed" && *++it)
+		{
+			Random::useFixedSeed = true;
+			Random::fixedSeed = std::stoull(*it);
+		}
 	}
 	printData = PrintData::IsPrintDataArgument(argv);
 	Files::Init(argv);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -148,10 +148,7 @@ int main(int argc, char *argv[])
 		else if(arg == "--nomute")
 			noTestMute = true;
 		else if(arg == "--rngseed" && *++it)
-		{
-			Random::useFixedSeed = true;
-			Random::fixedSeed = std::stoull(*it);
-		}
+			Random::SetFixedSeed(std::stoull(*it));
 	}
 	printData = PrintData::IsPrintDataArgument(argv);
 	Files::Init(argv);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -624,6 +624,7 @@ void PrintHelp()
 	cerr << "    --tests: print table of available tests, then exit." << endl;
 	cerr << "    --test <name>: run given test from resources directory." << endl;
 	cerr << "    --nomute: don't mute the game while running tests." << endl;
+	cerr << "    --rng-seed <seed>: every time the pseudo-random number generator is seeded, it will be given this value." << nedl;
 	PrintData::Help();
 	cerr << endl;
 	cerr << "Report bugs to: <https://github.com/endless-sky/endless-sky/issues>" << endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -624,7 +624,7 @@ void PrintHelp()
 	cerr << "    --tests: print table of available tests, then exit." << endl;
 	cerr << "    --test <name>: run given test from resources directory." << endl;
 	cerr << "    --nomute: don't mute the game while running tests." << endl;
-	cerr << "    --rng-seed <seed>: every time the pseudo-random number generator is seeded, it will be given this value." << nedl;
+	cerr << "    --rng-seed <seed>: every time the pseudo-random number generator is seeded, it will be given this value." << endl;
 	PrintData::Help();
 	cerr << endl;
 	cerr << "Report bugs to: <https://github.com/endless-sky/endless-sky/issues>" << endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -624,7 +624,8 @@ void PrintHelp()
 	cerr << "    --tests: print table of available tests, then exit." << endl;
 	cerr << "    --test <name>: run given test from resources directory." << endl;
 	cerr << "    --nomute: don't mute the game while running tests." << endl;
-	cerr << "    --rng-seed <seed>: every time the pseudo-random number generator is seeded, it will be given this value." << endl;
+	cerr << "    --rng-seed <seed>: every time the pseudo-random number generator is seeded,"
+		" it will be given this value." << endl;
 	PrintData::Help();
 	cerr << endl;
 	cerr << "Report bugs to: <https://github.com/endless-sky/endless-sky/issues>" << endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "Random.h"
 #include "audio/Audio.h"
 #include "Command.h"
 #include "Conversation.h"
@@ -41,6 +40,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Plugins.h"
 #include "Preferences.h"
 #include "PrintData.h"
+#include "Random.h"
 #include "Screen.h"
 #include "image/SpriteSet.h"
 #include "shader/SpriteShader.h"


### PR DESCRIPTION
Add optional command line option --rngseed which takes an integer as argument and uses this to seed the pseudo random number generator used in Random.* . The default (no seeding done) is not changed.

The intend is to make debugging more predictable, especially profiling. With this change and when specifying a seed, and least in my environment, especially integration tests seem to be reproducible, at least for repeated executions of the same executable in the same environment.

This is important when measuring the effect changes to the code which might (or should) influence in-game performance. Without this change, integration tests will always start with a different system setup, resulting in different outcomes/battles/asteroids, affecting runtime too much. This could still be worked with, but only using *a lot* of runs to get those statistical errors down. With this change, the game at least has the chance to play out the same way (given some conditions, like not changing the number of prngs being used), and thus, creates a much faster dev-cycle. However: once happy, improvements still have to be confirmed either without seed or with different seeds.

Future readers: this at the moment also in part hinges on the "lucky" fact that, while TaskQueue provides some level of parallelism to the game, which for repeatability in general is difficult, either the parallelism in TaskQueue does not matter (e. g., while loading images), or the potential parallelism in TaskQueue is currently not used, especially during the main game loop where prngs come in. Here, at least atm, TaskQueue is used, but only ever with one thread active at a time, in a defined round-robin manner. Thus, while each thread has a different prng state, since the order of tasks is fixed, as is the order in which they are handed to the threads, this by chance plays out.

Note that this is not meant to be used while actually playing, but only a debugging help, especially while profiling. Also note, that repeatability breaks down for a different number of threads, but also potentially between different builds or environments. Specifically, it will likely not help reproducing someone else's bug.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

