### PR TITLE
feat(profiling): add "linux-profile" build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ cmake_dependent_option(ES_STEAM "Build the game for the Steam Linux runtime" OFF
 cmake_dependent_option(ES_USE_SYSTEM_LIBRARIES "Use system libraries instead of the vcpkg ones." ON "APPLE OR ES_STEAM" OFF)
 cmake_dependent_option(ES_CREATE_BUNDLE "Create a Bundle instead of an executable. Not suitable for development purposes." OFF APPLE OFF)
 
-# Support Debug and Release configurations.
-set(CMAKE_CONFIGURATION_TYPES "Debug" "Release" CACHE STRING "" FORCE)
+# Support Debug, Release, and Profile configurations.
+set(CMAKE_CONFIGURATION_TYPES "Debug" "Release" "Profile" CACHE STRING "" FORCE)
 
 # Use C++20 without any compiler specific extensions.
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
@@ -161,8 +161,14 @@ if(NOT WIN32)
 		list(APPEND SANITIZER_OPTS "-fno-omit-frame-pointer" "-fsanitize=leak,vptr")
 	endif()
 endif()
-target_compile_options(EndlessSkyLib PUBLIC $<$<CONFIG:Debug>:${SANITIZER_OPTS}>)
-target_link_options(EndlessSkyLib PUBLIC $<$<CONFIG:Debug>:${SANITIZER_OPTS}>)
+# Enable some debug symbols, but no sanitizers on profiling builds, as those typically clash
+# with profiling libraries
+set(PROFILER_OPTS "-g")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	list(APPEND PROFILER_OPTS "-fno-omit-frame-pointer")
+endif()
+target_compile_options(EndlessSkyLib PUBLIC $<$<CONFIG:Debug>:${SANITIZER_OPTS}>$<$<CONFIG:Profiler>:${PROFILER_OPTS}>)
+target_link_options(EndlessSkyLib PUBLIC $<$<CONFIG:Debug>:${SANITIZER_OPTS}>$<$<CONFIG:Profiler>:${PROFILER_OPTS}>)
 
 # The 'mingw32' lib needs to be linked first.
 if(MINGW)
@@ -171,7 +177,7 @@ endif()
 
 # Link with the general libraries.
 target_link_libraries(ExternalLibraries INTERFACE SDL2::SDL2 PNG::PNG JPEG::JPEG avif
-	OpenAL::OpenAL ${MINIZIP_LIBRARIES} FLAC::FLAC++ "$<IF:$<CONFIG:Debug>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
+	OpenAL::OpenAL ${MINIZIP_LIBRARIES} FLAC::FLAC++ "$<IF:$<OR:$<CONFIG:Debug>,$<CONFIG:Profile>>,${LIBMAD_LIB_DEBUG},${LIBMAD_LIB_RELEASE}>")
 
 # Link the needed OS-specific dependencies, if any.
 if(WIN32)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -371,6 +371,11 @@
 			"configuration": "Release"
 		},
 		{
+			"name": "profile",
+			"hidden": true,
+			"configuration": "Profile"
+		},
+		{
 			"name": "ci",
 			"hidden": true,
 			"configuration": "Release",
@@ -391,6 +396,12 @@
 			"displayName": "Release",
 			"configurePreset": "linux",
 			"inherits": "release"
+		},
+		{
+			"name": "linux-profile",
+			"displayName": "Profile",
+			"configurePreset": "linux",
+			"inherits": "profile"
 		},
 		{
 			"name": "linux-gles-debug",


### PR DESCRIPTION
add a "Profiling" build type besides "Release" and "Debug", and adding the corresponding "linux-profile" target. The main reason is that both already existing targets are not sufficient for profiling or do not work at all:

- release: does not use "-g" and thus, leaves out important information for profiling. Adding "-g" to release would be an option, but would increase binary size to no benefit for most people.
- debug: adds sanitizer library options. This is an issue, because some profilers use the same techniques (overloading system calls) and thus, provoke runtime errors from the sanitizer libraries about not being called first. Those errors are not wrong, but they also prevent running the game with such a profiler (hpctoolkit is such an example). Not using sanitizers for debug builds would work, but I presume they are there for good reason, and thus, this isn't an option either.

Aside from those compiler options, usage is exactly the same as with either release or debug:

```
cmake --preset linux
cmake --build --preset linux-profile
```

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.
