### PR TITLE
Support animated hazes

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -36,6 +36,17 @@ Body::Body(const Sprite *sprite, Point position, Point velocity, Angle facing, d
 
 
 
+Body::Body(const Drawable &base, Point position, Point velocity, Angle facing, double zoom)
+	: Drawable(base)
+{
+	this->zoom = zoom;
+	this->position = position;
+	this->velocity = velocity;
+	this->angle = facing;
+}
+
+
+
 // Constructor, based on the animation from another Body object.
 Body::Body(const Body &other, Point position, Point velocity, Angle facing, double zoom, Point scale, double alpha)
 	: Drawable(other, zoom, scale, alpha)

--- a/source/Body.h
+++ b/source/Body.h
@@ -34,6 +34,7 @@ public:
 	Body() = default;
 	Body(const Sprite *sprite, Point position, Point velocity = Point(), Angle facing = Angle(),
 		double zoom = 1., Point scale = Point(1., 1.), double alpha = 1.);
+	explicit Body(const Drawable &base, Point position = Point(), Point velocity = Point(), Angle facing = Angle(), double zoom = 1.);
 	Body(const Body &other, Point position, Point velocity = Point(), Angle facing = Angle(),
 		double zoom = 1., Point scale = Point(1., 1.), double alpha = 1.);
 

--- a/source/Body.h
+++ b/source/Body.h
@@ -34,7 +34,8 @@ public:
 	Body() = default;
 	Body(const Sprite *sprite, Point position, Point velocity = Point(), Angle facing = Angle(),
 		double zoom = 1., Point scale = Point(1., 1.), double alpha = 1.);
-	explicit Body(const Drawable &base, Point position = Point(), Point velocity = Point(), Angle facing = Angle(), double zoom = 1.);
+	explicit Body(const Drawable &base, Point position = Point(), Point velocity = Point(),
+		Angle facing = Angle(), double zoom = 1.);
 	Body(const Body &other, Point position, Point velocity = Point(), Angle facing = Angle(),
 		double zoom = 1., Point scale = Point(1., 1.), double alpha = 1.);
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1195,7 +1195,7 @@ void Engine::Draw() const
 	else
 		motionBlur *= baseBlur;
 
-	GameData::Background().Draw(motionBlur,
+	GameData::Background().Draw(motionBlur, step,
 		(player.Flagship() ? player.Flagship()->GetSystem() : player.GetSystem()));
 
 	static const Set<Color> &colors = GameData::Colors();

--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -847,7 +847,7 @@ void GameData::SetBackgroundPosition(const Point &position)
 
 
 
-void GameData::SetHaze(const Sprite *sprite, bool allowAnimation)
+void GameData::SetHaze(const Drawable &sprite, bool allowAnimation)
 {
 	background.SetHaze(sprite, allowAnimation);
 }

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -36,6 +36,7 @@ class Conversation;
 class DataNode;
 class DataWriter;
 class Date;
+class Drawable;
 class Effect;
 class Fleet;
 class FormationPattern;
@@ -178,7 +179,7 @@ public:
 	static void StepBackground(const Point &vel, double zoom = 1.);
 	static const Point &GetBackgroundPosition();
 	static void SetBackgroundPosition(const Point &position);
-	static void SetHaze(const Sprite *sprite, bool allowAnimation);
+	static void SetHaze(const Drawable &sprite, bool allowAnimation);
 
 	static const std::string &Tooltip(const std::string &label);
 	static std::string HelpMessage(const std::string &name);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -151,7 +151,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 			else if(key == "asteroids" || key == "minables")
 				asteroids.clear();
 			else if(key == "haze")
-				haze = nullptr;
+				haze = Drawable();
 			else if(key == "starfield density")
 				starfieldDensity = 1.;
 			else if(key == "ramscoop")
@@ -400,7 +400,7 @@ void System::Load(const DataNode &node, Set<Planet> &planets, const ConditionsSt
 		else if(key == "jump range")
 			jumpRange = max(0., child.Value(valueIndex));
 		else if(key == "haze")
-			haze = SpriteSet::Get(value);
+			haze.LoadSprite(child);
 		else if(key == "starfield density")
 			starfieldDensity = child.Value(valueIndex);
 		else if(key == "trade" && child.Size() >= 3)
@@ -958,7 +958,7 @@ const set<const Outfit *> &System::Payloads() const
 
 
 // Get the background haze sprite for this system.
-const Sprite *System::Haze() const
+const Drawable &System::Haze() const
 {
 	return haze;
 }

--- a/source/System.h
+++ b/source/System.h
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "Drawable.h"
 #include "Point.h"
 #include "RaidFleet.h"
 #include "RandomEvent.h"
@@ -164,7 +165,7 @@ public:
 	// Get a list of all unique payload outfits from minables in this system.
 	const std::set<const Outfit *> &Payloads() const;
 	// Get the background haze sprite for this system.
-	const Sprite *Haze() const;
+	const Drawable &Haze() const;
 
 	// Get the price of the given commodity in this system.
 	int Trade(const std::string &commodity) const;
@@ -252,7 +253,7 @@ private:
 	std::vector<StellarObject> objects;
 	std::vector<Asteroid> asteroids;
 	std::set<const Outfit *> payloads;
-	const Sprite *haze = nullptr;
+	Drawable haze;
 	std::vector<RandomEvent<Fleet>> fleets;
 	std::vector<RandomEvent<Hazard>> hazards;
 	double habitable = 1000.;

--- a/source/shader/StarField.cpp
+++ b/source/shader/StarField.cpp
@@ -51,7 +51,11 @@ namespace {
 	const double STAR_ZOOM = 0.70;
 	const double HAZE_ZOOM = 0.90;
 
-	const Drawable DEFAULT_HAZE = Drawable(SpriteSet::Get("_menu/haze"));
+	const Drawable &DefaultHaze()
+	{
+		static const Drawable result = Drawable(SpriteSet::Get("_menu/haze"));
+		return result;
+	}
 
 	void AddHaze(DrawList &drawList, const vector<Body> &haze,
 		const Point &topLeft, const Point &bottomRight, double transparency)
@@ -80,7 +84,7 @@ void StarField::Init(int stars, int width)
 	SetUpGraphics();
 	MakeStars(stars, width);
 
-	lastHaze = DEFAULT_HAZE;
+	lastHaze = DefaultHaze();
 	for(size_t i = 0; i < HAZE_COUNT; ++i)
 	{
 		Point next;
@@ -139,7 +143,7 @@ void StarField::SetHaze(Drawable newHaze, bool allowAnimation)
 {
 	// If no sprite is given, set the default one.
 	if(!newHaze.GetSprite())
-		newHaze = DEFAULT_HAZE;
+		newHaze = DefaultHaze();
 
 	for(Body &body : haze[0])
 		static_cast<Drawable>(body) = newHaze;

--- a/source/shader/StarField.h
+++ b/source/shader/StarField.h
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "../Drawable.h"
 #include "../Point.h"
 #include "Shader.h"
 
@@ -41,10 +42,10 @@ public:
 	void FinishLoading();
 	const Point &Position() const;
 	void SetPosition(const Point &position);
-	void SetHaze(const Sprite *sprite, bool allowAnimation);
+	void SetHaze(Drawable newHaze, bool allowAnimation);
 
 	void Step(Point vel, double zoom = 1.);
-	void Draw(const Point &blur, const System *system = nullptr) const;
+	void Draw(const Point &blur, int step = 0, const System *system = nullptr) const;
 
 
 private:
@@ -70,7 +71,7 @@ private:
 	double clampSlope;
 
 	// Track the haze sprite, so we can animate the transition between different hazes.
-	const Sprite *lastSprite;
+	Drawable lastHaze;
 	mutable double transparency = 0.;
 	std::vector<Body> haze[2];
 


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Some of you may be surprised to learn that this is not already a thing.
This PR enables haze sprites to use multiple animated frames, and for the "haze" keyword in system definitions to have sprite animation properties as children, to modify the animation.

## Screenshots
Can't show an animation in a screenshot.

## Usage examples
```
system "Wherever"
    haze "whatever"
        "frame rate" 5
```

## Testing Done
It compiled.

## Save File
No.

## Artwork Checklist
N/A

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/221

## Performance Impact
Probably not enough to care about.
