### PR TITLE
feat(shaders): Allow disabling automatic GLSL version detection

### DIFF
--- a/source/shader/Shader.cpp
+++ b/source/shader/Shader.cpp
@@ -98,8 +98,8 @@ GLuint Shader::Compile(const char *str, GLenum type)
 
 	string contents(str);
 	if(contents.find("\n//autoversion off\n") == string::npos
-		&& !contents.starts_with("//autoversion off")
-		&& !contents.ends_with("//autoversion off"))
+		&& !contents.starts_with("//autoversion off\n")
+		&& !contents.ends_with("\n//autoversion off"))
 	{
 		static string version;
 		if(version.empty())


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Because MacOS's OpenGL implementation is broken, Endless Sky traditionally adds its own `#version` declaration with whatever value it gets from OpenGL. To maintain backward compatibility, this is still the default behavior, but you can now disable it by adding an `//autoversion off` line anywhere in the shader's contents. It's treated as a comment by the compiler, so it shouldn't conflict with any builtin GLSL feature.
Additionally, refactored the compilation function to replace `memcpy`ing with `std::string` operations and moved GLSL ES detection from runtime to compile-time via the `ES_GLES` macro.

## Wiki PR
https://github.com/endless-sky/endless-sky-wiki/pull/222

## Testing Done
The game starts.

## Performance Impact
None.
