### PR TITLE
fix: Missing Ojet firing force

### DIFF
--- a/data/successors/successor weapons.txt
+++ b/data/successors/successor weapons.txt
@@ -40,6 +40,7 @@ outfit `"Ojet" Bimodal Coilgun`
 		"reload" 30
 		"firing energy" 80
 		"firing heat" 120
+		"firing force" 25
 		# Because parent projectiles inherit the damage of their submunitions, we must subtract the total damage of all submunitions from the parent projectile to get the desired behavior (different damage profiles over different ranges).
 		"shield damage" -94
 		# 50 (parent) - 3*48 (child)


### PR DESCRIPTION
**Bug fix**
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds the same 25 `firing force` to the "Ojet" Bimodal Coilgun that its turreted variant already has.

## Testing Done
Works fine.