### PR TITLE
fix(crash): Guard against loading dimensions of sprites with no 1x dimension frames

### DIFF
--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -265,6 +265,9 @@ void ImageSet::LoadDimensions(Sprite *sprite) noexcept(false)
 	// Read only the first frame of the 1x resolution image in order to determine the dimensions of the sprite.
 	// (All frames are expected to have the same dimensions.)
 	size_t frames = paths[0].size();
+	// An ImageSet might exist for a sprite that only had 2x images defined, in which case it will have no frames.
+	if(!frames)
+		return;
 	buffer[0].Clear(frames);
 	int loadedFrames = buffer[0].Read(paths[0][0], 0, true);
 	if(!loadedFrames)


### PR DESCRIPTION
**Typo fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

If you have a 2x image for a sprite with no 1x image and that sprite uses deferred loading, the game will fail to load as a result of ImageSet::LoadDimensions attempting to load the 1x image dimensions where none exist.

## Testing Done

Yes.