### PR TITLE
fix: Don't call FinishLoading on undefined planets and ships

### DIFF
--- a/source/UniverseObjects.cpp
+++ b/source/UniverseObjects.cpp
@@ -98,7 +98,7 @@ void UniverseObjects::FinishLoading()
 
 	// And, update the ships with the outfits we've now finished loading.
 	for(auto &&it : ships)
-		if(!it.second.IsValid())
+		if(it.second.IsValid())
 			it.second.FinishLoading(true);
 	for(auto &&it : persons)
 		it.second.FinishLoading();


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

If your game refers to a ship that isn't defined, you'll get two errors in your logs for that ship. The first one is caused by Ship::FinishLoading, and the second is caused by UniverseObjects::CheckReferences. FinishLoading is called before CheckReferences, so the Ship doesn't know what its true model name is supposed to be if it isn't fully defined, as it isn't told what its true model name is until CheckReferences is called later on. This means that the warning logged by Ship::FinishLoading is completely useless.
```
2026-02-14 19:06:31 | W | ():
Defaulting missing "drag" attribute to 100.0
has outfits:
2026-02-14 19:06:32 | W | ship "Bactrian (Plasma Blaster Anti-Missile)" is referred to, but not fully defined.
```

This PR updates UniverseObjects::FinishLoading to not call Ship::FinishLoading on invalid ships. This prevents the extra useless error from being logged.

While I was here, I did the same thing with Planet::FinishLoading. It probably wouldn't cause any problems to call that on an invalid planet, but there's zero use in doing it too.

Of the other objects that have FinishLoading called on them in this function, persons and start conditions can't be referred to and minables are entirely harmless to load even if not defined, since all they do is iterate over their payload (which will be empty) to figure out what their total credit value is.

## Testing Done

Loaded the game with a plugin that referred to an undefined ship with and without this PR. With this PR, the extra warning isn't logged.