### PR TITLE
fix(ui): Correctly update zoom on sales maps

### DIFF
--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -81,6 +81,8 @@ MapSalesPanel::MapSalesPanel(const MapPanel &panel, bool isOutfitters)
 
 void MapSalesPanel::Step()
 {
+	MapPanel::Step();
+
 	loadingCircle.Step();
 	// Load any and deferred thumbnails that appear in the sales.
 	// This is done here instead of in the constructor because the constructor


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12267 (closes #12267).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a missing MapPanel::Step call needed to update the actual value of the animated zoom variable. MapDetailPanel already does that.

## Testing Done
yes.™

## Performance Impact
N/A
