### PR TITLE
feat(logging): Use a unique error message when a sprite's 2x frames are ignored because no 1x frames exist

### DIFF
--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -158,7 +158,7 @@ void ImageSet::ValidateFrames() noexcept(false)
 		{
 			if(paths[0].empty())
 				Logger::Log(prefix + "all frames for the " + specifier + " sprite will be ignored, "
-					"as it has no corresponding 1x frame(s).", Logger::Level::WARNING);
+					"as it has no corresponding normal resolution frame(s).", Logger::Level::WARNING);
 			else
 				Logger::Log(prefix + to_string(toResize.size() - paths[0].size())
 					+ " extra frame(s) for the " + specifier + " sprite will be ignored.", Logger::Level::WARNING);


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Ref: #12274 

Change the error log message that appears when there are no 1x frames from this:
`2026-02-15 17:32:01 | W | Sprite "land/beach16": 1 extra frames for the @2x sprite will be ignored.`
to this:
`2026-02-15 18:40:36 | W | Sprite "icon/beach16": all frames for the @2x sprite will be ignored, as it has no corresponding 1x frame(s).`

## Testing Done

Yes.