### PR TITLE
fix(content): In the Remnant Key Stone mission, account for if you obtained a Hai keystone without meeting the Hai

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -453,7 +453,7 @@ conversation "remnant key stones"
 		`	"No. The stone I have is one of a kind. I have not been able to find another like it."`
 			to display
 				"outfit (all): Quantum Keystone" == 1
-		`	"Sorry, but I can't say I do know where to find more of them."`
+		`	"Sorry, but I don't know where to find more of them."`
 	
 	`	The man raises an eyebrow. "Ah. Well, we have explored all of the Ember Waste, but have been unable to find any large concentrations of these stones, especially none that look like yours.`
 		goto explore


### PR DESCRIPTION
**Bug Fix**

This PR addresses an issue reported by lookacat on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The Remnant Key Stone mission has two variants: one where you know of the Hai and one where you do not. A problem with this is that these missions are determining if you know about the Hai based off of your ownership of a Hai Quantum Keystone, when there are ways to get your hands on a Quantum Keystone other than directly from the Hai, such as from the Cosmic Devil during the Deep: Scientist Rescue missions.

This PR updates these missions to actually check if you have made contact with the Hai instead of just assuming that your ownership of a Quantum Keystone means you know them.

## Testing Done

No.

## Save File

Want me to make one?