### PR TITLE
fix(text replacements): Replace `<origin>` with the source system for in-flight missions that aren't offered by a ship

### DIFF
--- a/data/drak/drak culture conversations.txt
+++ b/data/drak/drak culture conversations.txt
@@ -90,7 +90,7 @@ mission "Drak Revelations: Korath"
 		has "Efreti: Distress Call 7: done"
 	on offer
 		conversation
-			`Just as your ship reaches Mesuket, you blink, and are no longer in your cockpit.`
+			`Just as your ship reaches <origin>, you blink, and are no longer in your cockpit.`
 			`	On a rocky plateau, gravel and sand make up the base for structures being built by bulky, vaguely humanoid figures made of dirt and rust. A strong light shines down from above, illuminating the area.`
 			`	You feel as though time is rapidly progressing. As the months and years go by, the creatures build taller and grander towers, both elevating themselves and gradually blocking away the light. Eventually the entire plateau serves as the footing for a great domed tower.`
 			`	The light creeps in faintly by cracks and gaps, but those are being swiftly patched by the creatures, who seem to hiss at the light in disapproval. They begin heating up and glowing, hotter and hotter, until they cast off their dirty shells, taking forms of shiny, blazing bronze.`

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1640,6 +1640,8 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 		subs["<origin>"] = player.GetPlanet()->DisplayName();
 	else if(boardingShip)
 		subs["<origin>"] = boardingShip->GivenName();
+	else if(player.GetSystem())
+		subs["<origin>"] = player.GetSystem()->DisplayName();
 	subs["<planet>"] = result.destination ? result.destination->DisplayName() : "";
 	subs["<system>"] = result.destination ? result.destination->GetSystem()->DisplayName() : "";
 	subs["<destination>"] = subs["<planet>"] + " in the " + subs["<system>"] + " system";


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported by adversarius on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This `<origin>` replacement doesn't get used, as `<origin>` only ever gets replaced with the name of the planet that the mission offered on, or the name of the ship that you boarded for `boarding` and `assisting` missions.
<img width="573" height="373" alt="image" src="https://github.com/user-attachments/assets/a314db96-0b94-4251-8dc3-564c6dc26968" />

This PR changes it so that `<origin>` now also uses the name of the source system for `entering` and `transition` missions.

## Testing Done

No.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/224