### PR TITLE
fix(ui): Always show the player's cargo space on the boarding panel

### DIFF
--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -185,15 +185,18 @@ void BoardingPanel::Draw()
 
 	// This should always be true, but double check.
 	int crew = 0;
-	if(you && canCapture)
+	if(you)
 	{
-		crew = you->Crew();
 		info.SetString("cargo space", to_string(you->Cargo().Free()));
-		info.SetString("your crew", to_string(crew));
-		info.SetString("your attack",
-			Format::Number(attackOdds.AttackerPower(crew), 1, false));
-		info.SetString("your defense",
-			Format::Number(defenseOdds.DefenderPower(crew), 1, false));
+		if(canCapture)
+		{
+			crew = you->Crew();
+			info.SetString("your crew", to_string(crew));
+			info.SetString("your attack",
+				Format::Number(attackOdds.AttackerPower(crew), 1, false));
+			info.SetString("your defense",
+				Format::Number(defenseOdds.DefenderPower(crew), 1, false));
+		}
 	}
 	int vCrew = victim ? victim->Crew() : 0;
 	if(victim && (canCapture || victim->IsYours()))


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1473015961589125131).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
What the title says.

## Testing Done
none.

## Performance Impact
N/A
