### PR TITLE
feat(enhancement): Allow weapons to exclude submunition damage in their main projectile's damage

### DIFF
--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -117,6 +117,8 @@ void Weapon::Load(const DataNode &node)
 		}
 		else if(key == "triggers nuke alert")
 			triggersNukeAlert = true;
+		else if(key == "exclude submunition damage")
+			includeSubmunitionDamage = false;
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")
@@ -622,8 +624,9 @@ double Weapon::TotalDamage(int index) const
 		calculatedDamage = true;
 		for(int i = 0; i < DAMAGE_TYPES; ++i)
 		{
-			for(const auto &it : submunitions)
-				damage[i] += it.weapon ? it.weapon->TotalDamage(i) * it.count : 0.;
+			if(includeSubmunitionDamage)
+				for(const auto &it : submunitions)
+					damage[i] += it.weapon ? it.weapon->TotalDamage(i) * it.count : 0.;
 			doesDamage |= (damage[i] > 0.);
 		}
 	}

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -254,6 +254,10 @@ private:
 	std::map<const Effect *, int> targetEffects;
 	std::map<const Effect *, int> dieEffects;
 	std::vector<Submunition> submunitions;
+	// Whether the damage dealt by this weapon's submunitions are
+	// included in the damage of its projectiles when colliding
+	// with a target.
+	bool includeSubmunitionDamage = true;
 
 	bool isStreamed = false;
 	bool isSafe = false;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Currently, the damage of the submunitions of a weapon are added to the damage of the main projectile if the main projectile collides with something. This means that if we want to have a weapon whose first stage does a specific amount of damage less than the sum of all the submunitions, we need to give the main projectile negative damage. This feels somewhat silly to me. Therefore, I've added the following new tag to `weapon` nodes:
- `"exclude submunition damage"`: if present, projectiles created by this weapon do not include the sum of the damage of all submunitions.

## Usage examples

The following ship would explode, deal ion damage to everything within 100 units, and (with #12288) spray 100 fragmentation projectiles that travel 200 units from the explosion center that only deal shield and hull damage. The damage of the submunitions would NOT be included in the main 100 unit radius explosion due to the `"exclude submunition damage"` tag being present.
```
ship "Pineapple"
	...
	weapon
		"ion damage" 1000
		"blast radius" 100
		"exclude submunition damage"
		"submunitions" "fragmentation" 100
	...

outfit "fragmentation"
	weapon
		sprite "projectile/blaster"
		"inaccuracy" 180
			uniform
		"velocity" 20
		"lifetime" 10
		"hull damage" 50
		"shield damage" 50
		"hit force" 50
```

## Testing Done

None.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/227