### PR TITLE
docs: Fix formatting of Homebrew install command in developer md

### DIFF
--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -51,7 +51,7 @@ Endless Sky requires precompiled libraries to compile and play: [Download link](
 Install [Homebrew](https://brew.sh). Once it is installed, use it to install the tools and libraries you will need:
 
 ```bash
-$ brew install cmake ninja mad libpng jpeg-turbo sdl2 minizip libavif catch2 flac
+brew install cmake ninja mad libpng jpeg-turbo sdl2 minizip libavif catch2 flac
 ```
 
 **Note**: If you are on Apple Silicon (and want to compile for ARM), make sure that you are using ARM Homebrew!


### PR DESCRIPTION
**Documentation**

This PR removes a `$` preceding the homebrew dependency install command in the bash md code block

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removed a `$` preceding the homebrew install command.

## Performance Impact
Makes for easy and accurate copying into a terminal.
