### PR TITLE
fix(segfault): Properly report the collision type of a phasing weapon's target

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2431,7 +2431,8 @@ void Engine::DoCollisions(Projectile &projectile)
 			Point offset = projectile.Position() - target->Position();
 			double range = target->GetMask(step).Collide(offset, projectile.Velocity(), target->Facing());
 			if(range < 1.)
-				collisions.emplace_back(target.get(), CollisionType::SHIP, range);
+				collisions.emplace_back(target.get(),
+					projectile.IsTargetingShip() ? CollisionType::SHIP : CollisionType::MINABLE, range);
 		}
 	}
 	else

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -425,6 +425,13 @@ void Projectile::BreakTarget()
 
 
 
+bool Projectile::IsTargetingShip() const
+{
+	return targetIsShip;
+}
+
+
+
 // TODO: add more conditions in the future. For example maybe proximity to stars
 // and their brightness could could cause IR missiles to lose their locks more
 // often, and dense asteroid fields could do the same for radar and optically

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -96,6 +96,8 @@ public:
 	std::shared_ptr<Entity> TargetPtr() const;
 	// Clear the targeting information on this projectile.
 	void BreakTarget();
+	// Whether the target of this projectile is a ship.
+	bool IsTargetingShip() const;
 
 	// Get the distance that this projectile has traveled.
 	double DistanceTraveled() const;


### PR DESCRIPTION
**Bug fix**

Closes #12299.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Engine::DoCollision currently assumes that if a phasing weapon is targeting something, that the target is a ship, therefore recording the CollisionType of hitting the target as SHIP, which later causes the Body that was collided with to be cast to a Ship. It is not possible though for the Projectile::Target(Ptr) function to return a Minable. This PR updates DoCollision to properly report the collision type 

## Testing Done

Tested using an Arfecta with asteroid scanners to target and attack a minable asteroid. With this PR, it doesn't crash.
I will note that Gridfires currently do no damage to minables. No idea why, but it's a separate bug.

## Save File

See the linked issue.
