### PR TITLE
fix(collision detection): Properly record the impact position of a projectile in its ImpactInfo

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -387,7 +387,7 @@ Projectile::ImpactInfo Projectile::GetInfo(double intersection) const
 {
 	// Account for the distance that this projectile traveled before intersecting
 	// with the target.
-	return ImpactInfo(*weapon, position, distanceTraveled + dV.Length() * intersection);
+	return ImpactInfo(*weapon, position + velocity * intersection, distanceTraveled + dV.Length() * intersection);
 }
 
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

I noticed while testing #12300 that lasers with a blast radius don't properly deal damage to ships nearby the explosion that weren't directly impacted by the projectile. Upon further inspection, the explosion point is correct and the correct ships are having TakeDamage called on them in Engine::DoCollision, but the damage being applied to them is 0, meaning the problem is with DamageProfile.

Turns out, the ImpactInfo object that Projectile returns is not accounting for the movement of the projectile that frame when returning the position of the projectile's impact. This means that for a while now, explosions have been using a position that is one frame out of date, although this was only really noticeable on lasers where the distance traveled in a single frame is large.

## Testing Done

Added `"blast radius" 40` to a Heavy Laser and fired upon my own escorts while they were clumped together. Observed that on the master branch, only the ship I was targeting would take damage, unless I got close to the target, in which case nearby ships would start to be damaged too. With this PR, all ships near the impact point properly took damage.
