### PR TITLE
fix(npe): Fix a crash in Engine::Place when you have no flagship

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -403,8 +403,8 @@ void Engine::Place()
 
 	if(flagship)
 		camera.SnapTo(flagship->Center());
-	else if(player.GetStellarObject())
-		camera.SnapTo(player.GetStellarObject()->Position());
+	else if(object)
+		camera.SnapTo(planetPos);
 	else
 		camera.SnapTo(camera.Center());
 


### PR DESCRIPTION
**Bug fix**

Closes #12297.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Change Engine::Place to do the same thing as Engine::Step and use the player's current stellar object to position the camera if there is no flagship, and just stop all camera movement if there is no stellar object either.

## Testing Done

No, but I'm pretty sure.