### PR TITLE
Fix the engine flares of the 'olofez

### DIFF
--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -388,8 +388,8 @@ ship "'olofez"
 		"Thruster (Asteroid Class)"
 		"Steering (Asteroid Class)"
 	
-	engine -7 23
-	engine 7 23
+	engine -13 23
+	engine 13 23
 	gun 0 -28 "Fire-Lance"
 	explode "tiny explosion" 20
 	description "The 'olofez-Class Carried Chaser, named for a renowned artist who painted their visions of ancient hunts, is a fighter carried by most Exile capital ships."


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described by me in the Discord server.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Changed the engines of the 'olofez from
```
engine -7 23
engine 7 23
```
to
```
engine -13 23
engine 13 23
```

## Screenshots
The engines of the 'olofez on a white background:
<img width="568" height="307" alt="Screenshot From 2026-02-27 16-13-14" src="https://github.com/user-attachments/assets/39f53bdb-8f98-41d4-b248-36fe8dfc1445" />
The old engine flare positions:
<img width="317" height="235" alt="Screenshot From 2026-02-27 16-12-32" src="https://github.com/user-attachments/assets/14cda13a-5c42-4eeb-827d-8a20494398fb" />
The new engine flare positions:
<img width="297" height="224" alt="Screenshot From 2026-02-27 19-12-16" src="https://github.com/user-attachments/assets/aaa8b547-bd60-49fe-8e47-ad2365e5b805" />

## Testing Done
Bought an 'olofez, changed the engine flare positions in the save file, and flew around. They were in the correct position.

## Save File
Any save file with 'olofezes will do.

## Performance Impact
None.
