### PR TITLE
feat(mechanics): Implement 'to init' condition and 'on init' trigger on missions

### DIFF
--- a/source/Mission.h
+++ b/source/Mission.h
@@ -184,7 +184,10 @@ public:
 	// - ACCEPT, DECLINE, and DEFER if it is from PlayerInfo::MissionCallback(), as in this case the mission already
 	// used the UI to create a conversation or dialog that triggered the callback.
 	// - DAILY is called in PlayerInfo::AdvanceDate and never has access to the UI.
-	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, ABORT, DEFER, VISIT, STOPOVER, WAYPOINT, DAILY, DISABLED};
+	// - INIT is called during mission loading and also never have access to the UI. These are called
+	// while the job or mission list is being generated. They allow player conditions to be updated between jobs. In
+	// a way this allows some information to be passed between different jobs at generation stage
+	enum Trigger {COMPLETE, OFFER, ACCEPT, DECLINE, FAIL, ABORT, DEFER, VISIT, STOPOVER, WAYPOINT, DAILY, DISABLED, INIT};
 	bool Do(Trigger trigger, PlayerInfo &player, UI *ui = nullptr, const std::shared_ptr<Ship> &boardingShip = nullptr);
 
 	// Get a list of NPCs associated with this mission. Every time the player
@@ -272,6 +275,7 @@ private:
 	double passengerProb = 0.;
 	int64_t paymentApparent = 0;
 
+	ConditionSet toInit;
 	ConditionSet toOffer;
 	ConditionSet toAccept;
 	ConditionSet toComplete;

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2456,7 +2456,10 @@ Mission *PlayerInfo::BoardingMission(const shared_ptr<Ship> &ship)
 			if(availableBoardingMissions.back().IsFailed())
 				availableBoardingMissions.pop_back();
 			else
+			{
+				availableBoardingMissions.back().Do(Mission::INIT, *this);
 				return &availableBoardingMissions.back();
+			}
 		}
 
 	return nullptr;
@@ -2478,6 +2481,7 @@ void PlayerInfo::CreateEnteringMissions()
 				availableEnteringMissions.pop_back();
 			else
 			{
+				availableEnteringMissions.back().Do(Mission::INIT, *this);
 				hasPriorityMissions |= availableEnteringMissions.back().HasPriority();
 				nonBlockingMissions += availableEnteringMissions.back().IsNonBlocking();
 			}
@@ -2502,6 +2506,7 @@ void PlayerInfo::CreateTransitionMissions()
 				availableTransitionMissions.pop_back();
 			else
 			{
+				availableTransitionMissions.back().Do(Mission::INIT, *this);
 				hasPriorityMissions |= availableTransitionMissions.back().HasPriority();
 				nonBlockingMissions += availableTransitionMissions.back().IsNonBlocking();
 			}
@@ -4535,6 +4540,7 @@ void PlayerInfo::CreateMissions()
 			if(newMission.IsFailed())
 				continue;
 			newMission.RecalculateTrackedSystems();
+			newMission.Do(Mission::INIT, *this);
 			if(!mission.IsAtLocation(Mission::JOB))
 			{
 				hasPriorityMissions |= newMission.HasPriority();


### PR DESCRIPTION
**Feature**

This PR introduces an ability to communicate and modify player conditions between missions, during instantiation.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Introduce a new set of mission condition and triggers.
- `to init`: Performs a condition check before instantiation. If the check fails, the mission instantiation is skipped. Evaluates before the next mission's `to init` check.
- `on init`: Triggers when the mission is successfully instantiated. If the mission could not be instantiated (either `to init` is false, or a destination planet could not be determined), then this trigger does not fire. Triggers before the next mission is evaluated.

Because these items are performed per mission during instantiation, the combination of the two allows a mission to pass information (via player conditions) to missions that are instantiated after it (based on alphabetical order). 

Note: Player conditions used in the same mission are fixated during instantiation, before `on init`. You cannot yet use `on init` to change those values.

## Usage examples
```
mission ...
	to init
		"count" < 5
		random < 50
	on init
		"count" ++
```
Assuming `"count"` starts at 0, no further conditions in `to offer` and no planet restrictions, this mission has a 50% chance of being valid (and offered). After being offered 5 times, the mission will no longer appear.

## Testing Done
Plugins containing job missions that use this feature can be obtained from https://github.com/lovalmidas/endless-sky-test-plugins
Simply start a fresh pilot with default ES start. There is a job to begin the test. Upon next landing, the jobs will be present:

There are 5 jobs, named R0, R1, R2, R3, and R4. Exactly two of the five jobs will be offered. Two types of manipulation are done:
- `"test.mission.init_trigger: xx chance"` can be modified by a mission, effectively modifying the chance that other missions are offered during the same instantiation cycle.
- `"test.mission.init_trigger: count"` is incremented when a mission can be instantiated, then compared against a maximum check to then block other missions from appearing when the count is reached.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/231

## Performance Impact
Using `to init` over `to offer` will skip over source / destination planet searches and the rest of instantiation code, so may increase the performance when evaluating missions. 
