### PR TITLE
fix/typo copyright checker, found issues

### DIFF
--- a/source/Port.cpp
+++ b/source/Port.cpp
@@ -5,10 +5,6 @@ Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
 Foundation, either version 3 of the License, or (at your option) any later version.
 
-Endless Sky is free software: you can redistribute it and/or modify it under the
-terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later version.
-
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/source/Port.h
+++ b/source/Port.h
@@ -5,10 +5,6 @@ Endless Sky is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
 Foundation, either version 3 of the License, or (at your option) any later version.
 
-Endless Sky is free software: you can redistribute it and/or modify it under the
-terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later version.
-
 Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -503,7 +503,7 @@ def check_copyright(lines, file):
 	return errors, warnings
 
 
-# Checks whether the specified lines don't exceed the character limit. Parameters:
+# Checks whether the specified lines don't exceed the character limit, and consist of ASCII characters only. Parameters:
 # lines: the lines to check, without the terminating line separators
 # Returns a tuple of errors and warnings.
 def check_line_format(lines):

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -471,14 +471,16 @@ def check_copyright(lines, file):
 		while index_begin < len(lines) - len(copyright_end):
 			index = index_begin
 			for [copyright, is_regex] in copyright_end:
-				if is_regex and not re.search(copyright, lines[index]):
-					error_line = index
-					failed_check = copyright
-					break
-				elif copyright != lines[index]:
-					error_line = index
-					failed_check = copyright
-					break
+				if is_regex:
+					if not re.search(copyright, lines[index]):
+						error_line = index
+						failed_check = copyright
+						break
+				else:
+					if copyright != lines[index]:
+						error_line = index
+						failed_check = copyright
+						break
 				index += 1
 			if index - index_begin > 0:
 				found_copyright_end = True

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -434,7 +434,6 @@ def check_copyright(lines, file):
 		["Copyright \\(c\\) \\d{4}(?:(?:-|, )\\d{4})? by .*", True]
 	]
 	copyright_end = [
-		["", False],
 		["Endless Sky is free software: you can redistribute it and/or modify it under the", False],
 		["terms of the GNU General Public License as published by the Free Software", False],
 		["Foundation, either version 3 of the License, or (at your option) any later version.", False],
@@ -451,45 +450,60 @@ def check_copyright(lines, file):
 	index = 0
 	error_line = -1
 	complete = False
+	failed_check = '{{Undefined}}'
 	for [copyright, is_regex] in copyright_begin:
 		if is_regex:
 			if not re.search(copyright, lines[index]):
 				error_line = index
+				failed_check = copyright
 				break
 		else:
 			if copyright != lines[index]:
 				error_line = index
+				failed_check = copyright
 				break
 		index += 1
+	index += 1 # we know we want a blank line, will check for it later
 	not_found_error_line = index
+	found_copyright_end = False
 	if error_line == -1:
 		index_begin = index
 		while index_begin < len(lines) - len(copyright_end):
 			index = index_begin
 			for [copyright, is_regex] in copyright_end:
-				if is_regex:
-					if not re.search(copyright, lines[index]):
-						error_line = index
-						break
-				else:
-					if copyright != lines[index]:
-						error_line = index
-						break
+				if is_regex and not re.search(copyright, lines[index]):
+					error_line = index
+					failed_check = copyright
+					break
+				elif copyright != lines[index]:
+					error_line = index
+					failed_check = copyright
+					break
 				index += 1
+			if index - index_begin > 0:
+				found_copyright_end = True
+				if not lines[index_begin - 1] == "":
+					error_line = index_begin - 1
+					failed_check = "Expected one blank line before main copyright paragraph"
 			if error_line == -1:
 				complete = True
 				break
-			index_begin += 1
-			error_line = -1
+			if not found_copyright_end:
+				# we keep trying, shifting downward looking for the last half
+				index_begin += 1
+				error_line = -1
+			else:
+				break
 	if error_line != -1:
-		errors.append(Error(lines[error_line], error_line + 1, "invalid or missing copyright header"))
+		errors.append(Error(lines[error_line], error_line + 1,
+							f"invalid or missing copyright header [expected: '{failed_check}'"))
 	elif not complete:
 		errors.append(Error(lines[not_found_error_line], not_found_error_line + 1,
-							"invalid or incomplete copyright header"))
+							f"invalid or incomplete copyright header [expected: '{failed_check}']"))
 	return errors, warnings
 
 
-# Checks whether the specified lines don't exceed the character limit, and consist of ASCII characters only. Parameters:
+# Checks whether the specified lines don't exceed the character limit. Parameters:
 # lines: the lines to check, without the terminating line separators
 # Returns a tuple of errors and warnings.
 def check_line_format(lines):
@@ -501,10 +515,10 @@ def check_line_format(lines):
 		line_count += 1
 		if len(line) > 120:
 			errors.append(Error(line, line_count, "lines should hard wrap at 120 characters"))
-		for char in line:
-			if ord(char) < 0 or ord(char) > 127:
-				errors.append(Error(line, line_count, "files should be plain ASCII"))
-				break
+		# for char in line:
+		# 	if ord(char) < 0 or ord(char) > 127:
+		# 		errors.append(Error(line, line_count, "files should be plain ASCII"))
+		# 		break
 	return errors, warnings
 
 

--- a/utils/check_code_style.py
+++ b/utils/check_code_style.py
@@ -515,10 +515,10 @@ def check_line_format(lines):
 		line_count += 1
 		if len(line) > 120:
 			errors.append(Error(line, line_count, "lines should hard wrap at 120 characters"))
-		# for char in line:
-		# 	if ord(char) < 0 or ord(char) > 127:
-		# 		errors.append(Error(line, line_count, "files should be plain ASCII"))
-		# 		break
+		for char in line:
+			if ord(char) < 0 or ord(char) > 127:
+				errors.append(Error(line, line_count, "files should be plain ASCII"))
+				break
 	return errors, warnings
 
 


### PR DESCRIPTION
**Typo fix**
**CI/CD/Testing**

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
While making changes to the game it was discovered that the copyright checker was not catching instances where portions of the copyright were repeated, as exemplified by the changes discovered within Port.*

This change ensures that the copyright lines appear in order, correctly, without repeat.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
N/A

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
