### PR TITLE
Fix incorrect cost calculation when installing multiple outfits at once from the outfitter (infinite money glitch)

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -747,6 +747,7 @@ ShopPanel::TransactionResult OutfitterPanel::MoveOutfit(OutfitLocation fromLocat
 					// Pay for it and remove it from available stock.
 					player.Accounts().AddCredits(-cost);
 					player.AddStock(selectedOutfit, -1);
+					cost = player.StockDepreciation().Value(selectedOutfit, day);
 
 					// Install it on this ship.
 					ship->AddOutfit(selectedOutfit, 1);


### PR DESCRIPTION
Fixes multi-outfit installation using the most depreciated value for all purchases by adding a cost re-calculation to the middle of the installation loop.

**Bug fix**

This PR addresses the bug/feature described on discord here: https://discord.com/channels/251118043411775489/285540320823869441/1479246096537620806

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When you purchase multiple copies of a single outfit for installation on a ship, the code currently uses the same calculated cost for all outfits installed on the ship. For example, if you have a hyperdrive at 25% value in the outfitter and the rest are 100%, you could buy as many hyperdrives as will fit on your ship, and it will use the 25% value for purchasing all of those outfits. The depreciation values will be tracked properly for each unit moved, but not subtracted from your credits properly. This means that you can use keyboard shortcuts and continually buy and sell as many of an outfit that you've brought one "25%" to an outfitter and generate infinite money into your account.

## Testing Done
To test the bug and the fix, I can simply bring an outfit of any depreciation amount alongside an empty hull to guarantee that the ship can install as much of it as possible. I sell the one depreciated outfit to the outfitter, then use keyboard shortcuts to buy and sell multiple outfits of that outfit at the same time. Before the bug fix, your money will increase infinitely, and after the bugfix, your money will move between two given values. This should not affect any other gameplay since all I'm doing is recalculating cost during a purchase loop.

## Save File
This save file can be used to test these changes:
[Noelle Devonshire~Testable.txt](https://github.com/user-attachments/files/25782298/Noelle.Devonshire.Testable.txt)
The pilot is currently parked at an outfitter that has *one* hyperdrive at 25% depreciation, and no other planet stock of that outfit. There is also a ship with over 400 outfit space available, allowing you to easily ctrl-click buy and sell on the hyperdrive to move 20 at a time. Before the bugfix, you will buy for 250000 and sell for 962500 each time, but after the bugfix you will properly buy and sell for 962500 each time.

## Performance Impact
N/A I think?
