### PR TITLE
Part 2 Fighter AI improvements: Battery powered fighters

### DIFF
--- a/data/_ui/flight checks.txt
+++ b/data/_ui/flight checks.txt
@@ -32,6 +32,11 @@ conversation "flight check: overheating!"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of the <ship> warming up, you run through a mental checklist. Computers: check. Life support: check.`
 	`	By the time you reach the end of the checklist, it has grown uncomfortably warm. The air smells like ozone and hot metal, and your cameras are showing a plume of steam or smoke escaping from the hull near the engines. If your systems are running this hot while still in the atmosphere, they're likely to overheat the moment you hit hard vacuum. You are going to have to either install cooling systems, or trade out some components for lower-heat alternatives.`
 
+conversation "flight check: low battery!"
+	scene "scene/engine"
+	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of the <ship> warming up, you run through a mental checklist. Computers: check. Life support: check.`
+	`	As you're looking through the status checks of your carried ships, you notice they're not all equipped with enough battery for sustained flight. You'll either need to increase their power generation or battery capacity to solve the issue.`
+
 conversation "flight check: no bunks!"
 	scene "outfit/bunk room"
 	`You've heard enough horror stories about the sort of accidents that happen when starship systems malfunction to be completely convinced of the necessity of a pre-flight safety check. As you listen to the complex symphony of hums, rattles, and clicks of the <ship> warming up, you run through a mental checklist. Computers: check. Life support: check.`

--- a/data/_ui/help.txt
+++ b/data/_ui/help.txt
@@ -200,6 +200,18 @@ help "trading"
 help "friendly disabled"
 	`This ship is disabled and needs your help to patch them up! Pressing <Board selected ship> will fly you to their ship and get them up and running again. Just be sure to do it when no one is trying to kill you, or they could get caught in the crossfire!`
 
+help "low battery fighters"
+	`One or more of your fighters or drones has low battery power. They will automatically return to their carrier for recharging when their energy runs low.`
+	`Fighters powered only by batteries are effective in combat but must periodically dock with their carrier to recharge.`
+
+help "fighter fleet logistics"
+	`Fighter fleet logistics has been enabled. This enables carriers and fighters to support your escorted fleet. The following logistics are supported.`
+	``
+	`	Fleet refueling if your fighters have fuel and ramscoop.`
+
+help "try out fighter fleet logistics"
+	`You have a carrier which can support your fleet through logistics. In Preferences and Settings under the AI section, turn on "Fighter fleet logistics" to learn more.`
+
 help "control ship with mouse"
 	`You've enabled controlling your ship with your mouse.`
 	``

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1672,3 +1672,9 @@ tip "Fighters hit when disabled"
 
 tip "Universal ammo stocking"
 	`Controls whether the ammo for most secondary weapons that you have installed or in your cargo will be available for purchase at any outfitter, even if that outfitter does not normally sell ammo of that type. The description of each secondary weapon will indicate whether it can be restocked anywhere when this rule is true.`
+
+tip "cannot repair other"
+	`Prevents this ship from repairing or recharging other ships when boarding them. The ship can still dock with its carrier normally.`
+
+tip "Fighter return to carrier on low fuel"
+	`The minimum fuel a fighter must reserve to safely return to its carrier. Fighters with fuel levels below this threshold will automatically return to dock. This does not apply to fighters with flame weapons and normal (non-afterburner) thrust, since their fuel is ammunition rather than propulsion.`

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -175,8 +175,10 @@ namespace {
 	void Deploy(const Ship &ship, bool includingDamaged)
 	{
 		for(const Ship::Bay &bay : ship.Bays())
-			if(bay.ship && (includingDamaged || bay.ship->Health() > .75) &&
-					(!bay.ship->IsYours() || bay.ship->HasDeployOrder()))
+			if(bay.ship && (includingDamaged || bay.ship->Health() > .75)
+					&& (!bay.ship->IsYours() || bay.ship->HasDeployOrder())
+					&& (bay.ship->IsArmed(true) || !bay.ship->IsEnemyInEscortSystem())
+					&& !bay.ship->IsEnergyLow())
 				bay.ship->SetCommands(Command::DEPLOY);
 	}
 
@@ -733,6 +735,33 @@ void AI::Step(Command &activeCommands)
 	bool opportunisticEscorts = !Preferences::Has("Turrets focus fire");
 	bool fightersRetreat = Preferences::Has("Damaged fighters retreat");
 	const int npcMaxMiningTime = GameData::GetGamerules().NPCMaxMiningTime();
+
+	// Update cached escort fuel/enemy state every 16 frames (~4 times/sec).
+	if(flagship && !(step & 15))
+	{
+		auto flagshipPtr = player.FlagshipPtr();
+		if(flagshipPtr)
+		{
+			flagshipPtr->UpdateEscortsFuelState(flagshipPtr);
+			bool hasEnemy = false;
+			for(const auto &ship : ships)
+				if(ship->GetSystem() == flagship->GetSystem()
+						&& ship->GetGovernment()->IsEnemy(flagship->GetGovernment())
+						&& !ship->IsDisabled())
+				{
+					hasEnemy = true;
+					break;
+				}
+			flagshipPtr->SetEnemyInEscortSystem(hasEnemy);
+			for(const weak_ptr<Ship> &escortPtr : flagshipPtr->GetEscorts())
+			{
+				shared_ptr<Ship> escort = escortPtr.lock();
+				if(escort && escort->CanBeCarried())
+					escort->SetEnemyInEscortSystem(hasEnemy);
+			}
+		}
+	}
+
 	for(const auto &it : ships)
 	{
 		// A destroyed ship can't do anything.
@@ -742,11 +771,26 @@ void AI::Step(Command &activeCommands)
 		if(!it->GetSystem())
 			continue;
 
+		bool isStranded = false;
+
 		if(it.get() == flagship)
 		{
 			// Player cannot do anything if the flagship is landing.
 			if(!flagship->IsLanding())
 				MovePlayer(*it, activeCommands);
+			// Your flagship may request refueling from an escort tanker
+			// carrier. The flagship can also request help from your escorts
+			// for recharge.
+			if(!(step & 15) && flagship->MayRequestHelp() && (!flagship->IsDisabled() ^ flagship->IsEnergyLow()))
+			{
+				// If the flagship is a tanker carrier and only needs fuel (not energy/disabled),
+				// defer fuel help until all escorts are fully fueled (tier 5+).
+				bool gatedByPriority = flagship->IsTankerCarrier()
+						&& flagship->NeedsFuel() && !flagship->NeedsEnergy()
+						&& !flagship->IsDisabled() && !flagship->IsEscortsFullOfFuel();
+				if(!gatedByPriority)
+					AskForHelp(*it, isStranded, flagship);
+			}
 			continue;
 		}
 
@@ -754,7 +798,7 @@ void AI::Step(Command &activeCommands)
 		const Personality &personality = it->GetPersonality();
 		double healthRemaining = it->Health();
 		bool isPresent = (it->GetSystem() == playerSystem);
-		bool isStranded = IsStranded(*it);
+		isStranded = IsStranded(*it);
 		bool thisIsLaunching = (isPresent && HasDeployments(*it));
 		if(isStranded || it->IsDisabled())
 		{
@@ -780,6 +824,45 @@ void AI::Step(Command &activeCommands)
 				continue;
 			}
 		}
+		else if(Preferences::Has("Fighter fleet logistics") && !(step & 7)
+				&& flagship && (it->IsYours() || it->GetPersonality().IsEscort())
+				&& it->GetSystem() == flagship->GetSystem()
+				&& !it->CanBeCarried())
+		{
+			// Energy help and disabled help are always allowed.
+			if(it->NeedsEnergy() || it->IsDisabled())
+				AskForHelp(*it, isStranded, flagship);
+			// Fuel help is gated by the tiered refueling priority.
+			else if(it->Attributes().Get("fuel capacity") > 0. && it->Fuel() < 1.)
+			{
+				bool isPlayerEscort = it->IsYours();
+				bool needsOneJump = !it->JumpsRemaining();
+				bool shouldAsk = false;
+
+				if(isPlayerEscort)
+				{
+					// Tier 1: player escorts need 1 jump.
+					if(needsOneJump)
+						shouldAsk = true;
+					// Tier 3: player escorts fill to full (after all escorts have 1 jump).
+					else if(flagship->EscortsHaveOneJump())
+						shouldAsk = true;
+				}
+				else
+				{
+					// Tier 2: NPC escorts need 1 jump (after player escorts have 1 jump).
+					if(needsOneJump && flagship->PlayerEscortsHaveOneJump())
+						shouldAsk = true;
+					// Tier 4: NPC escorts fill to full (after player escorts are full).
+					else if(flagship->EscortsHaveOneJump() && flagship->PlayerEscortsFullFuel())
+						shouldAsk = true;
+				}
+
+				if(shouldAsk)
+					AskForHelp(*it, isStranded, flagship);
+			}
+		}
+
 		// Overheated ships are effectively disabled, and cannot fire, cloak, etc.
 		if(it->IsOverheated())
 			continue;
@@ -929,10 +1012,24 @@ void AI::Step(Command &activeCommands)
 		shared_ptr<Ship> shipToAssist = it->GetShipToAssist();
 		if(shipToAssist)
 		{
+			// In the one-jump phase of fleet logistics, drop assists for ships
+			// that already have enough fuel for a jump so the helper can move
+			// on to higher-priority ships.
+			bool fleetLogisticsOneJump = false;
+			if(Preferences::Has("Fighter fleet logistics") && it->IsYours() && flagship)
+			{
+				fleetLogisticsOneJump = !flagship->PlayerEscortsHaveOneJump()
+						|| !flagship->NpcEscortsHaveOneJump()
+						|| (!flagship->IsTankerCarrier() && flagship->NeedsFuel());
+			}
 			if(shipToAssist->IsDestroyed() || shipToAssist->GetSystem() != it->GetSystem()
 					|| shipToAssist->IsLanding() || shipToAssist->IsHyperspacing()
 					|| shipToAssist->GetGovernment()->IsEnemy(gov)
-					|| (!shipToAssist->IsDisabled() && !shipToAssist->NeedsFuel() && !shipToAssist->NeedsEnergy()))
+					|| (!shipToAssist->IsDisabled() && !it->CanRefuel(*shipToAssist)
+						&& shipToAssist->JumpsRemaining())
+					|| (fleetLogisticsOneJump && !shipToAssist->IsDisabled()
+						&& shipToAssist->JumpsRemaining())
+					|| it->IsEnergyLow())
 			{
 				if(target == shipToAssist)
 				{
@@ -1147,6 +1244,28 @@ void AI::Step(Command &activeCommands)
 			// to its mothership. So, it should continue to be deployed.
 			command |= Command::DEPLOY;
 		}
+		// Carriers actively recover their own disabled carried-type escorts.
+		if(it->HasBays() && !it->IsDisabled() && !it->GetShipToAssist())
+		{
+			for(const weak_ptr<Ship> &escortPtr : it->GetEscorts())
+			{
+				shared_ptr<Ship> escort = escortPtr.lock();
+				if(escort && escort->CanBeCarried() && escort->IsDisabled()
+						&& escort->GetSystem() == it->GetSystem()
+						&& it->BaysFree(escort->Attributes().Category()))
+				{
+					it->SetShipToAssist(escortPtr);
+					break;
+				}
+			}
+		}
+
+		// If escorts need fuel and this carrier has fighters that can shuttle fuel, stop.
+		bool mustRefuelEscorts = false;
+		if(!target && it->HasBays() && it->IsYours() && !it->EscortsHaveOneJump()
+				&& it->Fuel() > .1)
+			mustRefuelEscorts = true;
+
 		// If this ship has decided to recall all of its fighters because combat has ceased,
 		// it comes to a stop to facilitate their reboarding process.
 		bool mustRecall = false;
@@ -1165,7 +1284,7 @@ void AI::Step(Command &activeCommands)
 			}
 
 		// Construct movement / navigation commands as appropriate for the ship.
-		if(mustRecall || (strandedWithHelper && !it->GetPersonality().IsDerelict()))
+		if(mustRefuelEscorts || mustRecall || (strandedWithHelper && !it->GetPersonality().IsDerelict()))
 		{
 			// Stopping to let fighters board or to be refueled takes priority
 			// even over following orders from the player.
@@ -1233,6 +1352,9 @@ void AI::Step(Command &activeCommands)
 		else if((personality.IsTimid() || (it->IsYours() && healthRemaining < RETREAT_HEALTH))
 				&& parent->Position().Distance(it->Position()) > 500.)
 			MoveEscort(*it, command);
+		// AM-only fighters keep station by their carrier instead of attacking.
+		else if(it->CanBeCarried() && it->IsArmed(true) && !it->IsArmed(false) && parent)
+			KeepStation(*it, command, *parent);
 		// Otherwise, attack targets depending on your hunting attribute.
 		else if(target && (targetDistance < 2000. || personality.IsHunting()))
 			MoveIndependent(*it, command);
@@ -1382,6 +1504,7 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 	{
 		const Government *gov = ship.GetGovernment();
 		bool hasEnemy = false;
+		bool shipIsDisabled = ship.IsDisabled();
 
 		vector<Ship *> canHelp;
 		canHelp.reserve(ships.size());
@@ -1389,6 +1512,15 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 		{
 			// Never ask yourself for help.
 			if(helper.get() == &ship)
+				continue;
+
+			// If the ship is otherwise healthy it should not ask non-escorts for help.
+			// Healthy ships should only request help from fighters if any is required.
+			if(!shipIsDisabled && !isStranded && !helper->IsYours())
+				continue;
+
+			// Fighters returning to carriers ignore requests for help.
+			if(helper->CanBeCarried() && !helper->HasDeployOrder())
 				continue;
 
 			// If any able enemies of this ship are in its system, it cannot call for help.
@@ -1407,11 +1539,14 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 			// If the ship is already assisting someone else, it cannot help this ship.
 			if(helper->GetShipToAssist() && helper->GetShipToAssist().get() != &ship)
 				continue;
-			// If the ship is mining or chasing flotsam, it cannot help this ship.
-			if(helper->GetTargetAsteroid() || helper->GetTargetFlotsam())
+			// If the NPC ship is mining or chasing flotsam, it cannot help this ship.
+			if(!helper->IsYours() && (helper->GetTargetAsteroid() || helper->GetTargetFlotsam()))
 				continue;
-			// Your escorts only help other escorts, and your flagship never helps.
-			if((helper->IsYours() && !ship.IsYours()) || helper.get() == flagship)
+			// Your escorts only help other escorts and mission NPC escorts.
+			// Your flagship never helps.
+			if((helper->IsYours() && !(ship.IsYours()
+							|| (ship.GetPersonality().IsEscort() && !ship.GetGovernment()->IsEnemy())))
+					|| helper.get() == flagship)
 				continue;
 			// Your escorts should not help each other if already under orders.
 			auto foundOrders = orders.find(helper.get());
@@ -1423,6 +1558,17 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 				// harvesting flotsam.
 				if(helper->IsYours() && ship.IsYours()
 						&& !(helperOrders.Has(Orders::Types::MINE) || helperOrders.Has(Orders::Types::HARVEST)))
+					continue;
+			}
+
+			if(!shipIsDisabled)
+			{
+				// Battery powered ships should only get help if they're disabled.
+				if(ship.CanBeCarried() && ship.IsEnergyLow())
+					continue;
+
+				// Escorts do not request help with enemies in the system unless disabled.
+				if(ship.IsYours() && hasEnemy)
 					continue;
 			}
 
@@ -1453,14 +1599,24 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 // Determine if the selected ship is physically able to render assistance.
 bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel, const bool needsEnergy) const
 {
-	// A ship being assisted cannot assist.
-	if(helperList.find(&helper) != helperList.end())
+	// Fighters/drones with "cannot repair other" are excluded, but those without it can help.
+	// Disabled / absent ships can't offer assistance.
+	if((helper.CanBeCarried() && helper.Attributes().Get("cannot repair other"))
+			|| helper.GetSystem() != ship.GetSystem()
+			|| (helper.GetGovernment() != ship.GetGovernment() && helper.CannotAct(Ship::ActionType::COMMUNICATION))
+			|| helper.IsDisabled() || helper.IsOverheated() || helper.IsHyperspacing())
 		return false;
 
-	// Fighters, drones, and disabled / absent ships can't offer assistance.
-	if(helper.CanBeCarried() || helper.GetSystem() != ship.GetSystem() ||
-			(helper.GetGovernment() != ship.GetGovernment() && helper.CannotAct(Ship::ActionType::COMMUNICATION))
-			|| helper.IsOverheated() || helper.IsHyperspacing())
+	// Carriers should help their own fighters.
+	if(ship.GetParent().get() == &helper)
+		return true;
+
+	// Fighters with ramscoop collect their own fuel; don't assign fuel helpers to them.
+	if(needsFuel && ship.CanBeCarried() && ship.Attributes().Get("ramscoop") >= 1.)
+		return false;
+
+	// A ship being assisted cannot assist.
+	if(helperList.find(&helper) != helperList.end())
 		return false;
 
 	// An enemy cannot provide assistance, and only ships of the same government will repair disabled ships.
@@ -1469,7 +1625,26 @@ bool AI::CanHelp(const Ship &ship, const Ship &helper, const bool needsFuel, con
 		return false;
 
 	// If the helper has insufficient fuel or energy, it cannot help this ship unless this ship is also disabled.
-	if(!ship.IsDisabled() && ((needsFuel && !helper.CanRefuel(ship)) || (needsEnergy && !helper.CanGiveEnergy(ship))))
+	// Fleet logistics ramscoop drones bypass the strict CanRefuel check: in fuelless systems
+	// the escort is "stranded" (needsFuel=true) and CanRefuel demands the drone carry an
+	// entire jump's worth of fuel, which ramscoop drones rarely accumulate before being
+	// needed. The 25-unit minimum below ensures they still carry something meaningful.
+	bool isFleetLogisticsDrone = Preferences::Has("Fighter fleet logistics")
+			&& helper.CanBeCarried() && helper.Attributes().Get("ramscoop") >= 1.
+			&& !ship.CanBeCarried() && ship.Attributes().Get("fuel capacity") > 0.;
+	if(!ship.IsDisabled() && ((needsFuel && !helper.CanRefuel(ship) && !isFleetLogisticsDrone)
+			|| (needsEnergy && !helper.CanGiveEnergy(ship))))
+		return false;
+
+	// Fleet logistics: carried helpers must have collected enough fuel to meaningfully
+	// assist. Without this, drones with 0 fuel get assigned vacuously, travel to the
+	// escort, transfer nothing, and waste time that should be spent collecting fuel.
+	if(isFleetLogisticsDrone && ship.Fuel() < 1.
+			&& helper.Fuel() * helper.Attributes().Get("fuel capacity") < 25.)
+		return false;
+
+	// Helper is not able to continue helping because they must return to carrier for battery recharge.
+	if(helper.IsEnergyLow())
 		return false;
 
 	// For player's escorts, check if the player knows the helper's language.
@@ -1488,7 +1663,8 @@ bool AI::HasHelper(const Ship &ship, const bool needsFuel, const bool needsEnerg
 	if(helperList.find(&ship) != helperList.end())
 	{
 		shared_ptr<Ship> helper = helperList[&ship].lock();
-		if(helper && helper->GetShipToAssist().get() == &ship && CanHelp(ship, *helper, needsFuel, needsEnergy))
+		if(helper && !helper->IsDisabled() && helper->GetShipToAssist().get() == &ship
+				&& CanHelp(ship, *helper, needsFuel, needsEnergy))
 			return true;
 		else
 			helperList.erase(&ship);
@@ -2455,11 +2631,73 @@ bool AI::ShouldDock(const Ship &ship, const Ship &parent, const System *playerSy
 		return true;
 
 	// If a carried ship has fuel capacity but is very low, it should return if
-	// the parent can refuel it.
+	// the parent can refuel it. Honor the RTB fuel game rule unless the fighter
+	// has a flame weapon with non-fuel thrust (flame weapon fuel is ammo, not propulsion).
+	// Ramscoop fighters doing fleet logistics are intentionally deployed empty
+	// to collect fuel, so they skip the normal fuel RTB check entirely.
 	double maxFuel = ship.Attributes().Get("fuel capacity");
-	if(maxFuel && ship.Fuel() < .005 && parent.JumpNavigation().JumpFuel() < parent.Fuel() *
-			parent.Attributes().Get("fuel capacity") - maxFuel)
+	bool isRamscoopLogistics = maxFuel > 0. && ship.Attributes().Get("ramscoop") >= 1.
+			&& Preferences::Has("Fighter fleet logistics");
+	bool hasFlameWeapon = ship.HasFlameWeapon();
+	bool hasAfterburner = ship.Attributes().Get("afterburner thrust") > 0.;
+	bool hasNormalThrust = ship.Attributes().Get("thrust") > 0.;
+	bool honorRtbFuel = !hasFlameWeapon || hasAfterburner || !hasNormalThrust;
+	if(maxFuel && !isRamscoopLogistics)
+	{
+		double rtbFuel = GameData::GetGamerules().FighterRtbFuel();
+		if(honorRtbFuel && ship.Fuel() * maxFuel < rtbFuel
+				&& parent.JumpNavigation().JumpFuel() < parent.Fuel()
+					* parent.Attributes().Get("fuel capacity") - maxFuel)
+			return true;
+		if(ship.Fuel() < .005 && parent.JumpNavigation().JumpFuel() < parent.Fuel()
+				* parent.Attributes().Get("fuel capacity") - maxFuel)
+			return true;
+	}
+
+	// If a carried ship has low energy, return to carrier for recharge.
+	if(ship.IsEnergyLow())
 		return true;
+
+	// Defenseless fighters retreat when enemies are nearby.
+	if(!ship.IsArmed() && ship.IsEnemyInEscortSystem())
+		return true;
+
+	// When fleet logistics is enabled, fighters with ramscoop dock to deposit
+	// collected fuel only when the parent carrier or other carriers need fuel.
+	// While escorts need fuel (tiers 0-4), fighters stay deployed so AskForHelp
+	// can assign them to directly refuel escorts (the flagship cannot be a helper).
+	if(Preferences::Has("Fighter fleet logistics") && ship.Attributes().Get("ramscoop") >= 1.
+			&& ship.Attributes().Get("fuel capacity") > 0.)
+	{
+		double rawFuel = ship.Fuel() * ship.Attributes().Get("fuel capacity");
+		bool fighterCanRefuelParent = ship.CanRefuel(parent) && rawFuel > 25.;
+		bool refuelingIsAllowed = !ship.IsYours() || !orders.count(&ship) || fighterCanRefuelParent;
+		if(refuelingIsAllowed && fighterCanRefuelParent)
+		{
+			auto grandParent = parent.GetParent();
+			const Ship &fleetLeader = grandParent ? *grandParent : parent;
+
+			bool escortsNeedFuel = !fleetLeader.IsEscortsFullOfFuel();
+			bool flagshipNeedsFuel = !fleetLeader.IsTankerCarrier() && fleetLeader.NeedsFuel();
+			bool parentNeedsFuel = parent.Fuel() < 1.;
+			bool otherCarriersNeed = fleetLeader.OtherCarriersNeedFuel();
+
+			// Tiers 0-4: Escorts or non-tanker flagship need fuel.
+			// Stay deployed so AskForHelp can assign fighters directly to escorts.
+			if(escortsNeedFuel || flagshipNeedsFuel)
+				return false;
+
+			// Tier 5: All escorts fueled. Dock to deposit fuel for the carrier.
+			if(parentNeedsFuel)
+				return true;
+
+			// Tier 6: Parent carrier full. Other carriers still need fuel.
+			if(otherCarriersNeed)
+				return true;
+
+			// Tier 7: Fleet is completely full. No need to dock for refueling.
+		}
+	}
 
 	// NPC ships should always transfer cargo. Player ships should only
 	// transfer cargo if the player has the AI preference set for it.
@@ -5141,6 +5379,7 @@ void AI::IssueOrder(const OrderSingle &newOrder, const string &description)
 	// Other orders can be issued only to escorts.
 	bool includeFlagship = newOrder.type == Orders::Types::HOLD_FIRE;
 	const vector<weak_ptr<Ship>> &selected = player.SelectedEscorts();
+	bool isAttackOrder = (newOrder.type == Orders::Types::ATTACK || newOrder.type == Orders::Types::FINISH_OFF);
 	if(selected.empty())
 	{
 		for(const shared_ptr<Ship> &it : player.Ships())
@@ -5149,7 +5388,12 @@ void AI::IssueOrder(const OrderSingle &newOrder, const string &description)
 				if(it->IsDestroyed())
 					++destroyedCount;
 				else
-					ships.push_back(it.get());
+				{
+					bool antiMissileDefender = isAttackOrder
+							&& it->CanBeCarried() && !it->IsArmed() && it->IsArmed(true);
+					if(!antiMissileDefender)
+						ships.push_back(it.get());
+				}
 			}
 		who = (ships.empty() ? destroyedCount : ships.size()) > 1
 			? "Your fleet is " : includeFlagship ? "Your flagship is " : "Your escort is ";
@@ -5164,7 +5408,12 @@ void AI::IssueOrder(const OrderSingle &newOrder, const string &description)
 			if(ship->IsDestroyed())
 				++destroyedCount;
 			else
-				ships.push_back(ship.get());
+			{
+				bool antiMissileDefender = isAttackOrder
+						&& ship->CanBeCarried() && !ship->IsArmed() && ship->IsArmed(true);
+				if(!antiMissileDefender)
+					ships.push_back(ship.get());
+			}
 		}
 		who = (ships.empty() ? destroyedCount : ships.size()) > 1
 			? "The selected escorts are " : "The selected escort is ";

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1998,7 +1998,10 @@ void Engine::MoveShip(const shared_ptr<Ship> &ship)
 	// Boarding:
 	bool autoPlunder = !ship->IsYours();
 	// The player should not become a docked passenger on some other ship, but AI ships may.
-	shared_ptr<Ship> victim = ship->Board(autoPlunder, isFlagship);
+	// When a carried ship is assisting another ship (e.g. refueling an escort),
+	// it should board for assistance rather than dock into the victim's bays.
+	bool nonDocking = isFlagship || (ship->CanBeCarried() && ship->GetShipToAssist());
+	shared_ptr<Ship> victim = ship->Board(autoPlunder, nonDocking);
 	if(victim)
 		eventQueue.emplace_back(ship, victim,
 			ship->GetGovernment()->IsEnemy(victim->GetGovernment()) ?

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -89,6 +89,8 @@ void Gamerules::Load(const DataNode &node)
 		}
 		else if(key == "fleet multiplier")
 			storage.fleetMultiplier = max<double>(0., child.Value(1));
+		else if(key == "fighter return to carrier on low fuel")
+			storage.fighterRtbFuel = max<double>(0., child.Value(1));
 		else
 			storage.miscRules[key] = child.IsNumber(1) ? child.Value(1) : child.BoolValue(1);
 	}
@@ -141,6 +143,8 @@ void Gamerules::Save(DataWriter &out, const Gamerules &preset) const
 		}
 		if(storage.fleetMultiplier != preset.storage.fleetMultiplier)
 			out.Write("fleet multiplier", storage.fleetMultiplier);
+		if(storage.fighterRtbFuel != preset.storage.fighterRtbFuel)
+			out.Write("fighter return to carrier on low fuel", storage.fighterRtbFuel);
 
 		const map<string, int> &otherMiscRules = preset.storage.miscRules;
 		for(const auto &[rule, value] : storage.miscRules)
@@ -193,6 +197,8 @@ void Gamerules::Reset(const string &rule, const Gamerules &preset)
 		storage.systemArrivalMin = preset.storage.systemArrivalMin;
 	else if(rule == "fleet multiplier")
 		storage.fleetMultiplier = preset.storage.fleetMultiplier;
+	else if(rule == "fighter return to carrier on low fuel")
+		storage.fighterRtbFuel = preset.storage.fighterRtbFuel;
 	else
 	{
 		auto it = preset.storage.miscRules.find(rule);
@@ -322,6 +328,13 @@ void Gamerules::SetFleetMultiplier(double value)
 
 
 
+void Gamerules::SetFighterRtbFuel(double value)
+{
+	storage.fighterRtbFuel = max(0., value);
+}
+
+
+
 void Gamerules::SetMiscValue(const string &rule, int value)
 {
 	storage.miscRules[rule] = value;
@@ -359,6 +372,8 @@ int Gamerules::GetValue(const string &rule) const
 		return storage.systemArrivalMin.value_or(0.) * 1000;
 	if(rule == "fleet multiplier")
 		return storage.fleetMultiplier * 1000;
+	if(rule == "fighter return to carrier on low fuel")
+		return storage.fighterRtbFuel;
 
 	auto it = storage.miscRules.find(rule);
 	if(it == storage.miscRules.end())
@@ -462,6 +477,13 @@ optional<double> Gamerules::SystemArrivalMin() const
 double Gamerules::FleetMultiplier() const
 {
 	return storage.fleetMultiplier;
+}
+
+
+
+double Gamerules::FighterRtbFuel() const
+{
+	return storage.fighterRtbFuel;
 }
 
 

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -71,6 +71,7 @@ public:
 	void SetSystemDepartureMin(double value);
 	void SetSystemArrivalMin(std::optional<double> value);
 	void SetFleetMultiplier(double value);
+	void SetFighterRtbFuel(double value);
 	void SetMiscValue(const std::string &rule, int value);
 
 	int GetValue(const std::string &rule) const;
@@ -89,6 +90,7 @@ public:
 	double SystemDepartureMin() const;
 	std::optional<double> SystemArrivalMin() const;
 	double FleetMultiplier() const;
+	double FighterRtbFuel() const;
 
 	bool operator==(const Gamerules &other) const;
 
@@ -115,6 +117,7 @@ private:
 		double systemDepartureMin = 0.;
 		std::optional<double> systemArrivalMin;
 		double fleetMultiplier = 1.;
+		double fighterRtbFuel = 25.;
 
 		// Miscellaneous rules that are only used by the game data and not by the engine.
 		std::map<std::string, int> miscRules;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -565,12 +565,24 @@ bool MainPanel::ShowHelp(bool force)
 			forced.push_back("try out fighters transfer cargo");
 		else if(DoHelp("try out fighters transfer cargo"))
 			return true;
+
+		if(force)
+			forced.push_back("try out fighter fleet logistics");
+		else if(DoHelp("try out fighter fleet logistics"))
+			return true;
 	}
 	if(Preferences::Has("Fighters transfer cargo"))
 	{
 		if(force)
 			forced.push_back("fighters transfer cargo");
 		else if(DoHelp("fighters transfer cargo"))
+			return true;
+	}
+	if(Preferences::Has("Fighter fleet logistics"))
+	{
+		if(force)
+			forced.push_back("fighter fleet logistics");
+		else if(DoHelp("fighter fleet logistics"))
 			return true;
 	}
 	if(!flagship->IsHyperspacing() && flagship->Position().Length() > 10000.

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -786,6 +786,7 @@ void PreferencesPanel::DrawSettings()
 		EXPEND_AMMO,
 		FLOTSAM_SETTING,
 		FIGHTER_REPAIR,
+		"Fighter fleet logistics",
 		"Fighters transfer cargo",
 		"\t",
 		"HUD",

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -26,6 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Format.h"
 #include "FormationPattern.h"
 #include "GameData.h"
+#include "Gamerules.h"
 #include "Government.h"
 #include "JumpType.h"
 #include "Logger.h"
@@ -1369,7 +1370,7 @@ vector<string> Ship::FlightCheck() const
 			checks.emplace_back("afterburner only?");
 		if(!thrust && !afterburner)
 			checks.emplace_back("reverse only?");
-		if(energy <= battery)
+		if(energy <= battery && !canBeCarried)
 			checks.emplace_back("battery only?");
 		if(energy < thrustEnergy)
 			checks.emplace_back("limited thrust?");
@@ -1395,6 +1396,9 @@ vector<string> Ship::FlightCheck() const
 				break;
 			}
 		}
+		if(canBeCarried && GetSecondsToEmpty() < 10.
+				&& (attributes.Get("energy capacity") / max(0.0001, GetIdleEnergyPerFrame() * 60.)) > 10.)
+			checks.emplace_back("low battery?");
 	}
 
 	return checks;
@@ -1788,14 +1792,27 @@ void Ship::Launch(list<shared_ptr<Ship>> &ships, vector<Visual> &visuals)
 				if(maxFuel)
 				{
 					double spareFuel = fuel - navigation.JumpFuel();
-					if(spareFuel > 0.)
-						TransferFuel(spareFuel, bay.ship.get());
-					// If still low or out-of-fuel, re-stock the carrier and don't
-					// launch, except if some ammo was taken (since we can fight).
-					if(!tookAmmo && bay.ship->fuel < .25 * maxFuel)
+					bool isRamscoopFighter = bay.ship->Attributes().Get("ramscoop") >= 1.;
+					bool fleetLogistics = isYours && Preferences::Has("Fighter fleet logistics");
+					if(fleetLogistics && isRamscoopFighter)
 					{
-						TransferFuel(bay.ship->fuel, this);
-						continue;
+						// Ramscoop fighters deploy empty so they collect fuel via
+						// ramscoop rather than shuttling the carrier's own reserves.
+						// Deposit any existing fuel back into the carrier.
+						if(bay.ship->fuel > 0.)
+							TransferFuel(bay.ship->fuel, this);
+					}
+					else
+					{
+						if(spareFuel > 0.)
+							TransferFuel(spareFuel, bay.ship.get());
+						// If still low or out-of-fuel, re-stock the carrier and don't
+						// launch, except if some ammo was taken (since we can fight).
+						if(!tookAmmo && bay.ship->fuel < .25 * maxFuel)
+						{
+							TransferFuel(bay.ship->fuel, this);
+							continue;
+						}
 					}
 				}
 			}
@@ -1851,14 +1868,37 @@ shared_ptr<Ship> Ship::Board(bool autoPlunder, bool nonDocking)
 	{
 		SetShipToAssist(weak_ptr<Ship>());
 		SetTargetShip(shared_ptr<Ship>());
+		if(attributes.Get("cannot repair other"))
+			return victim;
 		bool helped = victim->isDisabled;
 		victim->hull = min(max(victim->hull, victim->MinimumHull() * 1.5), victim->MaxHull());
 		victim->isDisabled = false;
-		// Transfer some fuel if needed.
-		if(victim->NeedsFuel() && CanRefuel(*victim))
+		// Transfer fuel based on the fleet's tiered refueling priority.
+		// In the one-jump phase, only give enough for one jump. In the
+		// full-fuel phase, transfer all available fuel. Ramscoop fighters
+		// collect their own fuel and should not be refueled by the fleet.
+		bool fleetLogistics = isYours && Preferences::Has("Fighter fleet logistics");
+		bool isRamscoopFighter = victim->CanBeCarried()
+				&& victim->Attributes().Get("ramscoop") >= 1.;
+		bool inOneJumpPhase = false;
+		if(fleetLogistics)
+		{
+			auto parentPtr = GetParent();
+			const Ship *fleetLeader = parentPtr ? parentPtr.get() : this;
+			inOneJumpPhase = !fleetLeader->PlayerEscortsHaveOneJump()
+					|| !fleetLeader->NpcEscortsHaveOneJump()
+					|| (!fleetLeader->IsTankerCarrier() && fleetLeader->NeedsFuel());
+		}
+		bool shouldRefuelToFull = fleetLogistics && !inOneJumpPhase
+				&& CanRefuel(*victim) && !isRamscoopFighter;
+		if(!victim->JumpsRemaining() || shouldRefuelToFull)
 		{
 			helped = true;
-			double fuelTransferred = TransferFuel(victim->JumpFuelMissing(), victim.get());
+			double fuelTransferred = 0.;
+			if(victim->JumpFuelMissing())
+				fuelTransferred = TransferFuel(victim->JumpFuelMissing(), victim.get());
+			else if(!inOneJumpPhase)
+				fuelTransferred = TransferFuel(fuel, victim.get());
 			if(fuelTransferred >= 1.)
 			{
 				if(isYours)
@@ -3014,6 +3054,240 @@ bool Ship::NeedsEnergy() const
 {
 	return attributes.Get("energy capacity") && !energy && !attributes.Get("energy generation")
 			&& !attributes.Get("fuel energy") && !attributes.Get("solar collection");
+}
+
+
+
+bool Ship::MayRequestHelp() const
+{
+	return NeedsFuel() || NeedsEnergy() || IsDisabled();
+}
+
+
+
+double Ship::GetIdleEnergyPerFrame() const
+{
+	return attributes.Get("energy generation") - attributes.Get("energy consumption")
+		+ attributes.Get("fuel energy") + attributes.Get("solar collection");
+}
+
+
+
+double Ship::GetSecondsToEmpty() const
+{
+	double idleEnergy = GetIdleEnergyPerFrame();
+	if(idleEnergy >= 0.)
+		return 1e6;
+	return energy / max(0.0001, -idleEnergy) / 60.;
+}
+
+
+
+bool Ship::IsEnergyLow() const
+{
+	static const double LOW_OPERATING_TIME = 10.;
+	return canBeCarried && GetSecondsToEmpty() < LOW_OPERATING_TIME;
+}
+
+
+
+bool Ship::IsArmed(bool includeAntiMissile) const
+{
+	for(const Hardpoint &hardpoint : Weapons())
+	{
+		const Weapon *weapon = hardpoint.GetWeapon();
+		if(!weapon)
+			continue;
+		if(hardpoint.IsSpecial())
+		{
+			if(includeAntiMissile && weapon->AntiMissile())
+				return true;
+			continue;
+		}
+		const Outfit *ammo = weapon->Ammo();
+		if(ammo && !OutfitCount(ammo))
+			continue;
+		return true;
+	}
+	return false;
+}
+
+
+
+bool Ship::HasFlameWeapon() const
+{
+	for(const Hardpoint &hardpoint : Weapons())
+	{
+		const Weapon *weapon = hardpoint.GetWeapon();
+		if(weapon && weapon->ConsumesFuel())
+			return true;
+	}
+	return false;
+}
+
+
+
+bool Ship::IsEnemyInEscortSystem() const
+{
+	return isEnemyInEscortSystem;
+}
+
+
+
+void Ship::SetEnemyInEscortSystem(bool hasEnemy)
+{
+	isEnemyInEscortSystem = hasEnemy;
+}
+
+
+
+void Ship::UpdateEscortsFuelState(const shared_ptr<Ship> &flagship)
+{
+	bool playerOneJump = true;
+	bool npcOneJump = true;
+	bool playerFull = true;
+	bool npcFull = true;
+	bool needRefuelNpc = false;
+	bool carriersNeedFuel = false;
+
+	for(const weak_ptr<Ship> &escortPtr : escorts)
+	{
+		shared_ptr<Ship> escort = escortPtr.lock();
+		if(!escort || escort->GetSystem() != GetSystem() || escort->IsDisabled())
+			continue;
+
+		// Fighters are fuel collectors, not consumers in the priority system.
+		if(escort->CanBeCarried())
+			continue;
+
+		double fuelCap = escort->attributes.Get("fuel capacity");
+		if(fuelCap <= 0.)
+			continue;
+
+		double jumpFuel = escort->navigation.JumpFuel(escort->GetTargetSystem());
+		bool needsOneJump = (jumpFuel > 0. && escort->fuel < jumpFuel);
+		bool needsMoreFuel = (escort->fuel < fuelCap - .01);
+
+		if(escort->IsYours())
+		{
+			if(needsOneJump)
+				playerOneJump = false;
+			if(needsMoreFuel)
+				playerFull = false;
+		}
+		else
+		{
+			if(needsOneJump)
+				npcOneJump = false;
+			if(needsMoreFuel)
+			{
+				npcFull = false;
+				needRefuelNpc = true;
+			}
+		}
+
+		if(needsMoreFuel && escort->HasBays())
+			carriersNeedFuel = true;
+	}
+
+	playerEscortsHaveOneJump = playerOneJump;
+	npcEscortsHaveOneJump = npcOneJump;
+	playerEscortsFullFuel = playerFull;
+	npcEscortsFullFuel = npcFull;
+	escortsHaveOneJump = playerOneJump && npcOneJump;
+	isEscortsFullOfFuel = playerFull && npcFull;
+	refuelMissionNpcEscort = needRefuelNpc;
+	otherCarriersNeedFuel = carriersNeedFuel;
+
+	// Detect if this ship is a tanker carrier: has bays, fleet logistics enabled,
+	// and at least one carried or deployed fighter with ramscoop and fuel capacity.
+	bool isTanker = false;
+	if(HasBays() && Preferences::Has("Fighter fleet logistics"))
+	{
+		for(const Bay &bay : bays)
+			if(bay.ship && bay.ship->attributes.Get("ramscoop") >= 1.
+					&& bay.ship->attributes.Get("fuel capacity") > 0.)
+			{
+				isTanker = true;
+				break;
+			}
+		if(!isTanker)
+			for(const weak_ptr<Ship> &escortPtr : escorts)
+			{
+				shared_ptr<Ship> escort = escortPtr.lock();
+				if(escort && escort->CanBeCarried()
+						&& escort->attributes.Get("ramscoop") >= 1.
+						&& escort->attributes.Get("fuel capacity") > 0.)
+				{
+					isTanker = true;
+					break;
+				}
+			}
+	}
+	flagshipIsTankerCarrier = isTanker;
+}
+
+
+
+bool Ship::EscortsHaveOneJump() const
+{
+	return escortsHaveOneJump;
+}
+
+
+
+bool Ship::IsEscortsFullOfFuel() const
+{
+	return isEscortsFullOfFuel;
+}
+
+
+
+bool Ship::ShouldRefuelMissionNpcEscort() const
+{
+	return refuelMissionNpcEscort;
+}
+
+
+
+bool Ship::PlayerEscortsHaveOneJump() const
+{
+	return playerEscortsHaveOneJump;
+}
+
+
+
+bool Ship::NpcEscortsHaveOneJump() const
+{
+	return npcEscortsHaveOneJump;
+}
+
+
+
+bool Ship::PlayerEscortsFullFuel() const
+{
+	return playerEscortsFullFuel;
+}
+
+
+
+bool Ship::NpcEscortsFullFuel() const
+{
+	return npcEscortsFullFuel;
+}
+
+
+
+bool Ship::IsTankerCarrier() const
+{
+	return flagshipIsTankerCarrier;
+}
+
+
+
+bool Ship::OtherCarriersNeedFuel() const
+{
+	return otherCarriersNeedFuel;
 }
 
 
@@ -4458,6 +4732,13 @@ void Ship::DoGeneration()
 	hull = min(hull, maxHull);
 
 	isDisabled = isOverheated || hull < MinimumHull() || (!crew && RequiredCrew());
+
+	// Battery-powered fighters become disabled when energy is fully depleted
+	// and they have no way to self-recharge. They recover once recharged.
+	if(!isDisabled && canBeCarried && energy <= 0.
+			&& attributes.Get("energy capacity") > 0.
+			&& GetIdleEnergyPerFrame() <= 0.)
+		isDisabled = true;
 
 	// Update ship supply levels.
 	if(isDisabled)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -392,6 +392,34 @@ public:
 	bool NeedsFuel(bool followParent = true) const;
 	// Checks whether this ship needs energy to function.
 	bool NeedsEnergy() const;
+	// Check if this ship should request help (fuel, energy, or disabled).
+	bool MayRequestHelp() const;
+	// Get the net energy generated per frame at idle (can be negative).
+	double GetIdleEnergyPerFrame() const;
+	// Get the estimated seconds of operation remaining before energy is depleted.
+	double GetSecondsToEmpty() const;
+	// Check if this carried ship has critically low energy and should return to carrier.
+	bool IsEnergyLow() const;
+	// Check if this ship has usable weapons. If includeAntiMissile is true,
+	// anti-missile systems count as being armed.
+	bool IsArmed(bool includeAntiMissile = false) const;
+	// Check if this ship has any weapon that consumes fuel when firing (e.g. Flamethrower).
+	bool HasFlameWeapon() const;
+	// Check if any enemy ships are present in the system this ship's escorts are in.
+	bool IsEnemyInEscortSystem() const;
+	void SetEnemyInEscortSystem(bool hasEnemy);
+	// Update cached escort fuel state (expensive; call infrequently).
+	void UpdateEscortsFuelState(const std::shared_ptr<Ship> &flagship);
+	bool EscortsHaveOneJump() const;
+	bool IsEscortsFullOfFuel() const;
+	bool ShouldRefuelMissionNpcEscort() const;
+	// Per-tier fuel state accessors for the tiered refueling priority system.
+	bool PlayerEscortsHaveOneJump() const;
+	bool NpcEscortsHaveOneJump() const;
+	bool PlayerEscortsFullFuel() const;
+	bool NpcEscortsFullFuel() const;
+	bool IsTankerCarrier() const;
+	bool OtherCarriersNeedFuel() const;
 	// Get the amount of fuel missing for the next jump (smart refueling)
 	double JumpFuelMissing() const;
 	// Get the heat level at idle.
@@ -781,6 +809,19 @@ private:
 	double targeterStrength;
 
 	bool removeBays = false;
+
+	// Cached escort fuel state (updated infrequently via UpdateEscortsFuelState).
+	bool escortsHaveOneJump = true;
+	bool isEscortsFullOfFuel = true;
+	bool refuelMissionNpcEscort = false;
+	bool isEnemyInEscortSystem = false;
+	// Per-tier refueling priority state.
+	bool playerEscortsHaveOneJump = true;
+	bool npcEscortsHaveOneJump = true;
+	bool playerEscortsFullFuel = true;
+	bool npcEscortsFullFuel = true;
+	bool flagshipIsTankerCarrier = false;
+	bool otherCarriersNeedFuel = false;
 
 	// If this ship is disabled or dies as a result of something like corrosion damage,
 	// attribute the event to the last government that hit this ship.

--- a/tests/integration/config/preferences.txt
+++ b/tests/integration/config/preferences.txt
@@ -9,6 +9,7 @@
 "help: control ship with mouse" 1
 "help: dead" 1
 "help: disabled" 1
+"help: fighter fleet logistics" 1
 "help: fighters transfer cargo" 1
 "help: fleet asteroid mining" 1
 "help: fleet asteroid mining shortcuts" 1
@@ -39,5 +40,6 @@
 "help: shop with multiple ships" 1
 "help: stranded" 1
 "help: trading" 1
+"help: try out fighter fleet logistics" 1
 "help: try out fighters transfer cargo" 1
 "help: uninstalling and storage" 1


### PR DESCRIPTION
Including other fighter role enhancements.

This implements https://github.com/endless-sky/endless-sky/pull/6726 onto the latest master branch.

I evaluated complexity of breaking up the features and I am deciding to keep all of the features batched together.  The complexity to break up is significantly higher than merging them as a batch.

Introduction
------------

Tired of pesky energy generation outfits on fighters? Wish you could deploy fighters only carrying a battery? Wish your battery powered fighters would return to the carrier for a recharge?

This change implements a comprehensive set of fighter and drone AI improvements covering battery-powered flight, carrier recovery, defenseless fighter protection, tanker refueling, and anti-missile defense behavior.

The following sections detail carrier AI, fighter AI, and other ship AI enhancements bundled in this PR.

Battery-Powered Fighter Support
-------------------------------

- Player ship, escorts, fighters, and drones can be powered only by batteries (no power generation required).
- Battery powered fighters and drones automatically return to their carrier for recharge when energy runs low.
- Low powered fighters with a mix of battery and small energy generation also benefit from auto-recharge docking.
- A new `"low battery?"` flight check warning alerts the player when a carried ship has insufficient energy and would benefit from docking to recharge rather than attempting to self-recharge in space.
- New energy calculation methods (`GetSecondsToEmpty()`, `GetIdleEnergyPerFrame()`, `IsEnergyLow()`) provide accurate time-to-empty estimates across all outfit configurations: pure battery, negative idle power (e.g. Kahet outfits), small power generation, and fast-recharging supercapacitors.

Low-Energy Disable Behavior
---------------------------

- Ships out of battery become disabled and can call for help for a recharge. This includes escorts and the player flagship.
- Battery powered fighters out of power now have drag since they're disabled. No more floating off into infinity when out of battery power.
- Once recharged (by boarding or docking), disabled battery fighters resume normal operation automatically.

Ship Recovery AI Updates
------------------------

- Battery powered fighters sharing energy with other ships during recovery operations reserve enough energy to return to their parent carrier. This enables battery powered fighters and drones to be effective when aiding in disabled ship recovery.
- Fighters and drones can recover other ships and drones (including battery powered fighters and drones). This is useful when mining in the Ember Wastes with battery powered fighters and drones.
- Carriers will recover their own carried ships which were disabled during battle.
- New data file attribute `"cannot repair other"` disables a ship's ability to repair other ships. This could be activated on drones to prevent them from attempting repairs while still allowing them to dock with their carrier normally.

"No Suicide Pact" for Defenseless Fighters
------------------------------------------

- Fighters will refuse to launch if they have no weapons and there are enemies in the system.
- Fighters will retreat and re-dock with carrier if they have no weapons and enemies enter the system.
- Minimum 10 second flight time. Fighters will refuse to deploy if they do not have sufficient energy for 10 seconds of flight time overall.
  - Vulnerable fighters are less vulnerable in battle (like Boxwings) because they stay docked.
  - Fighters will only deploy if their outfits allow them sufficient flight time in battle.

Anti-Missile Defense AI Updates
-------------------------------

- Fighters equipped with anti-missile and no offensive weapons will still deploy since they're not considered completely defenseless. Their purpose is to defend the parent carrier.
- Fighters equipped with anti-missile and no offensive weapons do not chase targets when the player issues attack orders. They keep station by their parent carrier to defend the carrier from missile attacks.

Carrier Tanker Refueling AI
---------------------------

- When you have a carrier with lots of fuel and fighters or drones with fuel pods, they can be used to refuel your escort fleet.
- Smart refueling behavior: all escorts get 1 jump of fuel first, then all player escorts get 100% refueled, then mission NPC escorts get refueled.
- Escort fuel state is cached and updated infrequently (~5% of frames via random sampling) to avoid performance impact in large fleets.
- The carrier stops while refueling is in progress to facilitate the process.

RTB Fuel Game Rule
------------------

> **Note:** This is my first game rule.  In a separate PR I'm willing to create more game rules around fighter AI logic.  I would rather delete this game rule entirely than attempt to expand on the game rules here.  I can commit to opening a separate pull request for additional game rules with a "Fighter AI" section if that's desired but only after this pull request is merged.

- New game rule `"fighter return to carrier on low fuel"` (default: 25 fuel) controls the minimum fuel a fighter reserves to safely return to its carrier.
- Fighters with flame weapons (fuel-consuming weapons like the Flamethrower) and normal (non-afterburner) thrust ignore the RTB fuel level, since their fuel is ammunition rather than propulsion.
- Fighters with flame weapons AND an afterburner honor the RTB fuel level, since the afterburner consumes fuel for thrust and the fighter needs reserves for both the weapon and getting home.

Performance
-----------

All expensive operations (escort state scanning, enemy presence checks) are gated behind `Random::Int(20)` sampling to ensure they only run ~5% of frames. Cached booleans are read every frame but recalculated infrequently. All existing `Random::Int(N)` performance gates in the codebase are preserved.

Related Issues
--------------

closes https://github.com/endless-sky/endless-sky/issues/6724

closes https://github.com/endless-sky/endless-sky/issues/4241

closes https://github.com/endless-sky/endless-sky/issues/2336

Partially addresses https://github.com/endless-sky/endless-sky/issues/4034 because AI enhancements do a good job at being useful. Refueling ships and defenseless fighters automatically boarding in combat. Fighters also being repaired by other fighters and carriers makes them less annoying to use.

Overall, I want fighter gameplay to be useful and raising this PR from the dead is an attempt to give it another chance.