### PR TITLE
fix: Consider a mission invalid if it has an NPC with an invalid government

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -152,6 +152,7 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 		if(displayName.empty())
 			displayName = trueName;
 	}
+	isDefined = true;
 
 	// For the following keys, if this data node defines a new value for that
 	// key, the old values should be cleared (unless using the "add" keyword).
@@ -528,6 +529,13 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 	if(reputationMin > reputationMax)
 		reputationMin = reputationMax;
 	SetReputation(Reputation());
+}
+
+
+
+bool Government::IsDefined() const
+{
+	return isDefined;
 }
 
 

--- a/source/Government.h
+++ b/source/Government.h
@@ -78,6 +78,7 @@ public:
 	// Load a government's definition from a file.
 	void Load(const DataNode &node, const std::set<const System *> *visitedSystems,
 		const std::set<const Planet *> *visitedPlanets);
+	bool IsDefined() const;
 
 	// Get the display name of this government.
 	const std::string &DisplayName() const;
@@ -197,6 +198,7 @@ private:
 	unsigned id;
 	std::string trueName;
 	std::string displayName;
+	bool isDefined = false;
 	const Swizzle *swizzle = Swizzle::None();
 	ExclusiveItem<Color> color;
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -345,7 +345,7 @@ string NPC::Validate(bool asTemplate) const
 	if(!asTemplate && !government)
 		return "government (missing)";
 	// If a government is provided, it must be defined.
-	if(government && government->TrueName().empty())
+	if(government && !government->IsDefined())
 		return "government (undefined)";
 
 	// NPC templates have certain fields to validate that instantiated NPCs do not:


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug reported by kaiboyjiang on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When a plugin is removed, active missions that refer to content from that plugin are supposed to become invalidated and therefore be disabled. Mission NPCs check if their ships are defined and refer to valid outfits, but currently aren't checking the the government is defined. This means that a mission that has NPCs from a plugin government but otherwise refers to vanilla data won't be marked as invalid when it should be.

This PR updates the NPC validation check to see if the government is defined (by checking that its name is not empty).

## Testing Done

Maybe.

## Save File

[Kai Jiang.txt](https://github.com/user-attachments/files/25919700/Kai.Jiang.txt)
