### PR TITLE
fix(crash): Use a WeightedList to look for helpers in AI::AskForHelp instead of repeatedly adding to a vector

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1431,7 +1431,9 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 				continue;
 
 			// Prefer fast ships over slow ones.
-			canHelp.emplace_back(max<int>(1, min<int>(1000, 1. + .3 * helper->MaxVelocity())), helper.get());
+			// Cap the velocity we care about to 1000 units per frame to guard against plugin ships with
+			// ludicrous speeds.
+			canHelp.emplace_back(clamp<int>(1. + .3 * helper->MaxVelocity(), 1, 1000), helper.get());
 		}
 
 		if(!hasEnemy && !canHelp.empty())


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12346.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

AI::AskForHelp iterates over all ships to determine which ships the caller can ask for help from and gives a higher weight to asking help from faster ships. This weighting is done by adding multiple copies of the helper to a vector, then getting an element from the list at random. If there are a lot of ships in a system with very high max velocities, this can lead to so many helpers being added to the vector that it reaches the maximum vector side and crashes.

This PR changes this code to use a WeightedList instead of a vector, which is designed for exactly this type of thing.

## Testing Done

None, but I'm pretty sure this fixes it.
