### PR TITLE
Add cmath header for ceil() function

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -42,6 +42,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Weapon.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <memory>
 


### PR DESCRIPTION
## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Compiling source/OutfitterPanel.cpp failed with this error:
```
source/OutfitterPanel.cpp:838:97: error: ‘ceil’ was not declared in this scope
  838 |                                                         mustUninstall = max<int>(mustUninstall, ceil(it.second / ammo->Get(it.first)));
      |                                                                                                 ^~~~
```
I just added <cmath> to the included headers and now the file has been built successfully.
