### PR TITLE
Add support for CYGWIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ add_library(ExternalLibraries INTERFACE)
 target_link_libraries(EndlessSkyLib PUBLIC ExternalLibraries)
 
 # Enable sanitizers on debug builds, depending on platform support.
-if(NOT WIN32)
+if(NOT WIN32 AND NOT CYGWIN)
 	set(SANITIZER_OPTS "-g" "-fsanitize=address,undefined,pointer-compare,pointer-subtract,unreachable,builtin,integer-divide-by-zero,vla-bound,null,return,signed-integer-overflow,bounds,alignment,bool,enum,pointer-overflow")
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		list(APPEND SANITIZER_OPTS "-fno-omit-frame-pointer" "-fsanitize=leak,vptr")


### PR DESCRIPTION
**Feature**

Updated sanitizer options and added support for Cygwin.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

I tried to do an experiment and I compiled the game for running on CYGWIN.
Everything was fine except two errors:
```
source/main.cpp: In function ‘void GameLoop(PlayerInfo&, TaskQueue&, const Conversation&, const std::string&, bool)’:
source/main.cpp:517:78: error: ‘getpagesize’ was not declared in this scope; did you mean ‘getdtablesize’?
  517 |                                         virtualMemoryUse = stoul(statmStr) * getpagesize();
      |                                                                              ^~~~~~~~~~~
      |                                                                              getdtablesize
```
```
FAILED: [code=1] tests/endless-sky-tests.exe
ld: cannot find -lasan: No such file or directory
ld: cannot find -lubsan: No such file or directory
collect2: error: ld returned 1 exit status
```
but hopefully they are easy to fix.

According to:
https://man7.org/linux/man-pages/man2/getpagesize.2.html
function `getpagesize()` needs to be activated.
On Linux, it worked fine because `_GNU_SOURCE` automatically add those needed macros, but CYGWIN is not, so it has to be set explicitely. Perhaps, other platforms may need this change in the future.

Next, CYGWIN doesn't support ASAN and UBSAN, so it must fall to the same you already did for `WIN32`.

This PR provides my changes.
