### PR TITLE
fix(bug): Increase the payout of Bounty Hunting (Marauder X) to match its listed payment

### DIFF
--- a/data/human/jobs.txt
+++ b/data/human/jobs.txt
@@ -4024,7 +4024,7 @@ mission "Bounty Hunting (Marauder X)"
 		fleet "Marauder fleet X"
 		dialog phrase "generic hunted bounty fleet eliminated and payment dialog"
 		on kill
-			payment 5000000
+			payment 10000000
 			fail
 
 


### PR DESCRIPTION
This PR addresses the bug[reported on Discord.](https://discord.com/channels/251118043411775489/308902312741568512/1483979268269543525)

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR raises the actual payment of the Bounty Hunting (Marauder X) mission 5M to 10M, matching its apparent payment of 10M.

## Testing Done
0