### PR TITLE
docs: Update gcc versions in build instructions

### DIFF
--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -37,14 +37,12 @@ We recommend using Visual Studio 2022 or newer. If you are unsure of which editi
 We recommend the [MinGW Winlibs](https://winlibs.com/#download-release) distribution, which also includes various tools you'll need to build the game as well. It is possible to use other MinGW distributions too (like Msys2 for example), but you'll need to make sure to install [CMake](https://cmake.org/) (3.21 or later) and [Ninja](https://ninja-build.org/).
 
 When installing MinGW, use the following settings:
-- Version: `8.1.0` (or greater; this document assumes 8.1.0)
-- Architecture: `x86_64`
+- GCC Version: `14.2.0` (or greater; this document assumes 14.2.0)
+- Architecture: `x86_64` (or `i686` when compiling for 32-bit systems)
 - Threads: `posix`
-- Exception: `seh`
+- Exception: `seh` (or `dwarf` for `i686`)
 
-You'll need the POSIX version of MinGW. If you want your builds to have the same runtime library requirements as the official releases of Endless Sky, choose a version that links to the UCRT. For the Winlibs distribution mentioned above, the latest version is currently gcc 14 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it to the list).
-
-Endless Sky requires precompiled libraries to compile and play: [Download link](https://endless-sky.github.io/win64-dev.zip)
+If you want your builds to have the same runtime library requirements as the official releases of Endless Sky, choose a version that links to the UCRT. For the Winlibs distribution mentioned above, the latest version is currently gcc 15.2 ([direct download link](https://github.com/brechtsanders/winlibs_mingw/releases/download/15.2.0posix-13.0.0-ucrt-r6/winlibs-x86_64-posix-seh-gcc-15.2.0-mingw-w64ucrt-13.0.0-r6.zip)). Download and extract the zip file in a folder whose path doesn't contain a space (C:\ for example) and add the bin\ folder inside to your PATH (Press the Windows key and type "edit environment variables", then click on PATH and add it to the list).
 
 ### MacOS
 


### PR DESCRIPTION
**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Updated the required gcc version on Windows from 8.1.0 (which only has partial support for C++20, and may have outdated WinAPI headers) to 14.2, and bumped the direct download link once again. Also mentioned which version to download for 32-bit systems, removed a repeated mention of POSIX threading, and dropped the link to the old pre-vcpkg library package (does anyone actually use it?).