### PR TITLE
fix(ui): Properly disable shop buttons when an item shouldn't be able to be purchased

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -1390,7 +1390,7 @@ ShopPanel::TransactionResult OutfitterPanel::HandleShortcuts(SDL_Keycode key)
 	else if(key == 'i')
 	{
 		// Install up to <modifier> outfits from already owned equipment into each selected ship.
-		result = MoveOutfit(OutfitLocation::Cargo, OutfitLocation::Ship);
+		result = MoveOutfit(OutfitLocation::Cargo, OutfitLocation::Ship, "install");
 		if(!result && !result.canSource)
 			result = MoveOutfit(OutfitLocation::Storage, OutfitLocation::Ship, "install");
 	}

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -91,6 +91,7 @@ private:
 	// same quantity of the selected outfit.
 	const std::vector<Ship *> GetShipsToOutfit(bool isInstall = false) const;
 
+
 private:
 	// Record whether we've checked if the player needs ammo refilled.
 	bool checkedRefill = false;

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -61,6 +61,7 @@ protected:
 	class TransactionResult {
 	public:
 		TransactionResult(std::string error) : success(false), message(std::move(error)) {}
+		TransactionResult(const char *error) : success(false), message(error) {}
 		TransactionResult(bool canSource, bool canPlace, std::string error)
 			: canSource(canSource), canPlace(canPlace), success(false), message(std::move(error)) {}
 		TransactionResult(bool result) : success(result), message() {}


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12382.
Closes #12382.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

TransactionResult currently uses implicit conversions between bool and string to the result object for whether an outfit/ship can be purchased or otherwise acted upon. If the transaction is allowed, then `true` gets returned by the CanMoveOutfit function. Otherwise, a string is provided for the error message.

Since implicit conversions are of the devil, this wasn't being done properly for all error messages. Some error messages were not `std::string`s, but actually `const char *`s. For these error messages, an implicit conversion to a truthy `bool` was done instead of to `std::string`, meaning that cases where an action shouldn't be allowed instead were being allowed. This caused various bugs, including allowing you to purchase maps that you already purchased, and CRASH THE GAME if you clicked any of the buttons with no outfit selected (since the "no outfit selected" error message would be handled as truthy and therefore allow you to click the buttons).

I have solved this by adding a new implicit constructor to TransactionResult that handles `const char *`. I'm open to completely tossing the implicit constructors, though.

I have also fixed attempting to use the "install" button when it's disabled resulting in a dialog that says "no action specified."

## Testing Done

Yes.

## Save File

Just start a new pilot and buy local maps, or try to use one of the shop buttons before you select anything.