### PR TITLE
feat(balance): Adjust Quarg fleets in "Defend Laki Nemparu"

### DIFF
--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -779,7 +779,7 @@ mission "Wanderers: Kor Efret 3"
 		fleet
 			names "quarg"
 			variant
-				"Quarg Wardragon" 1
+				"Quarg Wardragon" 3
 	npc
 		government "Quarg (Kor Efret)"
 		personality heroic
@@ -787,8 +787,9 @@ mission "Wanderers: Kor Efret 3"
 		fleet
 			names "quarg"
 			variant
-				"Quarg Wardragon"
-				"Quarg Wyvern" 2
+				"Quarg Wardragon" 2
+				"Quarg Wyvern" 3
+				"Quarg Hydra"
 	npc
 		government "Quarg (Kor Efret)"
 		personality heroic
@@ -796,8 +797,7 @@ mission "Wanderers: Kor Efret 3"
 		fleet
 			names "quarg"
 			variant
-				"Quarg Wardragon" 3
-				"Quarg Hydra"
+				"Quarg Hydra" 2
 
 
 


### PR DESCRIPTION
**Balance**


This PR addresses #12391, my playtesting, and other comments made in the past.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Despite the [Quarg Revamp](https://github.com/endless-sky/endless-sky/pull/11102) adjusting Quarg fleets, those in the Wanderer campaign mission "Defend Laki Nemparu" are not enough to match the Quarg's assistance prior to the revamp, leading to the fight being significantly more difficult than other Wanderer missions.

Three Quarg fleets trickle into the fight to help even it out for the player. Before the Quarg Revamp, these fleets had:
```
- 1 Wardragon
- 3 Wardragons
- 5 Wardragons
```

After, they had:
```
- 1 Wardragon
- 1 Wardragon, 2 Wyverns
- 1 Hydra
```

Due to Skylance nerfs and balance adjustments, Wardragons are significantly weaker than they used to be, and I underestimated ~~how overpowered the original Wardragon was~~ how much weaker the new ships are compared to old Wardragons.

This PR buffs those fleets to be closer to the strength that they once were, and also uses the larger end of Quarg ships more thematically, now that it exists. The fleets are now:

```
- 3 Wardragons
- 2 Wardragons, 3 Wyverns, 1 Hydra
- 2 Hydras
```

Note that Mereti fleets have been unchanged throughout any balance changes. The Efreti fleets, however, have also changed in the past with the introduction of their other ships, so theirs may be slightly weaker too, but it's clear that most of this fight's current difficulty is a result of the Quarg balance changes.

If we wanted to, we could adjust Efret fleets too, if we want the fight to be more about them and less about the Quarg, but for now this PR address specifically the change in Quarg power.

## Testing Done
Playtested the fight many times with different combinations of Quarg ships. This one felt the most consistent of the tests, where the battle was often close, and not either too difficult or too easy.

I'll note that to me it feels like the Quarg take a bit too long to enter the fight, but it's always been that way.

## Save File
This save file can be used to test these changes:
[Shin.Tensus~Wanderers First Mereti Efret Invasion.txt](https://github.com/user-attachments/files/26648480/Shin.Tensus.Wanderers.First.Mereti.Efret.Invasion.txt)
