### PR TITLE
feat(ui): Uncap the max main zoom factor

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1431,7 +1431,7 @@ tip "Fleet: Harvest flotsam"
 
 # Settings
 tip "Main zoom factor"
-	`Increase the main zoom factor (the size of the UI and gameplay). Wraps back to 100 if the zoom exceeds your screen's limits. If the zoom factor is greater than 100, activates high DPI images if they are available.`
+	`Increase the main zoom factor (the size of the UI and gameplay). Wraps back to 100 if the zoom exceeds your screen's limits.`
 
 tip "View zoom factor"
 	`Increase the zoom factor of the gameplay view when in flight. Can also be changed by the + and - keys and the scroll wheel.`

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -55,7 +55,6 @@ namespace {
 	// Settings that require special handling.
 	const string ZOOM_FACTOR = "Main zoom factor";
 	const int ZOOM_FACTOR_MIN = 100;
-	const int ZOOM_FACTOR_MAX = 200;
 	const int ZOOM_FACTOR_INCREMENT = 10;
 	const string VIEW_ZOOM_FACTOR = "View zoom factor";
 	const string AUTO_AIM_SETTING = "Automatic aiming";
@@ -426,7 +425,7 @@ bool PreferencesPanel::Scroll(double dx, double dy)
 			int zoom = Screen::UserZoom();
 			if(dy < 0. && zoom > ZOOM_FACTOR_MIN)
 				zoom -= ZOOM_FACTOR_INCREMENT;
-			if(dy > 0. && zoom < ZOOM_FACTOR_MAX)
+			if(dy > 0.)
 				zoom += ZOOM_FACTOR_INCREMENT;
 
 			Screen::SetZoom(zoom);
@@ -1329,7 +1328,7 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 	{
 		int newZoom = Screen::UserZoom() + ZOOM_FACTOR_INCREMENT;
 		Screen::SetZoom(newZoom);
-		if(newZoom > ZOOM_FACTOR_MAX || Screen::Zoom() != newZoom)
+		if(Screen::Zoom() != newZoom)
 		{
 			// Notify the user why setting the zoom any higher isn't permitted.
 			// Only show this if it's not possible to zoom the view at all, as

--- a/source/Screen.cpp
+++ b/source/Screen.cpp
@@ -88,7 +88,7 @@ void Screen::SetZoom(int percent, bool noEvent)
 	if(!noEvent)
 		CustomEvents::SendResize();
 
-	USER_ZOOM = max(100, min(200, percent));
+	USER_ZOOM = max(100, percent);
 
 	// Make sure the zoom factor is not set too high for the full UI to fit.
 	static const int MIN_WIDTH = 1000; // Width of main menu


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The main zoom factor is currently locked to be a value between 100% and 200% in increments of 10%. Upon reaching 200%, the next step always wraps back around to 100%. At the same time, if your monitor/window is too small, then the game will wrap the zoom back to 100% sooner. This can be observed easily by playing the game in window mode and shrinking the size of the window, then incrementing the main zoom factor. The wrap-around point should be lower for the small window than when you're playing in a maximized window or fullscreen.

Given the fact that the game already caps against zooming in too far for your window size, I see zero reason why we should have an additional zoom cap at 200%. We've received complaints from players on 4k monitors that the game doesn't let them zoom in enough, so such players should be able to benefit from this uncapped zoom factor.

Also updated the tooltip for this preference, since it's outdated as of #12043.

## Testing Done

Tested that increasing the zoom level eventually wraps back around to 100%. My monitors only go up to 190% before wrapping around, though, so I can't actually properly test if this allows you to go above 200%. If anyone has a 4k monitor and could test, that'd be appreciated.