### PR TITLE
fix(bug): give the player a pilot's license in the Hai start

### DIFF
--- a/data/starts.txt
+++ b/data/starts.txt
@@ -222,6 +222,7 @@ start "hai space"
 			principal 1431000
 			interest 0.003
 			term 730
+	set "license: Pilot's"
 	set "species: human"
 	set "hai space start"
 	set "start: hai"


### PR DESCRIPTION
**Bug fix**

Fixes #12394 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Gives the player a pilot's license when they begin a new game using the Hai start.

## Save File
This save file can be used to test these changes:
N/A. Start a new game with the Hai start.
