### PR TITLE
Fix steam workflow

### DIFF
--- a/source/GameWindow.cpp
+++ b/source/GameWindow.cpp
@@ -90,11 +90,12 @@ bool GameWindow::Init(bool headless)
 
 	// When running the integration tests, don't create a window nor an OpenGL context.
 	if(headless)
-#if defined(__linux__) && !SDL_VERSION_ATLEAST(2, 0, 22)
+	{
+#if defined(__linux__)
 		setenv("SDL_VIDEODRIVER", "dummy", true);
-#else
-		SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
 #endif
+		SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+	}
 
 	// This needs to be called before any other SDL commands.
 	if(SDL_Init(SDL_INIT_VIDEO) != 0)


### PR DESCRIPTION
**CI/CD/Testing**

This PR addresses the bug with the steam CI

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Works around a reintroduced SDL bug where only the environment variable was accepted for hinting at the video driver.

## Testing Done
See workflow.