### PR TITLE
fix(segfault): Fix a crash when loading the game without a recent pilot

### DIFF
--- a/source/MenuPanel.cpp
+++ b/source/MenuPanel.cpp
@@ -172,7 +172,7 @@ void MenuPanel::Draw()
 		info.SetCondition("no pilot loaded");
 		info.SetString("pilot", "No Pilot Loaded");
 	}
-	if(!player.Pilot()->GetGamerules().LockGamerules())
+	if(player.Pilot() && !player.Pilot()->GetGamerules().LockGamerules())
 		info.SetCondition("gamerules unlocked");
 
 	GameData::Interfaces().Get("menu background")->Draw(info, this);
@@ -219,7 +219,7 @@ bool MenuPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		// StartConditionsPanel also handles the case where there's no scenarios.
 		GetUI().Push(new StartConditionsPanel(player, gamePanels, GameData::StartOptions(), nullptr));
 	}
-	else if(key == 'g' && !player.Pilot()->GetGamerules().LockGamerules())
+	else if(key == 'g' && player.Pilot() && !player.Pilot()->GetGamerules().LockGamerules())
 	{
 		GamerulesPanel *panel = new GamerulesPanel(player.Pilot()->GetGamerules(), true);
 		panel->SetCallback(player.Pilot().get(), &PilotProfile::Save);

--- a/source/PilotProfile.cpp
+++ b/source/PilotProfile.cpp
@@ -205,7 +205,7 @@ void PilotProfile::Load()
 	if(isLoaded)
 		return;
 	isLoaded = true;
-	assert(filePath.empty() && "should call SetIdentifier before calling Load");
+	assert(!filePath.empty() && "should call SetIdentifier before calling Load");
 
 	DataFile file(filePath);
 	for(const DataNode &child : file)


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Caught this while testing #12383.

No idea how I got this assert backwards. That implies it never worked to begin with, but I definitely was able to load up the game and play it normally when testing #12351.

## Testing Done

Loaded the game without a recent pilot. It worked.