### PR TITLE
fix(content): Add missing `invisible` tag and `fail` to Teciimach compatibility mission

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -2011,6 +2011,7 @@ event "remnant: teciimach bay deployment"
 ## Compatibility patch for pre-0.11.1 saves to revert Teciimach Canisters back to EMP Torpedoes.
 mission "Remnant: Teciimach Compatibility"
 	non-blocking
+	invisible
 	landing
 	to offer
 		has "event: remnant: teciimach deployment"

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -2017,6 +2017,7 @@ mission "Remnant: Teciimach Compatibility"
 		has "event: remnant: teciimach deployment"
 	on offer
 		event "remnant: teciimach compatibility"
+		fail
 
 event "remnant: teciimach compatibility"
 	outfitter "Remnant"

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -2010,9 +2010,9 @@ event "remnant: teciimach bay deployment"
 
 ## Compatibility patch for pre-0.11.1 saves to revert Teciimach Canisters back to EMP Torpedoes.
 mission "Remnant: Teciimach Compatibility"
-	non-blocking
-	invisible
 	landing
+	invisible
+	non-blocking
 	to offer
 		has "event: remnant: teciimach deployment"
 	on offer


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a missing `invisible` tag and `fail` to the Techiimach mission patch introduced in https://github.com/endless-sky/endless-sky/pull/12239, so the mission doesn't appear, as well as doesn't say permanently active.