### PR TITLE
Patir 3 fixes

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -2665,7 +2665,6 @@ mission "Ka'het: Patir Mystery 14"
 		not "ka'het: beyond Patir"
 	on offer
 		event "ssil vida changes"
-		fail "Ka'het: Voice From The Past 0"
 		conversation
 			`Although its architecture still feels wildly alien, time has helped you become familiar with the way <planet>'s main starport is organized. By now, it's not difficult for you to notice when something changes. Some are subtler than others - it wasn't long ago that additional barriers were placed between the rows of landing pads, much to your displeasure.`
 			`	Passing the arch that connects to the northern shipyards reveals a curious sight. A group of hangars that, until now, were marked as off-limits are now open, and crowds of construction workers are walking in and out of the area. Among the crowd, pairs of camels tow sections of Remnant spacecraft of all kinds; you step aside to let a convoy pass with some of the longest wings you have ever seen.`
@@ -2697,8 +2696,16 @@ mission "Ka'het: Patir Mystery 14"
 				`	"Sorry, but I cannot return there after what happened last time."`
 					decline
 			label go
+			branch VFTP
+				not "builder signal"
 			`	"I would come with you if I could," he signs with trepidation, "but I am required here at the moment, and it is a task that can be easily done by a single person. Follow the procedure Dusk showed you, and you will be done in no time."`
 				accept
+			label VFTP
+			action
+				fail "Ka'het: Voice From The Past 0"
+			`	"I would come with you if I could," he signs with trepidation, "but I am required here at the moment, and it is a task that can be easily done by a single person. Follow the procedure Dusk showed you, and you will be done in no time."`
+				accept
+
 	npc assist save
 		system "Patir"
 		government "Remnant"

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -2665,6 +2665,7 @@ mission "Ka'het: Patir Mystery 14"
 		not "ka'het: beyond Patir"
 	on offer
 		event "ssil vida changes"
+		fail "Ka'het: Voice From The Past 0"
 		conversation
 			`Although its architecture still feels wildly alien, time has helped you become familiar with the way <planet>'s main starport is organized. By now, it's not difficult for you to notice when something changes. Some are subtler than others - it wasn't long ago that additional barriers were placed between the rows of landing pads, much to your displeasure.`
 			`	Passing the arch that connects to the northern shipyards reveals a curious sight. A group of hangars that, until now, were marked as off-limits are now open, and crowds of construction workers are walking in and out of the area. Among the crowd, pairs of camels tow sections of Remnant spacecraft of all kinds; you step aside to let a convoy pass with some of the longest wings you have ever seen.`
@@ -3959,7 +3960,7 @@ mission "Ka'het: Patir Mystery 32"
 		event "Patir moves" 6
 		event "Patir returns" 20
 	on visit
-		dialog "You've arrived at <planet>, but either your escort, your passengers or your cargo are not with you!"
+		dialog "You've arrived at <planet>, but either your escort, your passengers or your cargo have been left behind in the Milky Way!"
 	npc save accompany
 		government "Remnant"
 		ship "Swan (Jump)" "Serene Pillar Lost"
@@ -4527,14 +4528,28 @@ mission "Ka'het: Voice From The Past 0"
 			dialog
 				`You make a close pass above this lifeless satellite, abandoned in a graveyard orbit for who knows how long. All of a sudden, your commlink emits a weak, garbled, whistle-like sound, as if receiving a communication from the Builder spacecraft. While you can't understand it, it might be worth paying another visit to the Remnant.`
 			set "builder signal"
-		to spawn
-			or
-				not "Ka'het: Patir Mystery 14: done"
-				has "Ka'het: Patir Mystery 36: done"
-		to despawn
-			and
-				has "Ka'het: Patir Mystery 14: done"
-				not "Ka'het: Patir Mystery 36: done"
+		on kill
+			dialog
+				`A glance at the radar screen reveals that the nearby Builder satellite exploded, presumably due to the damage incurred. A wasted opportunity.`
+			clear "builder signal"
+
+mission "Ka'het: Voice From The Past 0 Patir 3"
+	landing
+	invisible
+	non-blocking
+	to offer
+		has "Ka'het: Patir Mystery 35: done"
+	to complete
+		never
+	npc assist save
+		government "Builder"
+		system "Fereti"
+		personality derelict waiting
+		ship "Builder Satellite 2" "Valii'sei"
+		on assist
+			dialog
+				`You make a close pass above this lifeless satellite, abandoned in a graveyard orbit for who knows how long. All of a sudden, your commlink emits a weak, garbled, whistle-like sound, as if receiving a communication from the Builder spacecraft. While you can't understand it, it might be worth paying another visit to the Remnant.`
+			set "builder signal"
 		on kill
 			dialog
 				`A glance at the radar screen reveals that the nearby Builder satellite exploded, presumably due to the damage incurred. A wasted opportunity.`

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -3912,7 +3912,7 @@ mission "Ka'het: Patir Mystery 31"
 
 mission "Ka'het: Patir Mystery 32"
 	name "Logistics of a first contact"
-	description "Accompany the Remnant team and to <system> exactly on <date>. Together with them will come <cargo> and a Swan."
+	description "Accompany the Remnant team and their cargo to <system> exactly on <date>, making sure nobody is left behind on the jump in."
 	deadline 6
 	source "Caelian"
 	destination "Builder Settlement"

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -4539,6 +4539,7 @@ mission "Ka'het: Voice From The Past 0 Patir 3"
 	non-blocking
 	to offer
 		has "Ka'het: Patir Mystery 35: done"
+		not "builder signal"
 	to complete
 		never
 	npc assist save

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -3939,7 +3939,6 @@ mission "Ka'het: Patir Mystery 32"
 				`	"What is that?"`
 					goto what
 				`	"You are coming with us too?"`
-					goto what
 			`	"I wish! Maybe when flights become more frequent, and more routine. No, I am part of the ground crew of one of the instruments you will add to our grid near the Builder settlement. Still, it is a serious responsibility - I have co-handled its definition a few months back, and I will also manage some of its data once we have the first light.`
 			`	"You see, this is a very-long-baseline interferometer: an antenna will be put atop our Patir outpost, and another on your ship. As you move further away their processor will compare the results of each to form an enormous, virtual telescope studying the space nearby. Nothing new, of course," she decides to clarify. "The main difference is the galaxy from where these observations are made."`
 				goto choice

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -3960,7 +3960,7 @@ mission "Ka'het: Patir Mystery 32"
 		event "Patir moves" 6
 		event "Patir returns" 20
 	on visit
-		dialog "You've arrived at <planet>, but either your escort, your passengers or your cargo have been left behind in the Milky Way!"
+		dialog "Your escort, your passengers or your cargo have been left behind in the Milky Way, and the mission is a failure. If you wish to continue Patir content, you may wish to reload."
 	npc save accompany
 		government "Remnant"
 		ship "Swan (Jump)" "Serene Pillar Lost"


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

This PR improves the wording of an on-visit message (bringing the Swan beyond Patir), fixes a goto, and also blocks VFTP from starting during Patir 3 even if the mission was already active before updating the game