### PR TITLE
**Balance** Successors - High Houses: Slightly increase Aaulqra and Kaskhorade cargo space.

### DIFF
--- a/data/successors/successor ships.txt
+++ b/data/successors/successor ships.txt
@@ -30,7 +30,7 @@ ship "Aaulqra"
 		"drag" 8.75
 		"heat dissipation" 0.49
 		"fuel capacity" 600
-		"cargo space" 15
+		"cargo space" 25
 		"outfit space" 550
 		"weapon capacity" 240
 		"engine capacity" 120
@@ -203,7 +203,7 @@ ship "Kaskhorade"
 		"drag" 13.6
 		"heat dissipation" .5
 		"fuel capacity" 600
-		"cargo space" 140
+		"cargo space" 240
 		"outfit space" 570
 		"weapon capacity" 280
 		"engine capacity" 110


### PR DESCRIPTION
This PR is aimed at addressing my feedback on Successor High Houses military ships, from my playthrough of the Ghosts PR.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
1: Aaulqra:
This ship has the same (15) cargo capacity as the smaller Vesuade. Although unusually low cargo capacity is part of the flavor, a small increase to 25 will help differentiate it from the smaller warships and make it more potentially interesting for player use when the High Houses license is earned, as it becomes able to install a single outfit expansion. 25 cargo is still unusually low for a sizable medium ship, so the current description remains valid.

2: Kaskhorade:
The relationship in cargo sizes between the small utility (Seiitej) and medium-large utility (Kaskhorade) feels off. The Seiitej is 130 cargo, while the Kaskhorade is basically the same at 140, despite being about twice the size. This PR changes the Kaskhorade to 240 cargo space, about halfway to the Successor medium freighter (Odje), to better differentiate it as a medium utility ship that is larger than the Seiitej. This also makes it more potentially useful for a player flagship, where some sizable cargo capacity is desired to loot outfits.

## Testing Done
Replaced successor ships.txt in a local install with updated data from this PR. Observed that changed cargo space was updated as intended.

## Save File
N/A (Simple balance change)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
