### PR TITLE
Feat(content): Add undefined tribute message for pacifist planets

### DIFF
--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -159,3 +159,14 @@ phrase "free worlds failed"
 phrase "free worlds declined"
 	word
 		`You have declined an essential Free Worlds mission. If you want to continue the story line, revert to the autosave or another earlier snapshot of your pilot.`
+
+phrase "tribute pacifist undefined"
+	word
+		`This system is too small for wars and violence.`
+		`Why do you wish to engage in pointless bloodshed?`
+		`We will not fight. Join us in peace instead.`
+		`We cannot fight you, nor would we choose to. Have peace.`
+		`Peace be with you, captain. There is no need to rend the skies with your guns.`
+		`We will not fight you. We will not kill you. But neither will we pay a single cent of tribute.`
+		`Why should we fight over a piddling sum when it would cause so much death and horror to do so?`
+		`We beg you reconsider this rash decision.`

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -169,4 +169,4 @@ phrase "tribute pacifist undefined"
 		`Peace be with you, captain. There is no need to rend the skies with your guns.`
 		`We will not fight you. We will not kill you. But neither will we pay a single cent of tribute.`
 		`Why should we fight over a piddling sum when it would cause so much death and horror to do so?`
-		`We beg you reconsider this rash decision.`
+		`We beg that you reconsider this rash decision.`

--- a/data/dialog phrases.txt
+++ b/data/dialog phrases.txt
@@ -167,6 +167,6 @@ phrase "tribute pacifist undefined"
 		`We will not fight. Join us in peace instead.`
 		`We cannot fight you, nor would we choose to. Have peace.`
 		`Peace be with you, captain. There is no need to rend the skies with your guns.`
-		`We will not fight you. We will not kill you. But neither will we pay a single cent of tribute.`
+		`We will not fight you. We will not kill you. But neither will we pay a single credit of tribute.`
 		`Why should we fight over a piddling sum when it would cause so much death and horror to do so?`
 		`We beg that you reconsider this rash decision.`

--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -2429,6 +2429,8 @@ planet Harmony
 	spaceport `The spaceport is on the outskirts of one of the larger cities, with a few medium-sized skyscrapers and many tall smokestacks for factories and oil refineries. The starship hangars here are shaped like oversized barns, and close to the hangars, grain is stored in silos. The spaceport police are on horseback.`
 	spaceport `	Inside the building at the center of the port is a large cafeteria, with food of the simple "meat and potatoes" variety. You notice a few children and teenagers in rough, homemade clothing staring out the windows at the ships taking off and landing.`
 	security 0
+	"tribute hails"
+		undefined "tribute pacifist undefined"
 
 planet Haven
 	attributes frontier mining north "north pirate" pirate
@@ -4090,6 +4092,8 @@ planet "New Tibet"
 			"days since year start" > 35
 			"days since year start" < 55
 	security 0.1
+	"tribute hails"
+		undefined "tribute pacifist undefined"
 
 planet "New Tortuga"
 	attributes core "core pirate" factory pirate religious

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -194,6 +194,33 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 				}
 			}
 		}
+		else if(key == "tribute hails" && child.HasChildren())
+		{
+			for(const DataNode &grand : child)
+			{
+				if(grand.Size() != 2)
+				{
+					grand.PrintTrace("Skipping unrecognized attribute:");
+					continue;
+				}
+				bool removeTributePhrase = grand.Token(0) == "remove";
+				const string &grandKey = grand.Token(remove);
+				if(grandKey == "already paying")
+					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "undefined")
+					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "unworthy")
+					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet launching")
+					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet undefeated")
+					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "surrendered")
+					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
+		}
 		// Handle the attributes which can be "removed."
 		else if(!hasValue)
 		{
@@ -285,33 +312,6 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 					dailyTributePenalty = grand.Value(1);
 				else
 					grand.PrintTrace("Skipping unrecognized tribute attribute:");
-			}
-		}
-		else if(key == "tribute hails" && child.HasChildren())
-		{
-			for(const DataNode &grand : child)
-			{
-				if(grand.Size() != 2)
-				{
-					grand.PrintTrace("Skipping unrecognized attribute:");
-					continue;
-				}
-				bool removeTributePhrase = grand.Token(0) == "remove";
-				const string &grandKey = grand.Token(remove);
-				if(grandKey == "already paying")
-					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "undefined")
-					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "unworthy")
-					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "fleet launching")
-					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "fleet undefeated")
-					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "surrendered")
-					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else
-					grand.PrintTrace("Skipping unrecognized attribute:");
 			}
 		}
 		else if(key == "wormhole")

--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -194,33 +194,6 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 				}
 			}
 		}
-		else if(key == "tribute hails" && child.HasChildren())
-		{
-			for(const DataNode &grand : child)
-			{
-				if(grand.Size() != 2)
-				{
-					grand.PrintTrace("Skipping unrecognized attribute:");
-					continue;
-				}
-				bool removeTributePhrase = grand.Token(0) == "remove";
-				const string &grandKey = grand.Token(remove);
-				if(grandKey == "already paying")
-					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "undefined")
-					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "unworthy")
-					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "fleet launching")
-					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "fleet undefeated")
-					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "surrendered")
-					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else
-					grand.PrintTrace("Skipping unrecognized attribute:");
-			}
-		}
 		// Handle the attributes which can be "removed."
 		else if(!hasValue)
 		{
@@ -312,6 +285,33 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 					dailyTributePenalty = grand.Value(1);
 				else
 					grand.PrintTrace("Skipping unrecognized tribute attribute:");
+			}
+		}
+		else if(key == "tribute hails" && child.HasChildren())
+		{
+			for(const DataNode &grand : child)
+			{
+				if(grand.Size() != 2)
+				{
+					grand.PrintTrace("Skipping unrecognized attribute:");
+					continue;
+				}
+				bool removeTributePhrase = grand.Token(0) == "remove";
+				const string &grandKey = grand.Token(remove);
+				if(grandKey == "already paying")
+					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "undefined")
+					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "unworthy")
+					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet launching")
+					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet undefeated")
+					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "surrendered")
+					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
 			}
 		}
 		else if(key == "wormhole")


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #12412.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a new phrase with pacifist tribute messages and made that the `undefined` tribute hail for Harmony and New Tibet.

## Screenshots
Before:
<img width="697" height="358" alt="Screenshot 2026-04-26 at 5 04 50 PM" src="https://github.com/user-attachments/assets/85508d3d-1ea5-4874-afc4-003c30818e3d" />

After:
<img width="631" height="314" alt="Screenshot 2026-04-26 at 10 28 42 PM" src="https://github.com/user-attachments/assets/203b8114-c2f1-4a9f-af96-b09b6d8540d2" />


## Testing Done
With the changes from #12420:
- Flew to and demanded tribute from New Tibet and Harmony (both had the dynamic phrases in this PR).
- Flew to some other random planet with a defense fleet (it had the normal phrase).

Currently, this PR only works with the changes from that PR.

## Save File
Any save file should do.