### PR TITLE
fix: Don't require a value for the "tribute hails" key

### DIFF
--- a/source/Planet.cpp
+++ b/source/Planet.cpp
@@ -194,6 +194,38 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 				}
 			}
 		}
+		else if(key == "tribute hails" && child.HasChildren())
+		{
+			if(remove)
+			{
+				child.PrintTrace("Cannot \"remove\" a specific value from the given key:");
+				continue;
+			}
+			for(const DataNode &grand : child)
+			{
+				if(grand.Size() != 2)
+				{
+					grand.PrintTrace("Skipping unrecognized attribute:");
+					continue;
+				}
+				bool removeTributePhrase = grand.Token(0) == "remove";
+				const string &grandKey = grand.Token(remove);
+				if(grandKey == "already paying")
+					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "undefined")
+					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "unworthy")
+					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet launching")
+					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "fleet undefeated")
+					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else if(grandKey == "surrendered")
+					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
+				else
+					grand.PrintTrace("Skipping unrecognized attribute:");
+			}
+		}
 		// Handle the attributes which can be "removed."
 		else if(!hasValue)
 		{
@@ -285,33 +317,6 @@ void Planet::Load(const DataNode &node, Set<Wormhole> &wormholes, const Conditio
 					dailyTributePenalty = grand.Value(1);
 				else
 					grand.PrintTrace("Skipping unrecognized tribute attribute:");
-			}
-		}
-		else if(key == "tribute hails" && child.HasChildren())
-		{
-			for(const DataNode &grand : child)
-			{
-				if(grand.Size() != 2)
-				{
-					grand.PrintTrace("Skipping unrecognized attribute:");
-					continue;
-				}
-				bool removeTributePhrase = grand.Token(0) == "remove";
-				const string &grandKey = grand.Token(remove);
-				if(grandKey == "already paying")
-					tributeAlreadyPaying = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "undefined")
-					tributeUndefined = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "unworthy")
-					tributeUnworthy = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "fleet launching")
-					tributeFleetLaunching = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "fleet undefeated")
-					tributeFleetUndefeated = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else if(grandKey == "surrendered")
-					tributeSurrendered = removeTributePhrase ? nullptr : GameData::Phrases().Get(grand.Token(1));
-				else
-					grand.PrintTrace("Skipping unrecognized attribute:");
 			}
 		}
 		else if(key == "wormhole")


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described by https://github.com/endless-sky/endless-sky/pull/12418#issuecomment-4323450296

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The "tribute hails" key was below a `else if(!hasValue)` line in the if statement stack, causing it to require a value token even though it doesn't actually need a value.

## Testing Done

Nope.
