### PR TITLE
feat(ui): Change tooltips that overflow the screen to nudge on screen before trying to choose a different draw origin

### DIFF
--- a/source/Rectangle.cpp
+++ b/source/Rectangle.cpp
@@ -205,7 +205,7 @@ bool Rectangle::Contains(const Rectangle &other) const
 
 bool Rectangle::Overlaps(const Rectangle &other) const
 {
-	return !(other.Left() > Right() || other.Right() < Left() || other.Top() > Bottom() || other.Bottom() < Top());
+	return !(other.Left() >= Right() || other.Right() <= Left() || other.Top() >= Bottom() || other.Bottom() <= Top());
 }
 
 

--- a/source/Tooltip.cpp
+++ b/source/Tooltip.cpp
@@ -50,6 +50,23 @@ namespace {
 		return box;
 	}
 
+	Point Nudge(const Rectangle &box)
+	{
+		double x = 0.;
+		if(box.Left() < Screen::Left())
+			x = Screen::Left() - box.Left();
+		else if(box.Right() > Screen::Right())
+			x = Screen::Right() - box.Right();
+
+		double y = 0.;
+		if(box.Top() < Screen::Top())
+			y = Screen::Top() - box.Top();
+		else if(box.Bottom() > Screen::Bottom())
+			y = Screen::Bottom() - box.Bottom();
+
+		return Point(x, y);
+	}
+
 	// Determine where this tooltip should be positioned. Account for whether the
 	// default settings would generate a tooltip that goes off screen, and create
 	// an adjusted tooltip position if this occurs.
@@ -59,13 +76,17 @@ namespace {
 		// Generate a tooltip box from the given parameters.
 		Rectangle box = CreateBox(zone, boxSize, direction, corner);
 
-		// If the tooltip goes off one of the edges of the screen, swap the draw
-		// direction to go the other way. Also swap the corner that the tooltip
-		// is being drawn from as to not overlap the hover zone.
-		bool onScreen = true;
+		// If the tooltip goes off one of the edges of the screen, nudge its position
+		// to no longer go off screen.
+		Rectangle nudged = box + Nudge(box);
+
+		if(!zone.Overlaps(nudged))
+			return nudged;
+
+		// If the nudged box overlaps with the zone that we're trying to display a
+		// tooltip for, swap the draw direction to go the other way.
 		if(box.Left() < Screen::Left())
 		{
-			onScreen = false;
 			if(direction == Tooltip::Direction::UP_LEFT)
 			{
 				direction = Tooltip::Direction::UP_RIGHT;
@@ -81,7 +102,6 @@ namespace {
 		}
 		else if(box.Right() > Screen::Right())
 		{
-			onScreen = false;
 			if(direction == Tooltip::Direction::UP_RIGHT)
 			{
 				direction = Tooltip::Direction::UP_LEFT;
@@ -98,7 +118,6 @@ namespace {
 
 		if(box.Top() < Screen::Top())
 		{
-			onScreen = false;
 			if(direction == Tooltip::Direction::UP_RIGHT)
 			{
 				direction = Tooltip::Direction::DOWN_RIGHT;
@@ -114,7 +133,6 @@ namespace {
 		}
 		else if(box.Bottom() > Screen::Bottom())
 		{
-			onScreen = false;
 			if(direction == Tooltip::Direction::DOWN_RIGHT)
 			{
 				direction = Tooltip::Direction::UP_RIGHT;
@@ -129,11 +147,11 @@ namespace {
 			}
 		}
 
-		// If the initial box doesn't fit on screen, generate a new one with
-		// a different draw location. Don't bother checking if this second box
-		// fits on screen, because if it doesn't, that means that the screen
-		// is simply too small to fit this box.
-		return onScreen ? box : CreateBox(zone, boxSize, direction, corner);
+		// Don't bother checking if this second box overlaps, because if it doesn't,
+		// that means that the screen is simply too small to fit this box and not overlap
+		// the zone at the same time.
+		box = CreateBox(zone, boxSize, direction, corner);
+		return box + Nudge(box);
 	}
 }
 

--- a/source/Tooltip.cpp
+++ b/source/Tooltip.cpp
@@ -147,7 +147,7 @@ namespace {
 			}
 		}
 
-		// Don't bother checking if this second box overlaps, because if it doesn't,
+		// Don't bother checking if this second box overlaps, because if it does,
 		// that means that the screen is simply too small to fit this box and not overlap
 		// the zone at the same time.
 		box = CreateBox(zone, boxSize, direction, corner);


### PR DESCRIPTION
**UI**

Closes #12408.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Added a new Nudge function to Tooltip. Given a box, it returns a Point for how much the box needs to move to remain entirely on screen. If the tooltip would draw off screen, it is now nudged back onto the screen. If the new tooltip location after being nudged would overlap with the hover zone that the tooltip is being drawn for, it then chooses a different draw location (using the same logic as is being used in the current game when the tooltip goes off screen) to generate a new box and nudges that one if it draws off screen.

## Screenshots

The tooltip for the fleet limitation gamerule that I pointed out in the linked issue. This is without shrinking the screen.
<img width="884" height="824" alt="image" src="https://github.com/user-attachments/assets/04df2341-a801-4251-bf27-806105b18a62" />

Shrinking the screen height. The tooltip is now nudged upward.
<img width="826" height="733" alt="image" src="https://github.com/user-attachments/assets/b7bac25b-a8d2-4c64-9eb3-3180d5710697" />

Shrinking the screen width. The draw position gets swapped to a different corner, since simply nudging the initial position would cause it to overlap with the gamerule text.
<img width="936" height="772" alt="image" src="https://github.com/user-attachments/assets/d466a258-f304-42bc-8636-087c0734f257" />

## Testing Done

See screenshots.