### PR TITLE
Fix small typo in preferences panel

### DIFF
--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -775,7 +775,7 @@ void PreferencesPanel::DrawSettings()
 		"Trading",
 		"'Sell Outfits' without outfitter",
 		"Confirm 'Sell Outfits' button",
-		"Confirm 'Sell MInables' button",
+		"Confirm 'Sell Minables' button",
 		"Show parenthesis",
 		"",
 		"Gameplay",


### PR DESCRIPTION

**Typo fix**

## Acknowledgement
- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixed typo in "Confirm 'Sell Minables' button" setting, this typo was also causing the tooltip to not appear.