### PR TITLE
fix(segfault): Use the correct call convention for WinAPI functions on Win32

### DIFF
--- a/source/windows/WinWindow.cpp
+++ b/source/windows/WinWindow.cpp
@@ -58,7 +58,7 @@ void WinWindow::UpdateTitleBarTheme(SDL_Window *window)
 		value = themePreference == Preferences::TitleBarTheme::DARK;
 
 	HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
-	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
+	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT WINAPI (*)(HWND, DWORD, LPCVOID, DWORD)>(
 		GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
 	dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 	FreeLibrary(dwmapi);
@@ -78,7 +78,7 @@ void WinWindow::UpdateWindowRounding(SDL_Window *window)
 	auto value = static_cast<DWM_WINDOW_CORNER_PREFERENCE>(Preferences::GetWindowRounding());
 
 	HMODULE dwmapi = LoadLibraryW(L"dwmapi.dll");
-	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT (*)(HWND, DWORD, LPCVOID, DWORD)>(
+	auto dwmSetWindowAttribute = reinterpret_cast<HRESULT WINAPI (*)(HWND, DWORD, LPCVOID, DWORD)>(
 		GetProcAddress(dwmapi, "DwmSetWindowAttribute"));
 	dwmSetWindowAttribute(windowInfo.info.win.window, DWMWA_WINDOW_CORNER_PREFERENCE, &value, sizeof(value));
 	FreeLibrary(dwmapi);


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added the `WINAPI` specifier to the Windows DWM functions we call to make sure they use stdcall, which is what 32-bit Windows expects.
This crash can happen only with 32-bit versions of the game, because 64-bit Windows has just one call convention, and only on Win11 or newer versions of Win10, because older systems don't support the features we're using there, so they just skip the entire code section. Also for some reason it only happens on Release builds, but I'm not sure why.

## Testing Done
yes.

## Performance Impact
N/A
