### PR TITLE
fix(ui): Move map planet description to prevent overlapping with system name

### DIFF
--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -527,7 +527,7 @@ void MapDetailPanel::ResizeTextArea()
 	descriptionXOffset = mapInterface->GetValue("description x offset");
 	int descriptionWidth = mapInterface->GetValue("description width");
 	description->SetRect(Rectangle::FromCorner(
-		Point(Screen::Right() - descriptionXOffset - descriptionWidth, Screen::Top() + 20),
+		Point(Screen::Right() - descriptionXOffset - descriptionWidth, Screen::Top() + 50.),
 		Point(descriptionWidth - 20, mapInterface->GetValue("description height"))
 	));
 }
@@ -950,7 +950,7 @@ void MapDetailPanel::DrawInfo()
 	{
 		const Sprite *panelSprite = SpriteSet::Get("ui/description panel");
 		Point pos(Screen::Right() - descriptionXOffset - .5f * panelSprite->Width(),
-			Screen::Top() + .5f * panelSprite->Height());
+			Screen::Top() + 30. + .5f * panelSprite->Height());
 		SpriteShader::Draw(panelSprite, pos);
 
 		description->SetText(selectedPlanet->Description().ToString());
@@ -959,8 +959,6 @@ void MapDetailPanel::DrawInfo()
 			AddChild(description);
 			descriptionVisible = true;
 		}
-
-		selectedSystemOffset = -150;
 	}
 	else
 	{

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1160,7 +1160,7 @@ void MapPanel::DrawTravelPlan()
 void MapPanel::DrawSelectedSystem()
 {
 	const Sprite *sprite = SpriteSet::Get("ui/selected system");
-	SpriteShader::Draw(sprite, Point(0. + selectedSystemOffset, Screen::Top() + .5f * sprite->Height()));
+	SpriteShader::Draw(sprite, Point(0., Screen::Top() + .5f * sprite->Height()));
 
 	string text;
 	if(!player.KnowsName(*selectedSystem))
@@ -1182,13 +1182,9 @@ void MapPanel::DrawSelectedSystem()
 		text += " (" + to_string(jumps) + " jumps away)";
 
 	const Font &font = FontSet::Get(14);
-	Point pos(-175. + selectedSystemOffset, Screen::Top() + .5 * (30. - font.Height()));
+	Point pos(-175., Screen::Top() + .5 * (30. - font.Height()));
 	font.Draw({text, {350, Alignment::CENTER, Truncate::MIDDLE}},
 		pos, *GameData::Colors().Get("bright"));
-
-	// Reset the position of this UI element. If something is in the way, it will be
-	// moved back before it's drawn the next frame.
-	selectedSystemOffset = 0;
 }
 
 

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -169,10 +169,6 @@ protected:
 	const System *hoverSystem = nullptr;
 	Tooltip tooltip;
 
-	// An X offset in pixels to be applied to the selected system UI if something
-	// else gets in the way of its default position.
-	int selectedSystemOffset = 0;
-
 	bool fromMission = false;
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10521 (closes #10521).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Moved the planet description box 30 px down so that it doesn't overlap with the system name displayed at the top of the screen. Since the overlap is no longer possible, we also don't need to move the system name to the right dynamically depending on whether the description is visible.

## Screenshots
Before:
<img width="718" height="307" alt="image" src="https://github.com/user-attachments/assets/9ff08a9d-3fd0-4c21-8733-e1d71c94554e" />

After:
<img width="696" height="318" alt="image" src="https://github.com/user-attachments/assets/30551d7c-831a-40b9-8f50-8ac9bbc7d3b8" />

## Testing Done
See the screenshots.

## Performance Impact
N/A