### PR TITLE
feat(graphics): Allow disabling linear interpolation for textures

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1493,6 +1493,9 @@ tip "Ship outlines in HUD"
 tip "Cloaked ship outlines"
 	`Controls the display of cloaked escorts. When fancy, causes the ship to become transparent and applies a red outline. When fast, simply shifts the ship to being red.`
 
+tip "Linear filter"
+	`Use a standard linear filter to make textures look smoother. (Requires game restart.)`
+
 tip "Show status overlays"
 	`Display status overlays over top of all ships when in flight. Status overlays display a ship's shields and hull. If the damaged option is chosen, overlays only appear on ships that have taken damage.`
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1494,7 +1494,7 @@ tip "Cloaked ship outlines"
 	`Controls the display of cloaked escorts. When fancy, causes the ship to become transparent and applies a red outline. When fast, simply shifts the ship to being red.`
 
 tip "Linear filter"
-	`Use a standard linear filter to make textures look smoother. (Requires game restart.)`
+	`Use a standard linear interpolation filter to make sprites look smoother. (Requires game restart.)`
 
 tip "Show status overlays"
 	`Display status overlays over top of all ships when in flight. Status overlays display a ship's shields and hull. If the damaged option is chosen, overlays only appear on ships that have taken damage.`

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -218,6 +218,7 @@ void Preferences::Load()
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
 	settings["Animate main menu background"] = true;
+	settings["Linear filter"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -758,6 +758,7 @@ void PreferencesPanel::DrawSettings()
 		"Show hyperspace flash",
 		EXTENDED_JUMP_EFFECTS,
 		CLOAK_OUTLINE,
+		"Linear filter",
 		"\t",
 		"Performance",
 		"Show CPU / GPU load",

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -17,13 +17,10 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "ImageBuffer.h"
 #include "../Preferences.h"
-#include "../Screen.h"
 
 #include "../opengl.h"
 
 #include <SDL2/SDL.h>
-
-#include <algorithm>
 
 using namespace std;
 
@@ -42,9 +39,10 @@ namespace {
 		glGenTextures(1, target);
 		glBindTexture(type, *target);
 
-		// Use linear interpolation and no wrapping.
-		glTexParameteri(type, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(type, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		// Use linear interpolation (if not disabled in preferences) and no wrapping.
+		int filter = Preferences::Has("Linear filter") ? GL_LINEAR : GL_NEAREST;
+		glTexParameteri(type, GL_TEXTURE_MIN_FILTER, filter);
+		glTexParameteri(type, GL_TEXTURE_MAG_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		if(type == GL_TEXTURE_3D)


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Rendering low-resolution sprites is a choice between having the textures blurred or having them pixelated. I think the pixelated version looks better, so I'm adding a preference. It defaults to on, which matches the old behavior.

## Screenshots
Sprite reduction \ Linear filter | on | off
---|---|---
off | <img width="219" height="199" alt="image" src="https://github.com/user-attachments/assets/a6b15070-5946-440f-ba6d-a8ee9286c2f4" /> | <img width="213" height="210" alt="{3078D89E-CFD2-41A1-B12D-D7770AE4D984}" src="https://github.com/user-attachments/assets/6b6c0d5a-e678-4dd0-b3d4-14bd1b19daa6" />
all | <img width="208" height="204" alt="{F05AADE9-7C6F-4145-8D10-42EF8510BEA5}" src="https://github.com/user-attachments/assets/04020765-e4d9-4f0c-9399-7c44e9ba5db2" /> | <img width="217" height="210" alt="{12DD7022-8D52-4EEF-B684-255F731711CC}" src="https://github.com/user-attachments/assets/4fa80ae8-2783-4968-a7e8-765fb38d8d47" />

## Testing Done
See the screenshots.

## Performance Impact
We need to check the preference on sprite upload, but I don't think it's much of an impact.
