### PR TITLE
Increase the required crew of the Skein

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -3642,7 +3642,7 @@ ship "Skein"
 		"cost" 3500000
 		"shields" 3300
 		"hull" 6700
-		"required crew" 7
+		"required crew" 9
 		"bunks" 18
 		"mass" 850
 		"drag" 11.6


### PR DESCRIPTION
**Balance**

This PR addresses the bug described by me in the Discord server [here](https://discord.com/channels/251118043411775489/460553459381436416/1499448493503156254).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The Nest has 5 required crew and 14 bunks.
The Roost has 7 required crew and 16 bunks.
The Skein has 7 required crew and 18 bunks.

This PR increases the required crew of the Skein to 9. Reasons for this include:
- It is a clean progression.
- One crew member is probably needed per fighter bay for docking/undocking from the arm, repairing the fighter, etc.
- My OCD.

I should note that ships previously owned by the player will not be affected by this change. Only ships bought or captured after this change will have 9 required crew.

## Testing Done
None at all, nada, nil, naught, zero, zilch. Trust.

## Save File
Any save file with access to Skeins will work.

## Performance Impact
N/A