### PR TITLE
fix(typo): Ranseur file path in copyright

### DIFF
--- a/copyright
+++ b/copyright
@@ -2525,7 +2525,7 @@ Copyright: aust_paul
 License: public-domain
  Taken from https://freesound.org/people/aust_paul/sounds/30935/
 
-Files: sound/ranseur*
+Files: sounds/ranseur*
 Copyright: harrisonlace
 License: public-domain
  Taken from https://freesound.org/people/harrisonlace/sounds/634884/


### PR DESCRIPTION
**Typo fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The Ranseur sound in the copyright file was mistakenly pointing to a nonexistent `sound/` folder instead of `sounds/` (where the file actually lives). Fixed it.