### PR TITLE
fix: Register player's death when the flagship is destroyed by hazards

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2622,7 +2622,9 @@ void Engine::DoWeather(Weather &weather)
 		for(Body *body : affectedShips)
 		{
 			Ship *hit = static_cast<Ship *>(body);
-			hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr);
+			int eventType = hit->TakeDamage(visuals, damage.CalculateDamage(*hit), nullptr);
+			if(eventType)
+				eventQueue.emplace_back(nullptr, hit->shared_from_this(), eventType);
 		}
 	}
 }


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described [on Discord](https://discord.com/channels/251118043411775489/536900466655887360/1499768528507502784).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The game will now properly save any events that are generated from `Ship::TakeDamage` triggered by ships getting damaged by hazards. This also includes the destruction event that is required for marking the player as dead.

## Testing Done
yes.

## Performance Impact
N/A
