### PR TITLE
fix(ui): Don't display the loading animation for sprites that refer to an invalid image file

### DIFF
--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -189,7 +189,7 @@ bool MapPlanetCard::DrawIfFits(const Point &uiPoint)
 			SpriteShader::Add(spriteItem);
 			SpriteShader::Unbind();
 		}
-		else
+		else if(sprite->HasDimensions())
 			loadingCircle.Draw(iconPos);
 
 		// Check if drawing a category would not go out of the panel.

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -381,7 +381,7 @@ void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite, const 
 			swizzle = GameData::PlayerGovernment()->GetSwizzle();
 		SpriteShader::Draw(sprite, corner + iconOffset, scale, swizzle);
 	}
-	else
+	else if(sprite->HasDimensions())
 		loadingCircle.Draw(corner + iconOffset);
 }
 

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -314,7 +314,7 @@ double OutfitterPanel::DrawDetails(const Point &center)
 		{
 			if(thumbnail->IsLoaded())
 				SpriteShader::Draw(thumbnail, thumbnailCenter);
-			else
+			else if(thumbnail->HasDimensions())
 				loadingCircle.Draw(thumbnailCenter);
 		}
 
@@ -1095,7 +1095,7 @@ void OutfitterPanel::DrawOutfit(const Outfit &outfit, const Point &center, bool 
 	{
 		if(thumbnail->IsLoaded())
 			SpriteShader::Draw(thumbnail, center);
-		else
+		else if(thumbnail->HasDimensions())
 			loadingCircle.Draw(center);
 	}
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -252,7 +252,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	{
 		if(thumbnail->IsLoaded())
 			SpriteShader::Draw(thumbnail, center + Point(0., 10.), 1., swizzle);
-		else
+		else if(thumbnail->HasDimensions())
 			loadingCircle.Draw(center);
 	}
 	else if(sprite)


### PR DESCRIPTION
**Bug fix**

Fixes a bug reported on [Steam](https://steamcommunity.com/app/404410/discussions/1/842878662568197541/?tscn=1777587068).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

If a sprite has not been loaded, then a loading animation will be displayed in the shop for outfit/ship thumbnails, and in the planet card for planet sprites. An object that refers to an invalid image file will always be considered unloaded, and therefore display the loading animation, even though nothing will ever load.

This PR changes these UI panels to only display the loading animation for sprites that have dimensions, which will exclude sprites that refer to invalid image files.

## Testing Done

Nope.
