### PR TITLE
fix(bug): Allow passage thru Successor wormhole while hostile

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -5752,7 +5752,7 @@ planet "Stronghold of Flugbu"
 	security 0.5
 
 planet "Successor Wormhole"
-	attributes "requires: quantum keystone"
+	attributes "requires: quantum keystone" uninhabited
 	spaceport ``
 	wormhole "Successor Wormhole"
 


### PR DESCRIPTION
**Bug fix**

This PR addresses [this bug reported on Discord](https://discord.com/channels/251118043411775489/1287895983207878686/1491683253357117451).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The Successor wormhole was denying passage when the player was hostile against the Successor government. This PR adds `uninhabited` to the attributes of the wormhole to make it, as an astronomical phenomenon, more tolerant of the petty crimes of mortals.

## Testing Done
Slaughtered some Successor civilians without the PR; the wormhole prevented me from landing. After the PR, it has nothing to say on the matter (though it may be thinking disapproving thoughts).