### PR TITLE
Don't re-recurse the TextInput a second time

### DIFF
--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -418,7 +418,7 @@ bool Panel::DoTextInput(const string &text)
 		if(c->HasFocus())
 			return c->TextInput(text);
 	}
-	return EventVisit(&Panel::TextInput, text);
+	return Panel::TextInput(text);
 }
 
 


### PR DESCRIPTION
Minor fix, but if left alone, it will probably bite us one day.

**Bug fix**



## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The code as-is will attempt to re-recurse the text-input event through all children, even though they already rejected it. I don't think this will actually harm anything (it will just reject it again), but it should be cleaned up. 

## Testing Done
Tested shop panel quantity dropdown, which is the only place that uses this.


## Performance Impact
N/A