### PR TITLE
feat(ui): Update the tooltips of some gamerules for clarity

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1756,8 +1756,8 @@ tip "Lock gamerules"
 
 tip "Fighter crossfire immunity"
 	`Controls which carried ships (fighters and drones), when disabled, will not be hit by projectiles unless they are directly targeted. Fighters and drones are fragile ships that can be difficult and/or tedious to replace for the player, so this gamerule is a means of increasing their survivability without increasing their combat effectiveness. Disabled carried ships can still be hit by explosions, whether from weapons or exploding ships.`
-	`- "off": no carried ships are affected.`
-	`- "only player": only ships owned by the player are affected.`
+	`- "none": no carried ships are affected.`
+	`- "player": only ships owned by the player are affected.`
 	`- "all": all carried ships are affected.`
 
 tip "Universal ammo stocking"

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1728,7 +1728,7 @@ tip "Daily depreciation"
 	`The percentage of an item's depreciable value that it maintains day over day. Only impacts the exponential term of the depreciation calculation. If set to 100%, an item will still linearly lose value.`
 
 tip "Spawn attempt period"
-	`The number of frames on average that the game waits before attempting to spawn a person ship. The game rolls a random number between 0 and this value minus one every frame. If the value lands on 0, a person ship spawn attempt is made. There are 60 frames in a second.`
+	`The number of frames on average that the game waits before attempting to spawn a person ship. The game rolls a random number between 0 and this value minus one every frame. (There are 60 frames in a second.) If the value lands on 0, a person ship spawn attempt is made. In other words, higher values result in lower spawn rates of person ships.`
 
 tip "No spawn weight"
 	`When a person ship spawn attempt is made, this is the "weight" of the chance of having the spawn attempt fail. Each person ship has a "weight" associated with it which determines its chance of spawning. The chance of any single person ship spawning is its weight divided by the sum of the weights of all person ships and this value. That means that the chance of a spawn attempt failing is this number over that same sum.`
@@ -1754,8 +1754,11 @@ tip "Fleet multiplier"
 tip "Lock gamerules"
 	`Controls whether gamerules can be altered after a pilot has been created. If true, the gamerules button will not appear on the main menu for this pilot. If you set this to true on an existing pilot, you will not be able to return to this menu after leaving.`
 
-tip "Fighters hit when disabled"
+tip "Fighter crossfire immunity"
 	`Controls which carried ships (fighters and drones), when disabled, will not be hit by projectiles unless they are directly targeted. Fighters and drones are fragile ships that can be difficult and/or tedious to replace for the player, so this gamerule is a means of increasing their survivability without increasing their combat effectiveness. Disabled carried ships can still be hit by explosions, whether from weapons or exploding ships.`
+	`- "off": no carried ships are affected.`
+	`- "only player": only ships owned by the player are affected.`
+	`- "all": all carried ships are affected.`
 
 tip "Universal ammo stocking"
 	`Controls whether the ammo for most secondary weapons that you have installed or in your cargo will be available for purchase at any outfitter, even if that outfitter does not normally sell ammo of that type. The description of each secondary weapon will indicate whether it can be restocked anywhere when this rule is true.`

--- a/source/GamerulesPanel.cpp
+++ b/source/GamerulesPanel.cpp
@@ -59,7 +59,7 @@ namespace {
 	const string SYSTEM_ARRIVAL_MIN = "Minimum arrival distance";
 	const string FLEET_MULTIPLIER = "Fleet multiplier";
 	const string LOCK_GAMERULES = "Lock gamerules";
-	const string FIGHTERS_HIT_WHEN_DISABLED = "Fighters hit when disabled";
+	const string FIGHTERS_HIT_WHEN_DISABLED = "Fighter crossfire immunity";
 	const string UNIVERSAL_AMMO_STOCKING = "Universal ammo stocking";
 	const string SPAWN_RAID_FLEETS = "Spawn raid fleets";
 	const string FLEET_SIZE_LIMITATION = "Fleet size limitation";


### PR DESCRIPTION
**Feature**

This PR addresses some issues brought up in the 0.11.1 announcement post on Steam.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Made the following changes to gamerule tooltips for clarity:
- Mentioned in the person spawn attempt period tooltip that higher numbers result in lower spawn rates.
- Renamed "Fighters hit when disabled" to "Fighter crossfire immunity", as it was pointed out that the current name makes it sound like the chosen option is doing the reverse of what it actually is.
- Provided a list format of options under the crossfire immunity gamerule.

## Screenshots

<img width="751" height="600" alt="image" src="https://github.com/user-attachments/assets/cbba69cd-289d-471a-9214-28e89905214f" />

## Testing Done

I looked at it.
