### PR TITLE
fix(UI): Deactivate shop buttons aside from "Buy" when you have a license selected that you don't own

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -400,6 +400,10 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 				return "You cannot place licenses into " + LocationName(toLocation) + ".";
 			return "You already have one of these licenses, so there is no reason to buy another.";
 		}
+		if(fromLocation != OutfitLocation::Shop)
+			return "You cannot " + actionName + " licenses.";
+		if(toLocation != OutfitLocation::Ship)
+			return "You cannot place licenses into " + LocationName(toLocation) + ".";
 		return true;
 	}
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12394. Fixes #12394.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The outfitter code was always returning "true" when selecting a license you don't own. Added error messages for cases where you're not using the "Buy" button.

## Screenshots

<img width="1910" height="1012" alt="image" src="https://github.com/user-attachments/assets/1241f3df-0c14-488b-b605-d86982a863ba" />
<img width="342" height="188" alt="image" src="https://github.com/user-attachments/assets/593f8f44-9bb6-41b8-b04c-895e3d2ea003" />

## Testing Done

Yup.