### PR TITLE
feat(mechanics): Store whether the player's cloak command is active in the save file

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -542,8 +542,8 @@ void AI::UpdateKeys(PlayerInfo &player, const Command &activeCommands)
 		for(const auto &it : player.Ships())
 			if(!it->IsParked() && it->CloakingSpeed())
 			{
-				isCloaking = !isCloaking;
-				Messages::Add(*GameData::Messages().Get(isCloaking ?
+				player.SetCloaking(!player.IsCloaking());
+				Messages::Add(*GameData::Messages().Get(player.IsCloaking() ?
 					"engaging cloaking device" : "disengaging cloaking device"));
 				break;
 			}
@@ -803,12 +803,12 @@ void AI::Step(Command &activeCommands)
 				command |= Command::DEPLOY;
 				Deploy(*it, !fightersRetreat);
 			}
-			if(isCloaking)
+			if(player.IsCloaking())
 				command |= Command::CLOAK;
 		}
 
 		// Cloak if the AI considers it appropriate.
-		if(!it->IsYours() || !isCloaking)
+		if(!it->IsYours() || !player.IsCloaking())
 			if(DoCloak(*it, command))
 			{
 				// The ship chose to retreat from its target, e.g. to repair.
@@ -4977,7 +4977,7 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 		command |= Command::DEPLOY;
 		Deploy(ship, !Preferences::Has("Damaged fighters retreat"));
 	}
-	if(isCloaking)
+	if(player.IsCloaking())
 		command |= Command::CLOAK;
 
 	ship.SetCommands(command);

--- a/source/AI.h
+++ b/source/AI.h
@@ -250,8 +250,6 @@ private:
 	// each ship.
 	FireCommand firingCommands;
 
-	bool isCloaking = false;
-
 	bool escortsAreFrugal = true;
 	bool escortsUseAmmo = true;
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -365,6 +365,8 @@ void PlayerInfo::Load(const filesystem::path &path, const shared_ptr<PilotProfil
 			hasFullClearance = true;
 		else if(key == "launching")
 			shouldLaunch = true;
+		else if(key == "cloaked")
+			isCloaking = true;
 		else if(key == "playtime" && hasValue)
 			playTime = child.Value(1);
 		else if(key == "travel" && hasValue)
@@ -1033,6 +1035,20 @@ const StellarObject *PlayerInfo::GetStellarObject() const
 bool PlayerInfo::ShouldLaunch() const
 {
 	return shouldLaunch;
+}
+
+
+
+bool PlayerInfo::IsCloaking() const
+{
+	return isCloaking;
+}
+
+
+
+void PlayerInfo::SetCloaking(bool isCloaking)
+{
+	this->isCloaking = isCloaking;
 }
 
 
@@ -1865,6 +1881,8 @@ bool PlayerInfo::TakeOff(UI &ui, const bool distributeCargo)
 	for(const shared_ptr<Ship> &ship : ships)
 		if(!ship->IsParked() && !ship->IsDisabled())
 		{
+			if(isCloaking)
+				ship->SetCloaked();
 			// Recalculate the weapon cache in case a mass-less change had an effect.
 			ship->UpdateCaches(true);
 			if(ship->GetSystem() != system)
@@ -4943,6 +4961,10 @@ void PlayerInfo::Save(DataWriter &out) const
 	// entering their ship (i.e. because a mission forced them to take off).
 	if(shouldLaunch)
 		out.Write("launching");
+	// This flag is set if the player landed on the current planet while cloaked,
+	// meaning that they should take off while cloaked upon reloading this save.
+	if(isCloaking)
+		out.Write("cloaked");
 	for(const System *system : travelPlan)
 		out.Write("travel", system->TrueName());
 	if(travelDestination)

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -152,6 +152,9 @@ public:
 	// Check whether a mission conversation has raised a flag that the player
 	// must leave the planet immediately (without time to do anything else).
 	bool ShouldLaunch() const;
+	// Check whether the player has given the command for their fleet to cloak.
+	bool IsCloaking() const;
+	void SetCloaking(bool isCloaking);
 
 	// Access the player's accounting information.
 	const Account &Accounts() const;
@@ -485,6 +488,7 @@ private:
 	const System *system = nullptr;
 	const Planet *planet = nullptr;
 	bool shouldLaunch = false;
+	bool isCloaking = false;
 	bool isDead = false;
 	bool displayCarrierHelp = false;
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3081,6 +3081,23 @@ bool Ship::IsCloaked() const
 
 
 
+void Ship::SetCloaked()
+{
+	const double cloakingSpeed = CloakingSpeed();
+	const double cloakingFuel = attributes.Get("cloaking fuel");
+	const double cloakingEnergy = attributes.Get("cloaking energy");
+	const double cloakingHull = attributes.Get("cloaking hull");
+	const double cloakingShield = attributes.Get("cloaking shields");
+	bool canCloak = (!isDisabled && cloakingSpeed > 0. && !cloakDisruption
+		&& fuel >= cloakingFuel && energy >= cloakingEnergy
+		&& MinimumHull() < hull - cloakingHull && shields >= cloakingShield);
+
+	if(canCloak)
+		cloak = 1.;
+}
+
+
+
 double Ship::CloakingSpeed() const
 {
 	return attributes.Get("cloak") + attributes.Get("cloak by mass") * 1000. / Mass();

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -298,6 +298,8 @@ public:
 	// Depending on its "cloaking ..." attributes the ship will be unable to shoot, will not be seen on radar...
 	double Cloaking() const;
 	bool IsCloaked() const;
+	// If this ship is capable of cloaking, make it fully cloaked.
+	void SetCloaked();
 	// The amount of cloaking this ship can do, per frame.
 	double CloakingSpeed() const;
 	// If this ship should be immune to the next damage caused.


### PR DESCRIPTION
**Mechanics**

This PR addresses the feature described in issue #5706. Closes #5706.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

AI has a boolean used for tracking whether the player has issued a cloaking command. I've moved this to PlayerInfo, stored it in the save file, and added a check in PlayerInfo::TakeOff to cause any ship in your fleet capable of cloaking to become fully cloaked when launching from a planet if you have the cloaking command active.

## Testing Done

Yes.