### PR TITLE
fix: Allow the "ignore universal" token to work

### DIFF
--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -392,8 +392,8 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 			for(const DataNode &grand : child)
 			{
 				const string &grandKey = grand.Token(0);
-				if(grand.Size() == 1)
-					atrocityOutfits[GameData::Outfits().Get(grandKey)] = {true, deathSentenceForBlock};
+				if(grandKey == "ignore universal")
+					ignoreUniversalAtrocities = true;
 				else if(grandKey == "remove")
 				{
 					if(grand.Token(1) == "ignore universal")
@@ -406,8 +406,6 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 					else if(!atrocityOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
 						grand.PrintTrace("Invalid remove, outfit not found in existing atrocities:");
 				}
-				else if(grandKey == "ignore universal")
-						ignoreUniversalAtrocities = true;
 				else if(grandKey == "ignore")
 				{
 					if(grand.Token(1) == "ship" && grand.Size() >= 3)
@@ -417,6 +415,8 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 				}
 				else if(grandKey == "ship")
 					atrocityShips[grand.Token(1)] = {true, deathSentenceForBlock};
+				else
+					atrocityOutfits[GameData::Outfits().Get(grandKey)] = {true, deathSentenceForBlock};
 			}
 		}
 		else if(key == "enforces" && child.HasChildren())

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -349,13 +349,12 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 			}
 			for(const DataNode &grand : child)
 			{
-				if(grand.Size() < 2)
-				{
-					grand.PrintTrace("Skipping unrecognized attribute:");
-					continue;
-				}
 				const string &grandKey = grand.Token(0);
-				if(grandKey == "remove")
+				if(grandKey == "ignore universal")
+					ignoreUniversalIllegals = true;
+				else if(grand.Size() < 2)
+					grand.PrintTrace("Skipping unrecognized attribute:");
+				else if(grandKey == "remove")
 				{
 					if(grand.Token(1) == "ignore universal")
 						ignoreUniversalIllegals = false;
@@ -367,8 +366,6 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 					else if(!illegalOutfits.erase(GameData::Outfits().Get(grand.Token(1))))
 						grand.PrintTrace("Invalid remove, outfit not found in existing illegals:");
 				}
-				else if(grandKey == "ignore universal")
-					ignoreUniversalIllegals = true;
 				else if(grandKey == "ignore")
 				{
 					if(grand.Token(1) == "ship" && grand.Size() >= 3)


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described on Discord.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The parsing of the `illegals` node under `government` is skipping all lines with less than two tokens. The `"ignore universal"` flag is intended to only have one token. Therefore, you're currently requires to give a useless value to get this flag to work.

## Testing Done

Added this to the Quarg government and landed on one of their planets with nerve gas. I got fined on vanilla, alongside receiving a warning in the error log:
```
2026-05-17 16:39:04 | W | Skipping unrecognized attribute:
2026-05-17 16:39:04 | W | file /home/amazinite/Desktop/amazinite-endless-sky/data/governments.txt
2026-05-17 16:39:04 | W | L1670:   government Quarg
2026-05-17 16:39:04 | W | L1689:     illegals
2026-05-17 16:39:04 | W | L1690:       "ignore universal"
```

With this PR, I get no error and don't get fined when landing.