### PR TITLE
feat(mechanics): Evaluate conditional text in dialogs at display time instead of at instantiation time

### DIFF
--- a/source/DialogSettings.cpp
+++ b/source/DialogSettings.cpp
@@ -44,44 +44,35 @@ void DialogSettings::Load(const DataNode &node, const ConditionsStore *playerCon
 
 	for(const DataNode &child : node)
 		lines.emplace_back(child, playerConditions);
-
-	// If this dialog was loaded from a save file, then the dialog lines will have already been instantiated.
-	// Collapse them into the text field so that they can be properly saved again (as saving only looks at the text
-	// field). This also pre-computes the text for simple dialogs without `to display` or `phrase` nodes.
-	// One action shouldn't have multiple dialog nodes, but just in case, clear any prior text.
-	text.clear();
-	string resultText;
-	for(const DialogLine &line : lines)
-	{
-		// When checking for a pure-text dialog, reject a dialog with conditions or phrases.
-		if(!line.condition.IsEmpty() || line.text.empty())
-			return;
-
-		// Concatenated lines should start with a tab and be preceded by end-of-line.
-		const string &content = line.text;
-		if(!resultText.empty())
-		{
-			resultText += '\n';
-			if(!content.empty() && content[0] != '\t')
-				resultText += '\t';
-		}
-		resultText += content;
-	}
-	text = std::move(resultText);
 }
 
 
 
 void DialogSettings::Save(DataWriter &out) const
 {
-	// A Dialog being saved has already been instantiated, so all information
-	// is stored in the "text" variable.
+	// A Dialog being saved has already been instantiated, so we only
+	// need to store the text of each line, as all phrases have been
+	// converted into text.
 	out.Write("dialog");
 	out.BeginChild();
 	{
-		// Break the text up into paragraphs.
-		for(const string &line : Format::Split(text, "\n\t"))
-			out.Write(line);
+		for(const DialogLine &line : lines)
+		{
+			out.Write(line.text);
+			out.BeginChild();
+			{
+				if(!line.condition.IsEmpty())
+				{
+					out.Write("to", "display");
+					out.BeginChild();
+					{
+						line.condition.Save(out);
+					}
+					out.EndChild();
+				}
+			}
+			out.EndChild();
+		}
 	}
 	out.EndChild();
 }
@@ -98,54 +89,57 @@ bool DialogSettings::Validate() const
 
 
 
-const string &DialogSettings::Text() const
+string DialogSettings::Text() const
 {
-	return text;
+	string resultText;
+	for(const DialogLine &line : lines)
+	{
+		// Skip text that is disabled. It's technically possible for all lines of a
+		// dialog to be disabled and for this function to return an empty string. This
+		// will result in an empty dialog being displayed to the player and be
+		// considered a content error.
+		if(!line.condition.IsEmpty() && !line.condition.Test())
+			continue;
+
+		// Concatenated lines should start with a tab and be preceded by end-of-line.
+		const string &text = line.text;
+		if(!resultText.empty())
+		{
+			resultText += '\n';
+			if(!text.empty() && text[0] != '\t')
+				resultText += '\t';
+		}
+		resultText += text;
+	}
+
+	return resultText;
 }
 
 
 
 bool DialogSettings::IsEmpty() const
 {
-	return text.empty();
+	return lines.empty();
 }
 
 
 
 DialogSettings DialogSettings::Instantiate(const map<string, string> &subs) const
 {
-	string resultText;
-	if(!text.empty())
-		resultText = Format::Replace(Phrase::ExpandPhrases(text), subs);
-	else
-		for(const DialogLine &line : lines)
-		{
-			// Skip text that is disabled.
-			if(!line.condition.IsEmpty() && !line.condition.Test())
-				continue;
-
-			// Evaluate the phrase if we have one, otherwise copy the prepared text.
-			string content;
-			if(!line.text.empty())
-				content = line.text;
-			else
-				content = line.phrase->Get();
-
-			// Expand any ${phrases} and <substitutions>.
-			content = Format::Replace(Phrase::ExpandPhrases(content), subs);
-
-			// Concatenated lines should start with a tab and be preceded by end-of-line.
-			if(!resultText.empty())
-			{
-				resultText += '\n';
-				if(!content.empty() && content[0] != '\t')
-					resultText += '\t';
-			}
-			resultText += content;
-		}
-
 	DialogSettings result;
-	result.text = std::move(resultText);
+	for(const DialogLine &line : lines)
+	{
+		// Evaluate the phrase if we have one. Otherwise, copy the text.
+		string content = !line.text.empty() ? line.text : line.phrase->Get();
+
+		// Expand any ${phrases} and <substitutions>.
+		content = Format::Replace(Phrase::ExpandPhrases(content), subs);
+
+		// Re-store this line with its expanded text and conditions.
+		// Conditions are not evaluated until the text is displayed.
+		result.lines.emplace_back(content, line.condition);
+	}
+
 	return result;
 }
 
@@ -160,6 +154,13 @@ DialogSettings::DialogLine::DialogLine(std::string text)
 
 DialogSettings::DialogLine::DialogLine(const ExclusiveItem<Phrase> &phrase)
 	: phrase(phrase)
+{
+}
+
+
+
+DialogSettings::DialogLine::DialogLine(const string &text, const ConditionSet &condition)
+	: text(text), condition(condition)
 {
 }
 

--- a/source/DialogSettings.cpp
+++ b/source/DialogSettings.cpp
@@ -59,9 +59,9 @@ void DialogSettings::Save(DataWriter &out) const
 		for(const DialogLine &line : lines)
 		{
 			out.Write(line.text);
-			out.BeginChild();
+			if(!line.condition.IsEmpty())
 			{
-				if(!line.condition.IsEmpty())
+				out.BeginChild();
 				{
 					out.Write("to", "display");
 					out.BeginChild();
@@ -70,8 +70,8 @@ void DialogSettings::Save(DataWriter &out) const
 					}
 					out.EndChild();
 				}
+				out.EndChild();
 			}
-			out.EndChild();
 		}
 	}
 	out.EndChild();

--- a/source/DialogSettings.h
+++ b/source/DialogSettings.h
@@ -44,11 +44,11 @@ public:
 
 	bool Validate() const;
 
-	// Apply any replacements, evaluate any condition sets, and generate from any phrases.
+	// Apply any replacements and generate from any phrases.
 	DialogSettings Instantiate(const std::map<std::string, std::string> &subs) const;
 
-	// Get the text of this dialog (after it has been instantiated and converted into a single block of text).
-	const std::string &Text() const;
+	// Get the text of this dialog, evaluating any conditions.
+	std::string Text() const;
 	bool IsEmpty() const;
 
 
@@ -58,6 +58,7 @@ private:
 	public:
 		explicit DialogLine(std::string text);
 		explicit DialogLine(const ExclusiveItem<Phrase> &phrase);
+		DialogLine(const std::string &text, const ConditionSet &condition);
 		DialogLine(const DataNode &node, const ConditionsStore *playerConditions);
 
 		std::string text;
@@ -69,6 +70,4 @@ private:
 private:
 	// Lines of text under the `dialog` node that haven't yet been instantiated into a single paragraph.
 	std::vector<DialogLine> lines;
-	// The instantiated string from the dialog lines, with all text substitions applied and phrases expanded.
-	std::string text;
 };

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -206,7 +206,7 @@ string MissionAction::Validate() const
 
 
 
-const string &MissionAction::DialogText() const
+string MissionAction::DialogText() const
 {
 	return dialog.Text();
 }

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -59,7 +59,7 @@ public:
 	// Determine if this MissionAction references content that is not fully defined.
 	std::string Validate() const;
 
-	const std::string &DialogText() const;
+	std::string DialogText() const;
 
 	// Check if this action can be completed right now. It cannot be completed
 	// if it takes away money or outfits that the player does not have, or should

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4846,7 +4846,7 @@ void PlayerInfo::StepMissions(UI &ui)
 			// from the same destination.
 			if(visitText.empty())
 			{
-				const auto &text = mission.GetAction(Mission::VISIT).DialogText();
+				string text = mission.GetAction(Mission::VISIT).DialogText();
 				if(!text.empty())
 					visitText = Format::Replace(text, substitutions);
 			}


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #12070. Closes #12070.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Currently, dialog nodes in missions will evaluate `to display` condition sets when the mission is offered to the player. This PR changes it so that `to display` nodes are not evaluated until the point at which the dialog is displayed.

Note that phrases are still used to generate text when the mission is instantiated. This means that if you have something like an `on visit` with a `dialog phrase` with multiple possible outcomes, it'll display the same thing every time for the same instance of the mission. This is because text substitutions for mission data (e.g. payments) are done at instantiation time. If we waited until display time to generate text from a phrase, we wouldn't be able to use text substitutions without changing how mission text substitutions are handled.

## Testing Done

None yet.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/244
