### PR TITLE
fix: Prevent person ships from mind controlling your escorts

### DIFF
--- a/source/GameData.cpp
+++ b/source/GameData.cpp
@@ -69,8 +69,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <cassert>
 #include <filesystem>
-#include <iostream>
 #include <queue>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -498,6 +498,15 @@ void GameData::DestroyPersons(vector<string> &names)
 {
 	for(const string &name : names)
 		objects.persons.Get(name)->Destroy();
+}
+
+
+
+void GameData::HandleEvent(const ShipEvent &event)
+{
+	for(Person &person : objects.persons | views::values)
+		if(person.Do(event))
+			break;
 }
 
 

--- a/source/GameData.h
+++ b/source/GameData.h
@@ -60,6 +60,7 @@ class Point;
 class Politics;
 class Shader;
 class Ship;
+class ShipEvent;
 class Sprite;
 class StarField;
 class StartConditions;
@@ -119,6 +120,8 @@ public:
 	static void ResetPersons();
 	// Mark all persons in the given list as dead.
 	static void DestroyPersons(std::vector<std::string> &names);
+	// Handle any events that may have been taken against a Person.
+	static void HandleEvent(const ShipEvent &event);
 
 	static const Set<Color> &Colors();
 	static const Set<Swizzle> &Swizzles();

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -695,11 +695,6 @@ void MainPanel::StepEvents(bool &isActive)
 		if((event.Type() & ShipEvent::JUMP) && flagship && event.Actor().get() == flagship)
 			player.CreateEnteringMissions();
 
-		// Handle actions taken against person ships.
-		// Currently, only capture events can have any effect on person ships.
-		if(event.Type() & ShipEvent::CAPTURE)
-			GameData::HandleEvent(event);
-
 		// Remove the fully-handled event.
 		eventQueue.pop_front();
 		handledFront = false;

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -695,6 +695,11 @@ void MainPanel::StepEvents(bool &isActive)
 		if((event.Type() & ShipEvent::JUMP) && flagship && event.Actor().get() == flagship)
 			player.CreateEnteringMissions();
 
+		// Handle actions taken against person ships.
+		// Currently, only capture events can have any effect on person ships.
+		if(event.Type() & ShipEvent::CAPTURE)
+			GameData::HandleEvent(event);
+
 		// Remove the fully-handled event.
 		eventQueue.pop_front();
 		handledFront = false;

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Government.h"
 #include "Ship.h"
+#include "ShipEvent.h"
 #include "System.h"
 
 using namespace std;
@@ -190,4 +191,30 @@ void Person::ClearPlacement()
 {
 	if(!IsDestroyed())
 		Restore();
+}
+
+
+
+bool Person::Do(const ShipEvent &event)
+{
+	// First, check if this ship is part of this Person. If not, do nothing. If it
+	// is part of this Person and it just got captured, replace it with a copy of
+	// itself so that when this Person is respawned, it doesn't steal the ship away
+	// from the capturer.
+	const shared_ptr<Ship> &target = event.Target();
+	int type = event.Type();
+	for(shared_ptr<Ship> &ptr : ships)
+		if(ptr == target)
+		{
+			if(type & ShipEvent::CAPTURE)
+			{
+				shared_ptr<Ship> copy = make_shared<Ship>(*ptr);
+				// Unlike NPC, we don't copy the UUID here, since the next time
+				// this ship is spawned, it'll be a different instance.
+				copy->Destroy();
+				ptr.swap(copy);
+			}
+			return true;
+		}
+	return false;
 }

--- a/source/Person.h
+++ b/source/Person.h
@@ -27,6 +27,7 @@ class DataNode;
 class FormationPattern;
 class Government;
 class Ship;
+class ShipEvent;
 class System;
 
 
@@ -62,6 +63,11 @@ public:
 	bool IsPlaced() const;
 	// Mark this person as being no longer "placed" somewhere.
 	void ClearPlacement();
+
+	// Determine if this event is targeting a ship in this Person
+	// and handle the outcome of the event. Returns false if
+	// the event doesn't target this person.
+	bool Do(const ShipEvent &event);
 
 
 private:

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2871,6 +2871,11 @@ void PlayerInfo::HandleEvent(const ShipEvent &event, UI &ui)
 	// If the player's flagship was destroyed, the player is dead.
 	if((event.Type() & ShipEvent::DESTROY) && !ships.empty() && event.Target().get() == Flagship())
 		Die();
+
+	// Handle actions taken against person ships.
+	// Currently, only capture events can have any effect on person ships.
+	if(event.Type() & ShipEvent::CAPTURE)
+		GameData::HandleEvent(event);
 }
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #10379. Closes #10379.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Adds a function to Person to handle ship events. Capture events that target a ship in a Person fleet will now be handled the same way as capture events in NPCs by replacing the ship stored in the Person with a copy. This will prevent the respawning of the Person from stealing back ships you captured.

## Testing Done

Changed the data so that only the Tranquility person ship spawns, which I gave two escorts to. Increased the person ship spawn rate gamerule, waited for the fleet to spawn, and captured the escorts. On the master branch, after landing and departing, my escorts were no where to be seen since they got despawned as a part of the person fleet, and they reappeared under the command of the person fleet once it respawned. With this PR, my escorts were properly with me when I departed, and I was able to see the person fleet respawn with its own regenerated escorts instead of mind controlling mine.
