### PR TITLE
fix(content): Use zero-day event triggers for various compatibility/patch missions

### DIFF
--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -1991,7 +1991,7 @@ mission "Pond Strider Patch for v2"
 	to offer
 		has "event: pond strider mass production"
 	on offer
-		event "pond strider mass production v2"
+		event "pond strider mass production v2" 0
 		fail
 
 

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -541,7 +541,7 @@ mission "Ildaria Pirates Compatibility"
 	to offer
 		has "event: initial deployment 2"
 	on offer
-		event "remove pirates from Ildaria"
+		event "remove pirates from Ildaria" 0
 		fail
 
 event "initial deployment 3"

--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -142,7 +142,7 @@ mission "graveyard insights compatibility"
 	to offer
 		has "First Contact: Ka'het: Remnant 1B: offered"
 	on offer
-		event "graveyard insights"
+		event "graveyard insights" 0
 		fail
 
 event "graveyard insights"

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -141,7 +141,7 @@ mission "Remnant: Blood Test Patch v2"
 		not "Remnant: Scanning Tolerances: done"
 	on offer
 		set "remnant: blood test pure"
-		event "remnant: change hail"
+		event "remnant: change hail" 0
 		fail
 
 
@@ -742,7 +742,7 @@ mission "Remnant: Gascraft-Puffin Compatibility"
 	to offer
 		has "event: remnant: gascraft"
 	on offer
-		event "remnant: puffin"
+		event "remnant: puffin" 0
 		clear "event: remnant: gascraft"
 		fail
 
@@ -2893,7 +2893,7 @@ mission "Remnant: remnant research update compatibility"
 	to offer
 		has "event: remnant research update bjd1"
 	on offer
-		event "remnant: research update bjd1"
+		event "remnant: research update bjd1" 0
 		clear "event: remnant research update bjd1"
 		fail
 

--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -2016,7 +2016,7 @@ mission "Remnant: Teciimach Compatibility"
 	to offer
 		has "event: remnant: teciimach deployment"
 	on offer
-		event "remnant: teciimach compatibility"
+		event "remnant: teciimach compatibility" 0
 		fail
 
 event "remnant: teciimach compatibility"

--- a/data/wanderer/wanderers middle.txt
+++ b/data/wanderer/wanderers middle.txt
@@ -1159,7 +1159,7 @@ mission "Wanderers: Kor Mereti Quarg Attitude Patch"
 	to offer
 		has "event: wanderers: kor mereti friendly"
 	on offer
-		event "wanderers: kor mereti friendly"
+		event "wanderers: kor mereti friendly" 0
 		fail
 
 

--- a/data/wanderer/wanderers start.txt
+++ b/data/wanderer/wanderers start.txt
@@ -405,7 +405,7 @@ mission "Wanderer Hail Patch"
 	to offer
 		has "event: wanderer technology available"
 	on offer
-		event "wanderer technology available"
+		event "wanderer technology available" 0
 		fail
 
 
@@ -485,7 +485,7 @@ mission "Wanderers: Vara K'Chrai Facilities Patch"
 	to offer
 		has "Wanderers Conversation: offered"
 	on offer
-		event "wanderers: vara k'chrai facilities"
+		event "wanderers: vara k'chrai facilities" 0
 		fail
 
 
@@ -1659,7 +1659,7 @@ mission "Wanderers: Unfettered Invasion Patch"
 	to offer
 		has "event: wanderers: unfettered invasion"
 	on offer
-		event "wanderers: unfettered invasion starts"
+		event "wanderers: unfettered invasion starts" 0
 		fail
 
 # Giving Heavy Gust to old saves:
@@ -1671,7 +1671,7 @@ mission "Wanderers: Heavy Gust Patch"
 		has "event: wanderers: unfettered invasion starts"
 		not "event: wanderers: heavy gust mass production"
 	on offer
-		event "wanderers: heavy gust mass production"
+		event "wanderers: heavy gust mass production" 0
 		fail
 
 mission "Wanderers Invaded 0"
@@ -2136,7 +2136,7 @@ mission "Wanderers Hai Assistance Fleet patch"
 		has "Wanderers Hai Assistance Fleet: offered"
 		not "event: hai blockade"
 	on offer
-		event "hai blockade"
+		event "hai blockade" 0
 		fail
 
 
@@ -2353,7 +2353,7 @@ mission "eastern evacuation"
 			has "Wanderers Solifuge Recon 2: done"
 			has "Wanderers Pond Strider Recon 2: done"
 	on offer
-		event "eastern evacuation"
+		event "eastern evacuation" 0
 		fail
 
 mission "Wanderers Evacuation 1"
@@ -2555,7 +2555,7 @@ mission "Solifuge Shipyards Patch"
 		has "event: battle for sich'ka'ara ends"
 		not "event: solifuge deployment"
 	on offer
-		event "solifuge deployment"
+		event "solifuge deployment" 0
 		fail
 
 event "battle for sich'ka'ara ends"
@@ -2586,7 +2586,7 @@ mission "Wanderers: Kort Vek'kri Tribute Patch"
 	to offer
 		has "event: battle for sich'ka'ara ends"
 	on offer
-		event "kort vek'kri tribute clear"
+		event "kort vek'kri tribute clear" 0
 		fail
 
 event "kort vek'kri tribute clear"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #11685. Closes #11685.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The linked issue was caused by loading a save file that had completed part of the Wanderer story, but didn't yet have a compatibility event triggered. This PR changes all one-day event triggers in compatibility/patch missions to instead be zero-day triggers.

## Testing Done

None at all.