### PR TITLE
feat: Add a condition for determining if an event is scheduled

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4679,6 +4679,18 @@ void PlayerInfo::RegisterDerivedConditions()
 		return Random::Int(value);
 	});
 
+	// A condition for determining if an event is currently scheduled.
+	// Returns the number of days until the scheduled event will occur.
+	// If multiple events of the same name are scheduled, only the earliest
+	// event is considered.
+	conditions["scheduled event: "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
+		string event = ce.NameWithoutPrefix();
+		for(const ScheduledEvent &scheduled : scheduledEvents)
+			if(scheduled.event->TrueName() == event)
+				return scheduled.event->GetDate() - date;
+		return 0;
+	})
+
 	// Gamerule condition getter:
 	conditions["gamerule: "].ProvidePrefixed([](const ConditionEntry &ce) -> int64_t {
 		return GameData::GetGamerules().GetValue(ce.NameWithoutPrefix());

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4689,7 +4689,7 @@ void PlayerInfo::RegisterDerivedConditions()
 			if(scheduled.event->TrueName() == event)
 				return scheduled.event->GetDate() - date;
 		return 0;
-	})
+	});
 
 	// Gamerule condition getter:
 	conditions["gamerule: "].ProvidePrefixed([](const ConditionEntry &ce) -> int64_t {


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Came up with this idea as a potential method of preventing compatibility missions from offering when they don't need to. Ref: #12462

* `"scheduled event: <name>"`: if the event with the given name is scheduled to occur, returns the number of days until it will occur. If multiple events of the same name are scheduled, the earliest event will be used. If an event is not scheduled, returns 0.

## Usage examples

The following could be used to cause a mission to offer if the "war begins" event is less than 30 days away from triggering at the start of the game, or has already triggered (since the event already having been triggered would result in the condition returning 0).
```
to offer
	"scheduled event: war begins" < 30
```
If all you want to do is determine whether an event is scheduled or not, you'd just use `has`.
```
to offer
	has "scheduled event: war begins"
```

## Testing Done

None. Trust me, though.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/245
