### PR TITLE
fix(content): Lower the Hai Tracker Pod mass by 0.2 so that its mass equals its outfit space when full on ammunition

### DIFF
--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -378,7 +378,7 @@ outfit "Hai Tracker Pod"
 	index 02010
 	cost 150000
 	thumbnail "outfit/hai tracker pod"
-	"mass" 5
+	"mass" 4.8
 	"outfit space" -16
 	"weapon capacity" -16
 	"gun ports" -1


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

This PR addresses the bug described in issue #12438.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Closes #12438.

## Testing Done

Do I need to?