### PR TITLE
fix(content): Remove duplicate choice in Successor mission

### DIFF
--- a/data/successors/successor 1 prologue.txt
+++ b/data/successors/successor 1 prologue.txt
@@ -812,10 +812,6 @@ mission "Successors: Kaatrij First Contact 1"
 					to display
 						not "Successors: kijran"
 					goto kijran
-				`	"Can you tell me more about yourself?"`
-					to display
-						has "language: Successor"
-						not "Successors: kijran"
 			label kijran
 			action
 				set "Successors: kijran"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12310

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixes #12310. Removes a duplicate choice in the conversation associated with `Successors: Kaatrij First Contact 1`. The player no longer gets two choices to ask Saajret about themselves.

## Testing Done
Played though the mission a couple of times, following different paths through the dialogue. Seems to all work correctly.