### PR TITLE
Fix Electron Beam mission incorrectly completing without the outfit

### DIFF
--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -266,6 +266,7 @@ mission "FW Southern Recon 1B"
 		unmark "Wei"
 	to complete
 		not "FW Southern Recon 1B (Turret): done"
+		has "outfit: Electron Beam"
 	to fail
 		has "FW Southern Recon 1B (Turret): done"
 	on visit


### PR DESCRIPTION
## Description

Fixes #12468.

The `to complete` condition of mission `FW Southern Recon 1B` (the Electron Beam variant of the Free Worlds Southern Recon mission) only checked that the Turret variant of the mission wasn't completed. This allowed the mission to complete — and silently remove an installed Electron Beam from the player's ship — even when the player had never explicitly acquired one for the mission.

### Scenario reproduced by the reporter

1. Player captures a Navy Gunboat that has installed Electron Beams.
2. Player accepts the Reconnaissance mission and proceeds without using the "I already plundered one" dialogue option.
3. Upon returning to Sargas/Trinket, the mission auto-completes.
4. `outfit "Electron Beam" -1` runs, removing the installed weapon from the captured Gunboat and granting the player ~21 free outfit space, with no corresponding dialogue acknowledging the delivery as intentional.

## Fix

Added `has "outfit: Electron Beam"` to the `to complete` block so the mission only completes when the player actually has an Electron Beam available. When the player lacks one, the existing `on visit` dialog (`"You've returned to <planet>, but you don't have an Electron Beam..."`) is shown instead, letting them continue the mission as designed.

## Testing

- [ ] Verified that when the player has an Electron Beam installed, the mission completes correctly and removes the outfit.
- [ ] Verified that when the player has no Electron Beam, the `on visit` dialogue is shown and the mission remains active.
- [ ] Verified that the existing "I already plundered one" dialogue path during mission offer is unaffected.