### PR TITLE
feat(content): New description for Uuoru-Veldt-Stir

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -6149,8 +6149,8 @@ planet "Ut Divitas"
 
 planet Uuoru-Veldt-Stir
 	attributes successor uninhabited
-	landscape land/hills0
-	description `The landscape on this planet is marked by gently rolling hills and the occasional pond. Your sensors remark that the atmosphere outside, while oxygen-rich, is too thin to safely breathe, and while you see a preponderance of hardy plant life, there are no animals to be seen.`
+	landscape land/tundra1
+	description `Tucked into the wide glacial valleys of this planet are marshy lowlands dotted with meltwater ponds. Your ship's sensors remark that the atmosphere outside, while oxygen-rich, is too thin to safely breathe, and although you see a preponderance of hardy plant life, there are no animals to be seen.`
 	government Uninhabited
 
 planet "Uye Mpi"


### PR DESCRIPTION
**Content**

Follow-up to #12444.
## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Applies the new landscape `tundra1` added in #12444 to Uuoru-Veldt-Stir and changes the planet's description to match the new image.