### PR TITLE
ui: Allow issuing focus fire orders separately from firing flagship weapons with mouse controls

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2393,8 +2393,7 @@ void Engine::HandleMouseClicks()
 			}
 		}
 	}
-	if(!clickTarget && !clickedAsteroid
-		&& mouseButton == secondaryMouseButton)
+	if(!clickTarget && !clickedAsteroid && mouseButton == secondaryMouseButton)
 	{
 		UI::PlaySound(UI::UISound::TARGET);
 		ai.IssueMoveTarget(clickPoint + camera.Center(), playerSystem);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2353,11 +2353,12 @@ void Engine::HandleMouseClicks()
 			}
 		}
 
+	MouseButton secondaryMouseButton = isMouseTurningEnabled ? MouseButton::MIDDLE : MouseButton::RIGHT;
 	bool clickedAsteroid = false;
 	if(clickTarget)
 	{
 		UI::PlaySound(UI::UISound::TARGET);
-		if(mouseButton == MouseButton::RIGHT)
+		if(mouseButton == secondaryMouseButton)
 			ai.IssueShipTarget(clickTarget);
 		else
 		{
@@ -2387,13 +2388,13 @@ void Engine::HandleMouseClicks()
 				clickedAsteroid = true;
 				clickRange = range;
 				flagship->SetTargetAsteroid(minable);
-				if(mouseButton == MouseButton::RIGHT)
+				if(mouseButton == secondaryMouseButton)
 					ai.IssueAsteroidTarget(minable);
 			}
 		}
 	}
 	if(!clickTarget && !clickedAsteroid
-		&& mouseButton == (isMouseTurningEnabled ? MouseButton::MIDDLE : MouseButton::RIGHT))
+		&& mouseButton == secondaryMouseButton)
 	{
 		UI::PlaySound(UI::UISound::TARGET);
 		ai.IssueMoveTarget(clickPoint + camera.Center(), playerSystem);


### PR DESCRIPTION
**Bug fix**, I guess

This PR addresses a bug reported [on Discord](https://discord.com/channels/251118043411775489/251118265965871104/1509573030429462618).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Currently, the command that tells your escorts to focus on a particular ship or asteroid can be triggered via clicking the target with the right mouse button. The problem is that with mouse controls, the right button is also mapped to firing your primary weapons. #11084 was supposed to resolve this issue by remapping some actions from the right button to the middle one, but this particular case wasn't changed there. As the report suggests it might sometimes be desirable to fire at your target without your entire fleet joining you, I'm remapping the focus fire too, in this PR.

## Testing Done
Tested shooting and focusing fire on ships and asteroids.

## Wiki Update
Nah. We don't have the mouse controls documented in the wiki anyway.

## Performance Impact
None.
