### PR TITLE
fix(ui): Preload thumbnails of outfits in stock

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -170,6 +170,9 @@ void PlanetPanel::Step()
 				SpriteLoadManager::LoadDeferred(queue, outfit.first->Thumbnail());
 			for(const auto &outfit : player.Cargo().Outfits())
 				SpriteLoadManager::LoadDeferred(queue, outfit.first->Thumbnail());
+			for(const auto &[outfit, count] : player.GetStock())
+				if(count > 0)
+					SpriteLoadManager::LoadDeferred(queue, outfit->Thumbnail());
 			for(const auto &license : player.Licenses())
 			{
 				const Outfit *outfit = GameData::Outfits().Find(license + " License");


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
If you have sprite deferring enabled, and you load a save with an outfit in stock that isn't installed on any of your ships, placed in planetary storage or cargo, or sold by the standard outfitters on the planet, its thumbnail fails to load on master, which is fixed by this PR.

## Testing Done
yes.

## Performance Impact
N/A