### PR TITLE
fix(ui): Correct the length of shop sidebar scrollbar

### DIFF
--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -882,7 +882,7 @@ void ShopPanel::DrawShipsSidebar()
 	if(sidebarScroll.Scrollable())
 	{
 		Point top(Screen::Right() - 3, Screen::Top() + 10);
-		Point bottom(Screen::Right() - 3, Screen::Bottom() - 80);
+		Point bottom(Screen::Right() - 3, Screen::Bottom() - ButtonPanelHeight() - 10);
 
 		sidebarScrollbar.SyncDraw(sidebarScroll, top, bottom);
 	}


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Replaced an endpoint value hardcoded for the old shorter button panel with a dynamically selected ButtonPanelHeight to prevent it from overlapping with the button panel.

## Screenshots
Before:
<img width="269" height="73" alt="{52BA1660-F956-49E5-A4C7-53C8EE9CBED6}" src="https://github.com/user-attachments/assets/c4a1d790-7214-4b62-8f62-7ae8ffc0a741" />

After:
<img width="274" height="77" alt="{438D1DDB-24A9-4F3B-93EE-61AD9D329EB6}" src="https://github.com/user-attachments/assets/98d961ff-b702-4a87-b308-83d4a6dbe5ed" />

## Testing Done
yes.

## Performance Impact
N/A