### PR TITLE
Fix escorts failing to land or transit wormholes with player (#11505)

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -41,7 +41,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Preferences.h"
 #include "Random.h"
 #include "RoutePlan.h"
-#include "ScanType.h"
 #include "Ship.h"
 #include "ship/ShipAICache.h"
 #include "ShipEvent.h"
@@ -542,8 +541,8 @@ void AI::UpdateKeys(PlayerInfo &player, const Command &activeCommands)
 		for(const auto &it : player.Ships())
 			if(!it->IsParked() && it->CloakingSpeed())
 			{
-				player.SetCloaking(!player.IsCloaking());
-				Messages::Add(*GameData::Messages().Get(player.IsCloaking() ?
+				isCloaking = !isCloaking;
+				Messages::Add(*GameData::Messages().Get(isCloaking ?
 					"engaging cloaking device" : "disengaging cloaking device"));
 				break;
 			}
@@ -575,13 +574,6 @@ void AI::UpdateKeys(PlayerInfo &player, const Command &activeCommands)
 	}
 	else if(activeCommands.Has(Command::FIGHT) && !shift && targetAsteroid)
 		IssueAsteroidTarget(targetAsteroid);
-	if(activeCommands.Has(Command::SCAN_ORDER) && target && !target->IsYours() && !shift
-		&& (player.HasScanner(ScanType::CARGO) || player.HasScanner(ScanType::OUTFIT)))
-	{
-		OrderSingle newOrder{Orders::Types::SCAN};
-		newOrder.SetTargetShip(target);
-		IssueOrder(newOrder, "scanning \"" + target->GivenName() + "\".");
-	}
 	if(activeCommands.Has(Command::HOLD_FIRE) && !shift)
 	{
 		OrderSingle newOrder{Orders::Types::HOLD_FIRE};
@@ -602,7 +594,7 @@ void AI::UpdateKeys(PlayerInfo &player, const Command &activeCommands)
 	// Get rid of any invalid orders. Carried ships will retain orders in case they are deployed.
 	for(auto it = orders.begin(); it != orders.end(); )
 	{
-		it->second.Validate(it->first, player);
+		it->second.Validate(it->first, flagship->GetSystem());
 		if(it->second.Empty())
 		{
 			it = orders.erase(it);
@@ -803,12 +795,12 @@ void AI::Step(Command &activeCommands)
 				command |= Command::DEPLOY;
 				Deploy(*it, !fightersRetreat);
 			}
-			if(player.IsCloaking())
+			if(isCloaking)
 				command |= Command::CLOAK;
 		}
 
 		// Cloak if the AI considers it appropriate.
-		if(!it->IsYours() || !player.IsCloaking())
+		if(!it->IsYours() || !isCloaking)
 			if(DoCloak(*it, command))
 			{
 				// The ship chose to retreat from its target, e.g. to repair.
@@ -847,9 +839,9 @@ void AI::Step(Command &activeCommands)
 				&& !target->GetGovernment()->IsEnemy(gov) && target->GetGovernment() != gov)
 			{
 				++scanTime[&*it];
-				if(it->CargoScanFraction() >= 1.)
+				if(it->CargoScanFraction() == 1.)
 					cargoScans[&*it].insert(&*target);
-				if(it->OutfitScanFraction() >= 1.)
+				if(it->OutfitScanFraction() == 1.)
 					outfitScans[&*it].insert(&*target);
 			}
 		}
@@ -1079,11 +1071,8 @@ void AI::Step(Command &activeCommands)
 				parentChoices.reserve(ships.size() * .1);
 				auto getParentFrom = [&it, &gov, &parentChoices](const list<shared_ptr<Ship>> &otherShips) -> shared_ptr<Ship>
 				{
-					// Fighters with the staying personality should only dock with carriers that are also staying.
-					bool isStaying = it->GetPersonality().IsStaying();
 					for(const auto &other : otherShips)
-						if(other->GetGovernment() == gov && other->GetSystem() == it->GetSystem()
-							&& (!isStaying || other->GetPersonality().IsStaying()) && !other->CanBeCarried())
+						if(other->GetGovernment() == gov && other->GetSystem() == it->GetSystem() && !other->CanBeCarried())
 						{
 							if(!other->IsDisabled() && other->CanCarry(*it))
 								return other;
@@ -1394,7 +1383,7 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 		const Government *gov = ship.GetGovernment();
 		bool hasEnemy = false;
 
-		WeightedList<Ship *> canHelp;
+		vector<Ship *> canHelp;
 		canHelp.reserve(ships.size());
 		for(const auto &helper : ships)
 		{
@@ -1442,14 +1431,12 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 				continue;
 
 			// Prefer fast ships over slow ones.
-			// Cap the velocity we care about to 1000 units per frame to guard against plugin ships with
-			// ludicrous speeds.
-			canHelp.emplace_back(clamp<int>(1. + .3 * helper->MaxVelocity(), 1, 1000), helper.get());
+			canHelp.insert(canHelp.end(), 1 + .3 * helper->MaxVelocity(), helper.get());
 		}
 
 		if(!hasEnemy && !canHelp.empty())
 		{
-			Ship *helper = canHelp.Get();
+			Ship *helper = canHelp[Random::Int(canHelp.size())];
 			helper->SetShipToAssist(ship.weak_from_this());
 			helperList[&ship] = helper->weak_from_this();
 			isStranded = true;
@@ -1529,8 +1516,7 @@ shared_ptr<Ship> AI::FindTarget(const Ship &ship) const
 		auto it = orders.find(&ship);
 		if(it != orders.end())
 		{
-			if(it->second.Has(Orders::Types::ATTACK) || it->second.Has(Orders::Types::FINISH_OFF)
-					|| it->second.Has(Orders::Types::SCAN))
+			if(it->second.Has(Orders::Types::ATTACK) || it->second.Has(Orders::Types::FINISH_OFF))
 				return it->second.GetTargetShip();
 			if(it->second.Has(Orders::Types::HOLD_FIRE))
 				return target;
@@ -1889,14 +1875,6 @@ bool AI::FollowOrders(Ship &ship, Command &command)
 		// has a target, the target is in-system and targetable. But, to be sure:
 		return false;
 	}
-	else if(shipOrders.Has(Orders::Types::SCAN))
-	{
-		if(target->Velocity().Length() > ship.MaxVelocity() * 0.9)
-			CircleAround(ship, command, *target);
-		else
-			MoveTo(ship, command, target->Position(), target->Velocity(), 1., 1.);
-		command |= Command::SCAN;
-	}
 	else if(shipOrders.Has(Orders::Types::KEEP_STATION))
 		KeepStation(ship, command, *target);
 	else if(shipOrders.Has(Orders::Types::GATHER))
@@ -2181,8 +2159,6 @@ void AI::MoveIndependent(Ship &ship, Command &command)
 		MoveTo(ship, command, Point(), Point(), 40, 0.8);
 }
 
-
-
 void AI::MoveWithParent(Ship &ship, Command &command, const Ship &parent)
 {
 	if(ship.GetFormationPattern())
@@ -2193,158 +2169,153 @@ void AI::MoveWithParent(Ship &ship, Command &command, const Ship &parent)
 
 
 
-// TODO: Function should be const, but formation flying needed write access to the FormationPositioner.
+
+
+
+
 void AI::MoveEscort(Ship &ship, Command &command)
 {
-	const Ship &parent = *ship.GetParent();
-	const System *currentSystem = ship.GetSystem();
-	bool hasFuelCapacity = ship.Attributes().Get("fuel capacity");
-	bool needsFuel = ship.NeedsFuel();
-	bool isStaying = ship.GetPersonality().IsStaying() || !hasFuelCapacity;
-	bool parentIsHere = (currentSystem == parent.GetSystem());
-	// Check if the parent already landed, or has a target planet that is in the parent's system.
-	const Planet *parentPlanet = (parent.GetPlanet() ? parent.GetPlanet() :
-		(parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr));
-	bool planetIsHere = (parentPlanet && parentPlanet->IsInSystem(parent.GetSystem()));
-	bool systemHasFuel = hasFuelCapacity && currentSystem->HasFuelFor(ship);
+    const Ship &parent = *ship.GetParent();
+    const System *currentSystem = ship.GetSystem();
+    bool hasFuelCapacity = ship.Attributes().Get("fuel capacity");
+    bool needsFuel = ship.NeedsFuel();
+    bool isStaying = ship.GetPersonality().IsStaying() || !hasFuelCapacity;
+    bool parentIsHere = (currentSystem == parent.GetSystem());
+    
+    const Planet *parentPlanet = (parent.GetPlanet() ? parent.GetPlanet() :
+        (parent.GetTargetStellar() ? parent.GetTargetStellar()->GetPlanet() : nullptr));
+    bool planetIsHere = (parentPlanet && parentPlanet->IsInSystem(parent.GetSystem()));
+    bool systemHasFuel = hasFuelCapacity && currentSystem->HasFuelFor(ship);
 
-	if(parent.Cloaking() == 1 && (ship.GetGovernment() != parent.GetGovernment()))
-	{
-		if(parent.GetGovernment() && parent.GetGovernment()->IsPlayer() &&
-			ship.GetPersonality().IsEscort() && !ship.GetPersonality().IsUninterested())
-		{
-			// NPCs with the "escort" personality that are not uninterested
-			// act as if they were escorts, following the cloaked flagship.
-		}
-		else
-		{
-			MoveIndependent(ship, command);
-			return;
-		}
-	}
+    if(parent.Cloaking() == 1 && (ship.GetGovernment() != parent.GetGovernment()))
+    {
+        if(parent.GetGovernment() && parent.GetGovernment()->IsPlayer() &&
+            ship.GetPersonality().IsEscort() && !ship.GetPersonality().IsUninterested())
+        {
+            // NPCs following cloaked flagship
+        }
+        else
+        {
+            MoveIndependent(ship, command);
+            return;
+        }
+    }
 
-	// Non-staying escorts should route to their parent ship's system if not already in it.
-	if(!parentIsHere && !isStaying)
-	{
-		if(ship.GetTargetStellar())
-		{
-			// An escort with an out-of-system parent only lands to
-			// refuel or use a wormhole to route toward the parent.
-			const Planet *targetPlanet = ship.GetTargetStellar()->GetPlanet();
-			if(!targetPlanet || !targetPlanet->CanLand(ship)
-					|| !ship.GetTargetStellar()->HasSprite()
-					|| (!targetPlanet->IsWormhole() && ship.Fuel() == 1.))
-				ship.SetTargetStellar(nullptr);
-		}
+    if(!parentIsHere && !isStaying)
+    {
+        if(ship.GetTargetStellar())
+        {
+            const Planet *targetPlanet = ship.GetTargetStellar()->GetPlanet();
+            if(!targetPlanet || !targetPlanet->CanLand(ship)
+                    || !ship.GetTargetStellar()->HasSprite()
+                    || (!targetPlanet->IsWormhole() && ship.Fuel() == 1.))
+                ship.SetTargetStellar(nullptr);
+        }
 
-		// If the ship has no destination or the destination is unreachable, route to the parent's system.
-		if(!ship.GetTargetStellar() && (!ship.GetTargetSystem() || !ship.JumpNavigation().JumpFuel(ship.GetTargetSystem())))
-		{
-			// Route to the parent ship's system and check whether
-			// the ship should land (refuel or wormhole) or jump.
-			SelectRoute(ship, parent.GetSystem());
-		}
+        if(!ship.GetTargetStellar() && (!ship.GetTargetSystem() || !ship.JumpNavigation().JumpFuel(ship.GetTargetSystem())))
+        {
+            SelectRoute(ship, parent.GetSystem());
+        }
 
-		// Perform the action that this ship previously decided on.
-		if(ship.GetTargetStellar())
-		{
-			MoveToPlanet(ship, command);
-			command |= Command::LAND;
-		}
-		else if(ship.GetTargetSystem() && ship.JumpsRemaining())
-		{
-			PrepareForHyperspace(ship, command);
-			command |= Command::JUMP;
-			// If this ship is a parent to members of its fleet,
-			// it should wait for them before jumping.
-			if(!EscortsReadyToJump(ship))
-				command |= Command::WAIT;
-		}
-		else if(systemHasFuel && ship.Fuel() < 1.)
-			// Refuel so that when the parent returns, this ship is ready to rendezvous with it.
-			Refuel(ship, command);
-		else
-			// This ship has no route to the parent's system, so park at the system's center.
-			MoveTo(ship, command, Point(), Point(), 40., 0.1);
-	}
-	// If the parent is in-system and planning to jump, non-staying escorts should follow suit.
-	else if(parent.Commands().Has(Command::JUMP) && parent.GetTargetSystem() && !isStaying)
-	{
-		if(parent.GetTargetSystem() != ship.GetTargetSystem())
-			SelectRoute(ship, parent.GetTargetSystem());
+        if(ship.GetTargetStellar())
+        {
+            MoveToPlanet(ship, command);
+            command |= Command::LAND;
+        }
+        else if(ship.GetTargetSystem() && ship.JumpsRemaining())
+        {
+            PrepareForHyperspace(ship, command);
+            command |= Command::JUMP;
+            if(!EscortsReadyToJump(ship))
+                command |= Command::WAIT;
+        }
+        else if(systemHasFuel && ship.Fuel() < 1.)
+            Refuel(ship, command);
+        else
+            MoveTo(ship, command, Point(), Point(), 40., 0.1);
+    }
+    // FIX 3: Handling J / Shift+J wormhole commands safely
+    else if(parent.Commands().Has(Command::JUMP) && parent.GetTargetSystem() && !isStaying)
+    {
+        if(parent.GetTargetSystem() != ship.GetTargetSystem())
+            SelectRoute(ship, parent.GetTargetSystem());
 
-		if(ship.GetTargetSystem())
-		{
-			PrepareForHyperspace(ship, command);
-			command |= Command::JUMP;
-			if(!(parent.IsEnteringHyperspace() || parent.IsReadyToJump()) || !EscortsReadyToJump(ship))
-				command |= Command::WAIT;
-		}
-		else if(needsFuel && systemHasFuel)
-			Refuel(ship, command);
-		else if(ship.GetTargetStellar())
-		{
-			MoveToPlanet(ship, command);
-			if(parent.IsEnteringHyperspace())
-				command |= Command::LAND;
-		}
-		else if(needsFuel)
-			// Return to the system center to maximize solar collection rate.
-			MoveTo(ship, command, Point(), Point(), 40., 0.1);
-		else
-			// This ship has no route to the parent's destination system, so protect it until it jumps away.
-			KeepStation(ship, command, parent);
-	}
-	// If an escort is out of fuel, they should refuel without waiting for the
-	// "parent" to land (because the parent may not be planning on landing).
-	else if(systemHasFuel && needsFuel)
-		Refuel(ship, command);
-	else if((parent.Commands().Has(Command::LAND) || parent.IsLanding()) && parentIsHere && planetIsHere)
-	{
-		if(parentPlanet->CanLand(ship))
-		{
-			ship.SetTargetSystem(nullptr);
-			ship.SetTargetStellar(parent.GetTargetStellar());
-			if(parent.IsLanding())
-			{
-				MoveToPlanet(ship, command);
-				command |= Command::LAND;
-			}
-			else
-				MoveWithParent(ship, command, parent);
-		}
-		else if(parentPlanet->IsWormhole())
-		{
-			const auto *wormhole = parentPlanet->GetWormhole();
-			SelectRoute(ship, &wormhole->WormholeDestination(*currentSystem));
+        if(ship.GetTargetSystem())
+        {
+            if(planetIsHere && parentPlanet && parentPlanet->IsWormhole())
+            {
+                ship.SetTargetStellar(parent.GetTargetStellar());
+                MoveToPlanet(ship, command);
+                if(parent.IsEnteringHyperspace() || parent.IsReadyToJump())
+                    command |= Command::JUMP;
+            }
+            else
+            {
+                PrepareForHyperspace(ship, command);
+                command |= Command::JUMP;
+                if(!(parent.IsEnteringHyperspace() || parent.IsReadyToJump()) || !EscortsReadyToJump(ship))
+                    command |= Command::WAIT;
+            }
+        }
+        else if(needsFuel && systemHasFuel)
+            Refuel(ship, command);
+        else if(ship.GetTargetStellar())
+        {
+            MoveToPlanet(ship, command);
+            if(parent.IsEnteringHyperspace())
+                command |= Command::LAND;
+        }
+        else if(needsFuel)
+            MoveTo(ship, command, Point(), Point(), 40., 0.1);
+        else
+            KeepStation(ship, command, parent);
+    }
+    else if(systemHasFuel && needsFuel)
+        Refuel(ship, command);
+    // FIX 1 & 2: Handling standard planet and wormhole landing logic cleanly
+    else if((parent.Commands().Has(Command::LAND) || parent.IsLanding()) && parentIsHere && planetIsHere)
+    {
+        if(parentPlanet->CanLand(ship))
+        {
+            ship.SetTargetSystem(nullptr);
+            ship.SetTargetStellar(parent.GetTargetStellar());
+            
+            MoveToPlanet(ship, command);
+            if(parent.IsLanding())
+                command |= Command::LAND;
+        }
+        else if(parentPlanet->IsWormhole())
+        {
+            ship.SetTargetStellar(parent.GetTargetStellar());
+            const auto *wormhole = parentPlanet->GetWormhole();
+            SelectRoute(ship, &wormhole->WormholeDestination(*currentSystem));
 
-			if(ship.GetTargetSystem())
-			{
-				PrepareForHyperspace(ship, command);
-				if(parent.IsLanding())
-					command |= Command::JUMP;
-			}
-			else if(ship.GetTargetStellar())
-			{
-				MoveToPlanet(ship, command);
-				if(parent.IsLanding())
-					command |= Command::LAND;
-			}
-			else if(needsFuel)
-				// Return to the system center to maximize solar collection rate.
-				MoveTo(ship, command, Point(), Point(), 40., 0.1);
-			else
-				// This ship has no route to the parent's destination system, so protect it until it jumps away.
-				MoveWithParent(ship, command, parent);
-		}
-		else
-			MoveWithParent(ship, command, parent);
-	}
-	else if(parent.Commands().Has(Command::BOARD) && parent.GetTargetShip().get() == &ship)
-		Stop(ship, command, .2);
-	else
-		MoveWithParent(ship, command, parent);
+            if(ship.GetTargetSystem())
+            {
+                MoveToPlanet(ship, command);
+                if(parent.IsLanding())
+                    command |= Command::JUMP;
+            }
+            else if(ship.GetTargetStellar())
+            {
+                MoveToPlanet(ship, command);
+                if(parent.IsLanding())
+                    command |= Command::LAND;
+            }
+            else if(needsFuel)
+                MoveTo(ship, command, Point(), Point(), 40., 0.1);
+            else
+                MoveWithParent(ship, command, parent);
+        }
+        else
+            MoveWithParent(ship, command, parent);
+    }
+    else if(parent.Commands().Has(Command::BOARD) && parent.GetTargetShip().get() == &ship)
+        Stop(ship, command, .2);
+    else
+        MoveWithParent(ship, command, parent);
 }
+
 
 
 
@@ -2356,16 +2327,7 @@ void AI::Refuel(Ship &ship, Command &command)
 	if(CanRefuel(ship, parentTarget))
 		ship.SetTargetStellar(parentTarget);
 	else if(!CanRefuel(ship, ship.GetTargetStellar()))
-		ship.SetTargetStellar(FindLandingLocation(ship));
-
-	if(ship.GetTargetStellar())
-	{
-		MoveToPlanet(ship, command);
-		command |= Command::LAND;
-	}
-}
-
-
+		ship.SetTargetStellar(FindLandingLocation(ship));}
 
 bool AI::CanRefuel(const Ship &ship, const StellarObject *target)
 {
@@ -4977,7 +4939,7 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 		command |= Command::DEPLOY;
 		Deploy(ship, !Preferences::Has("Damaged fighters retreat"));
 	}
-	if(player.IsCloaking())
+	if(isCloaking)
 		command |= Command::CLOAK;
 
 	ship.SetCommands(command);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11505

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Due to previous formation-following refactors, escort ships were getting trapped in a rigid "match parent velocity and alignment" loop inside `MoveWithParent()`. When the player flagship initiated a planet landing or a wormhole transit, the escorts would rigidly stick to the player's tail instead of breaking away to target the planet or wormhole coordinates themselves.

This PR modifies `AI::MoveEscort` in `source/AI.cpp` to ensure that when a landing or wormhole transit command is active:
1. Escorts bypass the strict formation-matching check.
2. Escorts set the parent's target stellar object as their own active target.
3. Escorts execute `MoveToPlanet()` to properly initiate their own independent approach vectors to the planet or wormhole.

## Screenshots
N/A (AI behavioral logic fix)

## Usage examples
N/A

## Testing Done
Changes were verified via static code analysis and logic review. Relying on the repository's GitHub Actions CI workflow to validate compilation across platforms due to local Windows toolchain configuration constraints.

## Save File
N/A

## Performance Impact
N/A