### PR TITLE
Fix #12127: Remove 8px offset from job board

### DIFF
--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -657,7 +657,7 @@ bool MissionPanel::Hover(int x, int y)
 
     if(x < Screen::Left() + SIDE_WIDTH)
     {
-        // Υπολογισμός index για τις Available Missions
+        // Calculate index for available missions
         int relativeY = y + static_cast<int>(availableScroll) - 36 - Screen::Top();
         unsigned index = 0;
         if (relativeY > 0) {
@@ -691,7 +691,7 @@ bool MissionPanel::Hover(int x, int y)
     }
     else if(x >= Screen::Right() - SIDE_WIDTH)
     {
-        // Υπολογισμός index για τις Accepted Missions
+        // Calculate index for accepted missions
         int relativeY = y + static_cast<int>(acceptedScroll) - 36 - Screen::Top();
         int index = 0;
         if (relativeY > 0) {

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -596,7 +596,6 @@ bool MissionPanel::Click(int x, int y, MouseButton button, int clicks)
 
 bool MissionPanel::Drag(double dx, double dy)
 {
-    // If the mouse is dragging on the left or right panel, scroll that panel. Otherwise, pan the map as normal.
     double availableGap = (player.ShouldSortSeparateDeadline() || player.ShouldSortSeparatePossible()) ? 8. : 0.;
     double acceptedGap = player.ShouldSortSeparateDeadline() ? 8. : 0.;
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -860,7 +860,6 @@ Point MissionPanel::DrawList(const list<Mission> &missionList, Point pos, const 
 	const Color &selected = *GameData::Colors().Get("bright");
 	const Color &dim = *GameData::Colors().Get("dim");
 	const Sprite *fast = SpriteSet::Get("ui/fast forward");
-	bool separated = false;
 
 	for(auto it = missionList.begin(); it != missionList.end(); ++it)
 	{
@@ -868,14 +867,7 @@ Point MissionPanel::DrawList(const list<Mission> &missionList, Point pos, const 
 			continue;
 
 		pos.Y() += 20.;
-		if(separateDeadlineOrPossible && !separated
-				&& ((player.ShouldSortSeparateDeadline() && it->Deadline())
-						|| (player.ShouldSortSeparatePossible() && !it->CanAccept(player))))
-		{
-			pos.Y() += 8.;
-			separated = true;
-		}
-
+		
 		bool isSelected = it == selectIt;
 		if(isSelected)
 			FillShader::Fill(

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -454,7 +454,22 @@ bool MissionPanel::Click(int x, int y, MouseButton button, int clicks)
 			return false;
 		}
 		// Available missions
-		unsigned index = max(0, (y + static_cast<int>(availableScroll) - 36 - Screen::Top()) / 20);
+        int relativeY = y + static_cast<int>(availableScroll) - 36 - Screen::Top();
+        unsigned index = 0;
+        if (relativeY > 0) {
+            int currentY = 0;
+            bool separated = false;
+            for (const auto &it : available) {
+                currentY += 20;
+                if (!separated && ((player.ShouldSortSeparateDeadline() && it.Deadline())
+                        || (player.ShouldSortSeparatePossible() && !it.CanAccept(player)))) {
+                    currentY += 8;
+                    separated = true;
+                }
+                if (relativeY < currentY) break;
+                index++;
+            }
+        }
 		if(index < available.size())
 		{
 			const auto lastAvailableIt = availableIt;
@@ -475,7 +490,22 @@ bool MissionPanel::Click(int x, int y, MouseButton button, int clicks)
 	else if(x >= Screen::Right() - SIDE_WIDTH)
 	{
 		// Accepted missions
-		int index = max(0, (y + static_cast<int>(acceptedScroll) - 36 - Screen::Top()) / 20);
+        int relativeY = y + static_cast<int>(acceptedScroll) - 36 - Screen::Top();
+        int index = 0;
+        if (relativeY > 0) {
+            int currentY = 0;
+            bool separated = false;
+            for (const auto &it : accepted) {
+                if (!it.IsVisible()) continue;
+                currentY += 20;
+                if (!separated && player.ShouldSortSeparateDeadline() && it.Deadline()) {
+                    currentY += 8;
+                    separated = true;
+                }
+                if (relativeY < currentY) break;
+                index++;
+            }
+        }
 		if(index < AcceptedVisible())
 		{
 			const auto lastAcceptedIt = acceptedIt;
@@ -621,36 +651,72 @@ bool MissionPanel::Drag(double dx, double dy)
 // Check to see if the mouse is over either of the mission lists.
 bool MissionPanel::Hover(int x, int y)
 {
-	dragSide = 0;
-	int oldSort = hoverSort;
-	hoverSort = -1;
-	unsigned index = max(0, (y + static_cast<int>(availableScroll) - 36 - Screen::Top()) / 20);
-	if(x < Screen::Left() + SIDE_WIDTH)
-	{
-		if(index < available.size())
-		{
-			dragSide = -1;
+    dragSide = 0;
+    int oldSort = hoverSort;
+    hoverSort = -1;
 
-			// Hovering over sort buttons
-			if(y + static_cast<int>(availableScroll) < Screen::Top() + 30 && y >= Screen::Top() + 10
-				&& x >= Screen::Left() + SIDE_WIDTH - 110)
-			{
-				hoverSort = (x - Screen::Left() - SIDE_WIDTH + 110) / 30;
-				if(hoverSort > 3)
-					hoverSort = -1;
-			}
-		}
-	}
-	else if(x >= Screen::Right() - SIDE_WIDTH)
-	{
-		if(static_cast<int>(index) < AcceptedVisible())
-			dragSide = 1;
-	}
+    if(x < Screen::Left() + SIDE_WIDTH)
+    {
+        // Υπολογισμός index για τις Available Missions
+        int relativeY = y + static_cast<int>(availableScroll) - 36 - Screen::Top();
+        unsigned index = 0;
+        if (relativeY > 0) {
+            int currentY = 0;
+            bool separated = false;
+            for (const auto &it : available) {
+                currentY += 20;
+                if (!separated && ((player.ShouldSortSeparateDeadline() && it.Deadline())
+                        || (player.ShouldSortSeparatePossible() && !it.CanAccept(player)))) {
+                    currentY += 8;
+                    separated = true;
+                }
+                if (relativeY < currentY) break;
+                index++;
+            }
+        }
 
-	if(oldSort != hoverSort)
-		tooltip.Clear();
+        if(index < available.size())
+        {
+            dragSide = -1;
 
-	return dragSide || MapPanel::Hover(x, y);
+            // Hovering over sort buttons
+            if(y + static_cast<int>(availableScroll) < Screen::Top() + 30 && y >= Screen::Top() + 10
+                && x >= Screen::Left() + SIDE_WIDTH - 110)
+            {
+                hoverSort = (x - Screen::Left() - SIDE_WIDTH + 110) / 30;
+                if(hoverSort > 3)
+                    hoverSort = -1;
+            }
+        }
+    }
+    else if(x >= Screen::Right() - SIDE_WIDTH)
+    {
+        // Υπολογισμός index για τις Accepted Missions
+        int relativeY = y + static_cast<int>(acceptedScroll) - 36 - Screen::Top();
+        int index = 0;
+        if (relativeY > 0) {
+            int currentY = 0;
+            bool separated = false;
+            for (const auto &it : accepted) {
+                if (!it.IsVisible()) continue;
+                currentY += 20;
+                if (!separated && player.ShouldSortSeparateDeadline() && it.Deadline()) {
+                    currentY += 8;
+                    separated = true;
+                }
+                if (relativeY < currentY) break;
+                index++;
+            }
+        }
+
+        if(index < AcceptedVisible())
+            dragSide = 1;
+    }
+
+    if(oldSort != hoverSort)
+        tooltip.Clear();
+
+    return dragSide || MapPanel::Hover(x, y);
 }
 
 

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -596,24 +596,27 @@ bool MissionPanel::Click(int x, int y, MouseButton button, int clicks)
 
 bool MissionPanel::Drag(double dx, double dy)
 {
-	if(dragSide < 0)
-	{
-		availableScroll = max(0.,
-			min(available.size() * 20. + 190. - Screen::Height(),
-				availableScroll - dy));
-	}
-	else if(dragSide > 0)
-	{
-		acceptedScroll = max(0.,
-			min(accepted.size() * 20. + 160. - Screen::Height(),
-				acceptedScroll - dy));
-	}
-	else if(canDrag)
-		MapPanel::Drag(dx, dy);
+    // If the mouse is dragging on the left or right panel, scroll that panel. Otherwise, pan the map as normal.
+    double availableGap = (player.ShouldSortSeparateDeadline() || player.ShouldSortSeparatePossible()) ? 8. : 0.;
+    double acceptedGap = player.ShouldSortSeparateDeadline() ? 8. : 0.;
 
-	return true;
+    if(dragSide < 0)
+    {
+        availableScroll = max(0.,
+            min(available.size() * 20. + 190. + availableGap - Screen::Height(),
+                availableScroll - dy));
+    }
+    else if(dragSide > 0)
+    {
+        acceptedScroll = max(0.,
+            min(accepted.size() * 20. + 160. + acceptedGap - Screen::Height(),
+                acceptedScroll - dy));
+    }
+    else if(canDrag)
+        MapPanel::Drag(dx, dy);
+
+    return true;
 }
-
 
 
 // Check to see if the mouse is over either of the mission lists.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12127

## Acknowledgement

- [x] I acknowledge that I have read and understand the Contributing article.

## Summary
Removed the unnecessary 8px offset from the job board interface to ensure proper alignment and correct visual rendering.

## Performance Impact
N/A