### PR TITLE
Fix #12177: Actually remove auto-launch from Keystone Research 6

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3375,7 +3375,6 @@ mission "Remnant: Keystone Research 5"
 
 
 mission "Remnant: Keystone Research 6"
-	landing
 	name "Scan the <npc>"
 	description `Go scan the <npc> in <waypoints> to record the Key Stone post-wormhole.`
 	waypoint "Peragenor"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12177

## Acknowledgement

- [x] I acknowledge that I have read and understand the Contributing article.

## Summary
Fixed an issue where the auto-launch sequence was not properly removed from Keystone Research 6.

## Performance Impact
N/A