### PR TITLE
Rebalance and deploy the Flamethrower

### DIFF
--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1469,7 +1469,8 @@ event "catalytic ramscoop available"
 event "fw gets catalytic ramscoop"
 	outfitter "Delta V Advanced"
 		"Catalytic Ramscoop"
-	# FW starts to use flamethrowers after CR makes it a reasonable choice
+	# The Free Worlds start to use flamethrowers in a significant extent
+	# after the Catalytic Ramscoop makes it a reasonable choice.
 	fleet "Small Free Worlds"
 		add variant 2
 			"Hawk"
@@ -1505,7 +1506,7 @@ event "fw gets catalytic ramscoop"
 			"Falcon (Flamethrower)"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 4
-	# Pirates don't use CRs, but we simulate a delay in adoption here
+	# Pirates don't use Catalytic Ramscoops, but we simulate a delay in adoption here.
 	fleet "Small Southern Pirates"
 		add variant 1
 			"Fury (Flamethrower Pirate)"

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1518,7 +1518,7 @@ event "fw gets catalytic ramscoop"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 4
 	# Pirates don't use Catalytic Ramscoops, but we simulate that they adopted the flamethrower
-	# in relevant extent only after it became more popular and could e.g. be looted more oftenly.
+	# in relevant extent only after it became more popular and could e.g. be looted more often.
 	fleet "Small Southern Pirates"
 		add variant 1
 			"Fury (Flamethrower Pirate)"

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1343,17 +1343,24 @@ event "memorial on Deep"
 event "flamethrower available"
 	outfitter "Kraz Advanced"
 		"Flamethrower"
+	fleet "Small Free Worlds"
+		variant 3
+			"Fury (Laser)"
+			"Fury (Flamethrower)"
+		variant 2
+			"Hawk"
+			"Fury (Flamethrower)"
+		variant 1
+			"Fury (Flamethrower)"
+			"Sparrow" 2
 	fleet "Large Free Worlds"
-		add variant 1
-			"Falcon (Flamethrower)"
-		add variant 1
-			"Falcon (Flamethrower)"
-			"Hawk" 2
-			"Sparrow" 3
-		add variant 1
-			"Falcon (Flamethrower)"
-			"Bastion (Heavy)"
-			"Hawk (Rocket)"
+		variant 2
+			"Osprey (Laser)"
+			"Fury (Flamethrower)"
+		variant 1
+			"Falcon (Heavy)"
+			"Fury (Flamethrower)" 2
+			"Sparrow" 4
 
 
 
@@ -1483,12 +1490,12 @@ event "fw gets catalytic ramscoop"
 	# The Free Worlds start to use flamethrowers in a significant extent
 	# only after the catalytic ramscoop makes it a reasonable choice.
 	fleet "Small Free Worlds"
+		add variant 3
+			"Fury (Flamethrower Blaster)"
+			"Fury (Missile)"
 		add variant 2
 			"Hawk"
 			"Fury (Flamethrower Blaster)"
-		add variant 2
-			"Fury (Flamethrower Blaster)"
-			"Fury (Missile)"
 		add variant 1
 			"Osprey (Flamethrower)"
 	fleet "Large Free Worlds"
@@ -1499,14 +1506,14 @@ event "fw gets catalytic ramscoop"
 			"Bastion (Heavy)"
 			"Osprey (Flamethrower)"
 		add variant 1
-			"Falcon (Flamethrower Catalytic)"
+			"Falcon (Flamethrower)"
 		add variant 1
-			"Falcon (Flamethrower Catalytic)"
+			"Falcon (Flamethrower)"
 			"Hawk"
 			"Hawk (Plasma)"
 			"Sparrow" 3
 		add variant 2
-			"Falcon (Flamethrower Catalytic)"
+			"Falcon (Flamethrower)"
 			"Bastion (Heavy)"
 			"Hawk (Rocket)"
 		add variant 2
@@ -1514,7 +1521,7 @@ event "fw gets catalytic ramscoop"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 2
 		add variant 2
-			"Falcon (Flamethrower Catalytic)"
+			"Falcon (Flamethrower)"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 4
 	# Pirates don't use Catalytic Ramscoops, but we simulate that they adopted the flamethrower

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1469,6 +1469,7 @@ event "catalytic ramscoop available"
 event "fw gets catalytic ramscoop"
 	outfitter "Delta V Advanced"
 		"Catalytic Ramscoop"
+	# FW starts to use flamethrowers after CR makes it a reasonable choice
 	fleet "Small Free Worlds"
 		add variant 2
 			"Hawk"
@@ -1509,6 +1510,61 @@ event "fw gets catalytic ramscoop"
 			"Falcon (Flamethrower)"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 4
+	# Pirates don't use CRs, but we simulate a delay in adoption here
+	fleet "Small Southern Pirates"
+		add variant 1
+			"Fury (Flamethrower Pirate)"
+		add variant 1
+			"Hawk (Rocket)"
+			"Fury (Flamethrower Pirate)"
+			"Sparrow"
+		add variant 1
+			"Fury (Flamethrower Pirate)" 3
+		add variant 1
+			"Fury (Flamethrower Pirate)"
+			"Sparrow"
+	fleet "Large Southern Pirates"
+		add variant 1
+			"Osprey (Flamethrower Pirate)"
+		add variant 2
+			"Fury (Flamethrower Pirate)"
+			"Sparrow" 3
+		add variant 1
+			"Fury (Bomber)"
+			"Fury (Flamethrower Pirate)" 2
+		add variant 2
+			"Bastion (Flamethrower Pirate)"
+		add variant 1
+			"Falcon (Flamethrower Pirate)"
+			"Sparrow" 3
+		add variant 1
+			"Falcon (Flamethrower Pirate)"
+	fleet "Small CCOR"
+		add variant 1
+			"Saber (CCOR Flamethrower)"
+		add variant 1
+			"Saber (CCOR Flamethrower)"
+			"Berserker (CCOR)"
+	fleet "Large CCOR"
+		add variant 3
+			"Firebird (CCOR Flamethrower)"
+		add variant 1
+			"Firebird (CCOR Flamethrower)"
+			"Enforcer"
+		add variant 1
+			"Saber (CCOR Flamethrower)"
+			"Enforcer (CCOR)"
+		add variant 1
+			"Leviathan (CCOR Flamethrower)"
+		add variant 1
+			"Leviathan (CCOR Flamethrower)"
+			"Saber (CCOR Flamethrower)"
+			"Enforcer (CCOR)"
+			"Berserker (CCOR)"
+	# rare curiosity, otherwise the flamethrower is only used in the South
+	fleet "Large Core Pirates"
+		variant 1
+			"Vanguard (Flamethrower)"
 
 
 

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1343,6 +1343,17 @@ event "memorial on Deep"
 event "flamethrower available"
 	outfitter "Kraz Advanced"
 		"Flamethrower"
+	fleet "Large Free Worlds"
+		add variant 1
+			"Falcon (Flamethrower)"
+		add variant 1
+			"Falcon (Flamethrower)"
+			"Hawk" 2
+			"Sparrow" 3
+		add variant 1
+			"Falcon (Flamethrower)"
+			"Bastion (Heavy)"
+			"Hawk (Rocket)"
 
 
 
@@ -1470,7 +1481,7 @@ event "fw gets catalytic ramscoop"
 	outfitter "Delta V Advanced"
 		"Catalytic Ramscoop"
 	# The Free Worlds start to use flamethrowers in a significant extent
-	# after the Catalytic Ramscoop makes it a reasonable choice.
+	# only after the catalytic ramscoop makes it a reasonable choice.
 	fleet "Small Free Worlds"
 		add variant 2
 			"Hawk"
@@ -1488,14 +1499,14 @@ event "fw gets catalytic ramscoop"
 			"Bastion (Heavy)"
 			"Osprey (Flamethrower)"
 		add variant 1
-			"Falcon (Flamethrower)"
+			"Falcon (Flamethrower Catalytic)"
 		add variant 1
-			"Falcon (Flamethrower)"
+			"Falcon (Flamethrower Catalytic)"
 			"Hawk"
 			"Hawk (Plasma)"
 			"Sparrow" 3
 		add variant 2
-			"Falcon (Flamethrower)"
+			"Falcon (Flamethrower Catalytic)"
 			"Bastion (Heavy)"
 			"Hawk (Rocket)"
 		add variant 2
@@ -1503,10 +1514,11 @@ event "fw gets catalytic ramscoop"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 2
 		add variant 2
-			"Falcon (Flamethrower)"
+			"Falcon (Flamethrower Catalytic)"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 4
-	# Pirates don't use Catalytic Ramscoops, but we simulate a delay in adoption here.
+	# Pirates don't use Catalytic Ramscoops, but we simulate that they adopted the flamethrower
+	# in relevant extent only after it became more popular and could e.g. be looted more oftenly.
 	fleet "Small Southern Pirates"
 		add variant 1
 			"Fury (Flamethrower Pirate)"

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1480,17 +1480,12 @@ event "fw gets catalytic ramscoop"
 		add variant 1
 			"Osprey (Flamethrower)"
 	fleet "Large Free Worlds"
-		add variant 5
-			"Bastion (Flamethrower)"
 		add variant 4
 			"Osprey (Flamethrower)"
 			"Fury (Flamethrower Blaster)"
 		add variant 3
-			"Bastion (Flamethrower)"
+			"Bastion (Heavy)"
 			"Osprey (Flamethrower)"
-		add variant 2
-			"Bastion (Flamethrower)"
-			"Sparrow" 2
 		add variant 1
 			"Falcon (Flamethrower)"
 		add variant 1
@@ -1500,10 +1495,10 @@ event "fw gets catalytic ramscoop"
 			"Sparrow" 3
 		add variant 2
 			"Falcon (Flamethrower)"
-			"Bastion (Flamethrower)"
+			"Bastion (Heavy)"
 			"Hawk (Rocket)"
 		add variant 2
-			"Bastion (Flamethrower)"
+			"Bastion (Heavy)"
 			"Fury (Flamethrower Blaster)" 2
 			"Sparrow" 2
 		add variant 2
@@ -1519,6 +1514,8 @@ event "fw gets catalytic ramscoop"
 			"Fury (Flamethrower Pirate)"
 			"Sparrow"
 		add variant 1
+			"Clipper (Flamethrower)"
+		add variant 1
 			"Fury (Flamethrower Pirate)" 3
 		add variant 1
 			"Fury (Flamethrower Pirate)"
@@ -1529,42 +1526,21 @@ event "fw gets catalytic ramscoop"
 		add variant 2
 			"Fury (Flamethrower Pirate)"
 			"Sparrow" 3
+		add variant 2
+			"Clipper (Flamethrower)"
+			"Hawk (Bomber)"
+		add variant 1
+			"Clipper (Flamethrower)"
+			"Clipper (Heavy)"
+			"Clipper (Speedy)"
 		add variant 1
 			"Fury (Bomber)"
 			"Fury (Flamethrower Pirate)" 2
-		add variant 2
-			"Bastion (Flamethrower Pirate)"
 		add variant 1
 			"Falcon (Flamethrower Pirate)"
 			"Sparrow" 3
 		add variant 1
 			"Falcon (Flamethrower Pirate)"
-	fleet "Small CCOR"
-		add variant 1
-			"Saber (CCOR Flamethrower)"
-		add variant 1
-			"Saber (CCOR Flamethrower)"
-			"Berserker (CCOR)"
-	fleet "Large CCOR"
-		add variant 3
-			"Firebird (CCOR Flamethrower)"
-		add variant 1
-			"Firebird (CCOR Flamethrower)"
-			"Enforcer"
-		add variant 1
-			"Saber (CCOR Flamethrower)"
-			"Enforcer (CCOR)"
-		add variant 1
-			"Leviathan (CCOR Flamethrower)"
-		add variant 1
-			"Leviathan (CCOR Flamethrower)"
-			"Saber (CCOR Flamethrower)"
-			"Enforcer (CCOR)"
-			"Berserker (CCOR)"
-	# rare curiosity, otherwise the flamethrower is only used in the South
-	fleet "Large Core Pirates"
-		variant 1
-			"Vanguard (Flamethrower)"
 
 
 

--- a/data/human/campaign events.txt
+++ b/data/human/campaign events.txt
@@ -1469,6 +1469,46 @@ event "catalytic ramscoop available"
 event "fw gets catalytic ramscoop"
 	outfitter "Delta V Advanced"
 		"Catalytic Ramscoop"
+	fleet "Small Free Worlds"
+		add variant 2
+			"Hawk"
+			"Fury (Flamethrower Blaster)"
+		add variant 2
+			"Fury (Flamethrower Blaster)"
+			"Fury (Missile)"
+		add variant 1
+			"Osprey (Flamethrower)"
+	fleet "Large Free Worlds"
+		add variant 5
+			"Bastion (Flamethrower)"
+		add variant 4
+			"Osprey (Flamethrower)"
+			"Fury (Flamethrower Blaster)"
+		add variant 3
+			"Bastion (Flamethrower)"
+			"Osprey (Flamethrower)"
+		add variant 2
+			"Bastion (Flamethrower)"
+			"Sparrow" 2
+		add variant 1
+			"Falcon (Flamethrower)"
+		add variant 1
+			"Falcon (Flamethrower)"
+			"Hawk"
+			"Hawk (Plasma)"
+			"Sparrow" 3
+		add variant 2
+			"Falcon (Flamethrower)"
+			"Bastion (Flamethrower)"
+			"Hawk (Rocket)"
+		add variant 2
+			"Bastion (Flamethrower)"
+			"Fury (Flamethrower Blaster)" 2
+			"Sparrow" 2
+		add variant 2
+			"Falcon (Flamethrower)"
+			"Fury (Flamethrower Blaster)" 2
+			"Sparrow" 4
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1443,7 +1443,7 @@ ship "Falcon" "Falcon (Flamethrower)"
 	gun "Plasma Cannon"
 	gun "Plasma Cannon"
 	turret "Anti-Missile Turret"
-	turret "Quad Blaster Turret"
+	turret "Blaster Turret"
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -3582,6 +3582,33 @@ ship "Vanguard" "Vanguard (Particle)"
 	gun "Particle Cannon"
 
 
+ship "Vanguard" "Vanguard (Flamethrower)"
+	outfits
+		Flamethrower 6
+		"Plasma Cannon"
+		"Heavy Anti-Missile Turret"
+		"Fission Reactor"
+		"LP072a Battery Pack"
+		"D94-YV Shield Generator"
+		"Water Coolant System" 2
+		"Fuel Pod" 14
+		"Laser Rifle" 11
+		Ramscoop 2
+		"Small Radar Jammer" 2
+		"Impala Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Impala Plasma Steering"
+		"Scram Drive"
+	gun "Plasma Cannon"
+	gun Flamethrower
+	gun Flamethrower
+	gun Flamethrower
+	gun Flamethrower
+	gun Flamethrower
+	gun Flamethrower
+	turret "Heavy Anti-Missile Turret"
+
+
 
 ship "Wasp" "Wasp (Gatling)"
 	outfits

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1421,6 +1421,38 @@ ship "Falcon" "Falcon (Flamethrower)"
 		Flamethrower 2
 		"Plasma Cannon" 2
 		"Anti-Missile Turret"
+		"Blaster Turret"
+		"Quad Blaster Turret" 2
+		"Breeder Reactor"
+		"LP036a Battery Pack"
+		"LP072a Battery Pack"
+		"D14-RN Shield Generator"
+		"D67-TM Shield Generator"
+		"Liquid Nitrogen Cooler"
+		"Water Coolant System"
+		"Ramscoop"
+		"Fuel Pod" 3
+		"Laser Rifle" 15
+		"Small Radar Jammer" 2
+		"Impala Plasma Thruster"
+		"X1700 Ion Thruster"
+		"Orca Plasma Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+
+
+ship "Falcon" "Falcon (Flamethrower Catalytic)"
+	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
 		"Quad Blaster Turret" 3
 		"Breeder Reactor"
 		"LP036a Battery Pack"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -433,69 +433,6 @@ ship "Bastion" "Bastion (Scanner)"
 	gun "Plasma Cannon"
 
 
-ship "Bastion" "Bastion (Flamethrower)"
-	outfits
-		Flamethrower 2
-		"Plasma Cannon" 2
-		"Anti-Missile Turret"
-		"Quad Blaster Turret" 2
-		"Breeder Reactor"
-		"LP072a Battery Pack"
-		"D67-TM Shield Generator"
-		"Liquid Nitrogen Cooler"
-		"Water Coolant System"
-		"Catalytic Ramscoop"
-		"Fuel Pod"
-		"Large Radar Jammer"
-		"Laser Rifle" 8
-		"Outfits Expansion"
-		"Impala Plasma Thruster"
-		"Chipmunk Plasma Steering"
-		"Impala Plasma Steering"
-		Hyperdrive
-	gun Flamethrower
-	gun Flamethrower
-	gun "Plasma Cannon"
-	gun "Plasma Cannon"
-	turret "Anti-Missile Turret"
-	turret "Quad Blaster Turret"
-	turret "Quad Blaster Turret"
-
-
-ship "Bastion" "Bastion (Flamethrower Pirate)"
-	outfits
-		Flamethrower 2
-		"Plasma Cannon" 2
-		"Anti-Missile Turret"
-		"Gatling Turret"
-		"Javelin Turret"
-		"Breeder Reactor"
-		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
-		"D67-TM Shield Generator"
-		"Cooling Ducts"
-		"Liquid Nitrogen Cooler"
-		"Fuel Pod" 2
-		"Gatling Gun Ammo" 6000
-		Javelin 500
-		"Javelin Storage Crate"
-		"Laser Rifle" 8
-		"Outfits Expansion"
-		Ramscoop
-		"Small Radar Jammer"
-		"Impala Plasma Thruster"
-		"Chipmunk Plasma Steering"
-		"Impala Plasma Steering"
-		Hyperdrive
-	gun "Plasma Cannon"
-	gun Flamethrower
-	gun Flamethrower
-	gun "Plasma Cannon"
-	turret "Anti-Missile Turret"
-	turret "Javelin Turret"
-	turret "Gatling Turret"
-
-
 
 ship "Behemoth" "Behemoth (Hai)"
 	outfits
@@ -968,6 +905,28 @@ ship "Clipper" "Clipper (Speedy)"
 		"A370 Atomic Thruster"
 		"A255 Atomic Steering"
 		"Hyperdrive"
+
+
+ship "Clipper" "Clipper (Flamethrower)"
+	outfits
+		Flamethrower 2
+		"Javelin Pod" 2
+		"nGVF-BB Fuel Cell"
+		"LP072a Battery Pack"
+		"D67-TM Shield Generator"
+		"Fuel Pod" 2
+		Javelin 600
+		"Javelin Storage Crate" 2
+		"Outfits Expansion"
+		Ramscoop
+		"Greyhound Plasma Thruster"
+		"Chipmunk Plasma Thruster"
+		"Greyhound Plasma Steering"
+		Hyperdrive
+	gun "Javelin Pod"
+	gun "Javelin Pod"
+	gun Flamethrower
+	gun Flamethrower
 
 
 
@@ -1701,37 +1660,6 @@ ship "Firebird" "Firebird (CCOR)"
 		"Hyperdrive"
 
 
-ship "Firebird" "Firebird (CCOR Flamethrower)"
-	outfits
-		Flamethrower 2
-		"Plasma Cannon" 2
-		"Anti-Missile Turret"
-		"Javelin Turret"
-		"S3 Thermionic"
-		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
-		"D67-TM Shield Generator"
-		"Water Coolant System"
-		"Cooling Ducts"
-		"Fuel Pod" 4
-		Javelin 500
-		"Javelin Storage Crate"
-		"Outfits Expansion" 2
-		"Laser Rifle" 10
-		Ramscoop
-		"Small Radar Jammer"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		Hyperdrive
-	gun Flamethrower
-	gun Flamethrower
-	gun "Plasma Cannon"
-	gun "Plasma Cannon"
-	turret "Anti-Missile Turret"
-	turret "Javelin Turret"
-
-
-
 
 ship "Flivver" "Flivver (Hai)"
 	outfits
@@ -2398,36 +2326,6 @@ ship "Leviathan" "Leviathan (CCOR)"
 		"Chipmunk Plasma Steering"
 		"Scram Drive"
 
-
-ship "Leviathan" "Leviathan (CCOR Flamethrower)"
-	outfits
-		Flamethrower 2
-		"Plasma Cannon" 2
-		"Anti-Missile Turret"
-		"Javelin Turret" 3
-		"S3 Thermionic"
-		"LP144a Battery Pack"
-		"D41-HY Shield Generator"
-		"D67-TM Shield Generator" 2
-		"Liquid Nitrogen Cooler"
-		"Fuel Pod" 3
-		Javelin 1500
-		"Javelin Storage Crate" 3
-		"Laser Rifle" 64
-		Ramscoop 2
-		"Small Radar Jammer" 2
-		"Impala Plasma Thruster"
-		"Chipmunk Plasma Steering"
-		"Impala Plasma Steering"
-		Hyperdrive
-	gun Flamethrower
-	gun Flamethrower
-	gun "Plasma Cannon"
-	gun "Plasma Cannon"
-	turret "Javelin Turret"
-	turret "Javelin Turret"
-	turret "Javelin Turret"
-	turret "Anti-Missile Turret"
 
 
 ship "Leviathan" "Leviathan (Hai Engines)"
@@ -3253,29 +3151,6 @@ ship "Saber" "Saber (CCOR Javelin)"
 		"Hyperdrive"
 
 
-ship "Saber" "Saber (CCOR Flamethrower)"
-	outfits
-		Flamethrower 4
-		"Twin Blaster"
-		"Anti-Missile Turret"
-		"nGVF-CC Fuel Cell"
-		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
-		"Fuel Pod" 2
-		"Laser Rifle" 12
-		Ramscoop
-		"Security Station"
-		"Greyhound Plasma Thruster"
-		"Impala Plasma Steering"
-		Hyperdrive
-	gun Flamethrower
-	gun "Twin Blaster"
-	gun Flamethrower
-	gun Flamethrower
-	gun Flamethrower
-	turret "Anti-Missile Turret"
-
-
 
 ship "Scout" "Scout (Speedy)"
 	outfits
@@ -3580,33 +3455,6 @@ ship "Vanguard" "Vanguard (Particle)"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
 	gun "Particle Cannon"
-
-
-ship "Vanguard" "Vanguard (Flamethrower)"
-	outfits
-		Flamethrower 6
-		"Plasma Cannon"
-		"Heavy Anti-Missile Turret"
-		"Fission Reactor"
-		"LP072a Battery Pack"
-		"D94-YV Shield Generator"
-		"Water Coolant System" 2
-		"Fuel Pod" 14
-		"Laser Rifle" 11
-		Ramscoop 2
-		"Small Radar Jammer" 2
-		"Impala Plasma Thruster"
-		"Chipmunk Plasma Steering"
-		"Impala Plasma Steering"
-		"Scram Drive"
-	gun "Plasma Cannon"
-	gun Flamethrower
-	gun Flamethrower
-	gun Flamethrower
-	gun Flamethrower
-	gun Flamethrower
-	gun Flamethrower
-	turret "Heavy Anti-Missile Turret"
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -435,24 +435,24 @@ ship "Bastion" "Bastion (Scanner)"
 
 ship "Bastion" "Bastion (Flamethrower)"
 	outfits
-		"Anti-Missile Turret"
-		"Breeder Reactor"
-		"Catalytic Ramscoop"
-		"Chipmunk Plasma Steering"
-		"D67-TM Shield Generator"
 		Flamethrower 2
-		"Fuel Pod"
-		Hyperdrive
-		"Impala Plasma Steering"
-		"Impala Plasma Thruster"
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Quad Blaster Turret" 2
+		"Breeder Reactor"
 		"LP072a Battery Pack"
+		"D67-TM Shield Generator"
+		"Liquid Nitrogen Cooler"
+		"Water Coolant System"
+		"Catalytic Ramscoop"
+		"Fuel Pod"
 		"Large Radar Jammer"
 		"Laser Rifle" 8
-		"Liquid Nitrogen Cooler"
 		"Outfits Expansion"
-		"Plasma Cannon" 2
-		"Quad Blaster Turret" 2
-		"Water Coolant System"
+		"Impala Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Impala Plasma Steering"
+		Hyperdrive
 	gun Flamethrower
 	gun Flamethrower
 	gun "Plasma Cannon"
@@ -460,6 +460,40 @@ ship "Bastion" "Bastion (Flamethrower)"
 	turret "Anti-Missile Turret"
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
+
+
+ship "Bastion" "Bastion (Flamethrower Pirate)"
+	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Gatling Turret"
+		"Javelin Turret"
+		"Breeder Reactor"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"D67-TM Shield Generator"
+		"Cooling Ducts"
+		"Liquid Nitrogen Cooler"
+		"Fuel Pod" 2
+		"Gatling Gun Ammo" 6000
+		Javelin 500
+		"Javelin Storage Crate"
+		"Laser Rifle" 8
+		"Outfits Expansion"
+		Ramscoop
+		"Small Radar Jammer"
+		"Impala Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Impala Plasma Steering"
+		Hyperdrive
+	gun "Plasma Cannon"
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	turret "Anti-Missile Turret"
+	turret "Javelin Turret"
+	turret "Gatling Turret"
 
 
 
@@ -1425,25 +1459,25 @@ ship "Falcon" "Falcon (Plasma)"
 
 ship "Falcon" "Falcon (Flamethrower)"
 	outfits
-		"Anti-Missile Turret"
-		"Breeder Reactor"
-		"Catalytic Ramscoop"
-		"D14-RN Shield Generator"
-		"D67-TM Shield Generator"
 		Flamethrower 2
-		"Fuel Pod"
-		Hyperdrive
-		"Impala Plasma Thruster"
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Quad Blaster Turret" 3
+		"Breeder Reactor"
 		"LP036a Battery Pack"
 		"LP072a Battery Pack"
-		"Laser Rifle" 15
+		"D14-RN Shield Generator"
+		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
-		"Orca Plasma Steering"
-		"Plasma Cannon" 2
-		"Quad Blaster Turret" 3
-		"Small Radar Jammer" 2
 		"Water Coolant System"
+		"Catalytic Ramscoop"
+		"Fuel Pod"
+		"Laser Rifle" 15
+		"Small Radar Jammer" 2
+		"Impala Plasma Thruster"
 		"X1700 Ion Thruster"
+		"Orca Plasma Steering"
+		Hyperdrive
 	gun Flamethrower
 	gun Flamethrower
 	gun "Plasma Cannon"
@@ -1452,6 +1486,39 @@ ship "Falcon" "Falcon (Flamethrower)"
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
 	turret "Quad Blaster Turret"
+
+
+ship "Falcon" "Falcon (Flamethrower Pirate)"
+	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Gatling Turret" 2
+		"Javelin Turret"
+		"Breeder Reactor"
+		"LP036a Battery Pack"
+		"D41-HY Shield Generator"
+		"D67-TM Shield Generator"
+		"Liquid Nitrogen Cooler"
+		"Fuel Pod" 2
+		"Gatling Gun Ammo" 12000
+		Javelin 600
+		"Javelin Storage Crate" 2
+		"Laser Rifle" 15
+		Ramscoop
+		"Small Radar Jammer" 2
+		"Impala Plasma Thruster"
+		"X1700 Ion Thruster"
+		"Orca Plasma Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Gatling Turret"
+	turret "Gatling Turret"
+	turret "Anti-Missile Turret"
+	turret "Javelin Turret"
 
 
 ship "Falcon" "Falcon (Tractor Beam)"
@@ -1597,35 +1664,6 @@ ship "Firebird" "Firebird (Plasma)"
 		"Hyperdrive"
 
 
-ship "Firebird" "Firebird (Flamethrower)"
-	outfits
-		"Anti-Missile Turret"
-		"Catalytic Ramscoop"
-		"D14-RN Shield Generator"
-		"D67-TM Shield Generator"
-		Flamethrower 2
-		"Fuel Pod" 3
-		"Greyhound Plasma Thruster"
-		Hyperdrive
-		"Impala Plasma Steering"
-		"LP036a Battery Pack"
-		"LP072a Battery Pack"
-		"Large Radar Jammer"
-		"Liquid Nitrogen Cooler"
-		"Outfits Expansion" 2
-		"Plasma Cannon" 2
-		"Pulse Rifle" 2
-		"Quad Blaster Turret"
-		"S3 Thermionic"
-		Supercapacitor 2
-	gun Flamethrower
-	gun Flamethrower
-	gun "Plasma Cannon"
-	gun "Plasma Cannon"
-	turret "Anti-Missile Turret"
-	turret "Quad Blaster Turret"
-
-
 ship "Firebird" "Firebird (Heavy Blaster)"
 	outfits
 		"Heavy Blaster" 4
@@ -1661,6 +1699,37 @@ ship "Firebird" "Firebird (CCOR)"
 		"Greyhound Plasma Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+
+
+ship "Firebird" "Firebird (CCOR Flamethrower)"
+	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Javelin Turret"
+		"S3 Thermionic"
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
+		"D67-TM Shield Generator"
+		"Water Coolant System"
+		"Cooling Ducts"
+		"Fuel Pod" 4
+		Javelin 500
+		"Javelin Storage Crate"
+		"Outfits Expansion" 2
+		"Laser Rifle" 10
+		Ramscoop
+		"Small Radar Jammer"
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Anti-Missile Turret"
+	turret "Javelin Turret"
+
 
 
 
@@ -1884,22 +1953,42 @@ ship "Fury" "Fury (Flamethrower)"
 
 ship "Fury" "Fury (Flamethrower Blaster)"
 	outfits
-		"D14-RN Shield Generator"
 		"Energy Blaster" 4
 		Flamethrower 2
-		"Fuel Pod"
-		Hyperdrive
+		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
 		Supercapacitor
-		"X2200 Ion Steering"
+		"D14-RN Shield Generator"
+		"Fuel Pod"
 		"X2700 Ion Thruster"
+		"X2200 Ion Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun Flamethrower
+	gun "Energy Blaster"
+	gun "Energy Blaster"
+	gun "Energy Blaster"
+	gun "Energy Blaster"
+
+
+ship "Fury" "Fury (Flamethrower Pirate)"
+	outfits
+		Flamethrower 2
+		"Gatling Gun" 2
 		"nGVF-AA Fuel Cell"
+		"LP036a Battery Pack"
+		Supercapacitor
+		"D14-RN Shield Generator"
+		"Fuel Pod"
+		"Gatling Gun Ammo" 6000
+		"Small Radar Jammer"
+		"X2700 Ion Thruster"
+		"X2200 Ion Steering"
+		Hyperdrive
 	gun Flamethrower
 	gun Flamethrower
-	gun "Energy Blaster"
-	gun "Energy Blaster"
-	gun "Energy Blaster"
-	gun "Energy Blaster"
+	gun "Gatling Gun"
+	gun "Gatling Gun"
 
 
 ship "Fury" "Fury (Gatling)"
@@ -2308,6 +2397,37 @@ ship "Leviathan" "Leviathan (CCOR)"
 		"Impala Plasma Steering"
 		"Chipmunk Plasma Steering"
 		"Scram Drive"
+
+
+ship "Leviathan" "Leviathan (CCOR Flamethrower)"
+	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Javelin Turret" 3
+		"S3 Thermionic"
+		"LP144a Battery Pack"
+		"D41-HY Shield Generator"
+		"D67-TM Shield Generator" 2
+		"Liquid Nitrogen Cooler"
+		"Fuel Pod" 3
+		Javelin 1500
+		"Javelin Storage Crate" 3
+		"Laser Rifle" 64
+		Ramscoop 2
+		"Small Radar Jammer" 2
+		"Impala Plasma Thruster"
+		"Chipmunk Plasma Steering"
+		"Impala Plasma Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Javelin Turret"
+	turret "Javelin Turret"
+	turret "Javelin Turret"
+	turret "Anti-Missile Turret"
 
 
 ship "Leviathan" "Leviathan (Hai Engines)"
@@ -2844,28 +2964,57 @@ ship "Osprey" "Osprey (Missile)"
 
 ship "Osprey" "Osprey (Flamethrower)"
 	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Heavy Anti-Missile Turret"
+		"Quad Blaster Turret"
 		"Breeder Reactor"
-		"Catalytic Ramscoop"
+		Supercapacitor 4
 		"D14-RN Shield Generator"
 		"D67-TM Shield Generator"
-		Flamethrower 2
+		"Liquid Nitrogen Cooler"
+		"Catalytic Ramscoop"
 		"Fuel Pod"
-		"Heavy Anti-Missile Turret"
-		Hyperdrive
-		"Impala Plasma Steering"
-		"Impala Plasma Thruster"
 		"Large Radar Jammer"
 		"Laser Rifle" 3
-		"Liquid Nitrogen Cooler"
-		"Plasma Cannon" 2
-		"Quad Blaster Turret"
-		Supercapacitor 4
+		"Impala Plasma Thruster"
+		"Impala Plasma Steering"
+		Hyperdrive
 	gun Flamethrower
 	gun Flamethrower
 	gun "Plasma Cannon"
 	gun "Plasma Cannon"
 	turret "Quad Blaster Turret"
 	turret "Heavy Anti-Missile Turret"
+
+
+ship "Osprey" "Osprey (Flamethrower Pirate)"
+	outfits
+		Flamethrower 2
+		"Plasma Cannon" 2
+		"Anti-Missile Turret"
+		"Javelin Turret"
+		"Breeder Reactor"
+		Supercapacitor 3
+		"D23-QP Shield Generator"
+		"D67-TM Shield Generator"
+		"Liquid Nitrogen Cooler"
+		"Fuel Pod" 2
+		Javelin 500
+		"Javelin Storage Crate"
+		"Laser Rifle" 3
+		Ramscoop
+		"Small Radar Jammer" 2
+		"Impala Plasma Thruster"
+		"Impala Plasma Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Javelin Turret"
+	turret "Anti-Missile Turret"
+
 
 
 
@@ -3102,6 +3251,29 @@ ship "Saber" "Saber (CCOR Javelin)"
 		"Greyhound Plasma Steering"
 		"Chipmunk Plasma Steering"
 		"Hyperdrive"
+
+
+ship "Saber" "Saber (CCOR Flamethrower)"
+	outfits
+		Flamethrower 4
+		"Twin Blaster"
+		"Anti-Missile Turret"
+		"nGVF-CC Fuel Cell"
+		"LP072a Battery Pack"
+		"D41-HY Shield Generator"
+		"Fuel Pod" 2
+		"Laser Rifle" 12
+		Ramscoop
+		"Security Station"
+		"Greyhound Plasma Thruster"
+		"Impala Plasma Steering"
+		Hyperdrive
+	gun Flamethrower
+	gun "Twin Blaster"
+	gun Flamethrower
+	gun Flamethrower
+	gun Flamethrower
+	turret "Anti-Missile Turret"
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1421,38 +1421,6 @@ ship "Falcon" "Falcon (Flamethrower)"
 		Flamethrower 2
 		"Plasma Cannon" 2
 		"Anti-Missile Turret"
-		"Blaster Turret"
-		"Quad Blaster Turret" 2
-		"Breeder Reactor"
-		"LP036a Battery Pack"
-		"LP072a Battery Pack"
-		"D14-RN Shield Generator"
-		"D67-TM Shield Generator"
-		"Liquid Nitrogen Cooler"
-		"Water Coolant System"
-		"Ramscoop"
-		"Fuel Pod" 3
-		"Laser Rifle" 15
-		"Small Radar Jammer" 2
-		"Impala Plasma Thruster"
-		"X1700 Ion Thruster"
-		"Orca Plasma Steering"
-		Hyperdrive
-	gun Flamethrower
-	gun Flamethrower
-	gun "Plasma Cannon"
-	gun "Plasma Cannon"
-	turret "Anti-Missile Turret"
-	turret "Blaster Turret"
-	turret "Quad Blaster Turret"
-	turret "Quad Blaster Turret"
-
-
-ship "Falcon" "Falcon (Flamethrower Catalytic)"
-	outfits
-		Flamethrower 2
-		"Plasma Cannon" 2
-		"Anti-Missile Turret"
 		"Quad Blaster Turret" 3
 		"Breeder Reactor"
 		"LP036a Battery Pack"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -433,6 +433,35 @@ ship "Bastion" "Bastion (Scanner)"
 	gun "Plasma Cannon"
 
 
+ship "Bastion" "Bastion (Flamethrower)"
+	outfits
+		"Anti-Missile Turret"
+		"Breeder Reactor"
+		"Catalytic Ramscoop"
+		"Chipmunk Plasma Steering"
+		"D67-TM Shield Generator"
+		Flamethrower 2
+		"Fuel Pod"
+		Hyperdrive
+		"Impala Plasma Steering"
+		"Impala Plasma Thruster"
+		"LP072a Battery Pack"
+		"Large Radar Jammer"
+		"Laser Rifle" 8
+		"Liquid Nitrogen Cooler"
+		"Outfits Expansion"
+		"Plasma Cannon" 2
+		"Quad Blaster Turret" 2
+		"Water Coolant System"
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+
+
 
 ship "Behemoth" "Behemoth (Hai)"
 	outfits
@@ -1394,6 +1423,37 @@ ship "Falcon" "Falcon (Plasma)"
 		"Hyperdrive"
 
 
+ship "Falcon" "Falcon (Flamethrower)"
+	outfits
+		"Anti-Missile Turret"
+		"Breeder Reactor"
+		"Catalytic Ramscoop"
+		"D14-RN Shield Generator"
+		"D67-TM Shield Generator"
+		Flamethrower 2
+		"Fuel Pod"
+		Hyperdrive
+		"Impala Plasma Thruster"
+		"LP036a Battery Pack"
+		"LP072a Battery Pack"
+		"Laser Rifle" 15
+		"Liquid Nitrogen Cooler"
+		"Orca Plasma Steering"
+		"Plasma Cannon" 2
+		"Quad Blaster Turret" 3
+		"Small Radar Jammer" 2
+		"Water Coolant System"
+		"X1700 Ion Thruster"
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+	turret "Quad Blaster Turret"
+
+
 ship "Falcon" "Falcon (Tractor Beam)"
 	outfits
 		"Proton Gun" 4
@@ -1535,6 +1595,35 @@ ship "Firebird" "Firebird (Plasma)"
 		"X3700 Ion Thruster"
 		"A375 Atomic Steering"
 		"Hyperdrive"
+
+
+ship "Firebird" "Firebird (Flamethrower)"
+	outfits
+		"Anti-Missile Turret"
+		"Catalytic Ramscoop"
+		"D14-RN Shield Generator"
+		"D67-TM Shield Generator"
+		Flamethrower 2
+		"Fuel Pod" 3
+		"Greyhound Plasma Thruster"
+		Hyperdrive
+		"Impala Plasma Steering"
+		"LP036a Battery Pack"
+		"LP072a Battery Pack"
+		"Large Radar Jammer"
+		"Liquid Nitrogen Cooler"
+		"Outfits Expansion" 2
+		"Plasma Cannon" 2
+		"Pulse Rifle" 2
+		"Quad Blaster Turret"
+		"S3 Thermionic"
+		Supercapacitor 2
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Anti-Missile Turret"
+	turret "Quad Blaster Turret"
 
 
 ship "Firebird" "Firebird (Heavy Blaster)"
@@ -1791,6 +1880,26 @@ ship "Fury" "Fury (Flamethrower)"
 		"X2700 Ion Thruster"
 		"X2200 Ion Steering"
 		"Hyperdrive"
+
+
+ship "Fury" "Fury (Flamethrower Blaster)"
+	outfits
+		"D14-RN Shield Generator"
+		"Energy Blaster" 4
+		Flamethrower 2
+		"Fuel Pod"
+		Hyperdrive
+		"LP036a Battery Pack"
+		Supercapacitor
+		"X2200 Ion Steering"
+		"X2700 Ion Thruster"
+		"nGVF-AA Fuel Cell"
+	gun Flamethrower
+	gun Flamethrower
+	gun "Energy Blaster"
+	gun "Energy Blaster"
+	gun "Energy Blaster"
+	gun "Energy Blaster"
 
 
 ship "Fury" "Fury (Gatling)"
@@ -2731,6 +2840,32 @@ ship "Osprey" "Osprey (Missile)"
 	gun "Heavy Rocket Launcher"
 	gun "Torpedo Launcher"
 	gun "Torpedo Launcher"
+
+
+ship "Osprey" "Osprey (Flamethrower)"
+	outfits
+		"Breeder Reactor"
+		"Catalytic Ramscoop"
+		"D14-RN Shield Generator"
+		"D67-TM Shield Generator"
+		Flamethrower 2
+		"Fuel Pod"
+		"Heavy Anti-Missile Turret"
+		Hyperdrive
+		"Impala Plasma Steering"
+		"Impala Plasma Thruster"
+		"Large Radar Jammer"
+		"Laser Rifle" 3
+		"Liquid Nitrogen Cooler"
+		"Plasma Cannon" 2
+		"Quad Blaster Turret"
+		Supercapacitor 4
+	gun Flamethrower
+	gun Flamethrower
+	gun "Plasma Cannon"
+	gun "Plasma Cannon"
+	turret "Quad Blaster Turret"
+	turret "Heavy Anti-Missile Turret"
 
 
 

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -2327,7 +2327,6 @@ ship "Leviathan" "Leviathan (CCOR)"
 		"Scram Drive"
 
 
-
 ship "Leviathan" "Leviathan (Hai Engines)"
 	outfits
 		"Particle Cannon" 4
@@ -2912,7 +2911,6 @@ ship "Osprey" "Osprey (Flamethrower Pirate)"
 	gun "Plasma Cannon"
 	turret "Javelin Turret"
 	turret "Anti-Missile Turret"
-
 
 
 

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -829,7 +829,7 @@ outfit "Flamethrower"
 		"lifetime" 5
 		"reload" 1
 		"firing energy" .1
-		"firing fuel" .4
+		"firing fuel" .1
 		"firing heat" 4
 	description "A crude but impressive-looking weapon, the Flamethrower ignites your hyperspace fuel and directs a stream of it towards your adversaries. The damage it does is relatively minor, but it can be useful for causing a target that is already operating near its thermal capacity to overheat, temporarily taking it out of the fight."
 
@@ -844,10 +844,12 @@ outfit "Flamethrower Projectile"
 		"lifetime" 18
 		"random lifetime" 8
 		"damage dropoff" 0 198
-		"dropoff modifier" .5
+		"dropoff modifier" .7
 		"shield damage" .8
 		"hull damage" .7
-		"heat damage" 125
+		"heat damage" 200
+		"burn damage" 1
+
 
 effect "flamethrower die"
 	sprite "effect/explosion/small"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -847,8 +847,7 @@ outfit "Flamethrower Projectile"
 		"dropoff modifier" .7
 		"shield damage" .8
 		"hull damage" .7
-		"heat damage" 150
-		"burn damage" .5
+		"heat damage" 160
 
 
 effect "flamethrower die"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -829,7 +829,7 @@ outfit "Flamethrower"
 		"lifetime" 5
 		"reload" 1
 		"firing energy" .1
-		"firing fuel" .1
+		"firing fuel" .15
 		"firing heat" 4
 	description "A crude but impressive-looking weapon, the Flamethrower ignites your hyperspace fuel and directs a stream of it towards your adversaries. The damage it does is relatively minor, but it can be useful for causing a target that is already operating near its thermal capacity to overheat, temporarily taking it out of the fight."
 
@@ -847,8 +847,8 @@ outfit "Flamethrower Projectile"
 		"dropoff modifier" .7
 		"shield damage" .8
 		"hull damage" .7
-		"heat damage" 200
-		"burn damage" 1
+		"heat damage" 150
+		"burn damage" .5
 
 
 effect "flamethrower die"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -849,7 +849,6 @@ outfit "Flamethrower Projectile"
 		"hull damage" .7
 		"heat damage" 160
 
-
 effect "flamethrower die"
 	sprite "effect/explosion/small"
 		"no repeat"


### PR DESCRIPTION
# Integrating the Flamethrower properly into the Gameplay

This PR shall rectify an issue considering the lack of usefulness and overall integration into the actual gameplay addressed in [inner circles](https://discord.com/channels/251118043411775489/251125349109202944/1485707499452502126). For now the [Bunsen Burner](https://github.com/LixiChronikouOriou/ES-plugins/blob/main/README.md#BunsenBurner) plugin provides remedy.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Problem

The Flamethrower has two main issues.

Firstly, it is not feasibly usable. In [PR #7606](https://github.com/endless-sky/endless-sky/pull/7606) and [PR #9508](https://github.com/endless-sky/endless-sky/pull/9508) the Flamethrower got nerfed inter alia by significantly reducing its heat damage. However the ships' heat dissipation changes in ES 0.10.7 caused an indirect second nerf which, together with the exorbitant fuel consumption, renders the Flamethrower completely useless.

Secondly, this outfit feels strangely out of place. Besides getting a prominent place in the storytelling, introducing us to Barmy's pyromania, it can never be seen in the game besides the outfitter and a single mission related to the Flamethrower's development. There are no variants of ships and fleets which actually use the Flamethrower.

## Solution

Firstly, the Flamethrower's stats have been tweaked until it became useful again.

- *Heat Damage* has been increased to 9600/s.
- *Fuel Consumption* has been reduced to 9/s.
- *Dropoff Modifier* has been increased to 70%.

Note, that these stats are experimentally determined minimum (damage, dropoff) respectively maximum (fuel consumption) values which make the Flamethrower a feasible weapon. One still needs at least two Flamethrowers to gain an effect, so the drastically reduced fuel consumption is actually still pretty costly.

Secondly, reasonable ship variants have been added for typical FW fleet ships, namely the Bastion, Falcon, Fury and Osprey. Corresponding FW small and large fleet variants have been added with the event `fw gets catalytic ramscoop`. It seems reasonable that applying the Flamethrower becomes more feasible in combination with a Catalytic Ramscoop.

*Edit:* Also Southern Pirates have been equipped with flamethrowers.