### PR TITLE
Make Sheragi Large Hybrid Cooler consistent to description

### DIFF
--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -73,7 +73,7 @@ outfit "Large Hybrid Cooling"
 	"cooling" 24
 	"active cooling" 128
 	"cooling energy" 16.2
-	"fuel capacity" 200
+	"fuel capacity" -200
 	description "This Sheragi cooling system is primitive at best, but it works both actively and passively, allowing it to dissipate much more heat than a simple radiator would. It does, however, drain a lot of power when subjected to the heat of battle. It also includes cryogenic tanks to hold some additional fuel, which is used as a temporary heat reservoir."
 
 outfit "Fission Drive"

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -73,8 +73,8 @@ outfit "Large Hybrid Cooling"
 	"cooling" 24
 	"active cooling" 128
 	"cooling energy" 16.2
-	"fuel capacity" -200
-	description "This Sheragi cooling system is primitive at best, but it works both actively and passively, allowing it to dissipate much more heat than a simple radiator would. It does, however, drain a lot of power when subjected to the heat of battle. It also includes cryogenic tanks to hold some additional fuel, which is used as a temporary heat reservoir."
+	"heat capacity" 500
+	description "This Sheragi cooling system is primitive at best, but it works both actively and passively, allowing it to dissipate much more heat than a simple radiator would. It does, however, drain a lot of power when subjected to the heat of battle. It also includes cryogenic tanks which work as a heat sink."
 
 outfit "Fission Drive"
 	category "Engines"

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -25,7 +25,7 @@ ship "Emerald Sword"
 		"mass" 4360
 		"drag" 41
 		"heat dissipation" 0.22
-		"fuel capacity" 1000
+		"fuel capacity" 900
 		"cargo space" 169
 		"outfit space" 1190
 		"weapon capacity" 512

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -25,7 +25,7 @@ ship "Emerald Sword"
 		"mass" 4360
 		"drag" 41
 		"heat dissipation" 0.22
-		"fuel capacity" 900
+		"fuel capacity" 1000
 		"cargo space" 169
 		"outfit space" 1190
 		"weapon capacity" 512


### PR DESCRIPTION
# Make Sheragi Large Hybrid Cooler faithful to the lore

I noted this during my work on the [Sheragi Rebirth: Redux](https://github.com/LixiChronikouOriou/ES-plugins/blob/main/README.md#SheragiRebirthRedux) plugin.

## Issue

The description of the [Sheragi Large Hybrid Cooling](https://github.com/endless-sky/endless-sky/blob/cf6bd8f83a64400dbb23a48259a41b0d90efa04a/data/sheragi/sheragi%20outfits.txt#L64) says:
> It also includes cryogenic tanks to hold some additional fuel, which is used as a temporary heat reservoir.

In other words, the cooler *needs* additional fuel, and does not provide it, as in the current stats. The situation is comparable to the [Avgi Heatsink Partition](https://github.com/endless-sky/endless-sky/blob/cf6bd8f83a64400dbb23a48259a41b0d90efa04a/data/avgi/avgi%20outfits.txt#L115).

Note, that if we would let the stats as they're currently, than a lack of fuel would have to affect the cooling performance, which is not the case.

## Solution

This PR negates the attribute `fuel capacity` of the Large Hybrid Cooler, setting it to -200 instead of 200. For compensation the Emerald Sword gets an increased `fuel capacity` of 1000 instead of 900.

## Note

For changes on the PR see below. I'll summarize them here properly when the discussion is over.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.
