### PR TITLE
Fix #12349: Add text shadow to outfit counts for readability

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -246,7 +246,8 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 			}
 
 			Point labelPos = point + Point(-OUTFIT_SIZE / 2 + 20, OUTFIT_SIZE / 2 - 38);
-			font.Draw(label, labelPos, color);
+            font.Draw(label, labelPos + Point(1, 1), Color(0., 1.)); // Black shadow
+            font.Draw(label, labelPos, color);
 		}
 	}
 
@@ -277,9 +278,10 @@ void OutfitterPanel::DrawItem(const string &name, const Point &point)
 	if(!message.empty())
 	{
 		Point pos = point + Point(
-			OUTFIT_SIZE / 2 - 20 - font.Width(message),
-			OUTFIT_SIZE / 2 - 24);
-		font.Draw(message, pos, bright);
+            OUTFIT_SIZE / 2 - 20 - font.Width(message),
+            OUTFIT_SIZE / 2 - 24);
+        font.Draw(message, pos + Point(1, 1), Color(0., 1.)); // Black shadow
+        font.Draw(message, pos, bright);
 	}
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12349.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixed the text readability issue for outfit counts in the outfitter panel. 
Changes made in `OutfitterPanel.cpp`:
* Added a 1-pixel offset black shadow (`Color(0., 1.)`) to the text strings displaying the installed count and cargo/stock amounts in `DrawItem()`. This ensures the numbers remain legible even when drawn over brightly colored outfit thumbnails.
