### PR TITLE
Allow deployed, out of system carriables to use wormholes to reach the flagship

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2165,8 +2165,12 @@ void AI::MoveIndependent(Ship &ship, Command &command)
 	else if(ship.GetTargetStellar())
 	{
 		MoveToPlanet(ship, command);
-		if(!shouldStay && ship.Attributes().Get("fuel capacity") && ship.GetTargetStellar()->HasSprite()
-				&& ship.GetTargetStellar()->GetPlanet() && ship.GetTargetStellar()->GetPlanet()->CanLand(ship))
+		const StellarObject *targetStellar = ship.GetTargetStellar();
+		bool shouldLandOnTarget = !shouldStay;
+		shouldLandOnTarget &= targetStellar->HasSprite();
+		shouldLandOnTarget &= targetStellar->GetPlanet() && targetStellar->GetPlanet()->CanLand(ship);
+		shouldLandOnTarget &= (ship.Attributes().Get("fuel capacity") || targetStellar->GetPlanet()->IsWormhole());
+		if(shouldLandOnTarget)
 			command |= Command::LAND;
 		else if(ship.Position().Distance(ship.GetTargetStellar()->Position()) < 100.)
 			ship.SetTargetStellar(nullptr);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described on Steam: https://steamcommunity.com/app/404410/discussions/1/563659002336151286/
There's probably an issue about it somewhere, but I'm not going to look for it.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Player owned carriables (without fuel capacity, perhaps also non-carriables without fuel capacity) will not land on wormholes to reach the flagship because they use MoveIndependent but the command to land on the target stellar is not set when the ship cannot refuel.
This PR expands this check to allow ships without fuel capacity to land on wormholes.
I also rewrote the expression to spread the conditions across multiple expressions instead of one enormous one because I don't want to read that.

I considered sending ships in this situation through MoveEscort and potentially having a fallback to MoveIndependent, but I think this is the intended code path for this situation, and making the other change will likely have a much bigger impact.

This may also affect non player owned ships, allowing them to traverse wormholes when they previously could not, but I think that's probably fine, since any other ships in this situation would have just flown to the wormhole and sat there, never landing on it, which is silly.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Used the attached save file.
Take off.
Jump along the existing travel plan.
Arrive in Ultima Thule.
Deploy fighters.
Have fleet hold position (so I can get to the wormhole and the fighters are far enough away that they won't reach it until I have transited it).
Issue land command to flagship.
When near the wormhole, retract hold position command to escorts.
The flagship transits the wormhole before the fighters reach it.

Without this PR, the fighters will never transit after the flagship is already in Waypoint.
With this PR, they will.

## Save File
This save file can be used to test these changes:
[warp core fighter wormhole test~original.txt](https://github.com/user-attachments/files/28719254/warp.core.fighter.wormhole.test.original.txt)

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A, probably.
