### PR TITLE
Trade panel selling confirmations default to ok 

### DIFF
--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -267,7 +267,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		if(Preferences::Has("Confirm selling outfits"))
 			GetUI().Push(DialogPanel::CallFunctionIfOk([this]() { SellOutfitsOrMinables(false); },
-				OutfitSalesMessage(false), 2, Truncate::NONE, true));
+				OutfitSalesMessage(false), 1, Truncate::NONE, true));
 		else
 			SellOutfitsOrMinables(false);
 	}

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -259,7 +259,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 	{
 		if(Preferences::Has("Confirm selling minables"))
 			GetUI().Push(DialogPanel::CallFunctionIfOk([this]() { SellOutfitsOrMinables(true); },
-				OutfitSalesMessage(true), 2, Truncate::NONE, true));
+				OutfitSalesMessage(true), 1, Truncate::NONE, true));
 		else
 			SellOutfitsOrMinables(true);
 	}


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #12495

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When using the "Sell Minables" and "Sell Outfits" buttons, there can be a confirmation dialog (turned on and off with settings).
Currently, that confirmation dialog has "Cancel" selected when it first opens, so if you hit "enter" immediately, it cancels the sale.
As noted in the comments of the linked issue, if a person is at the dialog, they probably do want to sell. The dialog is there to prevent accidental sales. Even if a person accidentally hits the key or button on the trading panel, they probably won't then accidentally hit enter immediately. So, this PR changes it to have "Ok" selected initially so that a person who does want to sell doesn't need to first move the selection, which is probably most cases.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
None.

## Save File
N/A

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A
