### PR TITLE
Adjust wording in Patir Mystery 35

### DIFF
--- a/data/kahet/kahet missions.txt
+++ b/data/kahet/kahet missions.txt
@@ -4297,7 +4297,7 @@ mission "Ka'het: Patir Mystery 35"
 	on offer
 		conversation
 			`The pilgrimage of the Remnant and their payloads toward your ship takes the better part of an hour, again helped by the Tern flock. "We are a fair bit lighter than we thought we would be, given that we have next to no sample from the planetoid." Dusk has taken seat in the cockpit, watching out of the window as the last few payloads climb atop the ramp. In the horizon, the sea of iridium shines at just the right angle to hit your eyes.`
-			`	"One of those creatures was in Patir again when it moved. Again it turned motionless, and it was orbiting over us when a Ka'sei located right next to it blew it up. It is a great shame that we could not get to it in time: the next time you Patir returns, whenever that may be, we need to be prepared better to board it and plunder its content."`
+			`	"One of those creatures was in Patir again when it moved. Again it turned motionless, and it was orbiting over us when a Ka'sei located right next to it blew it up. It is a great shame that we could not get to it in time: the next time Patir returns, whenever that may be, we need to be prepared better to board it and plunder its content."`
 			choice
 				`	"Is it not a sapient being?"`
 				`	"I do not think I want to harvest the organs of a living creature, if that is what they are."`


### PR DESCRIPTION
**Typo fix**

This PR addresses the typo [described by RuningOnBravado in the Discord server](https://discord.com/channels/251118043411775489/536900466655887360/1515868759468933151).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Removed the extraneous "you".

## Testing Done
None.

## Save File
Any save file without Patir Mystery 35 will do.

## Performance Impact
N/A
