### PR TITLE
fix(ui): Remove double "of" and inaccurate tonnage reporting in trading panel dialog

### DIFF
--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -384,11 +384,7 @@ string TradingPanel::OutfitSalesMessage(bool sellMinables) const
 		tonsSold += static_cast<int>(count * outfit->Mass());
 		// Store a description of the count & item, followed by its value.
 		outfitValue.push_back({{}, count, value});
-		if(sellMinables && count == 1)
-			outfitValue.back().name = Format::CargoString(count, outfit->DisplayName());
-		if(sellMinables)
-			outfitValue.back().name = Format::CargoString(count, outfit->PluralName());
-		else if(count == 1)
+		if(count == 1)
 			outfitValue.back().name = outfit->DisplayName();
 		else
 			outfitValue.back().name = Format::Number(count) + " " + outfit->PluralName();
@@ -397,7 +393,7 @@ string TradingPanel::OutfitSalesMessage(bool sellMinables) const
 		return "Sell " + outfitValue[0].name + " for " + Format::CreditString(profit) + "?";
 	std::ostringstream out;
 	out << "Sell ";
-	out << Format::CargoString(tonsSold, sellMinables ? "of special commodities" : "of outfits");
+	out << Format::CargoString(tonsSold, sellMinables ? " special commodities" : " outfits");
 	out << " for " << Format::CreditString(profit) << '?' << endl;
 
 	// Sort by decreasing value.

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -384,7 +384,14 @@ string TradingPanel::OutfitSalesMessage(bool sellMinables) const
 		tonsSold += static_cast<int>(count * outfit->Mass());
 		// Store a description of the count & item, followed by its value.
 		outfitValue.push_back({{}, count, value});
-		if(count == 1)
+		if(sellMinables)
+		{
+			if(count == 1)
+				outfitValue.back().name = Format::Number(count) + " unit of " + outfit->DisplayName();
+			else
+				outfitValue.back().name = Format::Number(count) + " units of " + outfit->DisplayName();
+		}
+		else if(count == 1)
 			outfitValue.back().name = outfit->DisplayName();
 		else
 			outfitValue.back().name = Format::Number(count) + " " + outfit->PluralName();

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -385,12 +385,7 @@ string TradingPanel::OutfitSalesMessage(bool sellMinables) const
 		// Store a description of the count & item, followed by its value.
 		outfitValue.push_back({{}, count, value});
 		if(sellMinables)
-		{
-			if(count == 1)
-				outfitValue.back().name = Format::Number(count) + " unit of " + outfit->DisplayName();
-			else
-				outfitValue.back().name = Format::Number(count) + " units of " + outfit->DisplayName();
-		}
+			outfitValue.back().name = Format::SimplePluralization(count, "unit") + " of " + outfit->DisplayName();
 		else if(count == 1)
 			outfitValue.back().name = outfit->DisplayName();
 		else
@@ -400,7 +395,7 @@ string TradingPanel::OutfitSalesMessage(bool sellMinables) const
 		return "Sell " + outfitValue[0].name + " for " + Format::CreditString(profit) + "?";
 	std::ostringstream out;
 	out << "Sell ";
-	out << Format::CargoString(tonsSold, sellMinables ? " special commodities" : " outfits");
+	out << Format::CargoString(tonsSold, sellMinables ? "special commodities" : "outfits");
 	out << " for " << Format::CreditString(profit) << '?' << endl;
 
 	// Sort by decreasing value.


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1516887242126393464).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The trading panel dialog for selling minables or outfits currently has a double "of" in the text, and minables are reported in a number of tons, but the number shown is the number of units, assuming that 1 unit = 1 ton, which is not guranteed.
<img width="267" height="295" alt="image" src="https://github.com/user-attachments/assets/23a3b513-e155-466b-afe9-8363915b3587" />

## Screenshots + Testing Done

Minables now report number of units instead of tonnage.
<img width="281" height="229" alt="image" src="https://github.com/user-attachments/assets/1922cca7-d9c0-4576-85e1-5842d1fa600e" />

Both dialogs have removed the double "of".
<img width="283" height="186" alt="image" src="https://github.com/user-attachments/assets/7ab1d13c-5398-4021-9b55-f6b20304912d" />
