### PR TITLE
**Bug fix** Issue 4431 - made SpacerportPanel::Step() non-reentrant

### DIFF
--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Screen.h"
 #include "TextArea.h"
 #include "UI.h"
+#include <mutex>
 
 using namespace std;
 
@@ -77,10 +78,11 @@ void SpaceportPanel::UpdateNews()
 	newsMessage.Wrap(Format::Replace(news->Message(), subs));
 }
 
-
+std::mutex SpaceportPanel::spaceportMissionLock;
 
 void SpaceportPanel::Step()
 {
+	spaceportMissionLock.lock();
 	if(GetUI().IsTop(this) && port.HasService(Port::ServicesType::OffersMissions))
 	{
 		Mission *mission = player.MissionToOffer(Mission::SPACEPORT);
@@ -93,6 +95,7 @@ void SpaceportPanel::Step()
 		else
 			player.HandleBlockedMissions(Mission::SPACEPORT, GetUI());
 	}
+	spaceportMissionLock.unlock();
 }
 
 

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -55,7 +55,7 @@ private:
 	PlayerInfo &player;
 	std::shared_ptr<TextArea> description;
 	const Port &port;
-
+	static std::mutex spaceportMissionLock;
 	// Current news item (if any):
 	bool hasNews = false;
 	bool hasPortrait = false;


### PR DESCRIPTION
(The lines in parentheses (like this one) are instructions for filling out this template. These lines can be deleted.)
(The lines in double curly brackets ({{}}) should be replaced as it describes.)
(You can open a PR to add to or improve this template, if you find it lacking!)
**Bug fix**

This PR addresses the bug/feature described in issue #4431

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The issue is that multiple keystrokes or mouse requests to the spaceport button may run in parallel and on a slow/overloaded system they may execute concurrently causing the application to make two mission offers when a mission is available at the spaceport.  

The resolution is to make the block of code for offering a mission from the spaceport non-reentrant so that the requests execute sequentially and do not generate multiple dialogs at the same time.

## Screenshots
The second, inaccessible dialog remains after the first one is cleared and the game hangs.

<img width="929" height="733" alt="image" src="https://github.com/user-attachments/assets/7bd440a3-024b-4c83-a9df-a2982f3afb61" />


## Testing Done
Installed Prime 95 to load up my workstation cpu.  Defined a macro for my keyboard to spam the 'p' keystroke up/down every 1 millisecond.  Set the republic mission 'Republic Navy Advisory System [wildfire cargo]' to be offerred 100% of the time in .\data\human\jobs.txt.  Landed on a republic planet and fired off the 'p' macro.  Repeated 25 times with no duplicate windows appearing.


## Save File
Should work on any save.


## Performance Impact
None.  Unless two concurrent requests of microsecond scale having to process sequentially counts.


p.s. - my first PR on this repo.  God, please be merciful