### PR TITLE
Fix a crash introduced by 12497

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2166,10 +2166,18 @@ void AI::MoveIndependent(Ship &ship, Command &command)
 	{
 		MoveToPlanet(ship, command);
 		const StellarObject *targetStellar = ship.GetTargetStellar();
-		bool shouldLandOnTarget = !shouldStay;
-		shouldLandOnTarget &= targetStellar->HasSprite();
-		shouldLandOnTarget &= targetStellar->GetPlanet() && targetStellar->GetPlanet()->CanLand(ship);
-		shouldLandOnTarget &= (ship.Attributes().Get("fuel capacity") || targetStellar->GetPlanet()->IsWormhole());
+		bool shouldLandOnTarget = [shouldStay, targetStellar, ship]() {
+			if(shouldStay)
+				return false;
+			if(!targetStellar->HasSprite())
+				return false;
+			if(!targetStellar->GetPlanet())
+				return false;
+			if(!targetStellar->GetPlanet()->CanLand(ship))
+				return false;
+			if(!ship.Attributes().Get("fuel capacity") && !targetStellar->GetPlanet()->IsWormhole())
+				return false;
+		}();
 		if(shouldLandOnTarget)
 			command |= Command::LAND;
 		else if(ship.Position().Distance(ship.GetTargetStellar()->Position()) < 100.)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2177,6 +2177,7 @@ void AI::MoveIndependent(Ship &ship, Command &command)
 				return false;
 			if(!ship.Attributes().Get("fuel capacity") && !targetStellar->GetPlanet()->IsWormhole())
 				return false;
+			return true;
 		}();
 		if(shouldLandOnTarget)
 			command |= Command::LAND;


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

Thanks to bentwing38 on Discord for reporting this and @apttie for providing some debugging.

## Summary
`&=` is a bitwise operation and so does not short circuit like the logical operations (`&&`).
As a result, despite `shouldLandOnTarget` already being false and the expression having no possibility of changing that value, the call to `Planet::IsWormhole` is still executed, even though the previous expressions determined that there is no `Planet` object here.
This results in a segfault and the game crashes.

I've fixed this by creating an immediately executed lambda that does the short circuiting.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
I actually didn't.

## Save File
This save file can be used to test these changes, courtesy of bentwing38 on Discord:
[Will Greaves~new alpha version.txt](https://github.com/user-attachments/files/29181240/Will.Greaves.new.alpha.version.txt)
Just depart.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
Minimal.
