### PR TITLE
Fix the spaceport panel appearing on top of conversations and dialogs it created

### DIFF
--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -101,7 +101,7 @@ void PlanetPanel::Step()
 		if(callback)
 			callback();
 		if(selectedPanel)
-			GetUI().Pop(selectedPanel);
+			GetUI().Pop(selectedPanel.get());
 		GetUI().Pop(this);
 		return;
 	}
@@ -186,7 +186,7 @@ void PlanetPanel::Step()
 	// treating them all as the landing location. This is mainly to
 	// handle the intro mission in the event the player moves away
 	// from the landing before buying a ship.
-	const Panel *activePanel = selectedPanel ? selectedPanel : this;
+	const Panel *activePanel = selectedPanel ? selectedPanel.get() : this;
 	if(activePanel != spaceport.get() && GetUI().IsTop(activePanel))
 	{
 		Mission *mission = player.MissionToOffer(Mission::LANDING);
@@ -257,7 +257,7 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	if(player.IsDead())
 		return true;
 
-	Panel *oldPanel = selectedPanel;
+	Panel *oldPanel = selectedPanel.get();
 	const Ship *flagship = player.Flagship();
 
 	UI::UISound sound = UI::UISound::NORMAL;
@@ -291,21 +291,14 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 	}
 	else if(key == 't' && hasAccess
 			&& planet.GetPort().HasService(Port::ServicesType::Trading) && system.HasTrade())
-	{
-		selectedPanel = trading.get();
-		GetUI().Push(trading);
-	}
+		selectedPanel = trading;
 	else if(key == 'b' && hasAccess && planet.GetPort().HasService(Port::ServicesType::Bank))
-	{
-		selectedPanel = bank.get();
-		GetUI().Push(bank);
-	}
+		selectedPanel = bank;
 	else if(key == 'p' && hasAccess && planet.HasNamedPort())
 	{
-		selectedPanel = spaceport.get();
+		selectedPanel = spaceport;
 		if(isNewPress)
 			spaceport->UpdateNews();
-		GetUI().Push(spaceport);
 	}
 	else if(key == 's' && hasAccess && hasShipyard)
 	{
@@ -325,17 +318,19 @@ bool PlanetPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, b
 		return true;
 	}
 	else if(key == 'h' && hasAccess && planet.GetPort().HasService(Port::ServicesType::HireCrew))
-	{
-		selectedPanel = hiring.get();
-		GetUI().Push(hiring);
-	}
+		selectedPanel = hiring;
 	else
 		return false;
 
 	// If we are here, it is because something happened to change the selected
-	// planet UI panel. So, we need to pop the old selected panel:
-	if(oldPanel)
-		GetUI().Pop(oldPanel);
+	// planet UI panel. So, we need to push the new and pop the old selected panel:
+	if(oldPanel != selectedPanel.get())
+	{
+		if(oldPanel)
+			GetUI().Pop(oldPanel);
+		if(selectedPanel)
+			GetUI().Push(selectedPanel);
+	}
 
 	UI::PlaySound(sound);
 
@@ -596,7 +591,7 @@ void PlanetPanel::TakeOff(const bool distributeCargo)
 		if(callback)
 			callback();
 		if(selectedPanel)
-			GetUI().Pop(selectedPanel);
+			GetUI().Pop(selectedPanel.get());
 		GetUI().Pop(this);
 	}
 }

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -88,7 +88,7 @@ private:
 	std::shared_ptr<Panel> bank;
 	std::shared_ptr<SpaceportPanel> spaceport;
 	std::shared_ptr<Panel> hiring;
-	Panel *selectedPanel = nullptr;
+	std::shared_ptr<Panel> selectedPanel;
 
 	std::shared_ptr<TextArea> description;
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #4431 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Endless Sky stores it's "panels" in a "UI" object. The UI object contains a stack of panels, which are drawn and have events, such as key presses, passed down them. It also stores a queue of panels to push to the stack and a list of panels to remove from the stack.
Panels are added to and removed from the stack after events have been passed through the stack and before all the panels in the stack are `Step`ped.

When on the PlanetPanel, pressing the "p" key has it `Push` the SpaceportPanel to the UI, which places it in the queue to be added ot the stack. It is shortly thereafter added to the stack.
Once in the stack, the SpaceportPanel will be `Step`ped along with all the other panels. During this, it may offer a mission. Offering a mission may create a conversation or dialog panel which is pushed to the UI object, adding it to the queue for the stack.
This new panel will not be added to the stack until after new events have been propagated through the stack. It is therefore possible for the PlanetPanel to receive another "p" key press before the new panel is placed on the stack. (SpaceportPanel does not handle its own key presses. They are all sent to PlanetPanel.)

When it receives a "p", PlanetPanel sets its `selectedPanel` field to the SpaceportPanel object. It then has the UI pop the previously selected panel (if there was one) and pushes the newly selected panel. Since the newly selected panel is the same as the previously selected one, it both pushes and pops it. The SpaceportPanel is now in all three collections of panels held by the UI object.

After propagating the events, the UI object pushes panels from the queue onto the stack and removes any panels in the list of panels to remove. Since the conversation or dialog panel for the mission was added to the queue first, it is pushed to the stack first, then the SpaceportPanel is placed above it, making a sandwich. Then, panels are removed. The lowermost matching panel in the stack is removed, so the SpaceportPanel below the conversation or dialog is removed.

The result is that the SpaceportPanel is above the conversation or dialog panel it created when offering a mission.

This PR solves this by having PlanetPanel only push and pop panels if the currently selected panel is different to the previously selected panel.

It may still be possible that there could still be a case of the SpaceportPanel (or any of the other PlanetPanels) ending up on top of a conversation or dialog panel for a mission being offered by a PlanetPanel, but I can't reliably test that.

## Screenshots
N/A

## Usage examples
N/A

## Testing Done
Not much.

## Save File
No.

## Artwork Checklist
N/A

## Wiki Update
N/A

## Performance Impact
N/A?
