### PR TITLE
fix(controls): Fix weird RMB and LMB controls under certain circumstances

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2364,12 +2364,18 @@ void Engine::HandleMouseClicks()
 		}
 		else if(mouseButton == MouseButton::LEFT)
 		{
-			UI::PlaySound(UI::UISound::TARGET);
 			// Left click: has your flagship select or board the target.
 			if(clickTarget == flagship->GetTargetShip())
-				activeCommands |= Command::BOARD;
+			{
+				if(clickTarget->IsDisabled())
+				{
+					UI::PlaySound(UI::UISound::TARGET);
+					activeCommands |= Command::BOARD;
+				}
+			}
 			else
 			{
+				UI::PlaySound(UI::UISound::TARGET);
 				flagship->SetTargetShip(clickTarget);
 				if(clickTarget->IsYours())
 					player.SelectEscort(clickTarget.get(), hasShift);

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2357,11 +2357,14 @@ void Engine::HandleMouseClicks()
 	bool clickedAsteroid = false;
 	if(clickTarget)
 	{
-		UI::PlaySound(UI::UISound::TARGET);
 		if(mouseButton == secondaryMouseButton)
-			ai.IssueShipTarget(clickTarget);
-		else
 		{
+			UI::PlaySound(UI::UISound::TARGET);
+			ai.IssueShipTarget(clickTarget);
+		}
+		else if(mouseButton == MouseButton::LEFT)
+		{
+			UI::PlaySound(UI::UISound::TARGET);
 			// Left click: has your flagship select or board the target.
 			if(clickTarget == flagship->GetTargetShip())
 				activeCommands |= Command::BOARD;


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug described on [Discord](https://discord.com/channels/251118043411775489/536900466655887360/1518683919720120372).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When using the "Control ship with mouse" preference, the right mouse button is used for firing your flagship's weapons. It also does the following:
- Target the ship you're hovering over.
- If the ship you're hovering over is already targeted and is disabled, board it.
- If the ship you're hovering over is already targeted and is not disabled, board the nearest disabled ship, therefore changing your current target.
- The targeting audio effect is played every time you use RMB on a ship, even if nothing changes.

There are three problems to be addressed, all in Engine::HandleMouseClicks when you use one of the mouse buttons while hovering over a ship:
- If you didn't use the secondary mouse button, it assumes you used LMB. The secondary mouse button changes from RMB to MMB when mouse control is active.
- A targeting sound effect is always played when you use a mouse button while hovering over a ship, even if nothing happens.
- A board command is always sent when you double click on a target, even if that target is not disabled. AI::MovePlayer interprets a board command when your current target is not disabled as a request to locate the next boardable ship, which is desired behavior when the board command was sent by the board keybind, but not when double clicking on a ship.

## Testing Done

Turned on the mouse control preference. Flew around and fired at ships using RMB. Confirmed that only LMB is used for target selection. Using RMB while hovering over a ship no longer makes a sound when in mouse control mode. Double LMB clicking on a ship while there's a disabled ship somewhere else in the system no longer changes your target to board that other ship.

