### PR TITLE
fix(bug) Radrickson spelling Issue 11900

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10619,7 +10619,7 @@ mission "Timothy Radrickson: Log Fix 1"
 		not "Timothy Radrickson 2: Good Interlude: offered"
 		not "timothy radrickson 1 log entry correct"
 	on offer
-		remove log "People" "Timothy Radickson"
+		remove log "People" "Timothy Radrickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		fail
 
@@ -10633,7 +10633,7 @@ mission "Timothy Radrickson: Log Fix 2"
 		not "timothy radrickson 2 log entry correct"
 		not "Timothy Radrickson: Log Fix 1: offered"
 	on offer
-		remove log "People" "Timothy Radickson"
+		remove log "People" "Timothy Radrickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		fail
@@ -10648,7 +10648,7 @@ mission "Timothy Radrickson: Log Fix 3"
 		not "timothy radrickson 3 log entry correct"
 		not "Timothy Radrickson: Log Fix 2: offered"
 	on offer
-		remove log "People" "Timothy Radickson"
+		remove log "People" "Timothy Radrickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
@@ -10664,7 +10664,7 @@ mission "Timothy Radrickson: Log Fix 4"
 		not "timothy radrickson 4 log entry correct"
 		not "Timothy Radrickson: Log Fix 3: offered"
 	on offer
-		remove log "People" "Timothy Radickson"
+		remove log "People" "Timothy Radrickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
@@ -10680,7 +10680,7 @@ mission "Timothy Radrickson: Log Fix 6"
 		not "timothy radrickson 6 log entry correct"
 		not "Timothy Radrickson: Log Fix 4: offered"
 	on offer
-		remove log "People" "Timothy Radickson"
+		remove log "People" "Timothy Radrickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10619,7 +10619,7 @@ mission "Timothy Radrickson: Log Fix 1"
 		not "Timothy Radrickson 2: Good Interlude: offered"
 		not "timothy radrickson 1 log entry correct"
 	on offer
-		remove log "People" "Timothy Radrickson"
+		remove log "People" "Timothy Radickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		fail
 
@@ -10633,7 +10633,7 @@ mission "Timothy Radrickson: Log Fix 2"
 		not "timothy radrickson 2 log entry correct"
 		not "Timothy Radrickson: Log Fix 1: offered"
 	on offer
-		remove log "People" "Timothy Radrickson"
+		remove log "People" "Timothy Radickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		fail
@@ -10648,7 +10648,7 @@ mission "Timothy Radrickson: Log Fix 3"
 		not "timothy radrickson 3 log entry correct"
 		not "Timothy Radrickson: Log Fix 2: offered"
 	on offer
-		remove log "People" "Timothy Radrickson"
+		remove log "People" "Timothy Radickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
@@ -10664,7 +10664,7 @@ mission "Timothy Radrickson: Log Fix 4"
 		not "timothy radrickson 4 log entry correct"
 		not "Timothy Radrickson: Log Fix 3: offered"
 	on offer
-		remove log "People" "Timothy Radrickson"
+		remove log "People" "Timothy Radickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
@@ -10676,16 +10676,17 @@ mission "Timothy Radrickson: Log Fix 6"
 	invisible
 	non-blocking
 	to offer
-		has "Timothy Radrickson 5a: Timshank Redemption: offered"
+		has "Timothy Radrickson 6: News of Death: offered"
 		not "timothy radrickson 6 log entry correct"
 		not "Timothy Radrickson: Log Fix 4: offered"
 	on offer
-		remove log "People" "Timothy Radrickson"
+		remove log "People" "Timothy Radickson"
 		log "People" "Timothy Radrickson" `A stowaway I found on my ship. He requested a trip to Rand to start a new life, promising to pay back the money he owes.`
 		log "People" "Timothy Radrickson" `Timothy kept his promise, sending 50,000 credits to pay for his trip.`
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
 		log "People" "Timothy Radrickson" `Tried to help Timothy escape from his prison sentence there.`
+		log "Timothy is dead - or at least that is what's being reported in the news. Perhaps the plot to break him free really did work."
 		fail
 
 

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10686,7 +10686,7 @@ mission "Timothy Radrickson: Log Fix 6"
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
 		log "People" "Timothy Radrickson" `Tried to help Timothy escape from his prison sentence there.`
-		log "Timothy is dead - or at least that is what's being reported in the news. Perhaps the plot to break him free really did work."
+		log "People" "Timothy Radrickson" 'Timothy is dead - or at least that is what's being reported in the news. Perhaps the plot to break him free really did work.'
 		fail
 
 

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10686,7 +10686,6 @@ mission "Timothy Radrickson: Log Fix 6"
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
 		log "People" "Timothy Radrickson" `Tried to help Timothy escape from his prison sentence there.`
-		log "People" "Timothy Radrickson" `Timothy is dead - or at least that is what's being reported in the news. Perhaps the plot to break him free really did work.`
 		fail
 
 

--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10686,7 +10686,7 @@ mission "Timothy Radrickson: Log Fix 6"
 		log "People" "Timothy Radrickson" `Timothy has since become the governor of Rand.`
 		log "People" "Timothy Radrickson" `Charged with corruption and mired in scandal, Timothy has been disgraced and exiled to Oblivion.`
 		log "People" "Timothy Radrickson" `Tried to help Timothy escape from his prison sentence there.`
-		log "People" "Timothy Radrickson" 'Timothy is dead - or at least that is what's being reported in the news. Perhaps the plot to break him free really did work.'
+		log "People" "Timothy Radrickson" `Timothy is dead - or at least that is what's being reported in the news. Perhaps the plot to break him free really did work.`
 		fail
 
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #11900 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Fixed misspelling in mission text.

## Testing Done
Appears to properly modify Radrickson entry on mission completion.

## Save File

## Wiki Update
No

## Performance Impact
No