### PR TITLE
Rename linear filter setting

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1508,8 +1508,10 @@ tip "Cloaked ship outlines"
 	`- "fancy": causes the ship to become transparent and applies a red outline.`
 	`- "fast": simply shifts the ship to being red.`
 
-tip "Linear filter"
-	`Use a standard linear interpolation filter to make sprites look smoother. (Requires game restart.)`
+tip "Texture interpolation"
+	`Choose the interpolation method used when sampling textures. (Requires game restart.)`
+	`- "linear": produces a smoother, fuzzier image.`
+	`- "nearest": produces a sharper, blockier image`
 
 tip "Show status overlays"
 	`Display status overlays over top of all ships when in flight. Status overlays display a ship's shields and hull.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1508,7 +1508,7 @@ tip "Cloaked ship outlines"
 	`- "fancy": causes the ship to become transparent and applies a red outline.`
 	`- "fast": simply shifts the ship to being red.`
 
-tip "Texture interpolation"
+tip "Texture filtering"
 	`Choose the interpolation method used when sampling textures. (Requires game restart.)`
 	`- "linear": produces a smoother, fuzzier image.`
 	`- "nearest": produces a sharper, blockier image`

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -222,7 +222,7 @@ void Preferences::Load()
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
 	settings["Animate main menu background"] = true;
-	settings["Linear filter"] = true;
+	settings["Texture interpolation"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -222,7 +222,7 @@ void Preferences::Load()
 	settings["Draw background haze"] = true;
 	settings["Draw starfield"] = true;
 	settings["Animate main menu background"] = true;
-	settings["Texture interpolation"] = true;
+	settings["Texture filtering"] = true;
 	settings["Hide unexplored map regions"] = true;
 	settings["Turrets focus fire"] = true;
 	settings["Ship outlines in shops"] = true;

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -65,6 +65,7 @@ namespace {
 	const string CAMERA_ACCELERATION = "Camera acceleration";
 	const string LARGE_GRAPHICS_REDUCTION = "Reduce large graphics";
 	const string CLOAK_OUTLINE = "Cloaked ship outlines";
+	const string TEXTURE_INTERPOLATION = "Texture interpolation";
 	const string STATUS_OVERLAYS_ALL = "Show status overlays";
 	const string STATUS_OVERLAYS_FLAGSHIP = "   Show flagship overlay";
 	const string STATUS_OVERLAYS_ESCORT = "   Show escort overlays";
@@ -760,7 +761,7 @@ void PreferencesPanel::DrawSettings()
 		"Show hyperspace flash",
 		EXTENDED_JUMP_EFFECTS,
 		CLOAK_OUTLINE,
-		"Linear filter",
+		TEXTURE_INTERPOLATION,
 		"\t",
 		"Performance",
 		"Show CPU / GPU load",
@@ -955,6 +956,11 @@ void PreferencesPanel::DrawSettings()
 		else if(setting == CLOAK_OUTLINE)
 		{
 			text = Preferences::Has(CLOAK_OUTLINE) ? "fancy" : "fast";
+			isOn = true;
+		}
+		else if(setting == TEXTURE_INTERPOLATION)
+		{
+			text = Preferences::Has("Texture interpolation") ? "linear" : "nearest";
 			isOn = true;
 		}
 		else if(setting == AUTO_AIM_SETTING)

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -65,7 +65,7 @@ namespace {
 	const string CAMERA_ACCELERATION = "Camera acceleration";
 	const string LARGE_GRAPHICS_REDUCTION = "Reduce large graphics";
 	const string CLOAK_OUTLINE = "Cloaked ship outlines";
-	const string TEXTURE_INTERPOLATION = "Texture interpolation";
+	const string TEXTURE_FILTERING = "Texture filtering";
 	const string STATUS_OVERLAYS_ALL = "Show status overlays";
 	const string STATUS_OVERLAYS_FLAGSHIP = "   Show flagship overlay";
 	const string STATUS_OVERLAYS_ESCORT = "   Show escort overlays";
@@ -761,7 +761,7 @@ void PreferencesPanel::DrawSettings()
 		"Show hyperspace flash",
 		EXTENDED_JUMP_EFFECTS,
 		CLOAK_OUTLINE,
-		TEXTURE_INTERPOLATION,
+		TEXTURE_FILTERING,
 		"\t",
 		"Performance",
 		"Show CPU / GPU load",
@@ -958,9 +958,9 @@ void PreferencesPanel::DrawSettings()
 			text = Preferences::Has(CLOAK_OUTLINE) ? "fancy" : "fast";
 			isOn = true;
 		}
-		else if(setting == TEXTURE_INTERPOLATION)
+		else if(setting == TEXTURE_FILTERING)
 		{
-			text = Preferences::Has("Texture interpolation") ? "linear" : "nearest";
+			text = Preferences::Has("Texture filtering") ? "linear" : "nearest";
 			isOn = true;
 		}
 		else if(setting == AUTO_AIM_SETTING)

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -40,7 +40,7 @@ namespace {
 		glBindTexture(type, *target);
 
 		// Use linear interpolation (if not disabled in preferences) and no wrapping.
-		int filter = Preferences::Has("Linear interpolation") ? GL_LINEAR : GL_NEAREST;
+		int filter = Preferences::Has("Texture interpolation") ? GL_LINEAR : GL_NEAREST;
 		glTexParameteri(type, GL_TEXTURE_MIN_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_MAG_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -40,7 +40,7 @@ namespace {
 		glBindTexture(type, *target);
 
 		// Use linear interpolation (if not disabled in preferences) and no wrapping.
-		int filter = Preferences::Has("Linear filter") ? GL_LINEAR : GL_NEAREST;
+		int filter = Preferences::Has("Linear interpolation") ? GL_LINEAR : GL_NEAREST;
 		glTexParameteri(type, GL_TEXTURE_MIN_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_MAG_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -40,7 +40,7 @@ namespace {
 		glBindTexture(type, *target);
 
 		// Use linear interpolation (if not disabled in preferences) and no wrapping.
-		int filter = Preferences::Has("Texture interpolation") ? GL_LINEAR : GL_NEAREST;
+		int filter = Preferences::Has("Texture filtering") ? GL_LINEAR : GL_NEAREST;
 		glTexParameteri(type, GL_TEXTURE_MIN_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_MAG_FILTER, filter);
 		glTexParameteri(type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);


### PR DESCRIPTION
**UI Change**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Renames the recently introduced "Lienar filter" setting to "Texture filtering" with the options changing from "on/off" to "linear/nearest". And rewrites the tooltip to match.
This is because I don't think the name "Linear filter" is very useful for the setting. It doesn't tell use what is being filtered, or what happens when the linear filter is turned off.
The thing that is being filtered is the textures, and the options are linear or nearest neighbour.

## Testing Done
None.

## Wiki Update
N/A?
