### PR TITLE
**Feature**/**Bug fix** fix ships "disabled" due to lack of energy and no way to regen

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -764,7 +764,7 @@ void AI::Step(Command &activeCommands)
 		bool isPresent = (it->GetSystem() == playerSystem);
 		bool isStranded = IsStranded(*it);
 		bool thisIsLaunching = (isPresent && HasDeployments(*it));
-		if(isStranded || it->IsDisabled() || it->NeedsEnergy())
+		if(isStranded || it->IsDisabled())
 		{
 			// Attempt to find a friendly ship to render assistance.
 			if(!it->GetPersonality().IsDerelict())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -764,7 +764,7 @@ void AI::Step(Command &activeCommands)
 		bool isPresent = (it->GetSystem() == playerSystem);
 		bool isStranded = IsStranded(*it);
 		bool thisIsLaunching = (isPresent && HasDeployments(*it));
-		if(isStranded || it->IsDisabled())
+		if(isStranded || it->IsDisabled() || it->NeedsEnergy())
 		{
 			// Attempt to find a friendly ship to render assistance.
 			if(!it->GetPersonality().IsDerelict())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2752,8 +2752,8 @@ double Ship::TransferFuel(double amount, Ship *to)
 
 double Ship::TransferEnergy(double amount, Ship *to)
 {
-	// Do not give more energy than the ships current energy reserves.	
-	amount = min(energy, amount);	
+	// Do not give more energy than the ships current energy reserves.
+	amount = min(energy, amount);
 	if(to)
 	{
 		amount = min(to->attributes.Get("energy capacity") - to->energy, amount);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3030,7 +3030,8 @@ bool Ship::NeedsEnergy() const
 
 	// If ship can regenerate energy it does not need energy.
 	// A ship is considered to be unable to regenerate if it is generating less than 1 energy per second.
-	System::SolarGeneration generation = currentSystem->GetSolarGeneration(position, attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat"));
+	System::SolarGeneration generation = currentSystem->GetSolarGeneration(position,
+		attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat"));
 	if((attributes.Get("energy generation") + attributes.Get("fuel energy")
 		+ generation.energy - attributes.Get("energy consumption")) > 0.016)
 		return false;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3019,8 +3019,22 @@ bool Ship::NeedsFuel(bool followParent) const
 
 bool Ship::NeedsEnergy() const
 {
-	return attributes.Get("energy capacity") && !energy && !attributes.Get("energy generation")
-			&& !attributes.Get("fuel energy") && !attributes.Get("solar collection");
+	// If ship has no energy capacity it does not need energy
+	if (!attributes.Get("energy capacity"))
+		return false;
+
+	// If ship has energy, it does not need energy.
+	if ( energy > ( attributes.Get("energy capacity") * .01 ) )
+		return false;
+	
+	// If ship can regenerate energy it does not need energy.  
+	// A ship is considered to be unable to regenerate if it is generating less than 1 energy per second.
+	System::SolarGeneration generation = currentSystem->GetSolarGeneration(position,attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat"));
+	if ( ( attributes.Get("energy generation") + attributes.Get("fuel energy") + generation.energy - attributes.Get("energy consumption") ) > 0.016 )		
+		return false;
+		
+	// This ship definitely needs energy
+	return true;
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2356,7 +2356,7 @@ bool Ship::IsDisabled() const
 
 	double minimumHull = MinimumHull();
 	bool needsCrew = RequiredCrew() != 0;
-	return (hull < minimumHull || (!crew && needsCrew));
+	return (hull < minimumHull || (!crew && needsCrew) || NeedsEnergy());
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2752,7 +2752,8 @@ double Ship::TransferFuel(double amount, Ship *to)
 
 double Ship::TransferEnergy(double amount, Ship *to)
 {
-	amount = max(energy - attributes.Get("energy capacity"), amount);
+	// Do not give more energy than the ships current energy reserves.	
+	amount = min(energy, amount);	
 	if(to)
 	{
 		amount = min(to->attributes.Get("energy capacity") - to->energy, amount);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3020,19 +3020,20 @@ bool Ship::NeedsFuel(bool followParent) const
 bool Ship::NeedsEnergy() const
 {
 	// If ship has no energy capacity it does not need energy
-	if (!attributes.Get("energy capacity"))
+	if(!attributes.Get("energy capacity"))
 		return false;
 
 	// If ship has energy, it does not need energy.
-	if ( energy > ( attributes.Get("energy capacity") * .01 ) )
+	if(energy > (attributes.Get("energy capacity") * .01))
 		return false;
-	
-	// If ship can regenerate energy it does not need energy.  
+
+	// If ship can regenerate energy it does not need energy.
 	// A ship is considered to be unable to regenerate if it is generating less than 1 energy per second.
-	System::SolarGeneration generation = currentSystem->GetSolarGeneration(position,attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat"));
-	if ( ( attributes.Get("energy generation") + attributes.Get("fuel energy") + generation.energy - attributes.Get("energy consumption") ) > 0.016 )		
+	System::SolarGeneration generation = currentSystem->GetSolarGeneration(position, attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat"));
+	if((attributes.Get("energy generation") + attributes.Get("fuel energy")
+		+ generation.energy - attributes.Get("energy consumption")) > 0.016)
 		return false;
-		
+
 	// This ship definitely needs energy
 	return true;
 }

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2736,6 +2736,7 @@ bool Ship::CanGiveEnergy(const Ship &other) const
 
 double Ship::TransferFuel(double amount, Ship *to)
 {
+	// Do not give more fuel than the ship's current fuel reserves.
 	amount = min(fuel, amount);
 	if(to)
 	{
@@ -2752,7 +2753,7 @@ double Ship::TransferFuel(double amount, Ship *to)
 
 double Ship::TransferEnergy(double amount, Ship *to)
 {
-	// Do not give more energy than the ships current energy reserves.
+	// Do not give more energy than the ship's current energy reserves.
 	amount = min(energy, amount);
 	if(to)
 	{
@@ -3020,19 +3021,41 @@ bool Ship::NeedsFuel(bool followParent) const
 
 bool Ship::NeedsEnergy() const
 {
-	// If a ship has no energy capacity it does not need energy.
-	if(!attributes.Get("energy capacity"))
+	// If a ship has no energy capacity or already has some energy in reserves,
+	// it does not need energy. Since engines can use fractional thrust/turn,
+	// even a single unit of energy can still have use.
+	if(!attributes.Get("energy capacity") || energy > 1.)
 		return false;
 
-	// If a ship has energy, it does not need energy.
-	if(energy > 1.)
+	// If a ship has energy capacity but is low on energy, check to see if it is capable
+	// of generating its own energy.
+	// Just check standard energy generation first for simplicity. If gaining any energy at all from
+	// energy generation, the ship doesn't need energy.
+	double generation = attributes.Get("energy generation") - attributes.Get("energy consumption");
+	if(generation > 0.)
 		return false;
 
-	// If a ship can regenerate energy, it does not need energy.
-	// A ship is considered to be unable to regenerate if it is generating less than 1 energy per second.
-	double generation = currentSystem->GetSolarGeneration(position,
-		attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat")).energy
-		+ attributes.Get("energy generation") + attributes.Get("fuel energy") - attributes.Get("energy consumption");
+	// A ship may be gaining energy from other sources.
+	double solarCollection = attributes.Get("solar collection");
+	double fuelEnergy = attributes.Get("fuel energy");
+	if(!solarCollection && !fuelEnergy)
+		return true;
+	// If other energy sources are available, check how much energy the ship is getting from them.
+	System::SolarGeneration solar = currentSystem->GetSolarGeneration(position,
+		attributes.Get("ramscoop"), solarCollection, attributes.Get("solar heat"));
+	generation += solar.energy;
+	// "fuel energy" only provides energy if there is fuel present to burn.
+	// Due to fuel consumption not being fractional, a ship could theoretically have high fuel energy
+	// and fuel consumption such that it can only generate a large amount of energy on certain
+	// frames after gaining enough fuel. Such a ship might not technically need energy since it
+	// will eventually get it at some later frame, but this is also such an absurd scenario that
+	// it's not worth checking for, and would be better addressed by making fuel consumption
+	// fractional.
+	if(fuelEnergy && attributes.Get("fuel consumption") <= fuel + solar.fuel + attributes.Get("fuel generation"))
+		generation += fuelEnergy;
+	// Consider a ship disabled if it is gaining less than 1 energy per second.
+	// This accounts for ships that may be relying upon solar panels for energy, but are so far
+	// from the system center that the solar panel gains are negligible.
 	return generation < 0.016;
 }
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2736,7 +2736,7 @@ bool Ship::CanGiveEnergy(const Ship &other) const
 
 double Ship::TransferFuel(double amount, Ship *to)
 {
-	amount = max(fuel - attributes.Get("fuel capacity"), amount);
+	amount = min(fuel, amount);
 	if(to)
 	{
 		amount = min(to->attributes.Get("fuel capacity") - to->fuel, amount);
@@ -3020,24 +3020,20 @@ bool Ship::NeedsFuel(bool followParent) const
 
 bool Ship::NeedsEnergy() const
 {
-	// If ship has no energy capacity it does not need energy
+	// If a ship has no energy capacity it does not need energy.
 	if(!attributes.Get("energy capacity"))
 		return false;
 
-	// If ship has energy, it does not need energy.
-	if(energy > (attributes.Get("energy capacity") * .01))
+	// If a ship has energy, it does not need energy.
+	if(energy > 1.)
 		return false;
 
-	// If ship can regenerate energy it does not need energy.
+	// If a ship can regenerate energy, it does not need energy.
 	// A ship is considered to be unable to regenerate if it is generating less than 1 energy per second.
-	System::SolarGeneration generation = currentSystem->GetSolarGeneration(position,
-		attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat"));
-	if((attributes.Get("energy generation") + attributes.Get("fuel energy")
-		+ generation.energy - attributes.Get("energy consumption")) > 0.016)
-		return false;
-
-	// This ship definitely needs energy
-	return true;
+	double generation = currentSystem->GetSolarGeneration(position,
+		attributes.Get("ramscoop"), attributes.Get("solar collection"), attributes.Get("solar heat")).energy
+		+ attributes.Get("energy generation") + attributes.Get("fuel energy") - attributes.Get("energy consumption");
+	return generation < 0.016;
 }
 
 


### PR DESCRIPTION
**Feature**
**Bug fix**

This PR addresses the bug/feature described in issue #12523 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Ship::NeedsEnergy has been modified to account for Energy Consumption modules.
"" has been modified to calculate precise Solar energy generation.
"" has been modified to base the decision off net energy consumption rather than whether a ship is capable of producing energy.
Criteria for NeedsEnergy is if the ship has less than 1% of it's battery (to account for ships hovering around but not at 0 energy).
Criteria for NeedsEnergy has been set to less than 1 energy regenerated per second to account for rounding errors in double precision math.

Ships that have no energy and have no way to regenerate energy, while not in the disabled state, are effectively disabled and should ask for help -> Added NeedsEnergy to AskForHelp conditions.

## Testing Done
Tested in Postverta with Optikon drones (the poor things) both near and away from the star.
Away from the star the drones run out of energy on their own (slowly) or due to ion storm (sooner) and correctly ask for help.
Near the star the drones run out of energy only due to ion storm and correctly do not ask for help because their net energy generation > 1/second.


## Save File
[Sash Argh.txt](https://github.com/user-attachments/files/29316153/Sash.Argh.txt)

## Performance Impact
Additional function calls were added to generate solar generation information and retrieve attributes but they are gated behind preconditions to minimize performance impact.
No performance impact noticed in testing.