### PR TITLE
v0.11.3-alpha version numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT EndlessSky)
 set(CMAKE_VS_JUST_MY_CODE_DEBUGGING ON)
 
-project("Endless Sky" VERSION 0.11.2
+project("Endless Sky" VERSION 0.11.3
 	DESCRIPTION "Space exploration, trading, and combat game."
 	HOMEPAGE_URL https://endless-sky.github.io/
 	LANGUAGES CXX)

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
 Welcome to Endless Sky!
-version 0.11.2
+version 0.11.3-alpha
 
 The player's manual and other
 resources are available at:

--- a/endless-sky.6
+++ b/endless-sky.6
@@ -1,4 +1,4 @@
-.TH endless\-sky 6 "27 Jun 2026" "ver. 0.11.2" "Endless Sky"
+.TH endless\-sky 6 "27 Jun 2026" "ver. 0.11.3-alpha" "Endless Sky"
 
 .SH NAME
 endless\-sky \- a space exploration and combat game.

--- a/resources/EndlessSky-Info.plist
+++ b/resources/EndlessSky-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.2</string>
+	<string>0.11.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/source/GameVersion.h
+++ b/source/GameVersion.h
@@ -42,7 +42,7 @@ private:
 
 consteval GameVersion GameVersion::Running()
 {
-	return {0, 11, 2, 0, true};
+	return {0, 11, 3, 0, false};
 }
 
 

--- a/source/windows/WinApp.rc
+++ b/source/windows/WinApp.rc
@@ -3,8 +3,8 @@
 AppIcon ICON "../../icons/WinApp.ico"
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION 0,11,2,0
-	PRODUCTVERSION 0,11,2,0
+	FILEVERSION 0,11,3,0
+	PRODUCTVERSION 0,11,3,0
 {
 	BLOCK "StringFileInfo"
 	{
@@ -13,11 +13,11 @@ VS_VERSION_INFO VERSIONINFO
 		{
 			VALUE "CompanyName", "\0"
 			VALUE "FileDescription", "Endless Sky\0"
-			VALUE "FileVersion", "0.11.2\0"
+			VALUE "FileVersion", "0.11.3-alpha\0"
 			VALUE "InternalName", "Endless Sky\0"
 			VALUE "OriginalFilename", "Endless Sky.exe\0"
 			VALUE "ProductName", "Endless Sky\0"
-			VALUE "ProductVersion", "0.11.2\0"
+			VALUE "ProductVersion", "0.11.3-alpha\0"
 		}
 	}
 	BLOCK "VarFileInfo"


### PR DESCRIPTION
**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Updates version numbers to `0.11.3-alpha` or `0.11.3` where the suffix is not supported.
