### PR TITLE
Ships gather around flagship during JD hyperspace

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4758,13 +4758,16 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 		{
 			if(GetParent())
 			{
-				position = GetParent()->position;
-				position += Angle::Random().Unit() * HYPER_D;
+				auto parentPosition = GetParent()->position - target;
+				auto angleoffset = (HYPER_D * 360.)/(2 * 3.141592653589793 
+					* parentPosition.Length());
+				position = target + Angle((180 * atan2(parentPosition.Y(),
+					parentPosition.X()) / 3.141592653589793) + 90 - angleoffset
+					+ Random::Real() * 2 * angleoffset).Unit() * parentPosition.Length();
 			}
 			else
-			{
-				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.) + extraArrivalDistance);
-			}
+				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.) 
+					+ extraArrivalDistance);
 			return true;
 		}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4756,7 +4756,15 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 
 		if(isUsingJumpDrive)
 		{
-			position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.) + extraArrivalDistance);
+			if(GetParent())
+			{
+				position = GetParent()->position;
+				position += Angle::Random().Unit() * HYPER_D;
+			}
+			else
+			{
+				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.) + extraArrivalDistance);
+			}
 			return true;
 		}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4759,7 +4759,7 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 			if(GetParent())
 			{
 				auto parentPosition = GetParent()->position - target;
-				auto angleoffset = (HYPER_D * 360.)/(2 * 3.141592653589793
+				auto angleoffset = (HYPER_D * 360.) / (2 * 3.141592653589793
 					* parentPosition.Length());
 				position = target + Angle((180 * atan2(parentPosition.Y(),
 					parentPosition.X()) / 3.141592653589793) + 90 - angleoffset

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -33,6 +33,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "image/Mask.h"
 #include "Messages.h"
 #include "Phrase.h"
+#include "pi.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "Preferences.h"
@@ -4757,7 +4758,7 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 		if(isUsingJumpDrive)
 		{
 			Angle arrivalAngle;
-			if(parent)
+			if(parent && parent->GetSystem() == GetSystem())
 			{
 				Point parentPosition = parent->position - target;
 				double maxAngleOffset = HYPER_D / parentPosition.Length() * TO_DEG;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4756,18 +4756,16 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 
 		if(isUsingJumpDrive)
 		{
-			if(GetParent())
+			Angle arrivalAngle;
+			if(parent)
 			{
-				auto parentPosition = GetParent()->position - target;
-				auto angleoffset = (HYPER_D * 360.) / (2 * 3.141592653589793
-					* parentPosition.Length());
-				position = target + Angle((180 * atan2(parentPosition.Y(),
-					parentPosition.X()) / 3.141592653589793) + 90 - angleoffset
-					+ Random::Real() * 2 * angleoffset).Unit() * parentPosition.Length();
+				Point parentPosition = parent->position - target;
+				double maxAngleOffset = HYPER_D / parentPosition.Length() * TO_DEG;
+				arrivalAngle = Angle(parentPosition) + Angle::Random(maxAngleOffset) - maxAngleOffset / 2;
 			}
 			else
-				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.)
-					+ extraArrivalDistance);
+				arrivalAngle = Angle::Random();
+			position = target + arrivalAngle.Unit() * (300. * (Random::Real() + 1.) + extraArrivalDistance);
 			return true;
 		}
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4759,14 +4759,14 @@ bool Ship::DoHyperspaceLogic(vector<Visual> &visuals)
 			if(GetParent())
 			{
 				auto parentPosition = GetParent()->position - target;
-				auto angleoffset = (HYPER_D * 360.)/(2 * 3.141592653589793 
+				auto angleoffset = (HYPER_D * 360.)/(2 * 3.141592653589793
 					* parentPosition.Length());
 				position = target + Angle((180 * atan2(parentPosition.Y(),
 					parentPosition.X()) / 3.141592653589793) + 90 - angleoffset
 					+ Random::Real() * 2 * angleoffset).Unit() * parentPosition.Length();
 			}
 			else
-				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.) 
+				position = target + Angle::Random().Unit() * (300. * (Random::Real() + 1.)
 					+ extraArrivalDistance);
 			return true;
 		}


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #7486

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Ships now land within 1000 units of the flagship when using the Jump Drive.  Flagship still arrives in random location.

## Testing Done
Tested jumping around to different systems using JD equipped fleet.

## Save File

[Sash Argh.txt](https://github.com/user-attachments/files/29446855/Sash.Argh.txt)


## Performance Impact
None/Negligible.
