### PR TITLE
feat: Log a warning that about.txt is deprecated

### DIFF
--- a/source/Plugins.cpp
+++ b/source/Plugins.cpp
@@ -280,7 +280,14 @@ const Plugin *Plugins::Load(const filesystem::path &path)
 	plugin->name = std::move(name);
 	plugin->path = path;
 	// Read the deprecated about.txt content if no about text was specified.
-	plugin->aboutText = aboutText.empty() ? Files::Read(path / "about.txt") : std::move(aboutText);
+	if(aboutText.empty())
+	{
+		plugin->aboutText = Files::Read(path / "about.txt");
+		if(!plugin->aboutText.empty())
+			Logger::Log("about.txt is deprecated. Use plugin.txt instead.", Logger::Level::WARNING);
+	}
+	else
+		plugin->aboutText = std::move(aboutText);
 	plugin->version = std::move(version);
 	plugin->authors = std::move(authors);
 	plugin->tags = std::move(tags);


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When the game doesn't find the plugin description in the plugin.txt file, but reads it from the about.txt file, it now sends a warning to the log, mentioning that about.txt is deprecated and should not be used.

## Testing Done
yes.

## Wiki Update
The wiki already describes about.txt as deprecated.
