### PR TITLE
Fix CapsLock behavior when KMOD doesn't get toggled with the keypress

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -396,10 +396,10 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 		if(Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
 		{
 			const bool isCapsLockOn = SDL_GetModState() & KMOD_CAPS;
-			if (!hasSeenCapsLockOn && isCapsLockOn)
+			if(!hasSeenCapsLockOn && isCapsLockOn)
 				hasSeenCapsLockOn = true;
 
-			if (hasSeenCapsLockOn)
+			if(hasSeenCapsLockOn)
 				isFastForward = isCapsLockOn;
 		}
 	};

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -383,20 +383,17 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 				// The UI handled the event.
 			}
 			else if(event.type == SDL_KEYDOWN && !event.key.repeat
-					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
+					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD))
+					&& !Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
 			{
 				isFastForward = !isFastForward;
 			}
-			// Special case: If fastforward is on capslock, reconcile
-			// on keyup in case button state is out of sync.
-			else if(event.type == SDL_KEYUP
-				&& event.key.keysym.sym == SDLK_CAPSLOCK
-				&& Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD)
-				&& (SDL_GetModState() & KMOD_CAPS))
-			{
-				isFastForward = true;
-			}
 		}
+
+		// Special case: If fastforward is on capslock, update on mod state and not
+		// on keypress.
+		if(Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
+			isFastForward = SDL_GetModState() & KMOD_CAPS;
 	};
 
 	// Game loop when running the game normally.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -383,17 +383,20 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 				// The UI handled the event.
 			}
 			else if(event.type == SDL_KEYDOWN && !event.key.repeat
-					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD))
-					&& !Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
+					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
 			{
 				isFastForward = !isFastForward;
 			}
+			// Special case: If fastforward is on capslock, reconcile
+			// on keyup in case button state is out of sync.
+			else if(event.type == SDL_KEYUP
+				&& event.key.keysym.sym == SDLK_CAPSLOCK
+				&& Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD)
+				&& (SDL_GetModState() & KMOD_CAPS))
+			{
+				isFastForward = true;
+			}
 		}
-
-		// Special case: If fastforward is on capslock, update on mod state and not
-		// on keypress.
-		if(Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
-			isFastForward = SDL_GetModState() & KMOD_CAPS;
 	};
 
 	// Game loop when running the game normally.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -314,6 +314,7 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 	FrameTimer timer(frameRate);
 	bool isDebugPaused = false;
 	bool isFastForward = false;
+	bool hasSeenCapsLockOn = SDL_GetModState() & KMOD_CAPS;
 
 	// Limit how quickly full-screen mode can be toggled.
 	int toggleTimeout = 0;
@@ -326,7 +327,7 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 	const bool isHeadless = (testContext.CurrentTest() && !debugMode);
 
 	auto ProcessEvents = [&menuPanels, &gamePanels, &player, &cursorTime, &toggleTimeout, &debugMode, &isDebugPaused,
-			&isFastForward]
+			&isFastForward, &hasSeenCapsLockOn]
 	{
 		SDL_Event event;
 		while(SDL_PollEvent(&event))
@@ -383,17 +384,24 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 				// The UI handled the event.
 			}
 			else if(event.type == SDL_KEYDOWN && !event.key.repeat
-					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD))
-					&& !Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
+					&& (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
 			{
-				isFastForward = !isFastForward;
+				if(!(Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD) && hasSeenCapsLockOn))
+					isFastForward = !isFastForward;
 			}
 		}
 
-		// Special case: If fastforward is on capslock, update on mod state and not
-		// on keypress.
+		// Special case: If fastforward is on capslock, update on mod state,
+		// but only if we have ever observed capslock as functional
 		if(Command(SDLK_CAPSLOCK).Has(Command::FASTFORWARD))
-			isFastForward = SDL_GetModState() & KMOD_CAPS;
+		{
+			const bool isCapsLockOn = SDL_GetModState() & KMOD_CAPS;
+			if (!hasSeenCapsLockOn && isCapsLockOn)
+				hasSeenCapsLockOn = true;
+
+			if (hasSeenCapsLockOn)
+				isFastForward = isCapsLockOn;
+		}
 	};
 
 	// Game loop when running the game normally.


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12535 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Previously there was a rare edge case for users that want to use the CapsLock button to control fast-forward but don't use the CapsLock button to control the CapsLock state on the system (e.g. with X11 `-option caps:ctrl_modifier` or similar).
This fixes that issue. I tried to make it as elegant as possible, taking inspiration from the original behavior in the EV series.

## Testing Done
Change is **extremely** localized. **No automated tests were run, only a manual spot check with `caps:ctrl_modifier` on and off respectively.**


## Performance Impact
Although we do touch the main loop, the code is unlikely to have any noticeable performance effect.
