### PR TITLE
fix save file timestamp flicker on 64 bit windows systems

### DIFF
--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -210,7 +210,11 @@ void LoadPanel::Draw()
 				tooltip.IncrementCount();
 				if(tooltip.ShouldDraw())
 				{
-					tooltip.SetText(Format::TimestampString(time), true);
+					if (hoverFile != file){
+						hoverFile = file;
+						hoverFileTimestamp = Format::TimestampString(time);
+					}
+					tooltip.SetText(hoverFileTimestamp, true);
 					tooltip.SetZone(zone);
 				}
 			}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -210,7 +210,8 @@ void LoadPanel::Draw()
 				tooltip.IncrementCount();
 				if(tooltip.ShouldDraw())
 				{
-					if (hoverFile != file){
+					if(hoverFile != file)
+					{
 						hoverFile = file;
 						hoverFileTimestamp = Format::TimestampString(time);
 					}

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -200,7 +200,7 @@ void LoadPanel::Draw()
 			if(drawPoint.Y() > bottom - fadeOut)
 				continue;
 
-			Rectangle zone(drawPoint + Point(snapshotBox.Width() / 2., 10.), Point(snapshotBox.Width(), 20.));
+			Rectangle zone(drawPoint + Point(snapshotBox.Width() / 2., 10.), Point(snapshotBox.Width(), 19.9));
 			const Point textPoint(drawPoint.X() + hTextPad, zone.Center().Y() - font.Height() / 2);
 			bool isHovering = (hasHover && zone.Contains(hoverPoint));
 			bool isHighlighted = (file == selectedFile || isHovering);

--- a/source/LoadPanel.h
+++ b/source/LoadPanel.h
@@ -87,4 +87,7 @@ private:
 	bool sideHasFocus = false;
 	double sideScroll = 0;
 	double centerScroll = 0;
+
+	std::string hoverFile;
+	std::string hoverFileTimestamp;
 };

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -511,8 +511,7 @@ string Format::TimestampString(chrono::time_point<chrono::system_clock> time, bo
 
 string Format::TimestampString(filesystem::file_time_type time)
 {
-	auto sctp = time_point_cast<chrono::system_clock::duration>(time - filesystem::file_time_type::clock::now()
-		+ chrono::system_clock::now());
+	auto sctp = std::chrono::clock_cast<std::chrono::system_clock>(time);
 	return TimestampString(sctp);
 }
 

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -511,7 +511,8 @@ string Format::TimestampString(chrono::time_point<chrono::system_clock> time, bo
 
 string Format::TimestampString(filesystem::file_time_type time)
 {
-	auto sctp = std::chrono::clock_cast<std::chrono::system_clock>(time);
+	auto sctp = time_point_cast<chrono::system_clock::duration>(time - filesystem::file_time_type::clock::now()
+		+ chrono::system_clock::now());
 	return TimestampString(sctp);
 }
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12534 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Changed approach to just cache timestamp string.  It looks like a lot of the compile targets don't support C++20 yet.

## Testing Done
Started game with code changes and flicker is gone.

## Save File
Any save file will work

## Performance Impact
Should be faster than before.