### PR TITLE
feat(ci/cd): Update MacOS runners to `macos-15`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -129,7 +129,7 @@ jobs:
 
   cd_macos_x64:
     name: MacOS
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       OUTPUT: EndlessSky-macOS-continuous.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd_release.yaml
+++ b/.github/workflows/cd_release.yaml
@@ -193,7 +193,7 @@ jobs:
 
   release_macos_x64:
     name: MacOS x64
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -243,7 +243,7 @@ jobs:
 
   release_macos_arm:
     name: MacOS ARM
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -293,7 +293,7 @@ jobs:
 
   release_macos:
     name: MacOS Universal
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [release_macos_arm, release_macos_x64]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
     name: MacOS
     needs: changed
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.ci_config == 'true' }}
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -344,7 +344,7 @@ jobs:
     name: MacOS-ARM
     needs: changed
     if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.unit_tests == 'true' || needs.changed.outputs.cmake_files == 'true' || needs.changed.outputs.ci_config == 'true' }}
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OUTPUT: "Endless Sky ARM CI Test"


### PR DESCRIPTION
**CI/CD/Testing**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The last time a similar update was done (#11820), it seemed that the compiler provided by the MacOS 15 runners has higher deployment target requirements. However, with our recent changes to the deployment target (#12511), it won't make any difference anymore. The only reasonable way to bring back the compatibility with older MacOS versions seems to be switching to gcc.
The most important thing we gain from this update and the reason why I opened this PR is that the newer compiler (if we stay on Clang, at least until someone opens a PR to change it) has better C++20 support.

## Testing Done
We'll see.