### PR TITLE
Consolidating offer requirements into 'to offer' mission definition block

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1736,7 +1736,7 @@ mission "Remnant: Heavy Laser"
 	to offer
 		or
 			has "Remnant: Tech Retrieval: active"
-			has "Remnant: Tech Retrieval: done"		
+			has "Remnant: Tech Retrieval: done"
 		has "outfit: Heavy Laser"
 	on offer
 		conversation

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1737,7 +1737,7 @@ mission "Remnant: Heavy Laser"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"		
-		outfits "Heavy Laser"
+		outfit: "Heavy Laser"
 	on offer
 		conversation
 			`You remember that Taely was interested in seeing examples of technology from human space. Would you like to show her your Heavy Laser?`
@@ -1780,7 +1780,7 @@ mission "Remnant: Plasma Cannon"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfits "Plasma Cannon"
+		outfit: "Plasma Cannon"
 	on offer
 		conversation
 			`You recall that Taely was interested in examining examples of technology from ancestral space. Would you like to show her the Plasma Cannons you retrieved?`
@@ -1830,7 +1830,7 @@ mission "Remnant: Catalytic Ramscoop"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfits "Catalytic Ramscoop"
+		outfit: "Catalytic Ramscoop"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the Catalytic Ramscoop definitely fits the criteria. Would you like to show her?`
@@ -1871,7 +1871,7 @@ mission "Remnant: Electron Beam"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfits "Electron Beam"
+		outfit: "Electron Beam"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the electron beam certainly fits the criteria. Would you like to show her?`
@@ -1912,7 +1912,7 @@ mission "Remnant: D94-YV Shield Generator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfits "D94-YV Shield Generator"
+		outfit: "D94-YV Shield Generator"
 	on offer
 		conversation
 			`You know that Taely was interested in seeing examples of recently developed human technology, and the D94-YV Shield Generator probably fits the criteria. Would you like to show her?`
@@ -1953,7 +1953,7 @@ mission "Remnant: S-970 Regenerator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfits "S-970 Regenerator"
+		outfit: "S-970 Regenerator"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing instances of new human technology, and the S-970 Regenerator is definitely a recent development. Would you like to show her?`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1736,9 +1736,9 @@ mission "Remnant: Heavy Laser"
 	to offer
 		or
 			has "Remnant: Tech Retrieval: active"
-			has "Remnant: Tech Retrieval: done"
+			has "Remnant: Tech Retrieval: done"		
+		outfits "Heavy Laser"
 	on offer
-		require "Heavy Laser"
 		conversation
 			`You remember that Taely was interested in seeing examples of technology from human space. Would you like to show her your Heavy Laser?`
 			choice
@@ -1780,8 +1780,8 @@ mission "Remnant: Plasma Cannon"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
+		outfits "Plasma Cannon"
 	on offer
-		require "Plasma Cannon"
 		conversation
 			`You recall that Taely was interested in examining examples of technology from ancestral space. Would you like to show her the Plasma Cannons you retrieved?`
 			choice
@@ -1830,8 +1830,8 @@ mission "Remnant: Catalytic Ramscoop"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
+		outfits "Catalytic Ramscoop"
 	on offer
-		require "Catalytic Ramscoop"
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the Catalytic Ramscoop definitely fits the criteria. Would you like to show her?`
 			choice
@@ -1871,8 +1871,8 @@ mission "Remnant: Electron Beam"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
+		outfits "Electron Beam"
 	on offer
-		require "Electron Beam"
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the electron beam certainly fits the criteria. Would you like to show her?`
 			choice
@@ -1912,8 +1912,8 @@ mission "Remnant: D94-YV Shield Generator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
+		outfits "D94-YV Shield Generator"
 	on offer
-		require "D94-YV Shield Generator"
 		conversation
 			`You know that Taely was interested in seeing examples of recently developed human technology, and the D94-YV Shield Generator probably fits the criteria. Would you like to show her?`
 			choice
@@ -1953,8 +1953,8 @@ mission "Remnant: S-970 Regenerator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
+		outfits "S-970 Regenerator"
 	on offer
-		require "S-970 Regenerator"
 		conversation
 			`You recall that Taely was interested in seeing instances of new human technology, and the S-970 Regenerator is definitely a recent development. Would you like to show her?`
 			choice

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1737,7 +1737,7 @@ mission "Remnant: Heavy Laser"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"		
-		outfit: "Heavy Laser"
+		has "outfit: Heavy Laser"
 	on offer
 		conversation
 			`You remember that Taely was interested in seeing examples of technology from human space. Would you like to show her your Heavy Laser?`
@@ -1780,7 +1780,7 @@ mission "Remnant: Plasma Cannon"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfit: "Plasma Cannon"
+		has "outfit: Plasma Cannon"
 	on offer
 		conversation
 			`You recall that Taely was interested in examining examples of technology from ancestral space. Would you like to show her the Plasma Cannons you retrieved?`
@@ -1830,7 +1830,7 @@ mission "Remnant: Catalytic Ramscoop"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfit: "Catalytic Ramscoop"
+		has "outfit: Catalytic Ramscoop"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the Catalytic Ramscoop definitely fits the criteria. Would you like to show her?`
@@ -1871,7 +1871,7 @@ mission "Remnant: Electron Beam"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfit: "Electron Beam"
+		has "outfit: Electron Beam"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the electron beam certainly fits the criteria. Would you like to show her?`
@@ -1912,7 +1912,7 @@ mission "Remnant: D94-YV Shield Generator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfit: "D94-YV Shield Generator"
+		has "outfit: D94-YV Shield Generator"
 	on offer
 		conversation
 			`You know that Taely was interested in seeing examples of recently developed human technology, and the D94-YV Shield Generator probably fits the criteria. Would you like to show her?`
@@ -1953,7 +1953,7 @@ mission "Remnant: S-970 Regenerator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		outfit: "S-970 Regenerator"
+		has "outfit: S-970 Regenerator"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing instances of new human technology, and the S-970 Regenerator is definitely a recent development. Would you like to show her?`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -1734,10 +1734,10 @@ mission "Remnant: Heavy Laser"
 		not attributes "requires: gaslining"
 		not distance 0
 	to offer
+		has "outfit: Heavy Laser"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		has "outfit: Heavy Laser"
 	on offer
 		conversation
 			`You remember that Taely was interested in seeing examples of technology from human space. Would you like to show her your Heavy Laser?`
@@ -1777,10 +1777,10 @@ mission "Remnant: Plasma Cannon"
 		not attributes "requires: gaslining"
 		not distance 0
 	to offer
+		has "outfit: Plasma Cannon"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		has "outfit: Plasma Cannon"
 	on offer
 		conversation
 			`You recall that Taely was interested in examining examples of technology from ancestral space. Would you like to show her the Plasma Cannons you retrieved?`
@@ -1827,10 +1827,10 @@ mission "Remnant: Catalytic Ramscoop"
 		not attributes "requires: gaslining"
 		not distance 0
 	to offer
+		has "outfit: Catalytic Ramscoop"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		has "outfit: Catalytic Ramscoop"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the Catalytic Ramscoop definitely fits the criteria. Would you like to show her?`
@@ -1868,10 +1868,10 @@ mission "Remnant: Electron Beam"
 		not attributes "requires: gaslining"
 		not distance 0
 	to offer
+		has "outfit: Electron Beam"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		has "outfit: Electron Beam"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing examples of new human technology, and the electron beam certainly fits the criteria. Would you like to show her?`
@@ -1909,10 +1909,10 @@ mission "Remnant: D94-YV Shield Generator"
 		not attributes "requires: gaslining"
 		not distance 0
 	to offer
+		has "outfit: D94-YV Shield Generator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		has "outfit: D94-YV Shield Generator"
 	on offer
 		conversation
 			`You know that Taely was interested in seeing examples of recently developed human technology, and the D94-YV Shield Generator probably fits the criteria. Would you like to show her?`
@@ -1950,10 +1950,10 @@ mission "Remnant: S-970 Regenerator"
 		not attributes "requires: gaslining"
 		not distance 0
 	to offer
+		has "outfit: S-970 Regenerator"
 		or
 			has "Remnant: Tech Retrieval: active"
 			has "Remnant: Tech Retrieval: done"
-		has "outfit: S-970 Regenerator"
 	on offer
 		conversation
 			`You recall that Taely was interested in seeing instances of new human technology, and the S-970 Regenerator is definitely a recent development. Would you like to show her?`


### PR DESCRIPTION
**Refactor**

This PR addresses the bug/feature described in issue #12542

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Refactor mission definitions to use to offer: outfits instead of on offer: require.
To enable future functionality that calls mission.CanOffer().  Without this consolidation mission.CanOffer() yields incorrect results.

## Testing Done
In testing atm... looking for appropriate save file at remnant tech missions.  Will update on completion.

## Save File
Will upload

## Performance Impact
None