### PR TITLE
docs: Improve the description of `--tq-threads`

### DIFF
--- a/endless-sky.6
+++ b/endless-sky.6
@@ -53,8 +53,8 @@ prevents muting the game when running tests.
 .IP \fB\-c,\ \-\-rngseed\ <seed>
 every time the pseudo-random number generator is seeded, it will be given this value.
 
-.IP \fB\-c,\ \-\-tq-threads\ <number of threads>
-sets the number of threads used for the internal queue of tasks. Not specifying this will use a default depending on your system. This is only useful for debugging. Has to be at least 1.
+.IP \fB\-c,\ \-\-tq-threads\ <number>
+sets the number of threads used for the internal queue of tasks. Not specifying this will use a default depending on your system. Has to be at least 1.
 
 .IP \fB\-s,\ \-\-ships
 prints (to STDOUT) a table of ship stats (just the base stats, not considering any stored outfits). This option prevents the game from launching.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -636,9 +636,8 @@ void PrintHelp()
 	cerr << "    --nomute: don't mute the game while running tests." << endl;
 	cerr << "    --rng-seed <seed>: every time the pseudo-random number generator is seeded,"
 		" it will be given this value." << endl;
-	cerr << "    --tq-threads: sets the number of threads used for the internal queue of tasks."
-		" Not specifying this will use a default depending on your system. This is only useful for debugging."
-		" Has to be at least 1." << endl;
+	cerr << "    --tq-threads <number>: sets the number of threads used for the internal queue of tasks."
+		" Not specifying this will use a default depending on your system. Has to be at least 1." << endl;
 	PrintData::Help();
 	cerr << endl;
 	cerr << "Report bugs to: <https://github.com/endless-sky/endless-sky/issues>" << endl;


### PR DESCRIPTION
**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The current description of the `--tq-threads` parameter says that it's only useful for debugging. My testing has proven that it can also help with loading the game on memory-limited systems, because it controls how many sprites are loaded simultaneously, which can make a considerable difference in peak memory usage.