### PR TITLE
(optional feature/gamerule) mission markers for available missions

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -210,6 +210,8 @@ color "map: sale marker: no shop" 0. .12 .6 .4
 color "map: sale marker: has shop" .12 .48 .48 .4
 color "map: sale marker: item sold" .6 .48 0. .4
 color "map: sale marker: item stored" .36 .48 .24 .4
+color "map quest hint color" .933 .208 .867 1.
+color "map rng quest hint color" .639 .208 .933 1.
 
 # Colors used for the routing issue text in the map panel when
 # a route to the selected system cannot be determined.

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1790,5 +1790,5 @@ tip "Map markers for missions"
 tip "Map markers for RNG missions"
 	`In the Map screen, a dim purple marker is displayed next to systems with missions that are available but gated behind a random chance check.`
 
-tip "Show minor missons markers"
+tip "Show minor missions markers"
 	`Include missions flagged as minor, typically culture conversations, in the mission marker displays.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1785,17 +1785,10 @@ tip `Default admin cap`
 	`If the fleet size limitation is "admin cap," then this is the default maximum administrative capacity. Ships will have individual administrative costs that count toward your capacity. This value may be increased through story events. Changing this value on an existing pilot will have no effect.`
 
 tip "Map markers for missions"
-	`In the Map screen, a purple marker`
-	`is displayed next to systems with`
-	`available missions.`
+	`In the Map screen, a purple marker is displayed next to systems with available missions.`
 
 tip "Map markers for RNG missions"
-	`In the Map screen, a dim purple marker`
-	`is displayed next to systems with`
-	`missions that are available but`
-	`gated behind a random chance check.`
+	`In the Map screen, a dim purple marker is displayed next to systems with missions that are available but gated behind a random chance check.`
 
 tip "Show minor missons markers"
-	`Include missions flagged as minor,`
-	`typically culture conversations,`
-	`in the mission marker displays.`
+	`Include missions flagged as minor, typically culture conversations, in the mission marker displays.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1783,3 +1783,19 @@ tip "Default max escort crew"
 
 tip `Default admin cap`
 	`If the fleet size limitation is "admin cap," then this is the default maximum administrative capacity. Ships will have individual administrative costs that count toward your capacity. This value may be increased through story events. Changing this value on an existing pilot will have no effect.`
+
+tip "Map markers for missions"
+	`In the Map screen, a purple marker`
+	`is displayed next to systems with`
+	`available missions.`
+
+tip "Map markers for RNG missions"
+	`In the Map screen, a dim purple marker`
+	`is displayed next to systems with`
+	`missions that are available but`
+	`gated behind a random chance check.`
+
+tip "Show minor missons markers"
+	`Include missions flagged as minor,`
+	`typically culture conversations,`
+	`in the mission marker displays.`

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -39,3 +39,7 @@
 	"default max escort count" 6
 	"default max escort crew" 1000
 	"default admin cap" 25
+
+	"missionMarkers" false
+	"rngMissionMarkers" false
+	"minorMissionMarkers" false

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -382,6 +382,12 @@ bool ConditionSet::Test() const
 
 
 
+bool ConditionSet::TestNoRNG() const
+{
+	return EvaluateNoRNG();
+}
+
+
 int64_t ConditionSet::Evaluate() const
 {
 	switch(expressionOperator)
@@ -439,6 +445,80 @@ int64_t ConditionSet::Evaluate() const
 	return 0;
 }
 
+
+
+int64_t ConditionSet::EvaluateNoRNG() const
+{
+	if(conditionName == "random" && children.empty())
+		return 0;
+	switch(expressionOperator)
+	{
+		case ExpressionOp::VAR:
+		{
+			if(!conditions)
+				throw runtime_error("Unable to Evaluate ExpressionOp::VAR with condition name \"" + conditionName
+					+ "\" in ConditionSet without a pointer to a ConditionsStore!");
+			return conditions->Get(conditionName);
+		}
+		case ExpressionOp::LIT:
+			return literal;
+		case ExpressionOp::AND:
+		{
+			// An empty AND section returns true.
+			if(children.empty())
+				return 1;
+
+			int64_t result = 0;
+			for(const ConditionSet &child : children)
+			{
+				int64_t childResult = child.EvaluateNoRNG();
+				if(!childResult)
+					return 0;
+				// Assign the first non-zero result to the result variable.
+				if(!result)
+					result = childResult;
+			}
+			return result;
+		}
+		case ExpressionOp::OR:
+			for(const ConditionSet &child : children)
+			{
+				int64_t childResult = child.EvaluateNoRNG();
+				// Return the first non-zero result.
+				if(childResult)
+					return childResult;
+			}
+			return 0;
+		default:
+			break;
+	}
+
+	// If we have an accumulator function and children, then let's use the accumulator on the children.
+	// MAX and MIN are also handled by the accumulator.
+	BinFun accumulatorOp = Op(expressionOperator);
+	if(accumulatorOp != nullptr && !children.empty())
+		return accumulate(next(children.begin()), children.end(), children[0].EvaluateNoRNG(),
+			[&accumulatorOp](int64_t accumulated, const ConditionSet &b) -> int64_t {
+				return accumulatorOp(accumulated, b.EvaluateNoRNG());
+		});
+
+	// If we don't have an accumulator function, or no children, then return the default value.
+	return 0;
+}
+
+
+
+bool ConditionSet::isRNG() const
+{
+	if(conditionName == "random")
+		return true;
+	if(!children.empty())
+	for(auto &child : children){
+		if(child.isRNG())
+			return true;
+	}
+	return false;
+}
 
 
 set<string> ConditionSet::RelevantConditions() const

--- a/source/ConditionSet.cpp
+++ b/source/ConditionSet.cpp
@@ -513,7 +513,8 @@ bool ConditionSet::isRNG() const
 	if(conditionName == "random")
 		return true;
 	if(!children.empty())
-	for(auto &child : children){
+	for(auto &child : children)
+	{
 		if(child.isRNG())
 			return true;
 	}

--- a/source/ConditionSet.h
+++ b/source/ConditionSet.h
@@ -101,9 +101,12 @@ public:
 
 	// Check if the player's conditions satisfy this set of expressions.
 	bool Test() const;
+	bool TestNoRNG() const;
 
 	// Evaluate this expression into a numerical value. (The value can also be used as boolean.)
 	int64_t Evaluate() const;
+	int64_t EvaluateNoRNG() const;
+	bool isRNG() const;
 
 	/// Parse the remainder of a node into this ConditionSet.
 	bool ParseNode(const DataNode &node, int &tokenNr);

--- a/source/Gamerules.cpp
+++ b/source/Gamerules.cpp
@@ -111,6 +111,12 @@ void Gamerules::Load(const DataNode &node)
 			storage.defaultMaxEscortCrew = max<int>(0, child.Value(1));
 		else if(key == "default admin cap")
 			storage.defaultAdminCap = max<int>(0, child.Value(1));
+		else if(key == "missionMarkers")
+			storage.missionMarkers = child.BoolValue(1);
+		else if(key == "rngMissionMarkers")
+			storage.rngMissionMarkers = child.BoolValue(1);
+			else if(key == "minorMissionMarkers")
+			storage.minorMissionMarkers = child.BoolValue(1);
 		else
 			storage.miscRules[key] = child.IsNumber(1) ? child.Value(1) : child.BoolValue(1);
 	}
@@ -182,6 +188,12 @@ void Gamerules::Save(DataWriter &out, const Gamerules &preset) const
 			out.Write("default max escort crew", storage.defaultMaxEscortCrew);
 		if(storage.defaultAdminCap != preset.storage.defaultAdminCap)
 			out.Write("default admin cap", storage.defaultAdminCap);
+		if(storage.missionMarkers != preset.storage.missionMarkers)
+			out.Write("missionMarkers", storage.missionMarkers);
+		if(storage.rngMissionMarkers != preset.storage.rngMissionMarkers)
+			out.Write("rngMissionMarkers", storage.rngMissionMarkers);
+		if(storage.minorMissionMarkers != preset.storage.minorMissionMarkers)
+			out.Write("minorMissionMarkers", storage.minorMissionMarkers);
 
 		const map<string, int> &otherMiscRules = preset.storage.miscRules;
 		for(const auto &[rule, value] : storage.miscRules)
@@ -408,6 +420,27 @@ void Gamerules::SetDefaultAdminCap(int value)
 
 
 
+void Gamerules::SetMissionMarkers(bool value)
+{
+	storage.missionMarkers = value;
+}
+
+
+
+void Gamerules::SetRNGMissionMarkers(bool value)
+{
+	storage.rngMissionMarkers = value;
+}
+
+
+
+void Gamerules::SetMinorMissionMarkers(bool value)
+{
+	storage.minorMissionMarkers = value;
+}
+
+
+
 void Gamerules::SetMiscValue(const string &rule, int value)
 {
 	storage.miscRules[rule] = value;
@@ -455,6 +488,12 @@ int Gamerules::GetValue(const string &rule) const
 		return storage.defaultMaxEscortCrew;
 	if(rule == "default admin cap")
 		return storage.defaultAdminCap;
+	if(rule == "missionMarkers")
+		return storage.missionMarkers;
+	if(rule == "rngMissionMarkers")
+		return storage.rngMissionMarkers;
+	if(rule == "minorMissionMarkers")
+		return storage.minorMissionMarkers;
 
 	auto it = storage.miscRules.find(rule);
 	if(it == storage.miscRules.end())
@@ -593,6 +632,27 @@ int Gamerules::GetDefaultMaxEscortCrew() const
 int Gamerules::GetDefaultAdminCap() const
 {
 	return storage.defaultAdminCap;
+}
+
+
+
+bool Gamerules::GetMissionMarkers() const
+{
+	return storage.missionMarkers;
+}
+
+
+
+bool Gamerules::GetRNGMissionMarkers() const
+{
+	return storage.rngMissionMarkers;
+}
+
+
+
+bool Gamerules::GetMinorMissionMarkers() const
+{
+	return storage.minorMissionMarkers;
 }
 
 

--- a/source/Gamerules.h
+++ b/source/Gamerules.h
@@ -94,6 +94,9 @@ public:
 	void SetDefaultMaxEscortCount(int value);
 	void SetDefaultMaxEscortCrew(int value);
 	void SetDefaultAdminCap(int value);
+	void SetMissionMarkers(bool value);
+	void SetRNGMissionMarkers(bool value);
+	void SetMinorMissionMarkers(bool value);
 	void SetMiscValue(const std::string &rule, int value);
 
 	int GetValue(const std::string &rule) const;
@@ -117,6 +120,9 @@ public:
 	int GetDefaultMaxEscortCount() const;
 	int GetDefaultMaxEscortCrew() const;
 	int GetDefaultAdminCap() const;
+	bool GetMissionMarkers() const;
+	bool GetRNGMissionMarkers() const;
+	bool GetMinorMissionMarkers() const;
 
 	bool operator==(const Gamerules &other) const;
 
@@ -154,7 +160,10 @@ private:
 		// The administrative capacity of the player's fleet. Different ships will have different admin costs.
 		// This value can be increased for a pilot through gameplay.
 		int defaultAdminCap = 25;
-
+		// Mission markers display on map if enabled.
+		bool missionMarkers = false;
+		bool rngMissionMarkers = false;
+		bool minorMissionMarkers = false;
 		// Miscellaneous rules that are only used by the game data and not by the engine.
 		std::map<std::string, int> miscRules;
 	};

--- a/source/GamerulesPanel.cpp
+++ b/source/GamerulesPanel.cpp
@@ -68,7 +68,7 @@ namespace {
 	const string ADMIN_CAP = "Default admin cap";
 	const string MISSION_MARKERS = "Map markers for missions";
 	const string RNG_MISSION_MARKERS = "Map markers for RNG missions";
-	const string MINOR_MISSION_MARKERS = "Show minor missons markers";
+	const string MINOR_MISSION_MARKERS = "Show minor missions markers";
 
 	const string AMMO_RESTOCKING_NAME = "universal ammo restocking";
 
@@ -556,17 +556,14 @@ void GamerulesPanel::DrawGamerules()
 		else if(gamerule == MISSION_MARKERS)
 		{
 			text = gamerules.GetMissionMarkers() ? "true" : "false";
-			//isOn = gamerules.GetValue(MISSION_MARKERS);
 		}
 		else if(gamerule == RNG_MISSION_MARKERS)
 		{
 			text = gamerules.GetRNGMissionMarkers() ? "true" : "false";
-			//isOn = gamerules.GetValue(RNG_MISSION_MARKERS);
 		}
 		else if(gamerule == MINOR_MISSION_MARKERS)
 		{
 			text = gamerules.GetMinorMissionMarkers() ? "true" : "false";
-			//isOn = gamerules.GetValue(MINOR_MISSION_MARKERS);
 		}
 
 		if(gamerule == hoverItem)

--- a/source/GamerulesPanel.cpp
+++ b/source/GamerulesPanel.cpp
@@ -66,6 +66,9 @@ namespace {
 	const string MAX_ESCORT_COUNT = "Default max escort count";
 	const string MAX_ESCORT_CREW = "Default max escort crew";
 	const string ADMIN_CAP = "Default admin cap";
+	const string MISSION_MARKERS = "Map markers for missions";
+	const string RNG_MISSION_MARKERS = "Map markers for RNG missions";
+	const string MINOR_MISSION_MARKERS = "Show minor missons markers";
 
 	const string AMMO_RESTOCKING_NAME = "universal ammo restocking";
 
@@ -90,6 +93,9 @@ namespace {
 		{MAX_ESCORT_COUNT, "default max escort count"},
 		{MAX_ESCORT_CREW, "default max escort crew"},
 		{ADMIN_CAP, "default admin cap"},
+		{MISSION_MARKERS, "missionMarkers"},
+		{RNG_MISSION_MARKERS, "rngMissionMarkers"},
+		{MINOR_MISSION_MARKERS, "minorMissionMarkers"},
 	};
 
 	const int GAMERULES_PAGE_COUNT = 1;
@@ -412,6 +418,9 @@ void GamerulesPanel::DrawGamerules()
 		FIGHTERS_HIT_WHEN_DISABLED,
 		UNIVERSAL_AMMO_STOCKING,
 		SPAWN_RAID_FLEETS,
+		MISSION_MARKERS,
+		RNG_MISSION_MARKERS,
+		MINOR_MISSION_MARKERS,
 	};
 
 	bool isCategory = true;
@@ -543,6 +552,21 @@ void GamerulesPanel::DrawGamerules()
 		{
 			text = Format::AbbreviatedNumber(gamerules.GetDefaultAdminCap());
 			isOn = gamerules.GetFleetSizeLimitation() == Gamerules::FleetSizeLimitation::ADMIN_CAP;
+		}
+		else if(gamerule == MISSION_MARKERS)
+		{
+			text = gamerules.GetMissionMarkers() ? "true" : "false";
+			//isOn = gamerules.GetValue(MISSION_MARKERS);
+		}
+		else if(gamerule == RNG_MISSION_MARKERS)
+		{
+			text = gamerules.GetRNGMissionMarkers() ? "true" : "false";
+			//isOn = gamerules.GetValue(RNG_MISSION_MARKERS);
+		}
+		else if(gamerule == MINOR_MISSION_MARKERS)
+		{
+			text = gamerules.GetMinorMissionMarkers() ? "true" : "false";
+			//isOn = gamerules.GetValue(MINOR_MISSION_MARKERS);
 		}
 
 		if(gamerule == hoverItem)
@@ -907,6 +931,12 @@ void GamerulesPanel::HandleGamerulesString(const string &str)
 		GetUI().Push(DialogPanel::RequestIntegerWithValidation(&gamerules, &Gamerules::SetDefaultAdminCap, validate,
 			message, gamerules.GetDefaultAdminCap()));
 	}
+	else if(str == MISSION_MARKERS)
+		gamerules.SetMissionMarkers(!gamerules.GetMissionMarkers());
+	else if(str == RNG_MISSION_MARKERS)
+		gamerules.SetRNGMissionMarkers(!gamerules.GetRNGMissionMarkers());
+	else if(str == MINOR_MISSION_MARKERS)
+		gamerules.SetMinorMissionMarkers(!gamerules.GetMinorMissionMarkers());
 }
 
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1405,7 +1405,8 @@ void MapPanel::DrawMissions()
 	const Color &blockedColor = *colors.Get("blocked mission");
 	const Color &specialColor = *colors.Get("special mission");
 	const Color &waypointColor = *colors.Get("waypoint");
-	const Color &hintColor = *colors.Get("map system ring unexplored");
+	const Color &hintColor = *colors.Get("map quest hint color");
+	const Color &rngHintColor = *colors.Get("map rng quest hint color");
 	if(specialSystem)
 	{
 		// The special system pointer is larger than the others.
@@ -1460,20 +1461,21 @@ void MapPanel::DrawMissions()
 			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
 	}
 	// Calculate available quests every time user opens map and cache it
+	bool offerMinorMissions = true;
 	if(!cachedQuests){
 		questMissionCache.clear();
 		for(auto &mission : GameData::Missions()){
+			if(!offerMinorMissions && mission.second.IsMinor())
+				continue;
 			tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
 			if(get<0>(result)){
 				for(auto &sourceSystem : get<2>(result)){
-					if(mission.second.IsMinor())
-						questMissionCache[sourceSystem].minorQuest++;
-					else if(get<1>(result))
+					if(get<1>(result))
 						questMissionCache[sourceSystem].rngQuest++;
 					else
 						questMissionCache[sourceSystem].quest++;
 				}
-			}	
+			}
 		}
 		cachedQuests = true;
 	}
@@ -1495,9 +1497,7 @@ void MapPanel::DrawMissions()
 		if(it.second.quest > 0)
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, hintColor);
 		if(it.second.rngQuest > 0)
-			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, Color::Multiply(.65,hintColor));
-		if(it.second.minorQuest > 0)
-			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, Color::Multiply(.25,hintColor));
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, rngHintColor);
 	}
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -87,6 +87,8 @@ namespace {
 		unsigned drawn = 0;
 		unsigned available = 0;
 		unsigned unavailable = 0;
+		unsigned rngQuest = 0;
+		unsigned quest = 0;
 
 	private:
 		unsigned maximumActive = MapPanel::MAX_MISSION_POINTERS_DRAWN;
@@ -1401,6 +1403,7 @@ void MapPanel::DrawMissions()
 	const Color &blockedColor = *colors.Get("blocked mission");
 	const Color &specialColor = *colors.Get("special mission");
 	const Color &waypointColor = *colors.Get("waypoint");
+	const Color &hintColor = *colors.Get("map system ring unexplored");
 	if(specialSystem)
 	{
 		// The special system pointer is larger than the others.
@@ -1453,6 +1456,17 @@ void MapPanel::DrawMissions()
 			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
 		for(const System *mark : mission.TrackedSystems())
 			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
+	}	
+	for ( auto &mission : GameData::Missions() ){
+		tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
+		if(get<0>(result)){			
+			for( auto &sourceSystem : get<2>(result)){
+				if(get<1>(result))
+					missionCount[sourceSystem].rngQuest++;
+				else
+					missionCount[sourceSystem].quest++;
+			}
+		}		
 	}
 	// Draw the available and unavailable jobs.
 	for(auto &&it : missionCount)
@@ -1463,6 +1477,10 @@ void MapPanel::DrawMissions()
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, availableColor);
 		for(unsigned i = 0; i < counters.unavailable; ++i)
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, unavailableColor);
+		if(it.second.quest > 0)
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, hintColor);
+		if(it.second.rngQuest > 0)
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, Color::Multiply(.6,hintColor));
 	}
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1462,11 +1462,14 @@ void MapPanel::DrawMissions()
 	}
 	// Calculate available quests every time user opens map and cache it
 	auto pilot = player.Pilot().get();
-	if(pilot->GetGamerules().GetMissionMarkers() || pilot->GetGamerules().GetRNGMissionMarkers()){
+	if(pilot->GetGamerules().GetMissionMarkers() || pilot->GetGamerules().GetRNGMissionMarkers())
+	{
 		bool offerMinorMissions = pilot->GetGamerules().GetMinorMissionMarkers();
-		if(!cachedQuests){
+		if(!cachedQuests)
+		{
 			questMissionCache.clear();
-			for(auto &mission : GameData::Missions()){
+			for(auto &mission : GameData::Missions())
+			{
 				if(!offerMinorMissions && mission.second.IsMinor())
 					continue;
 				tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
@@ -1482,7 +1485,8 @@ void MapPanel::DrawMissions()
 			cachedQuests = true;
 		}
 		// Apply quest cache
-		for(auto &&it : questMissionCache){
+		for(auto &&it : questMissionCache)
+		{
 			missionCount[it.first].quest += it.second.quest;
 			missionCount[it.first].rngQuest += it.second.rngQuest;
 		}

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -89,6 +89,7 @@ namespace {
 		unsigned unavailable = 0;
 		unsigned rngQuest = 0;
 		unsigned quest = 0;
+		unsigned minorQuest = 0;
 
 	private:
 		unsigned maximumActive = MapPanel::MAX_MISSION_POINTERS_DRAWN;
@@ -1465,7 +1466,9 @@ void MapPanel::DrawMissions()
 			tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
 			if(get<0>(result)){
 				for(auto &sourceSystem : get<2>(result)){
-					if(get<1>(result))
+					if(mission.second.IsMinor())
+						questMissionCache[sourceSystem].minorQuest++;
+					else if(get<1>(result))
 						questMissionCache[sourceSystem].rngQuest++;
 					else
 						questMissionCache[sourceSystem].quest++;
@@ -1478,6 +1481,7 @@ void MapPanel::DrawMissions()
 	for(auto &&it : questMissionCache){
 		missionCount[it.first].quest += it.second.quest;
 		missionCount[it.first].rngQuest += it.second.rngQuest;
+		missionCount[it.first].minorQuest += it.second.minorQuest;
 	}
 	// Draw the available and unavailable jobs.
 	for(auto &&it : missionCount)
@@ -1491,7 +1495,9 @@ void MapPanel::DrawMissions()
 		if(it.second.quest > 0)
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, hintColor);
 		if(it.second.rngQuest > 0)
-			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, Color::Multiply(.6,hintColor));
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, Color::Multiply(.65,hintColor));
+		if(it.second.minorQuest > 0)
+			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, Color::Multiply(.25,hintColor));
 	}
 }
 

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -37,6 +37,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "MapShipyardPanel.h"
 #include "Mission.h"
 #include "MissionPanel.h"
+#include "PilotProfile.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
 #include "shader/PointerShader.h"
@@ -89,7 +90,6 @@ namespace {
 		unsigned unavailable = 0;
 		unsigned rngQuest = 0;
 		unsigned quest = 0;
-		unsigned minorQuest = 0;
 
 	private:
 		unsigned maximumActive = MapPanel::MAX_MISSION_POINTERS_DRAWN;
@@ -1461,29 +1461,31 @@ void MapPanel::DrawMissions()
 			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
 	}
 	// Calculate available quests every time user opens map and cache it
-	bool offerMinorMissions = true;
-	if(!cachedQuests){
-		questMissionCache.clear();
-		for(auto &mission : GameData::Missions()){
-			if(!offerMinorMissions && mission.second.IsMinor())
-				continue;
-			tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
-			if(get<0>(result)){
-				for(auto &sourceSystem : get<2>(result)){
-					if(get<1>(result))
-						questMissionCache[sourceSystem].rngQuest++;
-					else
-						questMissionCache[sourceSystem].quest++;
+	auto pilot = player.Pilot().get();
+	if(pilot->GetGamerules().GetMissionMarkers() || pilot->GetGamerules().GetRNGMissionMarkers()){
+		bool offerMinorMissions = pilot->GetGamerules().GetMinorMissionMarkers();
+		if(!cachedQuests){
+			questMissionCache.clear();
+			for(auto &mission : GameData::Missions()){
+				if(!offerMinorMissions && mission.second.IsMinor())
+					continue;
+				tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
+				if(get<0>(result)){
+					for(auto &sourceSystem : get<2>(result)){
+						if(get<1>(result))
+							questMissionCache[sourceSystem].rngQuest++;
+						else
+							questMissionCache[sourceSystem].quest++;
+					}
 				}
 			}
+			cachedQuests = true;
 		}
-		cachedQuests = true;
-	}
-	// Apply quest cache
-	for(auto &&it : questMissionCache){
-		missionCount[it.first].quest += it.second.quest;
-		missionCount[it.first].rngQuest += it.second.rngQuest;
-		missionCount[it.first].minorQuest += it.second.minorQuest;
+		// Apply quest cache
+		for(auto &&it : questMissionCache){
+			missionCount[it.first].quest += it.second.quest;
+			missionCount[it.first].rngQuest += it.second.rngQuest;
+		}
 	}
 	// Draw the available and unavailable jobs.
 	for(auto &&it : missionCount)
@@ -1494,9 +1496,9 @@ void MapPanel::DrawMissions()
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, availableColor);
 		for(unsigned i = 0; i < counters.unavailable; ++i)
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, unavailableColor);
-		if(it.second.quest > 0)
+		if(it.second.quest > 0 && pilot->GetGamerules().GetMissionMarkers())
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, hintColor);
-		if(it.second.rngQuest > 0)
+		if(it.second.rngQuest > 0 && pilot->GetGamerules().GetRNGMissionMarkers())
 			DrawPointer(system, counters.drawn, MAX_MISSION_POINTERS_DRAWN, rngHintColor);
 	}
 }

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -1395,6 +1395,7 @@ void MapPanel::DrawMissions()
 {
 	// Draw a pointer for each active or available mission.
 	map<const System *, PointerDrawCount> missionCount;
+	static map<const System *, PointerDrawCount> questMissionCache;
 
 	const Set<Color> &colors = GameData::Colors();
 	const Color &availableColor = *colors.Get("available job");
@@ -1456,17 +1457,27 @@ void MapPanel::DrawMissions()
 			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
 		for(const System *mark : mission.TrackedSystems())
 			DrawPointer(mark, missionCount[mark].drawn, missionCount[mark].MaximumActive(), waypointColor);
-	}	
-	for ( auto &mission : GameData::Missions() ){
-		tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
-		if(get<0>(result)){			
-			for( auto &sourceSystem : get<2>(result)){
-				if(get<1>(result))
-					missionCount[sourceSystem].rngQuest++;
-				else
-					missionCount[sourceSystem].quest++;
-			}
-		}		
+	}
+	// Calculate available quests every time user opens map and cache it
+	if(!cachedQuests){
+		questMissionCache.clear();
+		for(auto &mission : GameData::Missions()){
+			tuple<bool,bool,vector<const System*>> result = mission.second.CanOfferTheoretically(player);
+			if(get<0>(result)){
+				for(auto &sourceSystem : get<2>(result)){
+					if(get<1>(result))
+						questMissionCache[sourceSystem].rngQuest++;
+					else
+						questMissionCache[sourceSystem].quest++;
+				}
+			}	
+		}
+		cachedQuests = true;
+	}
+	// Apply quest cache
+	for(auto &&it : questMissionCache){
+		missionCount[it.first].quest += it.second.quest;
+		missionCount[it.first].rngQuest += it.second.rngQuest;
 	}
 	// Draw the available and unavailable jobs.
 	for(auto &&it : missionCount)

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -221,7 +221,7 @@ private:
 	// This is the coloring mode currently used in the cache.
 	int cachedCommodity = -10;
 	bool cachedQuests = false;
-	
+
 	std::vector<Node> nodes;
 	std::vector<Link> links;
 };

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -220,7 +220,8 @@ private:
 private:
 	// This is the coloring mode currently used in the cache.
 	int cachedCommodity = -10;
-
+	bool cachedQuests = false;
+	
 	std::vector<Node> nodes;
 	std::vector<Link> links;
 };

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1062,6 +1062,9 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	if(!toFail.IsEmpty() && toFail.Test())
 		return tuple(false, false, sourceSystems);
 
+	if(!HasSpace(player))
+		return tuple(false, false, sourceSystems);
+
 	bool result = toOffer.TestNoRNG();
 	if(!result)
 	{

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1062,12 +1062,12 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	if(!toFail.IsEmpty() && toFail.Test())
 		return tuple(false, false, sourceSystems);
 
-	// Don't show if already offered or failed.
-	if(!toFail.IsEmpty() && toFail.Test())
-		return tuple(false, false, sourceSystems);
-
 	// Because of Quarg Lagrange ringworld missions.
 	if(!HasSpace(player))
+		return tuple(false, false, sourceSystems);
+
+	// Because of Hai Jump Drive missions.
+	if(!CanAccept(player))
 		return tuple(false, false, sourceSystems);
 
 	bool result = toOffer.TestNoRNG();

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1097,7 +1097,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	if(sourceFilter.IsEmpty())
 		return tuple(retflag, randomflag, sourceSystems);
 
-	for(auto &visitedSystem : player.VisitedSystems() )
+	for(auto &visitedSystem : player.VisitedSystems())
 	{
 		for(auto &planet : GameData::Planets())
 		{

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1031,6 +1031,89 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 	return true;
 }
 
+#include "Logger.h"
+// Check if it's possible to offer or complete this mission right now.
+tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const PlayerInfo &player) const
+{	
+	vector<const System*> sourceSystems;
+	// Don't offer boarding or assisting missions for now
+	if(location == BOARDING || location == ASSISTING || location == JOB)
+	{
+		return tuple(false,false,sourceSystems);
+	}
+
+	if(repeat!=1)
+	{
+		return tuple(false,false,sourceSystems);
+	}
+
+	string missionName = this->TrueName();
+	string conditionStoreName = missionName + ": offered";
+	if(player.Conditions().Get(conditionStoreName)){
+		return tuple(false,false,sourceSystems);
+	}
+
+	// Don't show if already offered or failed.
+	if(!toFail.IsEmpty() && toFail.Test())
+		return tuple(false,false,sourceSystems);
+
+	// TODO: Investigate condition test
+	// Hacky but works
+	int offercount = 0;
+	for( int i = 0 ; i < 100 ; i++){
+		if(toOffer.Test())
+			offercount++;
+	}
+	if(offercount == 0){
+		return tuple(false,false,sourceSystems);
+	}
+
+	bool randomflag = false;
+	if ( offercount != 100)
+		randomflag = true;
+	
+	
+	bool retflag = false;
+	// check if source is on list of visited systems
+	for(auto &visitedSystem : player.VisitedSystems()){		
+		if(source)
+			for(auto &sourceSystem : source->Systems())
+			{
+				if(visitedSystem == sourceSystem){
+					Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
+					sourceSystems.push_back(sourceSystem);
+					retflag = true;
+				}
+			}
+	}
+	if(retflag)
+		return tuple(retflag,randomflag,sourceSystems);	
+
+	if(sourceFilter.IsEmpty())
+		return tuple(retflag,randomflag,sourceSystems);	
+
+	for(auto &visitedSystem : player.VisitedSystems() ){
+		for(auto &planet : GameData::Planets())
+		{
+			if(planet.second.GetSystem() == visitedSystem)
+				if(sourceFilter.Matches(&planet.second)){
+					Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
+					sourceSystems.push_back(visitedSystem);
+					retflag = true;
+				}
+		}
+	}	
+	return tuple(retflag,randomflag,sourceSystems);	
+}
+
+
+vector<const System*> Mission::GetSourceSystems() const{
+	if(source)
+		return source->Systems();
+	vector<const System*> empty;
+	return empty;
+}
+
 
 
 bool Mission::CanAccept(const PlayerInfo &player) const

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1031,7 +1031,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 	return true;
 }
 
-// #include "Logger.h"
+#include "Logger.h"
 // Check if it's possible to offer or complete this mission right now.
 tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const PlayerInfo &player) const
 {	
@@ -1079,7 +1079,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 			for(auto &sourceSystem : source->Systems())
 			{
 				if(visitedSystem == sourceSystem){
-					//Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
+					Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
 					sourceSystems.push_back(sourceSystem);
 					retflag = true;
 				}
@@ -1096,7 +1096,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 		{
 			if(planet.second.GetSystem() == visitedSystem)
 				if(sourceFilter.Matches(&planet.second)){
-					//Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
+					Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
 					sourceSystems.push_back(visitedSystem);
 					retflag = true;
 				}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1068,6 +1068,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 
 	bool randomflag = toOffer.isRNG();
 	
+	
 	// Check for additional prerequisites in On Offer set
 	auto it = actions.find(OFFER);
 	bool isFailed = false;

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1031,7 +1031,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 	return true;
 }
 
-#include "Logger.h"
+
 // Check if it's *possible* to offer this mission right now.
 tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	const PlayerInfo &player) const
@@ -1061,6 +1061,13 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	if(!toFail.IsEmpty() && toFail.Test())
 		return tuple(false, false, sourceSystems);
 
+	bool result = toOffer.TestNoRNG();
+	if(!result){
+		return tuple(false, false, sourceSystems);
+	}
+
+	bool randomflag = toOffer.isRNG();
+	
 	// Check for additional prerequisites in On Offer set
 	auto it = actions.find(OFFER);
 	bool isFailed = false;
@@ -1068,23 +1075,6 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, boardingShip))
 		return tuple(false, false, sourceSystems);
 
-	// TODO: Investigate condition test
-	// Hacky but works
-	int offercount = 0;
-	for(int i = 0; i < 459; i++)
-	{
-		if(toOffer.Test())
-			offercount++;
-	}
-	if(offercount == 0)
-	{
-		return tuple(false, false, sourceSystems);
-	}
-
-	bool randomflag = false;
-	if (offercount != 459)
-		randomflag = true;
-		
 	bool retflag = false;
 	// check if source is on list of visited systems
 	for(auto &visitedSystem : player.VisitedSystems()){		
@@ -1092,7 +1082,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 			for(auto &sourceSystem : source->Systems())
 			{
 				if(visitedSystem == sourceSystem){
-					Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
+					//Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
 					sourceSystems.push_back(sourceSystem);
 					retflag = true;
 				}
@@ -1109,7 +1099,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 		{
 			if(planet.second.GetSystem() == visitedSystem)
 				if(sourceFilter.Matches(&planet.second)){
-					Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
+					//Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
 					sourceSystems.push_back(visitedSystem);
 					retflag = true;
 				}

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1062,6 +1062,11 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	if(!toFail.IsEmpty() && toFail.Test())
 		return tuple(false, false, sourceSystems);
 
+	// Don't show if already offered or failed.
+	if(!toFail.IsEmpty() && toFail.Test())
+		return tuple(false, false, sourceSystems);
+
+	// Because of Quarg Lagrange ringworld missions.
 	if(!HasSpace(player))
 		return tuple(false, false, sourceSystems);
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1035,7 +1035,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 // Check if it's *possible* to offer this mission right now.
 tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	const PlayerInfo &player) const
-{	
+{
 	vector<const System*> sourceSystems;
 	string missionName = this->TrueName();
 	string conditionStoreName = missionName + ": offered";
@@ -1047,13 +1047,14 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 	}
 
 	// Not interested in repeatable missions(todo: make this optional?)
-	if(repeat!=1)
+	if(repeat != 1)
 	{
 		return tuple(false, false, sourceSystems);
 	}
 
 	// Exclude previously offered missions
-	if(player.Conditions().Get(conditionStoreName)){
+	if(player.Conditions().Get(conditionStoreName))
+	{
 		return tuple(false, false, sourceSystems);
 	}
 
@@ -1062,13 +1063,13 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 		return tuple(false, false, sourceSystems);
 
 	bool result = toOffer.TestNoRNG();
-	if(!result){
+	if(!result)
+	{
 		return tuple(false, false, sourceSystems);
 	}
 
 	bool randomflag = toOffer.isRNG();
-	
-	
+
 	// Check for additional prerequisites in On Offer set
 	auto it = actions.find(OFFER);
 	bool isFailed = false;
@@ -1078,35 +1079,37 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
 
 	bool retflag = false;
 	// check if source is on list of visited systems
-	for(auto &visitedSystem : player.VisitedSystems()){		
+	for(auto &visitedSystem : player.VisitedSystems())
+	{
 		if(source)
 			for(auto &sourceSystem : source->Systems())
 			{
-				if(visitedSystem == sourceSystem){
-					//Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
+				if(visitedSystem == sourceSystem)
+				{
 					sourceSystems.push_back(sourceSystem);
 					retflag = true;
 				}
 			}
 	}
 	if(retflag)
-		return tuple(retflag, randomflag, sourceSystems);	
+		return tuple(retflag, randomflag, sourceSystems);
 
 	if(sourceFilter.IsEmpty())
-		return tuple(retflag, randomflag, sourceSystems);	
+		return tuple(retflag, randomflag, sourceSystems);
 
-	for(auto &visitedSystem : player.VisitedSystems() ){
+	for(auto &visitedSystem : player.VisitedSystems() )
+	{
 		for(auto &planet : GameData::Planets())
 		{
 			if(planet.second.GetSystem() == visitedSystem)
-				if(sourceFilter.Matches(&planet.second)){
-					//Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
+				if(sourceFilter.Matches(&planet.second))
+				{
 					sourceSystems.push_back(visitedSystem);
 					retflag = true;
 				}
 		}
-	}	
-	return tuple(retflag, randomflag, sourceSystems);	
+	}
+	return tuple(retflag, randomflag, sourceSystems);
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1032,44 +1032,57 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 }
 
 #include "Logger.h"
-// Check if it's possible to offer or complete this mission right now.
-tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const PlayerInfo &player) const
+// Check if it's *possible* to offer this mission right now.
+tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(
+	const PlayerInfo &player) const
 {	
 	vector<const System*> sourceSystems;
-	// Don't offer boarding or assisting missions for now
-	if(location == BOARDING || location == ASSISTING || location == JOB)
-	{
-		return tuple(false,false,sourceSystems);
-	}
-
-	if(repeat!=1)
-	{
-		return tuple(false,false,sourceSystems);
-	}
-
 	string missionName = this->TrueName();
 	string conditionStoreName = missionName + ": offered";
+
+	// We're looking for planet or system based missions, not ship based
+	if(location == BOARDING || location == ASSISTING || location == JOB)
+	{
+		return tuple(false, false, sourceSystems);
+	}
+
+	// Not interested in repeatable missions(todo: make this optional?)
+	if(repeat!=1)
+	{
+		return tuple(false, false, sourceSystems);
+	}
+
+	// Exclude previously offered missions
 	if(player.Conditions().Get(conditionStoreName)){
-		return tuple(false,false,sourceSystems);
+		return tuple(false, false, sourceSystems);
 	}
 
 	// Don't show if already offered or failed.
 	if(!toFail.IsEmpty() && toFail.Test())
-		return tuple(false,false,sourceSystems);
+		return tuple(false, false, sourceSystems);
+
+	// Check for additional prerequisites in On Offer set
+	auto it = actions.find(OFFER);
+	bool isFailed = false;
+	const shared_ptr<Ship> boardingShip;
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, boardingShip))
+		return tuple(false, false, sourceSystems);
 
 	// TODO: Investigate condition test
 	// Hacky but works
 	int offercount = 0;
-	for( int i = 0 ; i < 459 ; i++){
+	for(int i = 0; i < 459; i++)
+	{
 		if(toOffer.Test())
 			offercount++;
 	}
-	if(offercount == 0){
-		return tuple(false,false,sourceSystems);
+	if(offercount == 0)
+	{
+		return tuple(false, false, sourceSystems);
 	}
 
 	bool randomflag = false;
-	if ( offercount != 459)
+	if (offercount != 459)
 		randomflag = true;
 		
 	bool retflag = false;
@@ -1086,10 +1099,10 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 			}
 	}
 	if(retflag)
-		return tuple(retflag,randomflag,sourceSystems);	
+		return tuple(retflag, randomflag, sourceSystems);	
 
 	if(sourceFilter.IsEmpty())
-		return tuple(retflag,randomflag,sourceSystems);	
+		return tuple(retflag, randomflag, sourceSystems);	
 
 	for(auto &visitedSystem : player.VisitedSystems() ){
 		for(auto &planet : GameData::Planets())
@@ -1102,7 +1115,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 				}
 		}
 	}	
-	return tuple(retflag,randomflag,sourceSystems);	
+	return tuple(retflag, randomflag, sourceSystems);	
 }
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1031,7 +1031,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 	return true;
 }
 
-#include "Logger.h"
+// #include "Logger.h"
 // Check if it's possible to offer or complete this mission right now.
 tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const PlayerInfo &player) const
 {	
@@ -1060,7 +1060,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 	// TODO: Investigate condition test
 	// Hacky but works
 	int offercount = 0;
-	for( int i = 0 ; i < 100 ; i++){
+	for( int i = 0 ; i < 459 ; i++){
 		if(toOffer.Test())
 			offercount++;
 	}
@@ -1069,10 +1069,9 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 	}
 
 	bool randomflag = false;
-	if ( offercount != 100)
+	if ( offercount != 459)
 		randomflag = true;
-	
-	
+		
 	bool retflag = false;
 	// check if source is on list of visited systems
 	for(auto &visitedSystem : player.VisitedSystems()){		
@@ -1080,7 +1079,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 			for(auto &sourceSystem : source->Systems())
 			{
 				if(visitedSystem == sourceSystem){
-					Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
+					//Logger::Log(std::format("{}|match by sourceSystem|{}",missionName,sourceSystem->TrueName()),Logger::Level::INFO);
 					sourceSystems.push_back(sourceSystem);
 					retflag = true;
 				}
@@ -1097,7 +1096,7 @@ tuple<bool,bool,vector<const System*>> Mission::CanOfferTheoretically(const Play
 		{
 			if(planet.second.GetSystem() == visitedSystem)
 				if(sourceFilter.Matches(&planet.second)){
-					Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
+					//Logger::Log(std::format("{}|match by planet|{}",missionName,visitedSystem->TrueName()),Logger::Level::INFO);
 					sourceSystems.push_back(visitedSystem);
 					retflag = true;
 				}

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -151,6 +151,8 @@ public:
 	// into account, so before actually offering a mission you should also check
 	// if the player has enough space.
 	bool CanOffer(const PlayerInfo &player, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
+	std::tuple<bool,bool,std::vector<const System*>> CanOfferTheoretically(const PlayerInfo &player) const;
+	std::vector<const System*> GetSourceSystems() const;
 	bool CanAccept(const PlayerInfo &player) const;
 	bool HasSpace(const PlayerInfo &player) const;
 	bool HasSpace(const Ship &ship) const;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This PR adds an **optional, off by default**, set of gamerules that create map markers around systems that have available missions.  The three game rules are

1) Show available missions (non-rng).  These are hints (pointers) to mostly main storyline missions.  If a player stops halfway through the Deep Archaeology questline and moves on to something else, they will have a persistent map marker reminding them there is a mission thread to be picked up again.  (or sim.)

2) Show available RNG missions.  These are hints for missions that spawn sporadically.  Not all of them have a high chance of spawning (some as low as 3%).  This is for players who are looking to scrape every last bit of content from the game without wasting time on systems that are 'empty'.  

3) Include 'minor' missions in hints.  Minor missions (mostly culture conversations) can be included for players who want to go even further in plumbing the depths of the game.  Some of these have as low as a 1% chance to offer and many go completely unnoticed by even veteran players.

## Screenshots
<img width="501" height="589" alt="image" src="https://github.com/user-attachments/assets/0d42f9ed-0a5e-4942-ab73-e2c98a003cce" />


## Usage examples
Load your favorite save file, turn on the options in Gamerules and see what content you've missed or forgotten about in your playthrough.
<img width="783" height="615" alt="image" src="https://github.com/user-attachments/assets/bd980ed5-32ad-4624-b696-28374843e455" />

## Testing Done
Test-played with the changes on in a very-old, intermediate and new save file.
Looking for additional feedback from playtesters.

## Save File
Any recent savefile should do.

## Wiki Update
TODO
(If this PR adds a new feature or modifies a feature that should be documented in the [GitHub wiki](https://github.com/endless-sky/endless-sky/wiki), open a PR to the [wiki repository](https://github.com/endless-sky/endless-sky-wiki) and provide a link.)

## Performance Impact
No performance impact when gamerules are disabled.
When enabled the mission flags introduce additional work at the opening of the map screen.  The amount of latency is proportional to the number of systems the player has visited as well as the number of missions there are (including plugins).
It ranges from completely negligible to about .5sec on my 10 year old machine.  (If in the course of the review of this PR the latency is deemed too long, I'll push the calculations off to a worker thread).

(edits: spelling)