### PR TITLE
feat(graphics): Support devices with the EXT version of framebuffer objects

### DIFF
--- a/source/RenderBuffer.cpp
+++ b/source/RenderBuffer.cpp
@@ -51,6 +51,9 @@ namespace {
 // Initialize the shaders.
 void RenderBuffer::Init()
 {
+	if(OpenGL::GetFboSupport() == OpenGL::FeatureSupport::NONE)
+		throw runtime_error("OpenGL framebuffer object support is required!");
+
 	shader = GameData::Shaders().Get("renderBuffer");
 	if(!shader->Object())
 		throw runtime_error("Could not find render buffer shader!");
@@ -117,9 +120,18 @@ RenderBuffer::RenderTargetGuard::RenderTargetGuard(RenderBuffer &b, int screenWi
 RenderBuffer::RenderBuffer(const Point &dimensions)
 	: size(dimensions)
 {
+	OpenGL::FeatureSupport fboSupport = OpenGL::GetFboSupport();
 	// Generate a framebuffer.
-	glGenFramebuffers(1, &framebuffer);
-	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	if(fboSupport == OpenGL::FeatureSupport::CORE)
+	{
+		glGenFramebuffers(1, &framebuffer);
+		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	}
+	else
+	{
+		glGenFramebuffersEXT(1, &framebuffer);
+		glBindFramebufferEXT(GL_FRAMEBUFFER, framebuffer);
+	}
 
 	// Generate the texture.
 	glGenTextures(1, &texid);
@@ -138,16 +150,24 @@ RenderBuffer::RenderBuffer(const Point &dimensions)
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, scaledSize.X(), scaledSize.Y(), 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
 	// Attach the texture to the frame buffer.
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texid, 0);
+	if(fboSupport == OpenGL::FeatureSupport::CORE)
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texid, 0);
+	else
+		glFramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texid, 0);
 	GLenum draw_buffers[] = {GL_COLOR_ATTACHMENT0};
 	glDrawBuffers(1, draw_buffers);
 
-	if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+	if(fboSupport == OpenGL::FeatureSupport::CORE ?
+			glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE
+			: glCheckFramebufferStatusEXT(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 		Logger::Log("Failed to initialize framebuffer for RenderBuffer.", Logger::Level::WARNING);
 
 
 	glBindTexture(GL_TEXTURE_2D, 0);
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	if(fboSupport == OpenGL::FeatureSupport::CORE)
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	else
+		glBindFramebufferEXT(GL_FRAMEBUFFER, 0);
 
 	// Default to the current viewport size at the time of construction.
 	glGetIntegerv(GL_VIEWPORT, lastViewport);
@@ -159,7 +179,10 @@ RenderBuffer::RenderBuffer(const Point &dimensions)
 RenderBuffer::~RenderBuffer()
 {
 	glDeleteTextures(1, &texid);
-	glDeleteFramebuffers(1, &framebuffer);
+	if(OpenGL::GetFboSupport() == OpenGL::FeatureSupport::CORE)
+		glDeleteFramebuffers(1, &framebuffer);
+	else
+		glDeleteFramebuffersEXT(1, &framebuffer);
 }
 
 
@@ -175,7 +198,10 @@ RenderBuffer::RenderTargetGuard RenderBuffer::SetTarget()
 	//       are done.
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING, reinterpret_cast<int*>(&lastFramebuffer));
 	glGetIntegerv(GL_VIEWPORT, lastViewport);
-	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	if(OpenGL::GetFboSupport() == OpenGL::FeatureSupport::CORE)
+		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	else
+		glBindFramebufferEXT(GL_FRAMEBUFFER, framebuffer);
 
 	const Point scaledSize = size * multiplier * Screen::Zoom() / 100.0;
 	glViewport(0, 0, scaledSize.X(), scaledSize.Y());
@@ -201,7 +227,10 @@ void RenderBuffer::Deactivate()
 {
 	// Restore the old settings.
 	glViewport(lastViewport[0], lastViewport[1], lastViewport[2], lastViewport[3]);
-	glBindFramebuffer(GL_FRAMEBUFFER, lastFramebuffer);
+	if(OpenGL::GetFboSupport() == OpenGL::FeatureSupport::CORE)
+		glBindFramebuffer(GL_FRAMEBUFFER, lastFramebuffer);
+	else
+		glBindFramebufferEXT(GL_FRAMEBUFFER, lastFramebuffer);
 }
 
 

--- a/source/opengl.cpp
+++ b/source/opengl.cpp
@@ -27,14 +27,13 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 namespace {
 	bool hasOpenGL3Support = true;
+	OpenGL::FeatureSupport fboSupport = OpenGL::FeatureSupport::NONE;
 
-#if defined(ES_GLES) || defined(_WIN32)
 	bool HasOpenGLExtension(const char *name)
 	{
 		auto extensions = reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS));
 		return strstr(extensions, name);
 	}
-#endif
 }
 
 
@@ -83,4 +82,18 @@ bool OpenGL::HasTexture2DArraySupport()
 bool OpenGL::HasClearBufferSupport()
 {
 	return hasOpenGL3Support;
+}
+
+
+
+OpenGL::FeatureSupport OpenGL::GetFboSupport()
+{
+	if(fboSupport == OpenGL::FeatureSupport::NONE)
+	{
+		if(hasOpenGL3Support || HasOpenGLExtension("_ARB_framebuffer_object"))
+			fboSupport = FeatureSupport::CORE;
+		else if(HasOpenGLExtension("_framebuffer_object"))
+			fboSupport = FeatureSupport::EXT;
+	}
+	return fboSupport;
 }

--- a/source/opengl.h
+++ b/source/opengl.h
@@ -31,6 +31,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 // A helper class for various OpenGL platform specific calls.
 class OpenGL {
 public:
+	enum class FeatureSupport {
+		NONE = 0,
+		EXT,
+		CORE
+	};
+
+
+public:
 #ifndef ES_GLES
 	static void DisableOpenGL3();
 #endif
@@ -39,4 +47,5 @@ public:
 	static bool HasVaoSupport();
 	static bool HasTexture2DArraySupport();
 	static bool HasClearBufferSupport();
+	static FeatureSupport GetFboSupport();
 };

--- a/source/opengl.h
+++ b/source/opengl.h
@@ -26,6 +26,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #endif
 #endif
 
+#if defined(__APPLE__) || defined(ES_GLES)
+#define glBindFramebufferEXT glBindFramebuffer
+#define glCheckFramebufferStatusEXT glCheckFramebufferStatus
+#define glDeleteFramebuffersEXT glDeleteFramebuffers
+#define glFramebufferTexture2DEXT glFramebufferTexture2D
+#define glGenFramebuffersEXT glGenFramebuffers
+#endif
+
 
 
 // A helper class for various OpenGL platform specific calls.


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Before the framebuffer objects became part of the core OpenGL standard, there was a common (working on multiple vendors' GPUs) extension providing them and it's pretty much the same as their newer core version. You need to suffix all function calls with `EXT`, but it's a trivial change.
This PR adds these `EXT` code paths that are chosen when the system determines that only the non-core version is available. Additionally, the game now throws a meaningful error message instead of crashing if neither implementation of framebuffer objects is available.

## Testing Done
Tested one device with the EXT version only (crashed upon creating `TextArea`s before this change), one device (well, the same device, but with different drivers) on OpenGL 2 with the ARB version, and one device supporting all modern OpenGL versions. Noticed no negative side-effects.

## Performance Impact
Negligible.