### PR TITLE
(feat) Support for non-standard keystones and jump drives

### DIFF
--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -1256,10 +1256,10 @@ mission "Longcow Antibiotics 1"
 	to offer
 		has "Coalition: First Contact: done"
 		random < 35
+		"ship attribute: jump drive" > 1
 	source
 		attributes arach
 		not attributes "coalition station"
-		"ship attribute: jump drive" > 1
 	stopover "New Finding"
 	destination "Corral of Meblumem"
 	on offer

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -880,10 +880,10 @@ mission "Kimek Gift"
 	deadline 2
 	to offer
 		has "Coalition: First Contact: done"
+		"ship attribute: jump drive" > 1
 	source "Second Cerulean"
 	destination "Cold Horizon"
 	on offer
-		require "Jump Drive"
 		conversation
 			`A Kimek in a lab coat is desperately running around the spaceport here, carrying a small package with some papers attached.`
 			`	As soon as she spots you, she quickly approaches you and says, "Human! The visitor I've heard about, you are! From the outside! A jump drive you have, if our space you've reached, yes?"`
@@ -1259,10 +1259,10 @@ mission "Longcow Antibiotics 1"
 	source
 		attributes arach
 		not attributes "coalition station"
+		"ship attribute: jump drive" > 1
 	stopover "New Finding"
 	destination "Corral of Meblumem"
 	on offer
-		require "Jump Drive"
 		conversation
 			`You see some Arachi talking among themselves in the spaceport, occasionally glancing at and pointing at you.`
 			`	One of them finally comes to you and says, "Greetings, Captain. Interested in performing a cargo mission for us, are you?"`
@@ -2399,11 +2399,11 @@ mission "Coalition: Expeditions Past 1"
 	to offer
 		"coalition jobs" >= 40
 		random < 5
+		"ship attribute: jump drive" > 1
 	source
 		government "Coalition"
 	destination "Ring of Friendship"
 	on offer
-		require "Jump Drive"
 		conversation
 			`As you exit your ship and start heading to the spaceport, you hear a rushed galloping getting closer. As you turn you see a Saryd Heliarch coming to you, gesturing for you to wait. She slows down once she sees you're obliging, and slowly walks to you while glancing at your ship.`
 			`	"Apologize for cutting you off, I must, Captain <last>, but in need of extended transport services, I am," she says. "Sedlitaris Quatcid, my name is, and a Heliarch tribune, I am. Brought to <destination>, I must be. A petition to the council, I am to make."`

--- a/data/coalition/coalition missions.txt
+++ b/data/coalition/coalition missions.txt
@@ -880,7 +880,7 @@ mission "Kimek Gift"
 	deadline 2
 	to offer
 		has "Coalition: First Contact: done"
-		"ship attribute: jump drive" > 1
+		has "ship attribute: jump drive"
 	source "Second Cerulean"
 	destination "Cold Horizon"
 	on offer
@@ -1256,7 +1256,7 @@ mission "Longcow Antibiotics 1"
 	to offer
 		has "Coalition: First Contact: done"
 		random < 35
-		"ship attribute: jump drive" > 1
+		has "ship attribute: jump drive"
 	source
 		attributes arach
 		not attributes "coalition station"
@@ -2399,7 +2399,7 @@ mission "Coalition: Expeditions Past 1"
 	to offer
 		"coalition jobs" >= 40
 		random < 5
-		"ship attribute: jump drive" > 1
+		has "ship attribute: jump drive"
 	source
 		government "Coalition"
 	destination "Ring of Friendship"

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -1927,10 +1927,7 @@ mission "Superstitious Hai [7]"
 	to offer
 		random < 5
 	to accept
-		or
-			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1957,10 +1954,7 @@ mission "Superstitious Hai [8]"
 	to offer
 		random < 5
 	to accept
-		or
-			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1988,10 +1982,7 @@ mission "Superstitious Hai [9]"
 	to offer
 		random < 5
 	to accept
-		or
-			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -2021,10 +2012,7 @@ mission "Superstitious Hai [10]"
 	to offer
 		random < 5
 	to accept
-		or
-			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -2053,10 +2041,7 @@ mission "Superstitious Hai [11]"
 	to offer
 		random < 5
 	to accept
-		or
-			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -2085,10 +2070,7 @@ mission "Superstitious Hai [12]"
 	to offer
 		random < 5
 	to accept
-		or
-			has "outfit (installed): Quantum Keystone"
-			has "outfit (installed): Shield Beetle Pendant"
-			has "outfit (installed): Tree Skeleton Key Stone"
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -172,7 +172,7 @@ mission "Wealthy Hai [1]"
 		random < 55
 	to accept
 		has "outfit (installed): Luxury Accommodations"
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -200,7 +200,7 @@ mission "Wealthy Hai [2]"
 		random < 15
 	to accept
 		has "outfit (installed): Luxury Accommodations"
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1756,7 +1756,7 @@ mission "Superstitious Hai [1]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1783,7 +1783,7 @@ mission "Superstitious Hai [2]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1811,7 +1811,7 @@ mission "Superstitious Hai [3]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -1841,7 +1841,7 @@ mission "Superstitious Hai [4]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1870,7 +1870,7 @@ mission "Superstitious Hai [5]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1899,7 +1899,7 @@ mission "Superstitious Hai [6]"
 	to offer
 		random < 5
 	to accept
-		has "outfit (installed): Quantum Keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1927,7 +1927,7 @@ mission "Superstitious Hai [7]"
 	to offer
 		random < 5
 	to accept
-		has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1954,7 +1954,7 @@ mission "Superstitious Hai [8]"
 	to offer
 		random < 5
 	to accept
-		has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -1982,7 +1982,7 @@ mission "Superstitious Hai [9]"
 	to offer
 		random < 5
 	to accept
-		has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -2012,7 +2012,7 @@ mission "Superstitious Hai [10]"
 	to offer
 		random < 5
 	to accept
-		has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -2041,7 +2041,7 @@ mission "Superstitious Hai [11]"
 	to offer
 		random < 5
 	to accept
-		has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination
@@ -2070,7 +2070,7 @@ mission "Superstitious Hai [12]"
 	to offer
 		random < 5
 	to accept
-		has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 	source
 		government "Hai"
 	destination

--- a/data/hai/hai jobs.txt
+++ b/data/hai/hai jobs.txt
@@ -172,7 +172,7 @@ mission "Wealthy Hai [1]"
 		random < 55
 	to accept
 		has "outfit (installed): Luxury Accommodations"
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -200,7 +200,7 @@ mission "Wealthy Hai [2]"
 		random < 15
 	to accept
 		has "outfit (installed): Luxury Accommodations"
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1756,7 +1756,7 @@ mission "Superstitious Hai [1]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1783,7 +1783,7 @@ mission "Superstitious Hai [2]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1811,7 +1811,7 @@ mission "Superstitious Hai [3]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -1841,7 +1841,7 @@ mission "Superstitious Hai [4]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1870,7 +1870,7 @@ mission "Superstitious Hai [5]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1899,7 +1899,7 @@ mission "Superstitious Hai [6]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1927,7 +1927,7 @@ mission "Superstitious Hai [7]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1954,7 +1954,7 @@ mission "Superstitious Hai [8]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -1982,7 +1982,7 @@ mission "Superstitious Hai [9]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 		not attributes "retirement"
@@ -2012,7 +2012,7 @@ mission "Superstitious Hai [10]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -2041,7 +2041,7 @@ mission "Superstitious Hai [11]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination
@@ -2070,7 +2070,7 @@ mission "Superstitious Hai [12]"
 	to offer
 		random < 5
 	to accept
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 	source
 		government "Hai"
 	destination

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -2392,12 +2392,7 @@ mission "Hai Pilgrimage"
 	passengers 1
 	to offer
 		random < 10
-		or
-			has "outfit: Quantum Keystone"
-			has "outfit: Quantum Key Stone"
-			has "outfit: Shield Beetle Pendant"
-			has "outfit: Tree Skeleton Key Stone"
-			has "ship attribute: quantum keystone"
+		"ship attribute: quantum keystone" > 1
 		has "First Contact: Hai: offered"
 	on offer
 		conversation

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -2397,6 +2397,7 @@ mission "Hai Pilgrimage"
 			has "outfit: Quantum Key Stone"
 			has "outfit: Shield Beetle Pendant"
 			has "outfit: Tree Skeleton Key Stone"
+			has "ship attribute: quantum keystone"
 		has "First Contact: Hai: offered"
 	on offer
 		conversation
@@ -2409,6 +2410,11 @@ mission "Hai Pilgrimage"
 				has "outfit: Quantum Key Stone"
 			branch huh
 				has "outfit: Tree Skeleton Key Stone"
+			branch normal
+				not has "outfit: Shield Beetle Pendant"
+				not has "outfit: Quantum Keystone"
+				not has "outfit: Quantum Key Stone"
+				not has "outfit: Tree Skeleton Key Stone"
 			label normal
 			`	"I see that you are wiser than most humans here," he says, pointing toward your ship. Its hatch is open, prominently displaying your keystone to any potential travelers. "You carry a shield against the tempest of space. Let no one else tell you otherwise." He pauses to take a breath. "Now, onto more worldly things. My name is Hareek. Are you willing and able to take me to <destination> for <payment>?"`
 				goto choice

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -2406,10 +2406,10 @@ mission "Hai Pilgrimage"
 			branch huh
 				has "outfit: Tree Skeleton Key Stone"
 			branch normal
-				not has "outfit: Shield Beetle Pendant"
-				not has "outfit: Quantum Keystone"
-				not has "outfit: Quantum Key Stone"
-				not has "outfit: Tree Skeleton Key Stone"
+				not "outfit: Shield Beetle Pendant"
+				not "outfit: Quantum Keystone"
+				not "outfit: Quantum Key Stone"
+				not "outfit: Tree Skeleton Key Stone"
 			label normal
 			`	"I see that you are wiser than most humans here," he says, pointing toward your ship. Its hatch is open, prominently displaying your keystone to any potential travelers. "You carry a shield against the tempest of space. Let no one else tell you otherwise." He pauses to take a breath. "Now, onto more worldly things. My name is Hareek. Are you willing and able to take me to <destination> for <payment>?"`
 				goto choice

--- a/data/hai/hai missions.txt
+++ b/data/hai/hai missions.txt
@@ -2392,7 +2392,7 @@ mission "Hai Pilgrimage"
 	passengers 1
 	to offer
 		random < 10
-		"ship attribute: quantum keystone" > 1
+		has "ship attribute: quantum keystone"
 		has "First Contact: Hai: offered"
 	on offer
 		conversation
@@ -2405,11 +2405,6 @@ mission "Hai Pilgrimage"
 				has "outfit: Quantum Key Stone"
 			branch huh
 				has "outfit: Tree Skeleton Key Stone"
-			branch normal
-				not "outfit: Shield Beetle Pendant"
-				not "outfit: Quantum Keystone"
-				not "outfit: Quantum Key Stone"
-				not "outfit: Tree Skeleton Key Stone"
 			label normal
 			`	"I see that you are wiser than most humans here," he says, pointing toward your ship. Its hatch is open, prominently displaying your keystone to any potential travelers. "You carry a shield against the tempest of space. Let no one else tell you otherwise." He pauses to take a breath. "Now, onto more worldly things. My name is Hareek. Are you willing and able to take me to <destination> for <payment>?"`
 				goto choice

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3650,8 +3650,8 @@ mission "Remnant: Expanded Horizons Astral 2"
 	waypoint "Sagittarius A*"
 	to offer
 		has "Remnant: Expanded Horizons Astral 1: done"
+		"ship attribute: jump drive" > 1
 	on offer
-		require "Jump Drive"
 		require "Research Laboratory"
 		conversation
 			`Dawn is just finishing her meal when you enter the spaceport cafeteria. She stands up as you approach and deposits the tray in a receptacle next to her table. "Well, ready to go?"`

--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3650,7 +3650,7 @@ mission "Remnant: Expanded Horizons Astral 2"
 	waypoint "Sagittarius A*"
 	to offer
 		has "Remnant: Expanded Horizons Astral 1: done"
-		"ship attribute: jump drive" > 1
+		has "ship attribute: jump drive"
 	on offer
 		require "Research Laboratory"
 		conversation


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue #10191 

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Changed mission requirements check that looked for hard-coded outfits to generic checks for quantum keystone and jump drive ship attributes.  This is to enable better compatibility with mods that use custom outfits for keystones and JDs.

## Testing Done
Ongoing

## Save File


## Performance Impact
None.  Data only changes.