### PR TITLE
feat(graphics): Always shrink textures that are too large to be uploaded

### DIFF
--- a/source/image/ImageBuffer.cpp
+++ b/source/image/ImageBuffer.cpp
@@ -156,8 +156,11 @@ uint32_t *ImageBuffer::Begin(int y, int frame)
 
 
 
-void ImageBuffer::ShrinkToHalfSize()
+bool ImageBuffer::ShrinkToHalfSize()
 {
+	if(width < 2 || height < 2)
+		return false;
+
 	ImageBuffer result(frames);
 	result.Allocate(width / 2, height / 2);
 
@@ -179,6 +182,7 @@ void ImageBuffer::ShrinkToHalfSize()
 	swap(width, result.width);
 	swap(height, result.height);
 	swap(pixels, result.pixels);
+	return true;
 }
 
 

--- a/source/image/ImageBuffer.h
+++ b/source/image/ImageBuffer.h
@@ -62,7 +62,9 @@ public:
 	const uint32_t *Begin(int y, int frame = 0) const;
 	uint32_t *Begin(int y, int frame = 0);
 
-	void ShrinkToHalfSize();
+	// Attempt to divide the width and height of this buffer by 2.
+	// Return false if either dimension is too small (< 2).
+	bool ShrinkToHalfSize();
 
 	// Read frames from a file. Return the number of frames read,
 	// or 0 if an error is encountered - either the

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Sprite.h"
 
+#include "../text/Format.h"
 #include "ImageBuffer.h"
 #include "../Logger.h"
 #include "../Preferences.h"
@@ -73,19 +74,20 @@ namespace {
 			++forcedShrinkCount;
 			doProxyCheck();
 		}
-		if(forcedShrinkCount)
-			Logger::Log("Shrank sprite \"" + name + "\" "
-				+ Format::SimplePluralization(forcedShrinkCount, "time")
-				+ " to fit within hardware limits. The new dimensions: W = " + to_string(buffer.Width())
-				+ ", H = " + to_string(buffer.Height()) + '.', Logger::Level::INFO);
 
 		if(proxySuccess)
+		{
+			if(forcedShrinkCount)
+				Logger::Log("Shrank sprite \"" + name + "\" " + Format::SimplePluralization(forcedShrinkCount, "time")
+					+ " to fit within hardware limits. The new dimensions: W = " + to_string(buffer.Width())
+					+ ", H = " + to_string(buffer.Height()) + '.', Logger::Level::INFO);
 #endif
 			// Upload the image data.
 			glTexImage3D(type, 0, GL_RGBA8, // target, mipmap level, internal format,
 				buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
 				0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
 #ifndef ES_GLES
+		}
 		else
 			Logger::Log("Sprite \"" + name + "\" could not be uploaded to the GPU. Dimensions: W = "
 				+ to_string(buffer.Width()) + ", H = " + to_string(buffer.Height())

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Sprite.h"
 
 #include "ImageBuffer.h"
+#include "../Logger.h"
 #include "../Preferences.h"
 
 #include "../opengl.h"
@@ -25,7 +26,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	void AddBuffer(ImageBuffer &buffer, uint32_t *target, bool noReduction)
+	void AddBuffer(const string &name, ImageBuffer &buffer, uint32_t *target, bool noReduction)
 	{
 		// Check whether this sprite is large enough to require size reduction.
 		Preferences::LargeGraphicsReduction setting = Preferences::GetLargeGraphicsReduction();
@@ -48,10 +49,44 @@ namespace {
 		if(type == GL_TEXTURE_3D)
 			glTexParameteri(type, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
+		// Check if the texture can be uploaded by using a proxy target,
+		// and shrink the buffer if the current texture size is too large.
+		unsigned forcedShrinkCount = 0;
+		int proxySuccess = 0;
+		int proxyType = type == GL_TEXTURE_3D ? GL_PROXY_TEXTURE_3D : GL_PROXY_TEXTURE_2D_ARRAY;
+		auto doProxyCheck = [&proxySuccess, proxyType, &buffer]() -> void {
+			glTexImage3D(proxyType, 0, GL_RGBA8, // target, mipmap level, internal format,
+				buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
+				0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr); // border, input format, data type, data.
+			glGetTexLevelParameteriv(proxyType, 0, GL_TEXTURE_WIDTH, &proxySuccess);
+		};
+		doProxyCheck();
+		while(!proxySuccess)
+		{
+			// TODO: We can implement a separate algorithm for shrinking by arbitrary factors,
+			// but the main use case is, considering the common sprite sizes in current vanilla data,
+			// weak and old hardware, where highest quality isn't to be expected anyway.
+			if(!buffer.ShrinkToHalfSize())
+				// Since the proxy upload failed and we can't shrink any more, give up.
+				break;
+			++forcedShrinkCount;
+			doProxyCheck();
+		}
+		if(forcedShrinkCount)
+			Logger::Log("Shrank sprite \"" + name + "\" "
+				+ (forcedShrinkCount == 1 ? "1 time" : to_string(forcedShrinkCount) + " times")
+				+ " to fit within hardware limits. The new dimensions: W = " + to_string(buffer.Width())
+				+ ", H = " + to_string(buffer.Height()) + '.', Logger::Level::INFO);
+
 		// Upload the image data.
-		glTexImage3D(type, 0, GL_RGBA8, // target, mipmap level, internal format,
-			buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
-			0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
+		if(proxySuccess)
+			glTexImage3D(type, 0, GL_RGBA8, // target, mipmap level, internal format,
+				buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
+				0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
+		else
+			Logger::Log("Sprite \"" + name + "\" could not be uploaded to the GPU. Dimensions: W = "
+				+ to_string(buffer.Width()) + ", H = " + to_string(buffer.Height())
+				+ ", D = " + to_string(buffer.Frames()) + '.', Logger::Level::WARNING);
 
 		// Unbind the texture.
 		glBindTexture(type, 0);
@@ -110,11 +145,11 @@ void Sprite::AddFrames(ImageBuffer &buffer1x, ImageBuffer &buffer2x, bool noRedu
 	// Only use the 2x resolution image if it is provided.
 	if(buffer2x.Pixels())
 	{
-		AddBuffer(buffer2x, &texture, noReduction);
+		AddBuffer(name, buffer2x, &texture, noReduction);
 		buffer1x.Clear();
 	}
 	else
-		AddBuffer(buffer1x, &texture, noReduction);
+		AddBuffer(name, buffer1x, &texture, noReduction);
 }
 
 
@@ -136,11 +171,11 @@ void Sprite::AddSwizzleMaskFrames(ImageBuffer &buffer1x, ImageBuffer &buffer2x, 
 	// Only use the 2x resolution image if it is provided.
 	if(buffer2x.Pixels())
 	{
-		AddBuffer(buffer2x, &swizzleMask, noReduction);
+		AddBuffer(name, buffer2x, &swizzleMask, noReduction);
 		buffer1x.Clear();
 	}
 	else
-		AddBuffer(buffer1x, &swizzleMask, noReduction);
+		AddBuffer(name, buffer1x, &swizzleMask, noReduction);
 }
 
 

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -49,6 +49,7 @@ namespace {
 		if(type == GL_TEXTURE_3D)
 			glTexParameteri(type, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
+#ifndef ES_GLES
 		// Check if the texture can be uploaded by using a proxy target,
 		// and shrink the buffer if the current texture size is too large.
 		unsigned forcedShrinkCount = 0;
@@ -78,15 +79,18 @@ namespace {
 				+ " to fit within hardware limits. The new dimensions: W = " + to_string(buffer.Width())
 				+ ", H = " + to_string(buffer.Height()) + '.', Logger::Level::INFO);
 
-		// Upload the image data.
 		if(proxySuccess)
+#endif
+			// Upload the image data.
 			glTexImage3D(type, 0, GL_RGBA8, // target, mipmap level, internal format,
 				buffer.Width(), buffer.Height(), buffer.Frames(), // width, height, depth,
 				0, GL_RGBA, GL_UNSIGNED_BYTE, buffer.Pixels()); // border, input format, data type, data.
+#ifndef ES_GLES
 		else
 			Logger::Log("Sprite \"" + name + "\" could not be uploaded to the GPU. Dimensions: W = "
 				+ to_string(buffer.Width()) + ", H = " + to_string(buffer.Height())
 				+ ", D = " + to_string(buffer.Frames()) + '.', Logger::Level::WARNING);
+#endif
 
 		// Unbind the texture.
 		glBindTexture(type, 0);

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -75,7 +75,7 @@ namespace {
 		}
 		if(forcedShrinkCount)
 			Logger::Log("Shrank sprite \"" + name + "\" "
-				+ (forcedShrinkCount == 1 ? "1 time" : to_string(forcedShrinkCount) + " times")
+				+ Format::SimplePluralization(forcedShrinkCount, "time")
 				+ " to fit within hardware limits. The new dimensions: W = " + to_string(buffer.Width())
 				+ ", H = " + to_string(buffer.Height()) + '.', Logger::Level::INFO);
 


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Added a proxy upload before an image buffer is uploaded to the GPU to check if the upload is possible. As long as this check fails, the buffer is being shrunk until the GPU accepts it or no further shrinking is possible. This isn't controlled by the normal reduction preference, and doesn't respect the `@1x` sprite marker, because I think it's better to have a sprite at a lower resolution than not have it at all.
I've been considering something like [stb](https://github.com/nothings/stb/blob/31c1ad37456438565541f4919958214b6e762fb4/stb_image_resize2.h) to resize buffers precisely to what OpenGL tells us in terms of texture limits, but the use case is pretty rare (mostly weak hardware), and the available OpenGL constants aren't guaranteed to be 100% accurate, so I went with applying the existing shrinking algorithm in a loop.

## Testing Done
Tested on hardware where quite a few larger textures were failing to upload before this change, which resulted in them becoming completely transparent. Now they render at a reduced resolution.

## Performance Impact
There might be a non-zero overhead, because we do a proxy check before every texture upload, but on the other hand we no longer try to allocate the VRAM for the texture if we know it'll fail, so I guess it's fine.