### PR TITLE
fix(ui): Display plugin dependencies that only contain game version

### DIFF
--- a/source/Plugin.cpp
+++ b/source/Plugin.cpp
@@ -24,7 +24,7 @@ using namespace std;
 // Checks if there are any dependencies of any kind.
 bool Plugin::PluginDependencies::IsEmpty() const
 {
-	return required.empty() && optional.empty() && conflicted.empty();
+	return gameVersion.empty() && required.empty() && optional.empty() && conflicted.empty();
 }
 
 


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Without this fix, plugin dependency metadata that only contains game version requirements is considered empty and doesn't get displayed on the plugin view page in preferences.

## Testing Done
yes.

## Performance Impact
None.
