### PR TITLE
(bugfix) make to offer conditions of Hai Legacy 1 and 2 the same.

### DIFF
--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -245,8 +245,8 @@ mission "Hai Legacy 2"
 		not "Hai Legacy 1: declined"
 		has "First Contact: Unfettered: offered"
 		"reputation: Hai (Unfettered)" < 0
-		not "Unfettered Jump Drive 2: offered"
-		"credits" >= 10000000
+		not "Unfettered Jump Drive 1: offered"
+		"credits" + "net worth" * ( 1 - "Hai Legacy 1: deferred" ) >= 10000000
 	to accept
 		has "ship model: Anomalocaris"
 	on offer


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in issue #12562

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Hai Legacy 1 and 2 should always offer under the same conditions.  Offering them under different conditions can temporarily lock the player from being able to complete the quest line.

## Testing Done
Tested with save file.

## Save File
Same as in Issue #12562 

## Performance Impact
None, this is a data only change.