### PR TITLE
content: drop unnecessary immediate launch from 'Remnant Keystone 6'

### DIFF
--- a/data/remnant/remnant 1 introduction.txt
+++ b/data/remnant/remnant 1 introduction.txt
@@ -3392,8 +3392,8 @@ mission "Remnant: Keystone Research 6"
 	on offer
 		conversation
 			`When you and the <npc> settle back onto the landing pad, there is already a dockworker waiting with a Key Stone. Once the Starling is settled, the dockworker climbs up the outside of the ship, hooks the keystone to a lift and disconnects it from the ship. As the keystone is hauled up to the roof another lift lowers the replacement Key Stone. The dockworker quickly installs it and jumps down, landing gracefully from the several-meter drop.`
-			`	"Ready? Let's go!" Aeolus signs as he fires up his systems and gestures an acknowledgment to the dockworker. You check your cameras and see the worker nimbly step clear of the engine exhausts as the two ships head back out of the dome.`
-				launch
+			`	"Ready? Let's go!" Aeolus signs as he fires up his systems and gestures an acknowledgment to the dockworker. You check your cameras and see the worker nimbly step clear of the engine exhausts.`
+				accept
 	on visit
 		dialog `You land on <planet>, but you have not scanned the <npc> in <waypoints>. Make sure you scan the ship before returning.`
 	on complete


### PR DESCRIPTION
**Content (Missions)**

Do not force an immediate launch during 'Remnant Keystone 6', as the player may wish to conduct business on Viminal first.

This PR addresses the bug/feature described in issue #12177

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Drop the `launch` keyword and slightly tweak the narrative text to remove the claim that the two ships are immediately launching. (Having the dockworker jump out of the way of both ship exhausts _as they're taking off_, ie the worker is still in motion and halfway through getting clear while the engines are firing, was a very questionable occurrence anyway.)
