### PR TITLE
docs: Update build instructions for RPM based distros.

### DIFF
--- a/docs/readme-developer.md
+++ b/docs/readme-developer.md
@@ -95,8 +95,9 @@ pkgconf
 ```
 Additionally, if you want to build unit tests:
 ```
-catch2-devel
+catch2-devel libubsan libasan
 ```
+While sufficient versions of other dependencies are available, Fedora 44 does not provide an up to date version of catch2 (3.0 or newer is required), so this will need to be built from source if unit tests are desired. When using Catch2 built from source, the `Catch2_DIR` environment variable must be set to the installation directory of Catch2 during the configuration step below.
 
 </details>
 


### PR DESCRIPTION
**Documentation**

The build documentation was slightly outdated:
- Needed libubsan and libasan to build tests.
- Has the same version catch2-devel caveat as for Ubuntu 22.04 for Fedora 44 (and I presume others).

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Testing Done

I successfully built and ran the game/tests from a Fedora 44 installation (and hermetic docker container to make certain there weren't any implicit dependencies left unspecified).

This does not add story content, artwork, features, or anything relevant to the PR sections that I deleted here.
