### PR TITLE
Update MissionAction::CanBeDone to better check availability of outfits to take

### DIFF
--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1012,20 +1012,21 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 		return false;
 
 	bool isFailed = IsFailed();
+	bool offersInFlight = (location & (Location::ASSISTING | Location::BOARDING | Location::ENTERING | Location::TRANSITION));
 	auto it = actions.find(OFFER);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, boardingShip))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight, boardingShip))
 		return false;
 
 	it = actions.find(ACCEPT);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, boardingShip))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight, boardingShip))
 		return false;
 
 	it = actions.find(DECLINE);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, boardingShip))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight, boardingShip))
 		return false;
 
 	it = actions.find(DEFER);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, boardingShip))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight, boardingShip))
 		return false;
 
 	return true;
@@ -1039,12 +1040,13 @@ bool Mission::CanAccept(const PlayerInfo &player) const
 		return false;
 
 	bool isFailed = IsFailed();
+	bool offersInFlight = (location & (Location::ASSISTING | Location::BOARDING | Location::ENTERING | Location::TRANSITION));
 	auto it = actions.find(OFFER);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight))
 		return false;
 
 	it = actions.find(ACCEPT);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, offersInFlight))
 		return false;
 	return HasSpace(player);
 }
@@ -1095,7 +1097,7 @@ bool Mission::IsSatisfied(const PlayerInfo &player) const
 
 	// Determine if any fines or outfits that must be transferred, can.
 	auto it = actions.find(COMPLETE);
-	if(it != actions.end() && !it->second.CanBeDone(player, IsFailed()))
+	if(it != actions.end() && !it->second.CanBeDone(player, IsFailed(), true))
 		return false;
 
 	// NPCs which must be accompanied or evaded must be present (or not),
@@ -1291,7 +1293,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 	}
 
 	// Don't update any further conditions if this action exists and can't be completed.
-	if(it != actions.end() && !it->second.CanBeDone(player, IsFailed(), boardingShip))
+	if(it != actions.end() && !it->second.CanBeDone(player, IsFailed(), player.GetPlanet(), boardingShip))
 		return false;
 
 	if(trigger == ACCEPT)
@@ -1829,7 +1831,7 @@ bool Mission::Enter(const System *system, PlayerInfo &player, UI &ui)
 {
 	const auto eit = onEnter.find(system);
 	const auto originalSize = didEnter.size();
-	if(eit != onEnter.end() && !didEnter.contains(&eit->second) && eit->second.CanBeDone(player, IsFailed()))
+	if(eit != onEnter.end() && !didEnter.contains(&eit->second) && eit->second.CanBeDone(player, IsFailed(), false))
 	{
 		eit->second.Do(player, &ui, this);
 		didEnter.insert(&eit->second);
@@ -1838,7 +1840,7 @@ bool Mission::Enter(const System *system, PlayerInfo &player, UI &ui)
 	// which may use a LocationFilter to govern which systems it can be performed in.
 	else
 		for(MissionAction &action : genericOnEnter)
-			if(!didEnter.contains(&action) && action.CanBeDone(player, IsFailed()))
+			if(!didEnter.contains(&action) && action.CanBeDone(player, IsFailed(), false))
 			{
 				action.Do(player, &ui, this);
 				didEnter.insert(&action);
@@ -1854,14 +1856,14 @@ bool Mission::Land(const Planet *planet, PlayerInfo &player, UI &ui)
 {
 	const auto lit = onLand.find(planet);
 	const auto originalSize = didLand.size();
-	if(lit != onLand.end() && !didLand.contains(&lit->second) && lit->second.CanBeDone(player, IsFailed()))
+	if(lit != onLand.end() && !didLand.contains(&lit->second) && lit->second.CanBeDone(player, IsFailed(), true))
 	{
 		lit->second.Do(player, &ui, this);
 		didLand.insert(&lit->second);
 	}
 	else
 		for(MissionAction &action : genericOnLand)
-			if(!didLand.contains(&action) && action.CanBeDone(player, IsFailed()))
+			if(!didLand.contains(&action) && action.CanBeDone(player, IsFailed(), true))
 			{
 				action.Do(player, &ui, this);
 				didLand.insert(&action);

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -111,6 +111,15 @@ namespace {
 				return "unknown trigger";
 		}
 	}
+
+	bool LocationInFlight(Mission::Location location)
+	{
+		return location & (
+			Mission::Location::ASSISTING |
+			Mission::Location::BOARDING |
+			Mission::Location::ENTERING |
+			Mission::Location::TRANSITION);
+	}
 }
 
 
@@ -1012,7 +1021,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 		return false;
 
 	bool isFailed = IsFailed();
-	bool offersInFlight = (location & (Location::ASSISTING | Location::BOARDING | Location::ENTERING | Location::TRANSITION));
+	bool offersInFlight = LocationInFlight(location);
 	auto it = actions.find(OFFER);
 	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight, boardingShip))
 		return false;
@@ -1040,7 +1049,7 @@ bool Mission::CanAccept(const PlayerInfo &player) const
 		return false;
 
 	bool isFailed = IsFailed();
-	bool offersInFlight = (location & (Location::ASSISTING | Location::BOARDING | Location::ENTERING | Location::TRANSITION));
+	bool offersInFlight = LocationInFlight(location);
 	auto it = actions.find(OFFER);
 	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight))
 		return false;

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1055,7 +1055,7 @@ bool Mission::CanAccept(const PlayerInfo &player) const
 		return false;
 
 	it = actions.find(ACCEPT);
-	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, offersInFlight))
+	if(it != actions.end() && !it->second.CanBeDone(player, isFailed, !offersInFlight))
 		return false;
 	return HasSpace(player);
 }

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -215,7 +215,7 @@ string MissionAction::DialogText() const
 
 // Check if this action can be completed right now. It cannot be completed
 // if it takes away money or outfits that the player does not have.
-bool MissionAction::CanBeDone(const PlayerInfo &player, bool isFailed, const shared_ptr<Ship> &boardingShip) const
+bool MissionAction::CanBeDone(const PlayerInfo &player, bool isFailed, bool executeWhenLanded, const shared_ptr<Ship> &boardingShip) const
 {
 	if(isFailed && !runsWhenFailed && trigger != "fail")
 		return false;
@@ -229,12 +229,13 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, bool isFailed, const sha
 		if(it.second > 0)
 			continue;
 
-		// Outfits may always be taken from the flagship. If landed, they may also be taken from
-		// the collective cargo hold of any in-system, non-disabled escorts (player.Cargo()). If
-		// boarding, consider only the flagship's cargo hold. If in-flight, show mission status
-		// by checking the cargo holds of ships that would contribute to player.Cargo if landed.
+		// Outfits may always be taken from the flagship, either installed or in cargo.
+		// If landed, they may also be taken from the player's pooled cargo.
+		// If in-flight, not boarding, and the action is to be executed while landed,
+		// show mission status by checking the cargo holds of ships that would
+		// contribute to pooled cargo if landed.
 		int available = flagship ? flagship->OutfitCount(it.first) : 0;
-		available += boardingShip ? flagship->Cargo().Get(it.first)
+		available += (boardingShip || !executeWhenLanded) ? flagship->Cargo().Get(it.first)
 				: CountInCargo(it.first, player);
 
 		if(available < -it.second)

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -215,7 +215,8 @@ string MissionAction::DialogText() const
 
 // Check if this action can be completed right now. It cannot be completed
 // if it takes away money or outfits that the player does not have.
-bool MissionAction::CanBeDone(const PlayerInfo &player, bool isFailed, bool executeWhenLanded, const shared_ptr<Ship> &boardingShip) const
+bool MissionAction::CanBeDone(const PlayerInfo &player, bool isFailed,
+	bool executeWhenLanded, const shared_ptr<Ship> &boardingShip) const
 {
 	if(isFailed && !runsWhenFailed && trigger != "fail")
 		return false;

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -65,7 +65,8 @@ public:
 	// if it takes away money or outfits that the player does not have, or should
 	// take place in a system that does not match the specified LocationFilter.
 	// It can also not be done if the mission is failed, and the trigger doesn't support it.
-	bool CanBeDone(const PlayerInfo &player, bool isFailed, bool executeWhenLanded, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
+	bool CanBeDone(const PlayerInfo &player, bool isFailed, bool executeWhenLanded,
+		const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	// Check if this action requires this ship to exist in order to ever be completed.
 	bool RequiresGiftedShip(const std::string &shipId) const;
 	// Perform this action. If a conversation is shown, the given destination

--- a/source/MissionAction.h
+++ b/source/MissionAction.h
@@ -65,7 +65,7 @@ public:
 	// if it takes away money or outfits that the player does not have, or should
 	// take place in a system that does not match the specified LocationFilter.
 	// It can also not be done if the mission is failed, and the trigger doesn't support it.
-	bool CanBeDone(const PlayerInfo &player, bool isFailed, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
+	bool CanBeDone(const PlayerInfo &player, bool isFailed, bool executeWhenLanded, const std::shared_ptr<Ship> &boardingShip = nullptr) const;
 	// Check if this action requires this ship to exist in order to ever be completed.
 	bool RequiresGiftedShip(const std::string &shipId) const;
 	// Perform this action. If a conversation is shown, the given destination


### PR DESCRIPTION
**Bug fix**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
When a mission action is to take an outfit from the player, the `CanBeDone` method will check if the player has that outfit to take.
However, the check has not kept up with the new places mission actions can occur.
Previously, (with the exception of fail and abort) a mission action could only occur when landed or when boarding a ship.
Now, a mission action can occur when entering a system; not landed, and not boarding a ship.
The existing check assumes that, if not boarding, we are landed, and so inspects the cargo of all active, in system ships. That is, all the ships whose cargo would be pooled if the player were to land. This is for the purposes of showing the status of in progress missions that may want to take an outfit upon completion in the map.
However, it means that missions that offer on entering or transition may offer even though the offer mission action cannot be done.
This is because the acto f actually taking the outfits does not take from the cargo holds of escorts, only from the flagship cargo hold or (if landed) the player's pooled cargo (or the flagship's installed outfits).
This PR updates `MissionAction::CanBeDone` to better match the actual behaviour. If this action is to be triggered when landed, it will check the cargo holds of escorts that would contribute to the pooled cargo hold if the player were to land right now, but if the action is to be executed in flight, even if not while boarding a ship, it will only consider the flagship's cargo hold.

## Testing Done
None.

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/248

## Performance Impact
Probably not relevant.
