### PR TITLE
Add an autocondition which checks how many of the given outfit can be taken by a GameAction

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4523,30 +4523,6 @@ void PlayerInfo::RegisterDerivedConditions()
 		return retVal;
 	});
 
-	// This condition matches the behaviour of the "require <outfit> <count>" mission trigger child.
-	conditions["outfit (require): "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
-		if(!flagship)
-			return 0;
-		const Outfit *outfit = GameData::Outfits().Find(ce.NameWithoutPrefix());
-		if(!outfit)
-			return 0;
-		int64_t retVal = 0;
-		retVal += flagship->OutfitCount(outfit);
-		if(planet)
-			retVal += cargo.Get(outfit);
-		else
-		{
-			for(const auto &ship : ships)
-			{
-				if(ship->IsDisabled() || ship->IsParked())
-					continue;
-				if(ship->GetActualSystem() == system)
-					retVal += ship->Cargo().Get(outfit);
-			}
-		}
-		return retVal;
-	});
-
 	// This condition corresponds to the method by which the flagship entered the current system.
 	conditions["entered system by: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		return !ce.NameWithoutPrefix().compare(EntryToString(entry)); });

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4509,6 +4509,20 @@ void PlayerInfo::RegisterDerivedConditions()
 		return retVal;
 	});
 
+	// This condition checks locations that a GameAction can take outfits from.
+	// That is, outfits installed on the flagship, and in player cargo (when landed) or flagship cargo (when not).
+	conditions["outfit (removable): "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
+		if(!flagship)
+			return 0;
+		const Outfit *outfit = GameData::Outfits().Find(ce.NameWithoutPrefix());
+		if(!outfit)
+			return 0;
+		int64_t retVal = 0;
+		retVal += flagship->OutfitCount(outfit);
+		retVal += (planet ? cargo : flagship->Cargo()).Get(outfit);
+		return retVal;
+	});
+
 	// This condition corresponds to the method by which the flagship entered the current system.
 	conditions["entered system by: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		return !ce.NameWithoutPrefix().compare(EntryToString(entry)); });

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4523,6 +4523,30 @@ void PlayerInfo::RegisterDerivedConditions()
 		return retVal;
 	});
 
+	// This condition matches the behaviour of the "require <outfit> <count>" mission trigger child.
+	conditions["outfit (require): "].ProvidePrefixed([this](const ConditionEntry &ce) -> int64_t {
+		if(!flagship)
+			return 0;
+		const Outfit *outfit = GameData::Outfits().Find(ce.NameWithoutPrefix());
+		if(!outfit)
+			return 0;
+		int64_t retVal = 0;
+		retVal += flagship->OutfitCount(outfit);
+		if(planet)
+			retVal += cargo.Get(outfit);
+		else
+		{
+			for(const auto &ship : ships)
+			{
+				if(ship->IsDisabled() || ship->IsParked())
+					continue;
+				if(ship->GetActualSystem() == system)
+					retVal += ship->Cargo().Get(outfit);
+			}
+		}
+		return retVal;
+	});
+
 	// This condition corresponds to the method by which the flagship entered the current system.
 	conditions["entered system by: "].ProvidePrefixed([this](const ConditionEntry &ce) -> bool {
 		return !ce.NameWithoutPrefix().compare(EntryToString(entry)); });


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Adds a new autocondition:
`outfit (removable): <outfit>` which gives the maximum number of the given outfit which can be removed by the "outfit <outfit>" game action child.

## Usage examples
```
to offer
    "outfit (removable): Heavy Laser" >= 2
```

## Testing Done
None

## Wiki Update
https://github.com/endless-sky/endless-sky-wiki/pull/249

## Performance Impact
N/A
