### PR TITLE
feat(content): Make deadline visible in the TMBR 0 mission summary

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -671,7 +671,7 @@ event "assisted the deep"
 mission "Deep: TMBR 0"
 	minor
 	name `Find "There Might Be Riots"`
-	description `Find and convince "There Might Be Riots" to throw a concert on <destination>.`
+	description `Find "There Might Be Riots" by <date> and convince them to throw a concert on <destination>.`
 	source
 		not system "Aludra"
 		attributes "deep"


### PR DESCRIPTION
#7969

**Content (Artwork / Missions / Jobs)**

This PR addresses the bug/feature described in issue #7969

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Add the mission deadline to the "Deep: TMBR 0" description, to help the player prioritise it correctly.
