### PR TITLE
Update post-war reactions.txt

### DIFF
--- a/data/human/post-war reactions.txt
+++ b/data/human/post-war reactions.txt
@@ -210,6 +210,12 @@ mission "War Reactions: Syndicate Orphan"
 					goto young
 				`	"I'm in a hurry. You're on your own."`
 					decline
+					to display
+						not "WR: Orphan: attacking"
+				`	"That's rough buddy, but I'm in a hurry. You're on your own."`
+					decline
+					to display
+						"WR: Orphan: attacking"
 			label attacking
 			action
 				set "WR: Orphan: attacking"

--- a/data/human/post-war reactions.txt
+++ b/data/human/post-war reactions.txt
@@ -215,7 +215,7 @@ mission "War Reactions: Syndicate Orphan"
 				`	"That's rough buddy, but I'm in a hurry. You're on your own."`
 					decline
 					to display
-						"WR: Orphan: attacking"
+						has "WR: Orphan: attacking"
 			label attacking
 			action
 				set "WR: Orphan: attacking"

--- a/data/human/post-war reactions.txt
+++ b/data/human/post-war reactions.txt
@@ -212,7 +212,7 @@ mission "War Reactions: Syndicate Orphan"
 					decline
 					to display
 						not "WR: Orphan: attacking"
-				`	"That's rough buddy, but I'm in a hurry. You're on your own."`
+				`	"That's rough, buddy, but I'm in a hurry. You're on your own."`
 					decline
 					to display
 						has "WR: Orphan: attacking"


### PR DESCRIPTION
getting the dialogue if you leave the orphan behind to make sense based on when you say it in the conversation.

(The lines in parentheses (like this one) are instructions for filling out this template. These lines can be deleted.)
(The lines in double curly brackets ({{}}) should be replaced as it describes.)
(You can open a PR to add to or improve this template, if you find it lacking!)

**Typo/Dialogue fix**

This PR addresses the bug/feature described in issue #{{insert number}}

## Acknowledgement

- [ x ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
I didn't like how the War Reactions: Syndicate Orphan dialogue sounds if you ask the kid why they're being attacked because the options given are copied over from an earlier part of the conversation so I added a couple lines to display a different response if and only if you've asked why the kid was being attacked.

If this goes well, I'd like to take a look at some other dialogue loops in the game (I'm thinking specifically about the 'date' first last goes on the the Ember Wastes)

## Testing Done
I did a couple runs of the dialogue in game and had no issues.

## Save File
tbh, I have no idea how to add a whole save file to a PR. I just deleted the lines 
        "War Reactions: Syndicate Orphan: declined"
	"War Reactions: Syndicate Orphan: offered"
        ""WR: Orphan: attacking"
and commented out the random chance in the mission "War Reactions: Syndicate Orphan" to get it to offer every time. 

## Artwork Checklist
no artwork changes


## Performance Impact
n/a
