### PR TITLE
feat(ui): Rename "max" to "capacity" in the ship energy/heat table

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -919,8 +919,8 @@ tip "charging shields:"
 tip "net change:"
 	`The sum of the energy consumed and heat generated from the above energy and heat values. Represents the worst case scenario when all systems are active at once.`
 
-tip "max:"
-	`Energy storage capacity and maximum safe level for heat generation. Energy capacity allows a ship to temporarily draw more energy than it produces. The heat maximum is the highest your heat generation can be without eventually causing your ship to overheat.`
+tip "capacity:"
+	`Energy storage capacity and heat capacity. Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries. The heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship.`
 
 
 

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -421,7 +421,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributesHeight += 20;
 	const double maxEnergy = attributes.Get("energy capacity");
 	const double maxHeat = 60. * ship.HeatDissipation() * ship.MaximumHeat();
-	tableLabels.push_back("max:");
+	tableLabels.push_back("capacity:");
 	energyTable.push_back(Format::Number(maxEnergy));
 	heatTable.push_back(Format::Number(maxHeat));
 	// Pad by 10 pixels on the top and bottom.


### PR DESCRIPTION
**Feature**

This PR addresses #12598.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
"max" in the energy/heat table is a little ambiguous. This PR changes it to instead read "capacity", and slightly updates the tooltip to match.

## Screenshots + Testing Done
<img width="505" height="359" alt="image" src="https://github.com/user-attachments/assets/a405cdeb-6e04-455a-be43-857dc9ee450e" />
