### PR TITLE
Trigger Timothy Radrickson 5e on landing.

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -10291,6 +10291,7 @@ mission "Timothy Radrickson 5d: Greenrock"
 
 
 mission "Timothy Radrickson 5e: Back to Oblivion"
+	landing
 	source Oblivion
 	to offer
 		has "Timothy Radrickson 5a: Timshank Redemption: done"


### PR DESCRIPTION
**Content (missions) / Bug fix**

I spent an hour trying to debug why this mission was not displaying for me, and I thought it was a deadline problem (I was landing the day before 5a expired), but it turned out I just hadn't clicked "Spaceport". Sigh.

Given the text reads "Your ship touches down…" and then discusses going to somewhere that is NOT the Spaceport, I think this fix is what the original author had intended.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Trigger 5e on landing.

## Screenshots
n/a

## Usage examples
Get all items on the list. Land on Oblivion.

## Testing Done
Landed on Oblivion with save file attached:

## Save File
This save file can be used to test these changes:
[Myfanwy Angharad~Timshank bug.txt](https://github.com/user-attachments/files/30862902/Myfanwy.Angharad.Timshank.bug.txt)

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
n/a