### PR TITLE
Fix IntelliSense squiggles in VSCode on Mac OS.

### DIFF
--- a/source/opengl.h
+++ b/source/opengl.h
@@ -17,7 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 // Include whichever header is used for OpenGL on this operating system.
 #ifdef __APPLE__
-#include <OpenGL/GL3.h>
+#include <OpenGL/gl3.h>
 #else
 #ifdef ES_GLES
 #include <GLES3/gl3.h>


### PR DESCRIPTION
**Build environment**

This PR eliminates the "missing OpenGL header" red squiggles in VSCode on MacOS (at least, on my machine).

MacOS is case-insensitive, so the build has always worked fine, but some aspect of VSCode's IntelliSense implementation is NOT case insensitive, and it could not find the header files.

The `locate` UNIX tool is case sensitive when searching its database, and it reports:

```console
% locate gl.h
...
/Library/Developer/CommandLineTools/SDKs/MacOSX26.2.sdk/System/Library/Frameworks/OpenGL.framework/Versions/A/Headers/gl.h
# and all other MacOS & iOS SDKs I have on my machine
...
% locate GL.h
# ...nothing relevant returned
```

Since it touches such a core element of the build, it should be validated on the CI machines and perhaps by other Mac devs before merging. But it makes me happy.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Change case of include statement to match case of real file.

## Screenshots
n/a

## Usage examples
n/a

## Testing Done
VSCode displayed red "missing import" errors, although was able to build with cmake without issue.
Now I don't get those. I've been using it for a few days like this without a problem.

## Save File
n/a

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
n/a
