### PR TITLE
feat(balance): Double the Pond Strider's fuel capacity

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -812,7 +812,7 @@ ship "Pond Strider"
 		"drag" 5.33
 		"hull repair rate" 1
 		"heat dissipation" .34
-		"fuel capacity" 300
+		"fuel capacity" 600
 		"cargo space" 71
 		"outfit space" 354
 		"weapon capacity" 144


### PR DESCRIPTION
**Balance**

This PR addresses issue #12505.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Doubled the Pond Strider's fuel capacity to 600.

The new fuel capacity is the higher of the two proposed values given in #12505. I felt this was the more appropriate value given the role and number of drones carried by the Strider. It also fits nicely in between the Tier 1 Aerie (500) and Tier 1.5 Ibis (700) medium warship carriers, although these ships aren't exactly comparable (they carry different numbers of different things).

If 600 is too high a fuel capacity, I wouldn't object to it being reduced to 500, although that feels a bit too low to me, given that the Lightning Bug has a fuel capacity of 600 and serves in a similar escort role. The other peaceful Hai warship, the Shield Beetle, has a fuel capacity of 500 presumably because it's far more powerful (it does not rely on drones that use ammunition for most of its ionization damage, and has much more shields and hull) and has ample outfit space.