### PR TITLE
fix(mechanics): Make sure that admin costs are saved and passed on to variants

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -647,6 +647,8 @@ void Ship::FinishLoading(bool isNewInstance)
 			static_cast<Body &>(*this) = *base;
 		if(customSwizzleName.empty())
 			customSwizzleName = base->CustomSwizzleName();
+		if(!administrativeCost.has_value())
+			administrativeCost = base->administrativeCost;
 		if(baseAttributes.Attributes().empty())
 			baseAttributes = base->baseAttributes;
 		if(bays.empty() && !base->bays.empty() && !removeBays)
@@ -974,6 +976,8 @@ void Ship::Save(DataWriter &out) const
 			out.Write("uncapturable");
 		if(customSwizzle && customSwizzle->IsLoaded())
 			out.Write("swizzle", customSwizzle->Name());
+		if(administrativeCost.has_value())
+			out.Write("administrative cost", administrativeCost.value());
 
 		out.Write("uuid", uuid.ToString());
 


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in the comments of #12540

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

If an admin cost was added to a ship, that cost wasn't being passed down to its variants, nor saved in the save file. This meant that capturing a variant of a ship would always have a default cost of 1, and reloading the save file would set the cost of anything you purchased to 1.

## Testing Done

Tested with #12540. Looked at the Auxiliaries in the shipyard. They all had the same fleet cost. Bought one and reloaded the save and it maintained its cost.