### PR TITLE
fix(segfault): Generate new pilot IDs using the stored pilots instead of looking for existing files

### DIFF
--- a/source/GameLoadingPanel.cpp
+++ b/source/GameLoadingPanel.cpp
@@ -22,6 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "image/MaskManager.h"
 #include "MenuAnimationPanel.h"
 #include "MenuPanel.h"
+#include "PilotProfile.h"
 #include "PlayerInfo.h"
 #include "Point.h"
 #include "image/SpriteSet.h"
@@ -57,6 +58,7 @@ void GameLoadingPanel::Step()
 		// Set the game's initial internal state.
 		GameData::FinishLoading();
 
+		PilotProfile::LoadProfiles();
 		player.LoadRecent();
 
 		// All sprites with collision masks should also have their 1x scaled versions, so create

--- a/source/PilotProfile.cpp
+++ b/source/PilotProfile.cpp
@@ -147,20 +147,14 @@ shared_ptr<PilotProfile> &PilotProfile::NewProfile()
 std::string PilotProfile::GetIdentifier(const std::string &pilotName)
 {
 	string name = pilotName;
-	string basePath = (Files::Pilots() / name).string();
+	map<string, shared_ptr<PilotProfile>> existingProfiles = GetProfileMap();
 	int index = 0;
 	while(true)
 	{
-		string path = basePath;
 		if(index++)
-		{
-			string suffix = " " + to_string(index);
-			path += suffix;
-			name = pilotName + suffix;
-		}
-		path += ".txt";
+			name = pilotName + " " + to_string(index);
 
-		if(!Files::Exists(path))
+		if(!existingProfiles.contains(name))
 			break;
 	}
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -36,6 +36,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "MainPanel.h"
 #include "MenuPanel.h"
 #include "Panel.h"
+#include "PilotProfile.h"
 #include "PlayerInfo.h"
 #include "PluginManager.h"
 #include "Preferences.h"
@@ -222,6 +223,7 @@ int main(int argc, char *argv[])
 
 			// Reference check the universe, as known to the player. If no player found,
 			// then check the default state of the universe.
+			PilotProfile::LoadProfiles();
 			if(!player.LoadRecent())
 				GameData::CheckReferences();
 			cout << "Parse completed with " << (hasErrors ? "at least one" : "no") << " error(s)." << endl;


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12622.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Following #12351, save files are given a pilot profile that is updated every time the main save file is updated. Since the pilot file is only created when needed, save files from versions of the game prior to this PR will not have a pilot file set up.

When a new pilot is created, PilotProfile::GetIdentifier is called to determine what the name of the save and pilot files should be. This allows two different pilots to share the same name by appending a numeric suffix to duplicate pilot names. The way that this function currently works is that it constructs a full file path and looks at the existing pilot profile files. Since, as I outlined, pilot files are only created when the save file is updated, this can result in the creation of saves with names that conflict with old save files. This overwrites the old save files if you manage to update the save, but can also result in a segfault per the reproduction steps in #12622.

This PR updates GetIdentifier to look at the currently available PilotProfiles instead of the currently existing pilot files. I've also added calls to PilotProfile::LoadProfiles alongside the calls to PlayerInfo::LoadRecent so that we actually have the PilotProfiles available when they're needed by GetIdentifier.

## Testing Done

Tested the same scenario as https://github.com/endless-sky/endless-sky/issues/12622#issuecomment-5310438377.