### PR TITLE
fix(segfault): Don't check if a ship definition is disabled + adjust the NeedsEnergy check

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1433,7 +1433,7 @@ void AI::AskForHelp(Ship &ship, bool &isStranded, const Ship *flagship)
 			{
 				// Disabled, overheated, or otherwise untargetable ships pose no threat.
 				bool harmless = helper->IsDisabled() || (helper->IsOverheated() && helper->Heat() >= 1.1)
-						|| !helper->IsTargetable();
+					|| !helper->IsTargetable() || helper->NeedsEnergy();
 				hasEnemy |= (system == helper->GetSystem() && !harmless);
 				if(hasEnemy)
 					break;
@@ -5095,7 +5095,7 @@ void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const Syste
 		if(it->GetGovernment() && it->GetSystem() == playerSystem)
 		{
 			governmentRosters[it->GetGovernment()].emplace_back(it.get());
-			if(!it->IsDisabled() && !it->IsOverheated() && !it->IsIonized())
+			if(!it->IsDisabled() && !it->IsOverheated() && !it->IsIonized() && !it->NeedsEnergy())
 				strength[it->GetGovernment()] += it->Strength();
 		}
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -92,7 +92,7 @@ namespace {
 			if(count == 0 || count == 2)
 				return Radar::BLINK;
 		}
-		if(ship.IsDisabled() || (ship.IsOverheated() && ((step / 20) % 2)))
+		if(ship.IsDisabled() || ship.NeedsEnergy() || (ship.IsOverheated() && ((step / 20) % 2)))
 			return Radar::INACTIVE;
 		if(ship.IsYours() || (ship.GetPersonality().IsEscort() && !ship.GetGovernment()->IsEnemy()))
 			return Radar::PLAYER;

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -84,7 +84,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 	else if(ship->IsDisabled())
 	{
 		const Ship *flagship = player.Flagship();
-		if(flagship->NeedsFuel(false) || flagship->IsDisabled())
+		if(flagship->NeedsFuel(false) || flagship->IsDisabled() || flagship->NeedsEnergy())
 			SetMessage("Sorry, we can't help you, because our ship is disabled.");
 	}
 	else
@@ -117,7 +117,7 @@ HailPanel::HailPanel(PlayerInfo &player, const shared_ptr<Ship> &ship, function<
 
 		if(ship->GetShipToAssist() == player.FlagshipPtr())
 			SetMessage("Hang on, we'll be there in a minute.");
-		else if(canGiveFuel || canRepair)
+		else if(canGiveFuel || canGiveEnergy || canRepair)
 		{
 			string helpOffer = "Looks like you've gotten yourself into a bit of trouble. "
 				"Would you like us to ";

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2374,7 +2374,7 @@ bool Ship::IsDisabled() const
 
 	double minimumHull = MinimumHull();
 	bool needsCrew = RequiredCrew() != 0;
-	return (hull < minimumHull || (!crew && needsCrew) || NeedsEnergy());
+	return (hull < minimumHull || (!crew && needsCrew));
 }
 
 
@@ -5029,7 +5029,8 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 	double dragForce = DragForce();
 	double slowMultiplier = 1. / (1. + slowness * .05);
 
-	if(isDisabled)
+	// Ships that can't move due to being disabled or a lack of energy should drift to a stop.
+	if(isDisabled || NeedsEnergy())
 		velocity *= 1. - dragForce;
 	else if(!pilotError)
 	{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2357,15 +2357,12 @@ bool Ship::IsIonized() const
 		return false;
 
 	// A ship can only be fully ionized if its engines or weapons require energy.
-	bool usesEnergy = attributes.Get("thrusting energy") > 0
-		|| attributes.Get("reverse thrusting energy") > 0
-		|| attributes.Get("turning energy") > 0
+	bool useEnergy = RequiresMovementEnergy()
 		|| any_of(outfits.begin(), outfits.end(), [](const auto &it) -> bool {
 			const Weapon *weapon = it.first->GetWeapon().get();
-			return weapon && weapon->FiringEnergy() > 0;
+			return weapon && weapon->FiringEnergy() > 0.;
 		});
-
-	return usesEnergy ? ionization > energy : false;
+	return useEnergy ? ionization > energy : false;
 }
 
 
@@ -3047,11 +3044,19 @@ bool Ship::NeedsEnergy() const
 	if(!currentSystem)
 		return false;
 
-	// If a ship has no energy capacity, no room for more energy, or already has
-	// some energy in reserves, it does not need energy. Since engines can use
-	// fractional thrust/turn, even a small unit of energy can still have use.
+	// Ships that don't need energy to move shouldn't ask for energy.
+	if(!RequiresMovementEnergy())
+		return false;
+
+	// If a ship has no energy capacity or no room for more energy, it does not need energy.
 	double capacity = attributes.Get("energy capacity");
-	if(!capacity || (capacity && energy >= capacity) || energy > 0.25)
+	if(!capacity || energy >= capacity)
+		return false;
+
+	// If this ship has even a small amount of energy in reserves, it does not need energy.
+	// Since engines can use fractional thrust/turn, even a small unit of energy can still have use.
+	// Using an epsilon of 1/2^8.
+	if(energy > 0.00390625)
 		return false;
 
 	// If a ship has energy capacity but is low on energy, check to see if it is capable
@@ -5320,6 +5325,17 @@ void Ship::DoEngineVisuals(vector<Visual> &visuals, bool isUsingAfterburner)
 					visuals.emplace_back(*it.first, pos, effectVelocity, afterburnerAngle, Point{}, point.zoom);
 		}
 	}
+}
+
+
+
+bool Ship::RequiresMovementEnergy() const
+{
+	bool hasForwardThrust = attributes.Get("thrust");
+	return attributes.Get("thrusting energy") > 0.
+		|| (!hasForwardThrust && attributes.Get("reverse thrusting energy") > 0.)
+		|| attributes.Get("turning energy") > 0.
+		|| (!hasForwardThrust && !attributes.Get("reverse thrust") && attributes.Get("afterburner energy") > 0.);
 }
 
 

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -902,8 +902,11 @@ void Ship::FinishLoading(bool isNewInstance)
 
 	// Ships read from a save file may have non-default shields or hull.
 	// Perform a full IsDisabled calculation.
-	isDisabled = true;
-	isDisabled = IsDisabled();
+	if(!isNewInstance)
+	{
+		isDisabled = true;
+		isDisabled = IsDisabled();
+	}
 
 	// Calculate this ship's jump information, e.g. how much it costs to jump, how far it can jump, how it can jump.
 	navigation.Calibrate(*this);
@@ -3039,10 +3042,16 @@ bool Ship::NeedsFuel(bool followParent) const
 
 bool Ship::NeedsEnergy() const
 {
-	// If a ship has no energy capacity or already has some energy in reserves,
-	// it does not need energy. Since engines can use fractional thrust/turn,
-	// even a single unit of energy can still have use.
-	if(!attributes.Get("energy capacity") || energy > 1.)
+	// If this ship doesn't have a system, then it isn't even spawned in, so it
+	// doesn't need energy.
+	if(!currentSystem)
+		return false;
+
+	// If a ship has no energy capacity, no room for more energy, or already has
+	// some energy in reserves, it does not need energy. Since engines can use
+	// fractional thrust/turn, even a small unit of energy can still have use.
+	double capacity = attributes.Get("energy capacity");
+	if(!capacity || (capacity && energy >= capacity) || energy > 0.25)
 		return false;
 
 	// If a ship has energy capacity but is low on energy, check to see if it is capable

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -586,6 +586,8 @@ private:
 	void StepTargeting();
 	void DoEngineVisuals(std::vector<Visual> &visuals, bool isUsingAfterburner);
 
+	// Whether this ship requires energy for movement.
+	bool RequiresMovementEnergy() const;
 
 	// Add or remove a ship from this ship's list of escorts.
 	void AddEscort(Ship &ship);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug described in issue #12627.
Fixes #12627.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Makes the following changes:
1. Ship::FinishLoading no longer calls Ship::IsDisabled if isNewInstance is true. isNewInstance is true when FinishLoading is called on ship definitions. The comment above where Ship::IsDisabled is called says that it is being called for the sake of checking ships loaded from the save file, which would be using isNewInstance = false. Therefore, the call is entirely pointless when the input is true.
2. Ship::NeedsEnergy now has a safeguard to check that the ship has a system, which is false for ship definitions. (It's also false for docked fighters, but they shouldn't be calling this function anyway. We could change this to check ActualSystem() if desired.) Additionally, it now also checks if the ship has an energy capacity that it is already at, and the check for any energy has been reduced from 1 to 1/2^8, since it's conceivable that a plugin creator may input exactly 1 for a ship's energy. Additionally, NeedsEnergy will return false for ships that don't need energy for movement.
3. Pulls NeedsEnergy back out of IsDisabled, and adds a few NeedsEnergy checks to locations of the code where I figured it makes sense to treat a disabled (i.e. low health) and immobile (from lack of energy) ship the same way.

## Testing Done

Bought a Shuttle and sold its fuel cell. Flew around until I ran out of energy and confirmed that I drifted to a stop. Confirmed that when in this state, I can ask nearby friendly ships for energy.
