### PR TITLE
Data schemata

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -81,6 +81,8 @@ target_sources(EndlessSkyLib PRIVATE
 	DataFile.h
 	DataNode.cpp
 	DataNode.h
+	DataSchema.cpp
+	DataSchema.h
 	DataWriter.cpp
 	DataWriter.h
 	Date.cpp

--- a/source/DataSchema.cpp
+++ b/source/DataSchema.cpp
@@ -13,16 +13,15 @@ using namespace std;
 
 
 
-void ApplySchema(const DataNode &node, const DataSchema &schema)
+bool ApplyField(const DataNode &node, const DataSchema &schema)
 {
-	for(const DataNode &child : node)
-	{
-		const string &key = child.Token(0);
-		auto it = find_if(schema.begin(), schema.end(),
-			[&](const DataField &f){ return key == f.key; });
-		if(it != schema.end())
-			it->apply(child);
-	}
+	const string &key = node.Token(0);
+	auto it = find_if(schema.begin(), schema.end(),
+		[&](const DataField &f){ return key == f.key; });
+	if(it == schema.end())
+		return false;
+	it->apply(node);
+	return true;
 }
 
 

--- a/source/DataSchema.cpp
+++ b/source/DataSchema.cpp
@@ -1,0 +1,59 @@
+#include "DataSchema.h"
+
+#include <algorithm>
+
+using namespace std;
+
+
+
+void ApplySchema(const DataNode &node, const DataSchema &schema)
+{
+	for(const DataNode &child : node)
+	{
+		const string &key = child.Token(0);
+		auto it = find_if(schema.begin(), schema.end(),
+			[&](const DataField &f){ return key == f.key; });
+		if(it != schema.end())
+			it->apply(child);
+	}
+}
+
+
+
+DataField Field::Double(string_view key, double &target)
+{
+	return DataField{key, [&target](const DataNode &node){
+		if(node.Size() >= 2)
+			target = node.Value(1);
+	}};
+}
+
+
+
+DataField Field::Int(string_view key, int &target)
+{
+	return DataField{key, [&target](const DataNode &node){
+		if(node.Size() >= 2)
+			target = static_cast<int>(node.Value(1));
+	}};
+}
+
+
+
+DataField Field::Int64(string_view key, int64_t &target)
+{
+	return DataField{key, [&target](const DataNode &node){
+		if(node.Size() >= 2)
+			target = static_cast<int64_t>(node.Value(1));
+	}};
+}
+
+
+
+DataField Field::String(string_view key, string &target)
+{
+	return DataField{key, [&target](const DataNode &node){
+		if(node.Size() >= 2)
+			target = node.Token(1);
+	}};
+}

--- a/source/DataSchema.cpp
+++ b/source/DataSchema.cpp
@@ -1,5 +1,12 @@
 #include "DataSchema.h"
 
+#include "audio/Audio.h"
+#include "Body.h"
+#include "Effect.h"
+#include "GameData.h"
+#include "audio/Sound.h"
+#include "image/SpriteSet.h"
+
 #include <algorithm>
 
 using namespace std;
@@ -30,6 +37,29 @@ DataField Field::Double(string_view key, double &target)
 
 
 
+DataField Field::EffectAmount(string_view key, map<const Effect *, double> &target)
+{
+	return DataField{key, [&target](const DataNode &node) {
+		if(node.Size() >= 2)
+		{
+			double amount = (node.Size() >= 3) ? node.Value(2) : 1.;
+			target[GameData::Effects().Get(node.Token(1))] += amount;
+		}
+	}};
+}
+
+
+
+DataField Field::EffectCount(string_view key, map<const Effect *, int> &target)
+{
+	return DataField{key, [&target](const DataNode &node) {
+		if(node.Size() >= 2)
+			++target[GameData::Effects().Get(node.Token(1))];
+	}};
+}
+
+
+
 DataField Field::Int(string_view key, int &target)
 {
 	return DataField{key, [&target](const DataNode &node){
@@ -45,6 +75,39 @@ DataField Field::Int64(string_view key, int64_t &target)
 	return DataField{key, [&target](const DataNode &node){
 		if(node.Size() >= 2)
 			target = static_cast<int64_t>(node.Value(1));
+	}};
+}
+
+
+
+DataField Field::SoundCount(string_view key, map<const Sound *, int> &target)
+{
+	return DataField{key, [&target](const DataNode &node) {
+		if(node.Size() >= 2)
+			++target[Audio::Get(node.Token(1))];
+	}};
+}
+
+
+
+DataField Field::Sprite(string_view key, const ::Sprite* &target)
+{
+	return DataField{key, [&target](const DataNode &node) {
+		if(node.Size() >= 2) {
+			target = SpriteSet::Get(node.Token(1));
+		}
+	}};
+}
+
+
+
+DataField Field::SpriteList(string_view key, vector<pair<Body, int>> &target)
+{
+	return DataField{key, [&target](const DataNode &node) {
+		if(node.Size() >= 2) {
+			target.emplace_back(Body(), 1);
+			target.back().first.LoadSprite(node);
+		}
 	}};
 }
 

--- a/source/DataSchema.h
+++ b/source/DataSchema.h
@@ -22,7 +22,7 @@ struct DataField {
 
 using DataSchema = std::vector<DataField>;
 
-void ApplySchema(const DataNode &node, const DataSchema &schema);
+bool ApplyField(const DataNode &node, const DataSchema &schema);
 
 namespace Field {
 	// basic field types that assign to a variable

--- a/source/DataSchema.h
+++ b/source/DataSchema.h
@@ -3,9 +3,15 @@
 #include "DataNode.h"
 
 #include <functional>
+#include <map>
 #include <string>
 #include <string_view>
 #include <vector>
+
+class Body;
+class Effect;
+class Sound;
+class Sprite;
 
 
 
@@ -24,4 +30,11 @@ namespace Field {
 	DataField Int(std::string_view key, int &target);
 	DataField Int64(std::string_view key, int64_t &target);
 	DataField String(std::string_view key, std::string &target);
+
+	// specialist fields
+	DataField EffectAmount(std::string_view key, std::map<const Effect *, double> &target);
+	DataField EffectCount(std::string_view key, std::map<const Effect *, int> &target);
+	DataField SoundCount(std::string_view key, std::map<const Sound *, int> &target);
+	DataField Sprite(std::string_view key, const ::Sprite* &target);
+	DataField SpriteList(std::string_view key, std::vector<std::pair<Body, int>> &target);
 };

--- a/source/DataSchema.h
+++ b/source/DataSchema.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "DataNode.h"
+
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+
+
+struct DataField {
+	std::string_view key;
+	std::function<void(const DataNode &)> apply;
+};
+
+using DataSchema = std::vector<DataField>;
+
+void ApplySchema(const DataNode &node, const DataSchema &schema);
+
+namespace Field {
+	// basic field types that assign to a variable
+	DataField Double(std::string_view key, double &target);
+	DataField Int(std::string_view key, int &target);
+	DataField Int64(std::string_view key, int64_t &target);
+	DataField String(std::string_view key, std::string &target);
+};

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -467,11 +467,11 @@ void Government::Load(const DataNode &node, const set<const System *> *visitedSy
 		else if(key == "default attitude")
 			defaultAttitude = child.Value(valueIndex);
 		else if(key == "player reputation")
-			initialPlayerReputation = add ? initialPlayerReputation + child.Value(valueIndex) : child.Value(valueIndex);
+			initialPlayerReputation = child.Value(valueIndex) + (add ? initialPlayerReputation : 0.);
 		else if(key == "crew attack")
-			crewAttack = max(0., add ? child.Value(valueIndex) + crewAttack : child.Value(valueIndex));
+			crewAttack = max(0., child.Value(valueIndex) + (add ? crewAttack : 0.));
 		else if(key == "crew defense")
-			crewDefense = max(0., add ? child.Value(valueIndex) + crewDefense : child.Value(valueIndex));
+			crewDefense = max(0., child.Value(valueIndex) + (add ? crewDefense : 0.));
 		else if(key == "bribe")
 			bribe = child.Value(valueIndex) + (add ? bribe : 0.);
 		else if(key == "bribe threshold")

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -265,18 +265,13 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 	isDefined = true;
 
 	DataSchema schema = Schema();
-	ApplySchema(node, schema);
 
 	for(const DataNode &child : node)
 	{
-		const string &key = child.Token(0);
-
-		// temporary
-		auto it = find_if(schema.begin(), schema.end(),
-			[&](const DataField &f){ return key == f.key; });
-		if(it != schema.end())
+		if(ApplyField(child, schema))
 			continue;
 
+		const string &key = child.Token(0);
 		bool hasValue = child.Size() >= 2;
 
 		if(key == "weapon")

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -15,13 +15,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Outfit.h"
 
-#include "audio/Audio.h"
-#include "Body.h"
 #include "DataNode.h"
 #include "DataSchema.h"
-#include "Effect.h"
 #include "GameData.h"
-#include "image/SpriteSet.h"
 #include "Weapon.h"
 
 #include <algorithm>
@@ -236,6 +232,24 @@ DataSchema Outfit::Schema()
 		Field::String("category", category),
 		Field::String("series", series),
 		Field::Int("index", index),
+		Field::SpriteList("flare sprite", flareSprites),
+		Field::SpriteList("reverse flare sprite", reverseFlareSprites),
+		Field::SpriteList("steering flare sprite", steeringFlareSprites),
+		Field::Sprite("flotsam sprite", flotsamSprite),
+		Field::Sprite("thumbnail", thumbnail),
+		Field::SoundCount("flare sound", flareSounds),
+		Field::SoundCount("reverse flare sound", reverseFlareSounds),
+		Field::SoundCount("steering flare sound", steeringFlareSounds),
+		Field::EffectCount("afterburner effect", afterburnerEffects),
+		Field::EffectAmount("jump effect", jumpEffects),
+		Field::SoundCount("hyperdrive sound", hyperSounds),
+		Field::SoundCount("hyperdrive in sound", hyperInSounds),
+		Field::SoundCount("hyperdrive out sound", hyperOutSounds),
+		Field::SoundCount("jump sound", jumpSounds),
+		Field::SoundCount("jump in sound", jumpInSounds),
+		Field::SoundCount("jump out sound", jumpOutSounds),
+		Field::SoundCount("cargo scan sound", cargoScanSounds),
+		Field::SoundCount("outfit scan sound", outfitScanSounds),
 		Field::Int64("cost", cost),
 		Field::Double("mass", mass),
 	};
@@ -265,52 +279,7 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 
 		bool hasValue = child.Size() >= 2;
 
-		if(key == "flare sprite" && hasValue)
-		{
-			flareSprites.emplace_back(Body(), 1);
-			flareSprites.back().first.LoadSprite(child);
-		}
-		else if(key == "reverse flare sprite" && hasValue)
-		{
-			reverseFlareSprites.emplace_back(Body(), 1);
-			reverseFlareSprites.back().first.LoadSprite(child);
-		}
-		else if(key == "steering flare sprite" && hasValue)
-		{
-			steeringFlareSprites.emplace_back(Body(), 1);
-			steeringFlareSprites.back().first.LoadSprite(child);
-		}
-		else if(key == "flare sound" && hasValue)
-			++flareSounds[Audio::Get(child.Token(1))];
-		else if(key == "reverse flare sound" && hasValue)
-			++reverseFlareSounds[Audio::Get(child.Token(1))];
-		else if(key == "steering flare sound" && hasValue)
-			++steeringFlareSounds[Audio::Get(child.Token(1))];
-		else if(key == "afterburner effect" && hasValue)
-			++afterburnerEffects[GameData::Effects().Get(child.Token(1))];
-		else if(key == "jump effect" && hasValue)
-			jumpEffects[GameData::Effects().Get(child.Token(1))] += child.Size() >= 3 ? child.Value(2) : 1.;
-		else if(key == "hyperdrive sound" && hasValue)
-			++hyperSounds[Audio::Get(child.Token(1))];
-		else if(key == "hyperdrive in sound" && hasValue)
-			++hyperInSounds[Audio::Get(child.Token(1))];
-		else if(key == "hyperdrive out sound" && hasValue)
-			++hyperOutSounds[Audio::Get(child.Token(1))];
-		else if(key == "jump sound" && hasValue)
-			++jumpSounds[Audio::Get(child.Token(1))];
-		else if(key == "jump in sound" && hasValue)
-			++jumpInSounds[Audio::Get(child.Token(1))];
-		else if(key == "jump out sound" && hasValue)
-			++jumpOutSounds[Audio::Get(child.Token(1))];
-		else if(key == "cargo scan sound" && hasValue)
-			++cargoScanSounds[Audio::Get(child.Token(1))];
-		else if(key == "outfit scan sound" && hasValue)
-			++outfitScanSounds[Audio::Get(child.Token(1))];
-		else if(key == "flotsam sprite" && hasValue)
-			flotsamSprite = SpriteSet::Get(child.Token(1));
-		else if(key == "thumbnail" && hasValue)
-			thumbnail = SpriteSet::Get(child.Token(1));
-		else if(key == "weapon")
+		if(key == "weapon")
 		{
 			if(!weapon)
 				weapon = make_shared<Weapon>();

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "audio/Audio.h"
 #include "Body.h"
 #include "DataNode.h"
+#include "DataSchema.h"
 #include "Effect.h"
 #include "GameData.h"
 #include "image/SpriteSet.h"
@@ -226,6 +227,22 @@ optional<double> Outfit::LowerLimit(const string &attribute)
 
 
 
+DataSchema Outfit::Schema()
+{
+	return {
+		// list in save file order for later schema writing
+		Field::String("display name", displayName),
+		Field::String("plural", pluralName),
+		Field::String("category", category),
+		Field::String("series", series),
+		Field::Int("index", index),
+		Field::Int64("cost", cost),
+		Field::Double("mass", mass),
+	};
+}
+
+
+
 void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 {
 	if(node.Size() >= 2)
@@ -233,22 +250,22 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 
 	isDefined = true;
 
+	DataSchema schema = Schema();
+	ApplySchema(node, schema);
+
 	for(const DataNode &child : node)
 	{
 		const string &key = child.Token(0);
+
+		// temporary
+		auto it = find_if(schema.begin(), schema.end(),
+			[&](const DataField &f){ return key == f.key; });
+		if(it != schema.end())
+			continue;
+
 		bool hasValue = child.Size() >= 2;
 
-		if(key == "display name" && hasValue)
-			displayName = child.Token(1);
-		else if(key == "category" && hasValue)
-			category = child.Token(1);
-		else if(key == "series" && hasValue)
-			series = child.Token(1);
-		else if(key == "index" && hasValue)
-			index = child.Value(1);
-		else if(key == "plural" && hasValue)
-			pluralName = child.Token(1);
-		else if(key == "flare sprite" && hasValue)
+		if(key == "flare sprite" && hasValue)
 		{
 			flareSprites.emplace_back(Body(), 1);
 			flareSprites.back().first.LoadSprite(child);
@@ -313,10 +330,6 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 			linkedOutfits.insert(GameData::Outfits().Get(child.Token(1)));
 		else if(key == "description" && hasValue)
 			description.Load(child, playerConditions);
-		else if(key == "cost" && hasValue)
-			cost = child.Value(1);
-		else if(key == "mass" && hasValue)
-			mass = child.Value(1);
 		else if(key == "licenses" && (child.HasChildren() || hasValue))
 		{
 			// Add any new licenses that were specified "inline".

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "DataSchema.h"
 #include "Dictionary.h"
 #include "Paragraphs.h"
 
@@ -58,6 +59,7 @@ public:
 
 
 public:
+	DataSchema Schema();
 	// An "outfit" can be loaded from an "outfit" node or from a ship's
 	// "attributes" node.
 	void Load(const DataNode &node, const ConditionsStore *playerConditions);


### PR DESCRIPTION
**Refactor**

This PR is a proposed/experimental solution to what I feel is the most duplicitous part of the codebase, converting DataNodes to instances of the classes they represent.

## Acknowledgement

- [X] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

* Add a new file DataSchema.cpp/h
* Add a new namespace "Field", and functions within that which encapsulate everything needed to reify a DataNode.
* Modifies `Outfit` to use the new Schema type, as an example.

Note that this introduces the read-only C++17 type `string_view` to the codebase for the first time. I think this is a good use case for string_view. You can read more about it here: https://devblogs.microsoft.com/cppblog/stdstring_view-the-duct-tape-of-string-types/

I believe C++17 is the minimum version we require? If not, I can convert them all to `string`, but that might measurably impact loading time.

Also, `EffectAmount` is only used for an outfit's `"jump effect"` to reduce the number of sparks, and that option is not yet used in the base game.

Willing to rename/modify anything per feedback.

## Screenshots
n/a

## Usage examples
Old:
```cpp
else if(child == "flob" && hasValue)
  // do flob things
```
New:
```cpp
Field::GenericHandlerForThingsThatWorkLikeAFlob("flob", ...other needed args e.g. ivar)
```

## Testing Done
Launched, landed, viewed outfitter.

## Future Plans

* Convert more classes to use schemata
* Template-ify the simplest DataFields, such as ivar assignment and set emplacement, so we don't need one for each kind.
* One of the main reasons for doing this was to centralise all the places that handle the "add" keyword. I haven't done that yet, but it's on the list. [this list.]
* Use the same system for file writing (converting classes to DataNode vectors suitable for streaming to disk).

The original plan was to have each class describe its own schema and for Foo::Load() to pass that to an ApplySchema() function but I realised that for now there will probably still need to be a few special cases that ::Load needs to handle, so I changed it to an ApplyField function and moved it inside the loop. Maybe the grander idea can come later.

## Save File
any will do

## Artwork Checklist
n/a

## Wiki Update
n/a

## Performance Impact
I was unable to feel a difference in loading time on game launch, but it adds an abstraction layer over an if/else chain so it will be a bit slower loading.
