### PR TITLE
Prevent the Remnant Expanded Horizons Astral job from choosing hte current system as the waypoint

### DIFF
--- a/data/remnant/remnant jobs.txt
+++ b/data/remnant/remnant jobs.txt
@@ -117,6 +117,7 @@ mission "Remnant: Expanded Horizons Astral job"
 	source
 		government "Remnant"
 	waypoint
+		not distance 0
 		not attributes "pleiades"
 		not attributes "tangled shroud"
 		not attributes "twilight"
@@ -146,6 +147,7 @@ mission "Remnant: Expanded Horizons Astral job late"
 	source
 		government "Remnant"
 	waypoint
+		not distance 0
 		not attributes "pleiades"
 		not attributes "inaccessible"
 		not attributes "tangled shroud"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described on Discord: https://discord.com/channels/251118043411775489/536900466655887360/1535761073603612692

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The Remnant Expanded Horizons Astral job selects a system as a waypoint. It is possible for the filter to select the system you are currently in as the waypoint. This is problematic because it results in the waypoint being marked as visited immediately (before the mission is even fully instantiated), removing it from the list of waypoints left to visit. As a result, the "\<waypoints\>" substitution is not given a value and anywhere in the mission text that expected to use that repllacement is left as-is.
The mission will also complete immediately upon a reload or after taking off and landing again.

This PR changes the waypoint filter in the mission by adding:
`not distance 0`
This should exclude the current system.

## Testing Done
None.
