### PR TITLE
fix: Don't un-pause animations when a ship is exploding

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4204,6 +4204,7 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 {
 	if(!IsDestroyed())
 		return 0;
+	PauseAnimation();
 
 	// Make sure the shields are zero, as well as the hull.
 	levels.shields = 0.;


### PR DESCRIPTION
**Bug fix**

This PR addresses a bug mentioned on [Discord](https://discord.com/channels/251118043411775489/308902312741568512/1540193792962072706).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When a ship is disabled, it calls PauseAnimation in DoGeneration. PauseAnimation only causes a ship's animations to be paused for a single frame, so it must be continually called every frame that we want the animations to be paused.
https://github.com/endless-sky/endless-sky/blob/1e5f2c4bb16133539b885fd3b983d93536bf937b/source/Ship.cpp#L4465-L4466

DoGeneration is skipped over if the ship is in the process of exploding.
https://github.com/endless-sky/endless-sky/blob/1e5f2c4bb16133539b885fd3b983d93536bf937b/source/Ship.cpp#L1652-L1654

This means that a ship's animations pause when it becomes disabled, but resume when the ship starts exploding.

This PR adds a PauseAnimation call to StepDestroyed if the ship is in the process of exploding so that animations don't resume.

## Testing Done

None, but I'm pretty sure it works.