### PR TITLE
feat(ui): Display more details in ship info, such as max instantaneous energy draw and movement stats with afterburners active

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -495,6 +495,9 @@ tip "mass:"
 tip "max speed:"
 	`The maximum speed of this ship when using thrusters. Excludes the effect of afterburners, unless there are no normal thrusters installed.`
 
+tip "    w/ afterburner:"
+	`Movement while both your primary thrusters and afterburners are active.`
+
 tip "movement:"
 	`How quickly this ship can accelerate and turn.`
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -899,28 +899,31 @@ tip "  + outfits:"
 
 # Ship heat and energy summary fields:
 tip "idle:"
-	`Energy and heat generated when this ship is idle, i.e. not firing weapons, turning, or thrusting.`
+	`Energy and heat generated per second when this ship is idle, i.e. not firing weapons, turning, or thrusting.`
 
 tip "moving:"
-	`Energy consumed and heat generated when this ship is turning and thrusting. This is in addition to the "idle" amount.`
+	`Energy consumed and heat generated per second when this ship is turning and thrusting. This is in addition to the "idle" amount.`
 
 tip "firing:"
-	`Energy consumed and heat generated when this ship is firing all its weapons. This is in addition to the "idle" amount.`
+	`Energy consumed and heat generated per second when this ship is firing all its weapons. This is in addition to the "idle" amount. Note that weapons may consume or generate more energy or heat than this at the moment they fire, and this is the average value over time.`
 
 tip "shields / hull:"
-	`Energy consumed and heat generated when this ship is recharging shields and repairing its hull at the same time. This is in addition to the "idle" amount.`
+	`Energy consumed and heat generated per second when this ship is recharging shields and repairing its hull at the same time. This is in addition to the "idle" amount.`
 
 tip "repairing hull:"
-	`Energy consumed and heat generated when this ship is repairing its hull. This is in addition to the "idle" amount.`
+	`Energy consumed and heat generated per second when this ship is repairing its hull. This is in addition to the "idle" amount.`
 
 tip "charging shields:"
-	`Energy consumed and heat generated when this ship is recharging its shields. This is in addition to the "idle" amount.`
+	`Energy consumed and heat generated per second when this ship is recharging its shields. This is in addition to the "idle" amount.`
 
 tip "net change:"
-	`The sum of the energy consumed and heat generated from the above energy and heat values. Represents the worst case scenario when all systems are active at once.`
+	`The sum of the energy consumed and heat generated per second from the above energy and heat values. Represents the worst case scenario when all systems are active at once.`
 
 tip "capacity:"
 	`Energy storage capacity and heat capacity. Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries. The heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship.`
+
+tip "surge:"
+	`This ship lacks energy storage. Therefore, this is the greatest amount of energy that can be drawn by any of this ship's systems in a single instant, such as the energy required for a single shot of a weapon. Systems that require more than this amount of energy to activate will be unusable.`
 
 
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1294,6 +1294,9 @@ tip "limited thrust?"
 tip "limited turn?"
 	`This ship's energy supply is not sufficient to run the steering at full power. Its turn rate will be diminished.`
 
+tip "limited movement?"
+	`This ship's energy supply is not sufficient to run both thrusters and steering at the same time. Its movement will be diminished.`
+
 tip "solar power?"
 	`This ship is powered entirely by solar energy. It could be difficult to maneuver if you fly too far from the center of a star system, because your engines will only have a fraction of the power they require.`
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1307,7 +1307,7 @@ tip "no bays?"
 	`There are insufficient bays available to carry this ship. If it took off, it would be unable to leave this star system.`
 
 tip "insufficient energy to fire?"
-	`This ship has insufficient energy storage to fire an installed weapon.`
+	`This ship has insufficient energy storage to fire an installed weapon. Install outfits that increase your energy storage, or if you have no energy storage, ensure that your "surge" energy is greater than the firing energy per shot of your weapons.`
 
 
 

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -905,7 +905,19 @@ tip "idle:"
 	`Energy and heat generated per second when this ship is idle, i.e. not firing weapons, turning, or thrusting.`
 
 tip "moving:"
-	`Energy consumed and heat generated per second when this ship is turning and thrusting. This is in addition to the "idle" amount.`
+	`Energy consumed and heat generated per second when this ship is turning and thrusting. Includes the cost of using an afterburner if one is installed, or uses the cost of using reverse thrust if that is greater than the cost of forward thrust. This is in addition to the "idle" amount.`
+
+tip "thrusting:"
+	`Energy consumed and heat generated per second when this ship is thrusting. This is in addition to the "idle" amount.`
+
+tip "reversing:"
+	`Energy consumed and heat generated per second when this ship is using reverse thrusters. This is in addition to the "idle" amount.`
+
+tip "afterburner:"
+	`Energy consumed and heat generated per second when this ship is using its afterburner. This is in addition to the "idle" amount.`
+
+tip "turning:"
+	`Energy consumed and heat generated per second when this ship is turning. This is in addition to the "idle" amount.`
 
 tip "firing:"
 	`Energy consumed and heat generated per second when this ship is firing all its weapons. This is in addition to the "idle" amount. Note that weapons may consume or generate more energy or heat than this at the moment they fire, and this is the average value over time.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -935,8 +935,8 @@ tip "net change:"
 	`The sum of the energy consumed and heat generated per second from the above energy and heat values. Represents the worst case scenario when all possible systems are active at once.`
 
 tip "capacity:"
-    `Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries.`
-    `Heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship. If the "net change" value for heat is greater than this value, then the ship can overheat itself.`
+	`Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries.`
+	`Heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship. If the "net change" value for heat is greater than this value, then the ship can overheat itself.`
 
 tip "surge:"
 	`This ship lacks energy storage. Therefore, this is the greatest amount of energy that can be drawn by any of this ship's systems in a single instant, such as the energy required for a single shot of a weapon. Systems that require more than this amount of energy to activate will be unusable.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -902,7 +902,7 @@ tip "  + outfits:"
 
 # Ship heat and energy summary fields:
 tip "idle:"
-	`Energy and heat generated per second when this ship is idle, i.e. not firing weapons, turning, or thrusting.`
+	`Energy and heat generated per second when this ship is idle, i.e. not firing weapons, moving, or using any other systems.`
 
 tip "moving:"
 	`Energy consumed and heat generated per second when this ship is turning and thrusting. Includes the cost of using an afterburner if one is installed, or uses the cost of using reverse thrust if that is greater than the cost of forward thrust. This is in addition to the "idle" amount.`
@@ -932,10 +932,11 @@ tip "charging shields:"
 	`Energy consumed and heat generated per second when this ship is recharging its shields. This is in addition to the "idle" amount.`
 
 tip "net change:"
-	`The sum of the energy consumed and heat generated per second from the above energy and heat values. Represents the worst case scenario when all systems are active at once.`
+	`The sum of the energy consumed and heat generated per second from the above energy and heat values. Represents the worst case scenario when all possible systems are active at once.`
 
 tip "capacity:"
-	`Energy storage capacity and heat capacity. Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries. The heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship.`
+    `Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries.`
+    `Heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship. If the "net change" value for heat is greater than this value, then the ship can overheat itself.`
 
 tip "surge:"
 	`This ship lacks energy storage. Therefore, this is the greatest amount of energy that can be drawn by any of this ship's systems in a single instant, such as the energy required for a single shot of a weapon. Systems that require more than this amount of energy to activate will be unusable.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -936,7 +936,7 @@ tip "net change:"
 
 tip "capacity:"
 	`Energy capacity allows a ship to temporarily draw more energy than it produces, and can be increased by installing batteries.`
-	`Heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship. If the "net change" value for heat is greater than this value, then the ship can overheat itself.`
+	`Heat capacity is the highest your heat generation can be without eventually causing your ship to overheat, and is influenced by the mass of the ship. If the "net change" value for heat is greater than this value, then the ship can overheat itself. Weapons with high firing heat per shot can cause you to become overheated even if "net change" is below heat capacity.`
 
 tip "surge:"
 	`This ship lacks energy storage. Therefore, this is the greatest amount of energy that can be drawn by any of this ship's systems in a single instant, such as the energy required for a single shot of a weapon. Systems that require more than this amount of energy to activate will be unusable.`

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -1323,6 +1323,8 @@ vector<string> Ship::FlightCheck() const
 			checks.emplace_back("limited thrust?");
 		if(energy < turnEnergy)
 			checks.emplace_back("limited turn?");
+		if(energy < thrustEnergy + turnEnergy)
+			checks.emplace_back("limited movement?");
 		if(energy - .8 * solar < .2 * (turnEnergy + thrustEnergy))
 			checks.emplace_back("solar power?");
 		if(fuel < 0.)

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -423,6 +423,14 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	tableLabels.push_back("capacity:");
 	energyTable.push_back(Format::Number(maxEnergy));
 	heatTable.push_back(Format::Number(maxHeat));
+
+	if(scrollingPanel && !maxEnergy)
+	{
+		attributesHeight += 20;
+		tableLabels.push_back("surge:");
+		energyTable.push_back(Format::Number(idleEnergyPerFrame));
+		heatTable.push_back("N/A");
+	}
 	// Pad by 10 pixels on the top and bottom.
 	attributesHeight += 30;
 }

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -390,9 +390,38 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		movingEnergyPerFrame += attributes.Get("reverse thrusting energy");
 		movingHeatPerFrame += attributes.Get("reverse thrusting heat");
 	}
-	tableLabels.push_back("moving:");
-	energyTable.push_back(Format::Number(-60. * movingEnergyPerFrame));
-	heatTable.push_back(Format::Number(60. * movingHeatPerFrame));
+	// If this is a scrolling panel, break up movement into each individual movement capability.
+	if(scrollingPanel)
+	{
+		tableLabels.push_back("thrusting:");
+		energyTable.push_back(Format::Number(-60. * attributes.Get("thrusting energy")));
+		heatTable.push_back(Format::Number(60. * attributes.Get("thrusting heat")));
+		if(reverseThrust)
+		{
+			attributesHeight += 20;
+			tableLabels.push_back("reversing:");
+			energyTable.push_back(Format::Number(-60. * attributes.Get("reverse thrusting energy")));
+			heatTable.push_back(Format::Number(60. * attributes.Get("reverse thrusting heat")));
+		}
+		if(afterburnerThrust)
+		{
+			attributesHeight += 20;
+			tableLabels.push_back("afterburner:");
+			energyTable.push_back(Format::Number(-60. * attributes.Get("afterburner energy")));
+			heatTable.push_back(Format::Number(60. * attributes.Get("afterburner heat")));
+		}
+		attributesHeight += 20;
+		tableLabels.push_back("turning:");
+		energyTable.push_back(Format::Number(-60. * attributes.Get("turning energy")));
+		heatTable.push_back(Format::Number(60. * attributes.Get("turning heat")));
+	}
+	else
+	{
+		// Otherwise, just display a singular worst-case value.
+		tableLabels.push_back("moving:");
+		energyTable.push_back(Format::Number(-60. * movingEnergyPerFrame));
+		heatTable.push_back(Format::Number(60. * movingHeatPerFrame));
+	}
 
 	// Add energy and heat while firing to the table.
 	attributesHeight += 20;

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -370,13 +370,26 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 
 	// Add energy and heat while moving to the table.
 	attributesHeight += 20;
-	const double movingEnergyPerFrame =
-		max(attributes.Get("thrusting energy"), attributes.Get("reverse thrusting energy"))
-		+ attributes.Get("turning energy")
-		+ attributes.Get("afterburner energy");
-	const double movingHeatPerFrame = max(attributes.Get("thrusting heat"), attributes.Get("reverse thrusting heat"))
-		+ attributes.Get("turning heat")
-		+ attributes.Get("afterburner heat");
+	double reverseThrust = attributes.Get("reverse thrust");
+	double movingEnergyPerFrame = attributes.Get("turning energy");
+	double movingHeatPerFrame = attributes.Get("turning heat");
+	if(mainThrust && reverseThrust)
+	{
+		movingEnergyPerFrame += max(attributes.Get("thrusting energy") + attributes.Get("afterburner energy"),
+			attributes.Get("reverse thrusting energy"));
+		movingHeatPerFrame += max(attributes.Get("thrusting heat") + attributes.Get("afterburner heat"),
+			attributes.Get("reverse thrusting heat"));
+	}
+	else if(mainThrust)
+	{
+		movingEnergyPerFrame += attributes.Get("thrusting energy") + attributes.Get("afterburner energy");
+		movingHeatPerFrame += attributes.Get("thrusting heat") + attributes.Get("afterburner heat");
+	}
+	else if(reverseThrust)
+	{
+		movingEnergyPerFrame += attributes.Get("reverse thrusting energy");
+		movingHeatPerFrame += attributes.Get("reverse thrusting heat");
+	}
 	tableLabels.push_back("moving:");
 	energyTable.push_back(Format::Number(-60. * movingEnergyPerFrame));
 	heatTable.push_back(Format::Number(60. * movingHeatPerFrame));

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -252,7 +252,10 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 
 	double fullMass = emptyMass + attributes.Get("cargo space");
 	isGeneric &= (fullMass != emptyMass);
-	double forwardThrust = attributes.Get("thrust") ? attributes.Get("thrust") : attributes.Get("afterburner thrust");
+	double thrust = attributes.Get("thrust");
+	double afterburnerThrust = attributes.Get("afterburner thrust");
+	double mainThrust = thrust ? thrust : afterburnerThrust;
+	double allThrust = thrust + afterburnerThrust;
 	attributeLabels.push_back(string());
 	attributeValues.push_back(string());
 	attributesHeight += 10;
@@ -260,8 +263,14 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeValues.push_back(string());
 	attributesHeight += 20;
 	attributeLabels.push_back("max speed:");
-	attributeValues.push_back(Format::Number(60. * forwardThrust / ship.Drag()));
+	attributeValues.push_back(Format::Number(60. * mainThrust / ship.Drag()));
 	attributesHeight += 20;
+	if(scrollingPanel && thrust && afterburnerThrust)
+	{
+		attributeLabels.push_back("   w/ afterburner:");
+		attributeValues.push_back(Format::Number(60. * allThrust / ship.Drag()));
+		attributesHeight += 20;
+	}
 
 	// Movement stats are influenced by inertia reduction.
 	double reduction = 1. + attributes.Get("inertia reduction");
@@ -269,13 +278,24 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	currentMass /= reduction;
 	fullMass /= reduction;
 	attributeLabels.push_back("acceleration:");
-	double baseAccel = 3600. * forwardThrust * (1. + attributes.Get("acceleration multiplier"));
+	double baseAccel = 3600. * mainThrust * (1. + attributes.Get("acceleration multiplier"));
 	if(!isGeneric)
 		attributeValues.push_back(Format::Number(baseAccel / currentMass));
 	else
 		attributeValues.push_back(Format::Number(baseAccel / fullMass)
 			+ " - " + Format::Number(baseAccel / emptyMass));
 	attributesHeight += 20;
+	if(scrollingPanel && thrust && afterburnerThrust)
+	{
+		double maxAccel = 3600. * allThrust * (1. + attributes.Get("acceleration multiplier"));
+		attributeLabels.push_back("    w/ afterburner:");
+		if(!isGeneric)
+			attributeValues.push_back(Format::Number(maxAccel / currentMass));
+		else
+			attributeValues.push_back(Format::Number(maxAccel / fullMass)
+				+ " - " + Format::Number(maxAccel / emptyMass));
+		attributesHeight += 20;
+	}
 
 	attributeLabels.push_back("turning:");
 	double baseTurn = 60. * attributes.Get("turn") * (1. + attributes.Get("turn multiplier"));


### PR DESCRIPTION
**Feature**

This PR addresses a bunch of related changes discussed on [Discord](https://discord.com/channels/251118043411775489/285540320823869441/1538815219923419196) and related to #12598.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

The energy/heat table in ship info displays various details about the energy and heat of your ship in per-second values. None of these tooltips actually specify that their values are per-second, though. This PR updates these tooltips to include this detail.

In addition to this, the table will now gain a new "surge:" row when the energy capacity of the ship is 0. This value can be compared directly against the firing energy per shot of installed weapons to determine if they can be fired without installing a battery.

I also tacked on a bunch of other things as the result of discussions on Discord. See the screenshots for everything.

## Screenshots + Testing Done

The new "surge" row.
<img width="523" height="398" alt="image" src="https://github.com/user-attachments/assets/71a41547-6e12-4eac-ba2c-bcd04105f5f1" />

Only appears when you have no energy capacity, as otherwise it's not a relevant stat to display to the player.
<img width="256" height="181" alt="image" src="https://github.com/user-attachments/assets/a44045ab-5197-4b87-8048-b0139697bb5c" />

Updated the other tooltips in this table.
<img width="509" height="288" alt="image" src="https://github.com/user-attachments/assets/f99d42d2-d81a-4ee9-bbbb-d50a6e046c1c" />

Movement stats when you have an afterburner on top of your main thrusters. These extra lines will not display if you don't have an afterburner installed, or only an afterburner and no main thrusters.
<img width="498" height="201" alt="image" src="https://github.com/user-attachments/assets/73cafe36-d164-47a3-97aa-fceec06dec11" />

None of the new details appear in the ship info panel because we don't have space for them right now (assuming a ship with drone and fighter bays).
<img width="689" height="570" alt="image" src="https://github.com/user-attachments/assets/df67ace6-2a19-4467-b484-7748c0bb8b84" />

Updated the warning that appears when you don't have enough energy to fire a weapon to explain how to remedy the warning, which can be done with either installing a battery or getting a better generator.
<img width="338" height="256" alt="image" src="https://github.com/user-attachments/assets/c2b276af-e3e9-475a-8bdd-67ef5e846144" />

Added a new warning for if you have the power to use thrusters or turning alone, but not both at once.
<img width="359" height="170" alt="image" src="https://github.com/user-attachments/assets/97a97b37-74a2-490f-960d-03bfb3e57fd5" />

"moving:" is now broken out into the separate movement modes within the outfitter.
<img width="250" height="170" alt="image" src="https://github.com/user-attachments/assets/417e77bd-84a9-41e9-a590-5aec594993a9" />

With reversing and afterburner only appearing as necessary.
<img width="248" height="216" alt="image" src="https://github.com/user-attachments/assets/fc4e9ee7-fb91-4479-9a7a-1525c8273d1e" />

This is summarized into "moving:" as it is now in the ship info panel, with a fix to only account for reverse thrust costs if you have reverse thrusting installed.
<img width="247" height="183" alt="image" src="https://github.com/user-attachments/assets/29cf7d1f-0ec2-4a3c-b3a6-6843b5913696" />

