### PR TITLE
feat(enhancement): Support animated thumbnails in shops and map sales

### DIFF
--- a/source/Drawable.cpp
+++ b/source/Drawable.cpp
@@ -117,6 +117,20 @@ float Drawable::GetFrame(int step) const
 
 
 
+void Drawable::PauseAnimation() const
+{
+	++pause;
+}
+
+
+
+void Drawable::UnpauseAnimation() const
+{
+	pause = 0;
+}
+
+
+
 // Zoom factor. This controls how big the sprite should be drawn.
 double Drawable::Zoom() const
 {
@@ -253,13 +267,6 @@ void Drawable::SetFrameRate(float framesPerSecond)
 void Drawable::AddFrameRate(float framesPerSecond)
 {
 	frameRate += framesPerSecond / 60.f;
-}
-
-
-
-void Drawable::PauseAnimation()
-{
-	++pause;
 }
 
 

--- a/source/Drawable.h
+++ b/source/Drawable.h
@@ -51,6 +51,8 @@ public:
 	bool InheritsParentSwizzle() const;
 	// Get the sprite frame for the given time step.
 	float GetFrame(int step = -1) const;
+	void PauseAnimation() const;
+	void UnpauseAnimation() const;
 
 	// Positional attributes.
 	double Zoom() const;
@@ -71,7 +73,6 @@ protected:
 	// Adjust the frame rate.
 	void SetFrameRate(float framesPerSecond);
 	void AddFrameRate(float framesPerSecond);
-	void PauseAnimation();
 	// Set what animation step we're on. This affects future calls to Body::GetMask()
 	// and Drawable::GetFrame().
 	void SetStep(int step) const;
@@ -105,7 +106,7 @@ private:
 	mutable bool randomize = false;
 	bool repeat = true;
 	bool rewind = false;
-	int pause = 0;
+	mutable int pause = 0;
 
 	// Cache the frame calculation so it doesn't have to be repeated if given
 	// the same step over and over again.

--- a/source/LoadingCircle.cpp
+++ b/source/LoadingCircle.cpp
@@ -37,14 +37,14 @@ void LoadingCircle::Step()
 
 
 
-void LoadingCircle::Draw(const Point &position, double progress) const
+void LoadingCircle::Draw(const Point &position, double progress, double zoom) const
 {
 	// Draw the loading circle.
 	Angle a(rotation);
 	PointerShader::Bind();
 	for(int i = 0; i < static_cast<int>(progress * ticks); ++i)
 	{
-		PointerShader::Add(position, a.Unit(), 8.f, 20.f, size, Color(.5f, 0.f));
+		PointerShader::Add(position, a.Unit(), 8.f, 20.f, size * zoom, Color(.5f, 0.f));
 		a += angleOffset;
 	}
 	PointerShader::Unbind();

--- a/source/LoadingCircle.h
+++ b/source/LoadingCircle.h
@@ -29,7 +29,7 @@ public:
 	// Rotate the initial tick mark position, if this loading circle has a rotation speed.
 	void Step();
 	// Provide the position of the center of the circle and the progress percentage.
-	void Draw(const Point &position, double progress = 1.) const;
+	void Draw(const Point &position, double progress = 1., double zoom = 1.) const;
 
 
 private:

--- a/source/MapOutfitterPanel.cpp
+++ b/source/MapOutfitterPanel.cpp
@@ -68,16 +68,16 @@ void MapOutfitterPanel::LoadCatalogThumbnails() const
 
 
 
-const Sprite *MapOutfitterPanel::SelectedSprite() const
+const Drawable &MapOutfitterPanel::SelectedSprite() const
 {
-	return selected ? selected->Thumbnail() : nullptr;
+	return selected->Thumbnail();
 }
 
 
 
-const Sprite *MapOutfitterPanel::CompareSprite() const
+const Drawable &MapOutfitterPanel::CompareSprite() const
 {
-	return compare ? compare->Thumbnail() : nullptr;
+	return compare->Thumbnail();
 }
 
 

--- a/source/MapOutfitterPanel.h
+++ b/source/MapOutfitterPanel.h
@@ -39,8 +39,8 @@ public:
 protected:
 	virtual void LoadCatalogThumbnails() const override;
 
-	virtual const Sprite *SelectedSprite() const override;
-	virtual const Sprite *CompareSprite() const override;
+	virtual const Drawable &SelectedSprite() const override;
+	virtual const Drawable &CompareSprite() const override;
 	virtual const ItemInfoDisplay &SelectedInfo() const override;
 	virtual const ItemInfoDisplay &CompareInfo() const override;
 

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -19,9 +19,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "CategoryList.h"
 #include "CategoryType.h"
 #include "Command.h"
-#include "Drawable.h"
 #include "DialogPanel.h"
 #include "text/DisplayText.h"
+#include "Drawable.h"
 #include "shader/FillShader.h"
 #include "text/Font.h"
 #include "text/FontSet.h"
@@ -367,7 +367,8 @@ bool MapSalesPanel::DrawHeader(Point &corner, const string &category)
 
 
 
-void MapSalesPanel::DrawSprite(const Point &corner, const Drawable &drawable, bool animate, const Swizzle *swizzle) const
+void MapSalesPanel::DrawSprite(const Point &corner, const Drawable &drawable, bool animate,
+	const Swizzle *swizzle) const
 {
 	const Sprite *sprite = drawable.GetSprite();
 	if(!sprite)

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "CategoryList.h"
 #include "CategoryType.h"
 #include "Command.h"
+#include "Drawable.h"
 #include "DialogPanel.h"
 #include "text/DisplayText.h"
 #include "shader/FillShader.h"
@@ -32,9 +33,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Layout.h"
 #include "PlayerInfo.h"
 #include "Point.h"
-#include "shader/PointerShader.h"
 #include "Preferences.h"
-#include "shader/RingShader.h"
 #include "Screen.h"
 #include "image/Sprite.h"
 #include "image/SpriteSet.h"
@@ -83,6 +82,7 @@ void MapSalesPanel::Step()
 {
 	MapPanel::Step();
 
+	++step;
 	loadingCircle.Step();
 	// Load any and deferred thumbnails that appear in the sales.
 	// This is done here instead of in the constructor because the constructor
@@ -367,8 +367,9 @@ bool MapSalesPanel::DrawHeader(Point &corner, const string &category)
 
 
 
-void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite, const Swizzle *swizzle) const
+void MapSalesPanel::DrawSprite(const Point &corner, const Drawable &drawable, const Swizzle *swizzle) const
 {
+	const Sprite *sprite = drawable.GetSprite();
 	if(!sprite)
 		return;
 	Point iconOffset(.5 * ICON_HEIGHT, .5 * ICON_HEIGHT);
@@ -379,7 +380,7 @@ void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite, const 
 		// No swizzle was specified, so default to the player swizzle.
 		if(!swizzle)
 			swizzle = GameData::PlayerGovernment()->GetSwizzle();
-		SpriteShader::Draw(sprite, corner + iconOffset, scale, swizzle);
+		SpriteShader::Draw(sprite, corner + iconOffset, scale, swizzle, drawable.GetFrame(step));
 	}
 	else if(sprite->HasDimensions())
 		loadingCircle.Draw(corner + iconOffset);
@@ -387,7 +388,7 @@ void MapSalesPanel::DrawSprite(const Point &corner, const Sprite *sprite, const 
 
 
 
-void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, const Swizzle *swizzle, bool isForSale,
+void MapSalesPanel::Draw(Point &corner, const Drawable &drawable, const Swizzle *swizzle, bool isForSale,
 		bool isSelected, const string &name, const string &variantName,
 		const string &price, const string &info, const string &storage)
 {
@@ -415,7 +416,7 @@ void MapSalesPanel::Draw(Point &corner, const Sprite *sprite, const Swizzle *swi
 		if(isSelected)
 			FillShader::Fill(Rectangle::FromCorner(corner, blockSize), selectionColor);
 
-		DrawSprite(corner, sprite, swizzle);
+		DrawSprite(corner, drawable, swizzle);
 
 		const Color &mediumColor = *GameData::Colors().Get("medium");
 		const Color &dimColor = *GameData::Colors().Get("dim");

--- a/source/MapSalesPanel.cpp
+++ b/source/MapSalesPanel.cpp
@@ -332,13 +332,13 @@ void MapSalesPanel::DrawInfo() const
 			topLeft.X() += compareInfo.PanelWidth() + box->Width();
 
 			SpriteShader::Draw(box, topLeft + Point(-50., 100.));
-			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite(), SelectedSpriteSwizzle());
-			DrawSprite(topLeft + Point(-95., 105.), CompareSprite(), CompareSpriteSwizzle());
+			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite(), true, SelectedSpriteSwizzle());
+			DrawSprite(topLeft + Point(-95., 105.), CompareSprite(), true, CompareSpriteSwizzle());
 		}
 		else
 		{
 			SpriteShader::Draw(box, topLeft + Point(-60., 50.));
-			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite(), SelectedSpriteSwizzle());
+			DrawSprite(topLeft + Point(-95., 5.), SelectedSprite(), true, SelectedSpriteSwizzle());
 		}
 		selectedInfo.DrawAttributes(topLeft);
 	}
@@ -367,7 +367,7 @@ bool MapSalesPanel::DrawHeader(Point &corner, const string &category)
 
 
 
-void MapSalesPanel::DrawSprite(const Point &corner, const Drawable &drawable, const Swizzle *swizzle) const
+void MapSalesPanel::DrawSprite(const Point &corner, const Drawable &drawable, bool animate, const Swizzle *swizzle) const
 {
 	const Sprite *sprite = drawable.GetSprite();
 	if(!sprite)
@@ -380,6 +380,10 @@ void MapSalesPanel::DrawSprite(const Point &corner, const Drawable &drawable, co
 		// No swizzle was specified, so default to the player swizzle.
 		if(!swizzle)
 			swizzle = GameData::PlayerGovernment()->GetSwizzle();
+		if(animate)
+			drawable.UnpauseAnimation();
+		else
+			drawable.PauseAnimation();
 		SpriteShader::Draw(sprite, corner + iconOffset, scale, swizzle, drawable.GetFrame(step));
 	}
 	else if(sprite->HasDimensions())
@@ -416,7 +420,7 @@ void MapSalesPanel::Draw(Point &corner, const Drawable &drawable, const Swizzle 
 		if(isSelected)
 			FillShader::Fill(Rectangle::FromCorner(corner, blockSize), selectionColor);
 
-		DrawSprite(corner, drawable, swizzle);
+		DrawSprite(corner, drawable, isSelected, swizzle);
 
 		const Color &mediumColor = *GameData::Colors().Get("medium");
 		const Color &dimColor = *GameData::Colors().Get("dim");

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -30,7 +30,6 @@ class Information;
 class ItemInfoDisplay;
 class PlayerInfo;
 class Point;
-class Sprite;
 class Swizzle;
 
 

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 class CategoryList;
+class Drawable;
 class Information;
 class ItemInfoDisplay;
 class PlayerInfo;
@@ -53,8 +54,8 @@ protected:
 	virtual bool Drag(double dx, double dy) override;
 	virtual bool Scroll(double dx, double dy) override;
 
-	virtual const Sprite *SelectedSprite() const = 0;
-	virtual const Sprite *CompareSprite() const = 0;
+	virtual const Drawable &SelectedSprite() const = 0;
+	virtual const Drawable &CompareSprite() const = 0;
 	virtual const Swizzle *SelectedSpriteSwizzle() const;
 	virtual const Swizzle *CompareSpriteSwizzle() const;
 	virtual const ItemInfoDisplay &SelectedInfo() const = 0;
@@ -72,8 +73,8 @@ protected:
 	void DrawInfo() const;
 
 	bool DrawHeader(Point &corner, const std::string &category);
-	void DrawSprite(const Point &corner, const Sprite *sprite, const Swizzle * swizzle) const;
-	void Draw(Point &corner, const Sprite *sprite, const Swizzle *swizzle, bool isForSale, bool isSelected,
+	void DrawSprite(const Point &corner, const Drawable &drawable, const Swizzle *swizzle) const;
+	void Draw(Point &corner, const Drawable &drawable, const Swizzle *swizzle, bool isForSale, bool isSelected,
 		const std::string &name, const std::string &variantName, const std::string &price,
 		const std::string &info, const std::string &storage);
 
@@ -89,6 +90,8 @@ protected:
 
 
 protected:
+	// Step count for animations.
+	int step = 0;
 	double scroll = 0.;
 	double maxScroll = 0.;
 

--- a/source/MapSalesPanel.h
+++ b/source/MapSalesPanel.h
@@ -73,7 +73,7 @@ protected:
 	void DrawInfo() const;
 
 	bool DrawHeader(Point &corner, const std::string &category);
-	void DrawSprite(const Point &corner, const Drawable &drawable, const Swizzle *swizzle) const;
+	void DrawSprite(const Point &corner, const Drawable &drawable, bool animate, const Swizzle *swizzle) const;
 	void Draw(Point &corner, const Drawable &drawable, const Swizzle *swizzle, bool isForSale, bool isSelected,
 		const std::string &name, const std::string &variantName, const std::string &price,
 		const std::string &info, const std::string &storage);

--- a/source/MapShipyardPanel.cpp
+++ b/source/MapShipyardPanel.cpp
@@ -70,16 +70,16 @@ void MapShipyardPanel::LoadCatalogThumbnails() const
 
 
 
-const Sprite *MapShipyardPanel::SelectedSprite() const
+const Drawable &MapShipyardPanel::SelectedSprite() const
 {
-	return selected ? selected->Thumbnail() ? selected->Thumbnail() : selected->GetSprite() : nullptr;
+	return selected->Thumbnail();
 }
 
 
 
-const Sprite *MapShipyardPanel::CompareSprite() const
+const Drawable &MapShipyardPanel::CompareSprite() const
 {
-	return compare ? compare->Thumbnail() ? compare->Thumbnail() : compare->GetSprite() : nullptr;
+	return compare->Thumbnail();
 }
 
 
@@ -253,17 +253,13 @@ void MapShipyardPanel::DrawItems()
 			if(!parkedInSystem && onlyShowStorageHere)
 				continue;
 
-			const Sprite *sprite = ship->Thumbnail();
-			if(!sprite)
-				sprite = ship->GetSprite();
-
 			const string parking_details =
 				onlyShowSoldHere || parkedInSystem == 0
 				? ""
 				: parkedInSystem == 1
 				? "1 ship parked"
 				: Format::Number(parkedInSystem) + " ships parked";
-			Draw(corner, sprite, ship->CustomSwizzle(), isForSale, ship == selected,
+			Draw(corner, ship->Thumbnail(), ship->CustomSwizzle(), isForSale, ship == selected,
 					ship->DisplayModelName(), ship->VariantMapShopName(), price, info, parking_details);
 			list.push_back(ship);
 		}

--- a/source/MapShipyardPanel.h
+++ b/source/MapShipyardPanel.h
@@ -40,8 +40,8 @@ public:
 protected:
 	virtual void LoadCatalogThumbnails() const override;
 
-	virtual const Sprite *SelectedSprite() const override;
-	virtual const Sprite *CompareSprite() const override;
+	virtual const Drawable &SelectedSprite() const override;
+	virtual const Drawable &CompareSprite() const override;
 	virtual const Swizzle *SelectedSpriteSwizzle() const override;
 	virtual const Swizzle *CompareSpriteSwizzle() const override;
 	virtual const ItemInfoDisplay &SelectedInfo() const override;

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -354,7 +354,7 @@ void Outfit::Load(const DataNode &node, const ConditionsStore *playerConditions)
 		else if(key == "flotsam sprite" && hasValue)
 			flotsamSprite = SpriteSet::Get(child.Token(1));
 		else if(key == "thumbnail" && hasValue)
-			thumbnail = SpriteSet::Get(child.Token(1));
+			thumbnail.LoadSprite(child);
 		else if(key == "weapon")
 		{
 			if(!weapon)
@@ -576,7 +576,7 @@ const vector<string> &Outfit::Licenses() const
 
 
 // Get the image to display in the outfitter when buying this item.
-const Sprite *Outfit::Thumbnail() const
+const Drawable &Outfit::Thumbnail() const
 {
 	return thumbnail;
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "Dictionary.h"
+#include "Drawable.h"
 #include "Paragraphs.h"
 
 #include <map>
@@ -103,7 +104,7 @@ public:
 	// Get the licenses needed to buy or operate this ship.
 	const std::vector<std::string> &Licenses() const;
 	// Get the image to display in the outfitter when buying this item.
-	const Sprite *Thumbnail() const;
+	const Drawable &Thumbnail() const;
 
 	// Return true if this Outfit's attributes Dictionary is empty. Does not determine
 	// whether this Outfit contains any sprites, effects, sounds, or a weapon.
@@ -181,7 +182,7 @@ private:
 	std::string series;
 	int index = 0;
 	Paragraphs description;
-	const Sprite *thumbnail = nullptr;
+	Drawable thumbnail;
 	int64_t cost = 0;
 	double mass = 0.;
 	// Licenses needed to purchase this item.

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -312,7 +312,7 @@ double OutfitterPanel::DrawDetails(const Point &center)
 
 		const Sprite *background = SpriteSet::Get("ui/outfitter unselected");
 		SpriteShader::Draw(background, thumbnailCenter);
-		DrawThumbnail(thumbnail, thumbnailCenter);
+		DrawThumbnail(thumbnail, true, thumbnailCenter);
 
 		const bool hasDescription = outfitInfo.DescriptionHeight();
 
@@ -1108,7 +1108,7 @@ void OutfitterPanel::DrawOutfit(const Outfit &outfit, const Point &center, bool 
 {
 	const Sprite *back = SpriteSet::Get(isSelected ? "ui/outfitter selected" : "ui/outfitter unselected");
 	SpriteShader::Draw(back, center);
-	DrawThumbnail(outfit.Thumbnail(), center);
+	DrawThumbnail(outfit.Thumbnail(), isSelected, center);
 
 	// Draw the outfit name.
 	const string &name = outfit.DisplayName();

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -302,22 +302,17 @@ double OutfitterPanel::DrawDetails(const Point &center)
 			collapsed.contains(DESCRIPTION));
 		selectedItem = selectedOutfit->DisplayName();
 
-		const Sprite *thumbnail = selectedOutfit->Thumbnail();
-		const float tileSize = thumbnail
-			? max(thumbnail->Height(), static_cast<float>(TileSize()))
+		const Drawable &thumbnail = selectedOutfit->Thumbnail();
+		const Sprite *thumbnailSprite = thumbnail.GetSprite();
+		const float tileSize = thumbnailSprite
+			? max(thumbnailSprite->Height(), static_cast<float>(TileSize()))
 			: static_cast<float>(TileSize());
 		const Point thumbnailCenter(center.X(), center.Y() + 20 + static_cast<int>(tileSize / 2));
 		const Point startPoint(center.X() - INFOBAR_WIDTH / 2 + 20, center.Y() + 20 + tileSize);
 
 		const Sprite *background = SpriteSet::Get("ui/outfitter unselected");
 		SpriteShader::Draw(background, thumbnailCenter);
-		if(thumbnail)
-		{
-			if(thumbnail->IsLoaded())
-				SpriteShader::Draw(thumbnail, thumbnailCenter);
-			else if(thumbnail->HasDimensions())
-				loadingCircle.Draw(thumbnailCenter);
-		}
+		DrawThumbnail(thumbnail, thumbnailCenter);
 
 		const bool hasDescription = outfitInfo.DescriptionHeight();
 
@@ -1111,17 +1106,9 @@ bool OutfitterPanel::ShipCanRemove(const Ship *ship, const Outfit *outfit)
 
 void OutfitterPanel::DrawOutfit(const Outfit &outfit, const Point &center, bool isSelected, bool isOwned) const
 {
-	const Sprite *thumbnail = outfit.Thumbnail();
-	const Sprite *back = SpriteSet::Get(
-		isSelected ? "ui/outfitter selected" : "ui/outfitter unselected");
+	const Sprite *back = SpriteSet::Get(isSelected ? "ui/outfitter selected" : "ui/outfitter unselected");
 	SpriteShader::Draw(back, center);
-	if(thumbnail)
-	{
-		if(thumbnail->IsLoaded())
-			SpriteShader::Draw(thumbnail, center);
-		else if(thumbnail->HasDimensions())
-			loadingCircle.Draw(center);
-	}
+	DrawThumbnail(outfit.Thumbnail(), center);
 
 	// Draw the outfit name.
 	const string &name = outfit.DisplayName();

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -205,7 +205,7 @@ void Ship::Load(const DataNode &node, const ConditionsStore *playerConditions)
 		if(key == "sprite")
 			LoadSprite(child);
 		else if(key == "thumbnail" && hasValue)
-			thumbnail = SpriteSet::Get(child.Token(1));
+			thumbnail.LoadSprite(child);
 		else if(key == "name" && hasValue)
 			givenName = child.Token(1);
 		else if(key == "display name" && hasValue)
@@ -573,7 +573,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			pluralModelName = model->pluralModelName;
 		if(noun.empty())
 			noun = model->noun;
-		if(!thumbnail)
+		if(!thumbnail.GetSprite())
 			thumbnail = model->thumbnail;
 	}
 
@@ -655,6 +655,12 @@ void Ship::FinishLoading(bool isNewInstance)
 	}
 	else if(removeBays)
 		bays.clear();
+
+	// If this ship wasn't given a thumbnail, fall back onto copying the
+	// in-flight sprite and animations.
+	if(!thumbnail.GetSprite())
+		thumbnail = Drawable(*this);
+
 	// Check that all the "equipped" weapons actually match what your ship
 	// has, and that they are truly weapons. Remove any excess weapons and
 	// warn if any non-weapon outfits are "installed" in a hardpoint.
@@ -908,8 +914,7 @@ void Ship::Save(DataWriter &out) const
 		if(!noun.empty())
 			out.Write("noun", noun);
 		SaveSprite(out);
-		if(thumbnail)
-			out.Write("thumbnail", thumbnail->Name());
+		thumbnail.SaveSprite(out, "thumbnail");
 
 		if(neverDisabled)
 			out.Write("never disabled");
@@ -1222,7 +1227,7 @@ string Ship::Description() const
 
 
 // Get the shipyard thumbnail for this ship.
-const Sprite *Ship::Thumbnail() const
+const Drawable &Ship::Thumbnail() const
 {
 	return thumbnail;
 }

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Armament.h"
 #include "CargoHold.h"
 #include "Command.h"
+#include "Drawable.h"
 #include "EsUuid.h"
 #include "FireCommand.h"
 #include "Outfit.h"
@@ -184,7 +185,7 @@ public:
 	// Get this ship's description.
 	std::string Description() const;
 	// Get the shipyard thumbnail for this ship.
-	const Sprite *Thumbnail() const;
+	const Drawable &Thumbnail() const;
 	// Get this ship's cost.
 	int64_t Cost() const;
 	int64_t ChassisCost() const;
@@ -629,7 +630,7 @@ private:
 	std::string variantMapShopName;
 	std::string noun;
 	Paragraphs description;
-	const Sprite *thumbnail = nullptr;
+	Drawable thumbnail;
 	// Characteristics of this particular ship:
 	EsUuid uuid;
 	std::string givenName;

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -148,7 +148,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 			const float spriteScale = min(1.f, (INFOBAR_WIDTH - 60.f) / max(shipSprite->Width(), shipSprite->Height()));
 			const Swizzle *swizzle = selectedShip->CustomSwizzle()
 				? selectedShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-			DrawThumbnail(*selectedShip, spriteCenter, spriteScale, swizzle);
+			DrawThumbnail(*selectedShip, true, spriteCenter, spriteScale, swizzle);
 		}
 
 		const bool hasDescription = shipInfo.DescriptionHeight();

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -148,7 +148,7 @@ double ShipyardPanel::DrawDetails(const Point &center)
 			const float spriteScale = min(1.f, (INFOBAR_WIDTH - 60.f) / max(shipSprite->Width(), shipSprite->Height()));
 			const Swizzle *swizzle = selectedShip->CustomSwizzle()
 				? selectedShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-			SpriteShader::Draw(shipSprite, spriteCenter, spriteScale, swizzle);
+			DrawThumbnail(*selectedShip, spriteCenter, spriteScale, swizzle);
 		}
 
 		const bool hasDescription = shipInfo.DescriptionHeight();

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -24,7 +24,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "shader/FillShader.h"
 #include "text/Font.h"
 #include "text/FontSet.h"
-#include "text/Format.h"
 #include "GameData.h"
 #include "Gamerules.h"
 #include "Government.h"
@@ -125,6 +124,7 @@ ShopPanel::ShopPanel(PlayerInfo &player, bool isOutfitter)
 
 void ShopPanel::Step()
 {
+	++step;
 	loadingCircle.Step();
 	if(!checkedHelp && GetUI().IsTop(this) && player.Ships().size() > 1)
 	{
@@ -208,13 +208,13 @@ void ShopPanel::Draw()
 		{
 			static const Color selected(.8f, 1.f);
 			Point size(sprite->Width() * scale, sprite->Height() * scale);
-			OutlineShader::Draw(sprite, dragPoint, size, selected);
+			DrawOutline(*dragShip, dragPoint, size, selected);
 		}
 		else
 		{
 			const Swizzle *swizzle = dragShip->CustomSwizzle()
 				? dragShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-			SpriteShader::Draw(sprite, dragPoint, scale, swizzle);
+			DrawThumbnail(*dragShip, dragPoint, scale, swizzle);
 		}
 	}
 
@@ -239,28 +239,33 @@ void ShopPanel::UpdateTooltipActivation()
 
 
 
-void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
+void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected) const
 {
-	const Sprite *back = SpriteSet::Get(
-		isSelected ? "ui/shipyard selected" : "ui/shipyard unselected");
+	const Sprite *back = SpriteSet::Get(isSelected ? "ui/shipyard selected" : "ui/shipyard unselected");
 	SpriteShader::Draw(back, center);
 
-	const Sprite *thumbnail = ship.Thumbnail();
-	const Sprite *sprite = ship.GetSprite();
+	const Drawable &thumbnail = ship.Thumbnail();
+	const Sprite *sprite = thumbnail.GetSprite();
 	const Swizzle *swizzle = ship.CustomSwizzle() ? ship.CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-	if(thumbnail)
+	if(sprite)
 	{
-		if(thumbnail->IsLoaded())
-			SpriteShader::Draw(thumbnail, center + Point(0., 10.), 1., swizzle);
-		else if(thumbnail->HasDimensions())
-			loadingCircle.Draw(center);
-	}
-	else if(sprite)
-	{
-		// Make sure the ship sprite leaves 10 pixels padding all around.
-		const float zoomSize = SHIP_SIZE - 60.f;
-		float zoom = min(1.f, zoomSize / max(sprite->Width(), sprite->Height()));
-		SpriteShader::Draw(sprite, center, zoom, swizzle);
+		float zoom = 1.f;
+		Point nudge;
+		// If the thumbnail sprite matches the main sprite of the ship, then we need to make sure
+		// that the thumbnail doesn't overflow the area it's being drawn within.
+		if(sprite == ship.GetSprite())
+		{
+			// Make sure the ship sprite leaves 10 pixels padding all around.
+			float zoomSize = SHIP_SIZE - 60.f;
+			zoom = min(1.f, zoomSize / max(sprite->Width(), sprite->Height()));
+		}
+		else
+		{
+			// Dedicated thumbnails are expected to be sized to the shop UI.
+			// We just nudge them up slightly.
+			nudge += Point(0., 10.);
+		}
+		DrawThumbnail(thumbnail, center + nudge, zoom, swizzle);
 	}
 
 	// Draw the ship name.
@@ -269,6 +274,32 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 	Point offset(-SIDEBAR_CONTENT / 2, -.5f * SHIP_SIZE + 10.f);
 	font.Draw({name, {SIDEBAR_CONTENT, Alignment::CENTER, Truncate::MIDDLE}},
 		center + offset, *GameData::Colors().Get("bright"));
+}
+
+
+
+void ShopPanel::DrawOutline(const Drawable &thumbnail, const Point &center, const Point &size, const Color &color) const
+{
+	const Sprite *sprite = thumbnail.GetSprite();
+	if(!sprite)
+		return;
+	if(sprite->IsLoaded())
+		OutlineShader::Draw(sprite, center, size, color, Point(0., -1.), thumbnail.GetFrame(step));
+	else if(sprite->HasDimensions())
+		loadingCircle.Draw(center);
+}
+
+
+
+void ShopPanel::DrawThumbnail(const Drawable &thumbnail, const Point &center, float zoom, const Swizzle *swizzle) const
+{
+	const Sprite *sprite = thumbnail.GetSprite();
+	if(!sprite)
+		return;
+	if(sprite->IsLoaded())
+		SpriteShader::Draw(sprite, center, zoom, swizzle, thumbnail.GetFrame(step));
+	else if(sprite->HasDimensions())
+		loadingCircle.Draw(center);
 }
 
 
@@ -824,12 +855,12 @@ void ShopPanel::DrawShipsSidebar()
 			if(Preferences::Has(SHIP_OUTLINES))
 			{
 				Point size(sprite->Width() * scale, sprite->Height() * scale);
-				OutlineShader::Draw(sprite, point, size, isSelected ? selected : unselected);
+				DrawOutline(*ship, point, size, isSelected ? selected : unselected);
 			}
 			else
 			{
 				const Swizzle *swizzle = ship->CustomSwizzle() ? ship->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-				SpriteShader::Draw(sprite, point, scale, swizzle);
+				DrawThumbnail(*ship, point, scale, swizzle);
 			}
 		}
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -202,20 +202,10 @@ void ShopPanel::Draw()
 
 	if(dragShip && isDraggingShip && dragShip->GetSprite())
 	{
-		const Sprite *sprite = dragShip->GetSprite();
-		float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
-		if(Preferences::Has(SHIP_OUTLINES))
-		{
-			static const Color selected(.8f, 1.f);
-			Point size(sprite->Width() * scale, sprite->Height() * scale);
-			DrawOutline(*dragShip, dragPoint, size, selected);
-		}
-		else
-		{
-			const Swizzle *swizzle = dragShip->CustomSwizzle()
-				? dragShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-			DrawThumbnail(*dragShip, false, dragPoint, scale, swizzle);
-		}
+		static const Color selected(.8f, 1.f);
+		const Swizzle *swizzle = dragShip->CustomSwizzle() ? dragShip->CustomSwizzle()
+			: GameData::PlayerGovernment()->GetSwizzle();
+		DrawShipIcon(*dragShip, dragPoint, selected, swizzle);
 	}
 
 	// Check to see if we need to scroll things onto the screen.
@@ -278,15 +268,25 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 
 
 
-void ShopPanel::DrawOutline(const Drawable &thumbnail, const Point &center, const Point &size, const Color &color) const
+void ShopPanel::DrawShipIcon(const Drawable &thumbnail, const Point &center, const Color &color,
+	const Swizzle *swizzle) const
 {
 	const Sprite *sprite = thumbnail.GetSprite();
 	if(!sprite)
 		return;
 	if(sprite->IsLoaded())
-		OutlineShader::Draw(sprite, center, size, color, Point(0., -1.));
+	{
+		float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
+		if(Preferences::Has(SHIP_OUTLINES))
+		{
+			Point size(sprite->Width() * scale, sprite->Height() * scale);
+			OutlineShader::Draw(sprite, center, size, color);
+		}
+		else
+			SpriteShader::Draw(sprite, center, scale, swizzle);
+	}
 	else if(sprite->HasDimensions())
-		loadingCircle.Draw(center);
+		loadingCircle.Draw(center, 1., ICON_SIZE);
 }
 
 
@@ -855,21 +855,9 @@ void ShopPanel::DrawShipsSidebar()
 		if(isSelected && ShouldHighlight(ship.get()))
 			SpriteShader::Draw(background, point);
 
-		const Sprite *sprite = ship->GetSprite();
-		if(sprite)
-		{
-			float scale = ICON_SIZE / max(sprite->Width(), sprite->Height());
-			if(Preferences::Has(SHIP_OUTLINES))
-			{
-				Point size(sprite->Width() * scale, sprite->Height() * scale);
-				DrawOutline(*ship, point, size, isSelected ? selected : unselected);
-			}
-			else
-			{
-				const Swizzle *swizzle = ship->CustomSwizzle() ? ship->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-				DrawThumbnail(*ship, false, point, scale, swizzle);
-			}
-		}
+		const Swizzle *swizzle = ship->CustomSwizzle() ? ship->CustomSwizzle()
+			: GameData::PlayerGovernment()->GetSwizzle();
+		DrawShipIcon(*ship, point, isSelected ? selected : unselected, swizzle);
 
 		shipZones.emplace_back(point, Point(ICON_TILE, ICON_TILE), ship.get());
 

--- a/source/ShopPanel.cpp
+++ b/source/ShopPanel.cpp
@@ -214,7 +214,7 @@ void ShopPanel::Draw()
 		{
 			const Swizzle *swizzle = dragShip->CustomSwizzle()
 				? dragShip->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-			DrawThumbnail(*dragShip, dragPoint, scale, swizzle);
+			DrawThumbnail(*dragShip, false, dragPoint, scale, swizzle);
 		}
 	}
 
@@ -265,7 +265,7 @@ void ShopPanel::DrawShip(const Ship &ship, const Point &center, bool isSelected)
 			// We just nudge them up slightly.
 			nudge += Point(0., 10.);
 		}
-		DrawThumbnail(thumbnail, center + nudge, zoom, swizzle);
+		DrawThumbnail(thumbnail, isSelected, center + nudge, zoom, swizzle);
 	}
 
 	// Draw the ship name.
@@ -284,20 +284,27 @@ void ShopPanel::DrawOutline(const Drawable &thumbnail, const Point &center, cons
 	if(!sprite)
 		return;
 	if(sprite->IsLoaded())
-		OutlineShader::Draw(sprite, center, size, color, Point(0., -1.), thumbnail.GetFrame(step));
+		OutlineShader::Draw(sprite, center, size, color, Point(0., -1.));
 	else if(sprite->HasDimensions())
 		loadingCircle.Draw(center);
 }
 
 
 
-void ShopPanel::DrawThumbnail(const Drawable &thumbnail, const Point &center, float zoom, const Swizzle *swizzle) const
+void ShopPanel::DrawThumbnail(const Drawable &thumbnail, bool animate, const Point &center, float zoom,
+	const Swizzle *swizzle) const
 {
 	const Sprite *sprite = thumbnail.GetSprite();
 	if(!sprite)
 		return;
 	if(sprite->IsLoaded())
+	{
+		if(animate)
+			thumbnail.UnpauseAnimation();
+		else
+			thumbnail.PauseAnimation();
 		SpriteShader::Draw(sprite, center, zoom, swizzle, thumbnail.GetFrame(step));
+	}
 	else if(sprite->HasDimensions())
 		loadingCircle.Draw(center);
 }
@@ -860,7 +867,7 @@ void ShopPanel::DrawShipsSidebar()
 			else
 			{
 				const Swizzle *swizzle = ship->CustomSwizzle() ? ship->CustomSwizzle() : GameData::PlayerGovernment()->GetSwizzle();
-				DrawThumbnail(*ship, point, scale, swizzle);
+				DrawThumbnail(*ship, false, point, scale, swizzle);
 			}
 		}
 

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -89,7 +89,7 @@ protected:
 protected:
 	void DrawShip(const Ship &ship, const Point &center, bool isSelected) const;
 	void DrawOutline(const Drawable &thumbnail, const Point &center, const Point &size, const Color &color) const;
-	void DrawThumbnail(const Drawable &thumbnail, const Point &center, float zoom = 1.f,
+	void DrawThumbnail(const Drawable &thumbnail, bool animate, const Point &center, float zoom = 1.f,
 		const Swizzle *swizzle = Swizzle::None()) const;
 
 	void CheckForMissions(Mission::Location location) const;

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -27,6 +27,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "ScrollBar.h"
 #include "ScrollVar.h"
 #include "ShipInfoDisplay.h"
+#include "Swizzle.h"
 #include "Tooltip.h"
 
 #include <map>
@@ -35,6 +36,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 class CategoryList;
+class Drawable;
 class Outfit;
 class Planet;
 class PlayerInfo;
@@ -85,7 +87,10 @@ protected:
 
 
 protected:
-	void DrawShip(const Ship &ship, const Point &center, bool isSelected);
+	void DrawShip(const Ship &ship, const Point &center, bool isSelected) const;
+	void DrawOutline(const Drawable &thumbnail, const Point &center, const Point &size, const Color &color) const;
+	void DrawThumbnail(const Drawable &thumbnail, const Point &center, float zoom = 1.f,
+		const Swizzle *swizzle = Swizzle::None()) const;
 
 	void CheckForMissions(Mission::Location location) const;
 	void ValidateSelectedShips();
@@ -155,12 +160,15 @@ protected:
 	static constexpr double BUTTON_HEIGHT = 30.;
 	static constexpr double BUTTON_WIDTH = 73.;
 
+
 protected:
 	PlayerInfo &player;
 	// Remember the current day, for calculating depreciation.
 	int day;
 	const Planet *planet = nullptr;
 	const bool isOutfitter;
+	// Step counter for thumbnail animations.
+	int step = 0;
 
 	// The player-owned ship that was first selected in the sidebar (or most recently purchased).
 	Ship *playerShip = nullptr;

--- a/source/ShopPanel.h
+++ b/source/ShopPanel.h
@@ -88,7 +88,8 @@ protected:
 
 protected:
 	void DrawShip(const Ship &ship, const Point &center, bool isSelected) const;
-	void DrawOutline(const Drawable &thumbnail, const Point &center, const Point &size, const Color &color) const;
+	void DrawShipIcon(const Drawable &thumbnail, const Point &center, const Color &color,
+		const Swizzle *swizzle) const;
 	void DrawThumbnail(const Drawable &thumbnail, bool animate, const Point &center, float zoom = 1.f,
 		const Swizzle *swizzle = Swizzle::None()) const;
 

--- a/source/image/SpriteLoadManager.cpp
+++ b/source/image/SpriteLoadManager.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "SpriteLoadManager.h"
 
+#include "../Drawable.h"
 #include "ImageSet.h"
 #include "../Preferences.h"
 #include "Sprite.h"
@@ -207,6 +208,13 @@ void SpriteLoadManager::LoadSprite(TaskQueue &queue, const shared_ptr<ImageSet> 
 bool SpriteLoadManager::IsDeferred(const Sprite *sprite)
 {
 	return deferred.contains(sprite);
+}
+
+
+
+void SpriteLoadManager::LoadDeferred(TaskQueue &queue, const Drawable &drawable)
+{
+	LoadDeferred(queue, drawable.GetSprite());
 }
 
 

--- a/source/image/SpriteLoadManager.h
+++ b/source/image/SpriteLoadManager.h
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <string>
 
+class Drawable;
 class ImageSet;
 class PlayerInfo;
 class Sprite;
@@ -42,6 +43,7 @@ public:
 	static bool IsDeferred(const Sprite *sprite);
 	// Begin loading a sprite that was previously deferred. This is done for various images to speed up
 	// the program's startup and reduce VRAM usage.
+	static void LoadDeferred(TaskQueue &queue, const Drawable &drawable);
 	static void LoadDeferred(TaskQueue &queue, const Sprite *sprite);
 	// Cull old stellar objects and thumbnails that haven't been seen in a while.
 	static void CullOldImages(TaskQueue &queue);


### PR DESCRIPTION
**Feature**

This PR addresses the feature described in issue #5524.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Updates the "thumbnail" node of ships and outfits in game data to be able to take animation information. A ship or outfit thumbnail with multiple frames will then appear as animated when selected within the shops and map sales panels for outfitters and shipyards. In the shop, your currently selected escort will always be animated, in addition to the item you have selected in the shop. And in the shipyard, since the currently selected ship displays its top-down view in the middle section, that top-down view will also be animated now, meaning that any ships that are currently animated will appear as animated in the shipyard.

If a ship does not define a thumbnail, it will fall back onto using the top-down view of the ship, just as it does now, and that copied view will share the same animation details as the main sprite.

## Testing Done

Ignore the sprites with static-y frames. I explained what was happening [here](https://github.com/endless-sky/endless-sky/pull/12639#issuecomment-5377506185) but don't want to bother re-recording everything. Have an animated jump drive from #10233.

https://github.com/user-attachments/assets/00e01b23-be5b-46f0-a7e3-c383a6971e10

In the shipyard, selected a ship whose main sprite is animated. Observed the animation in the shop.

https://github.com/user-attachments/assets/2a8823ba-dd65-41d5-886f-e6bb5f9b3b85

Deleted the "thumbnail" node on the Shuttle, since its main sprite is animated. Observed the Shuttle's main sprite appearing in place of the thumbnail with the proper animations.

https://github.com/user-attachments/assets/26931d7c-cfbb-4eb3-b992-500830597b76

Repeated these tests in the map sales panels and observed the same behavior, including when you shift+click an item to compare two items. (Borked Scout thumbnail animation with the Shuttle main sprite animating as expected.)

https://github.com/user-attachments/assets/1274b464-1c83-4714-9604-20c8a20a01de

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/254