### PR TITLE
fix(sprite loading): Drop all 2x frames if they don't match the number of 1x frames

### DIFF
--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -182,7 +182,7 @@ void ImageSet::ValidateFrames() noexcept(false)
 		// Masks should only have 1 frame or the same number of frames as the 1x resolution.
 		// If there are fewer frames of swizzle mask than base image, only use the
 		// first swizzle mask frame.
-		else if(!is2x && size != 1)
+		else if(!is2x && size != 1 && size != normalFrames)
 		{
 			Logger::Log("Discarding " + to_string(size - 1) + " frames of swizzle mask because there"
 				" are more frames of animation. Only the first swizzle mask frame will be used.", Logger::Level::WARNING);

--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -184,7 +184,7 @@ void ImageSet::ValidateFrames() noexcept(false)
 		// first swizzle mask frame.
 		else if(!is2x && size != 1 && size != normalFrames)
 		{
-			Logger::Log("Discarding " + to_string(size - 1) + " frames of swizzle mask because there"
+			Logger::Log(prefix + "Discarding " + to_string(size - 1) + " frames of swizzle mask because there"
 				" are more frames of animation. Only the first swizzle mask frame will be used.", Logger::Level::WARNING);
 			toResize.resize(1);
 		}

--- a/source/image/ImageSet.cpp
+++ b/source/image/ImageSet.cpp
@@ -152,24 +152,48 @@ void ImageSet::ValidateFrames() noexcept(false)
 			}
 		}
 
-	auto DropPaths = [&](vector<filesystem::path> &toResize, const string &specifier)
+	int normalFrames = paths[0].size();
+	auto DropPaths = [&](vector<filesystem::path> &toResize, const string &specifier, bool is2x)
 	{
-		if(toResize.size() > paths[0].size())
+		int size = toResize.size();
+		if(!size)
+			return;
+		// Neither 2x nor masks should have more frames than the 1x resolution.
+		// Truncate down to the number of normal frames if this occurs.
+		if(size > normalFrames)
 		{
-			if(paths[0].empty())
+			if(!normalFrames)
 				Logger::Log(prefix + "all frames for the " + specifier + " sprite will be ignored, "
 					"as it has no corresponding normal resolution frame(s).", Logger::Level::WARNING);
 			else
-				Logger::Log(prefix + to_string(toResize.size() - paths[0].size())
+				Logger::Log(prefix + to_string(size - normalFrames)
 					+ " extra frame(s) for the " + specifier + " sprite will be ignored.", Logger::Level::WARNING);
-			toResize.resize(paths[0].size());
+			toResize.resize(normalFrames);
+		}
+		// The number of 2x frames can't be less than the number of 1x frames.
+		// Discard all 2x frames if there aren't enough to cover each 1x frame.
+		else if(is2x && size < normalFrames)
+		{
+			Logger::Log(prefix + "sprite has " + to_string(normalFrames - size) + " more normal resolution "
+				"frame(s) than " + specifier + " frames. All " + specifier + " frames will be dropped to prevent "
+				"sprite loading issues.", Logger::Level::WARNING);
+			toResize.clear();
+		}
+		// Masks should only have 1 frame or the same number of frames as the 1x resolution.
+		// If there are fewer frames of swizzle mask than base image, only use the
+		// first swizzle mask frame.
+		else if(!is2x && size != 1)
+		{
+			Logger::Log("Discarding " + to_string(size - 1) + " frames of swizzle mask because there"
+				" are more frames of animation. Only the first swizzle mask frame will be used.", Logger::Level::WARNING);
+			toResize.resize(1);
 		}
 	};
 
 	// Drop any @2x and mask paths that will not be used.
-	DropPaths(paths[1], "@2x");
-	DropPaths(paths[2], "mask");
-	DropPaths(paths[3], "@2x mask");
+	DropPaths(paths[1], "@2x", true);
+	DropPaths(paths[2], "mask", false);
+	DropPaths(paths[3], "@2x mask", false);
 }
 
 
@@ -184,15 +208,7 @@ void ImageSet::Load() noexcept(false)
 	// not actually be allocated until the first image is loaded (at which point
 	// the sprite's dimensions will be known).
 	size_t frames = paths[0].size();
-	// If there are fewer frames of swizzle mask than base image, only use the
-	// first swizzle mask frame. Send a warning if any are discarded.
 	size_t swizzleMaskFrames = paths[2].size();
-	if(swizzleMaskFrames > 1 && swizzleMaskFrames < frames)
-	{
-		Logger::Log("Discarding " + to_string(swizzleMaskFrames - 1) + " frames of swizzle mask because there"
-			" are more frames of animation. Only the first swizzle mask frame will be used.", Logger::Level::WARNING);
-		swizzleMaskFrames = 1;
-	}
 
 	// Check whether we need to generate collision masks.
 	bool makeMasks = IsMasked(name);

--- a/source/image/Sprite.cpp
+++ b/source/image/Sprite.cpp
@@ -139,7 +139,10 @@ bool Sprite::HasDimensions() const
 void Sprite::AddFrames(ImageBuffer &buffer1x, ImageBuffer &buffer2x, bool noReduction)
 {
 	isLoaded = true;
-	// The 1x image determines the dimensions of the sprite's size.
+	// The 1x image determines the dimensions of the sprite's size
+	// and its number of frames. ImageSet should ensure that either 1x
+	// and 2x buffers contain the same number of frames, or the 2x buffer
+	// is empty.
 	width = buffer1x.Width();
 	height = buffer1x.Height();
 	frames = buffer1x.Frames();
@@ -148,7 +151,7 @@ void Sprite::AddFrames(ImageBuffer &buffer1x, ImageBuffer &buffer2x, bool noRedu
 	if(!buffer1x.Pixels())
 		return;
 
-	// Only use the 2x resolution image if it is provided.
+	// Use only the 2x resolution image if it is provided.
 	if(buffer2x.Pixels())
 	{
 		AddBuffer(name, buffer2x, &texture, noReduction);
@@ -174,7 +177,7 @@ void Sprite::AddSwizzleMaskFrames(ImageBuffer &buffer1x, ImageBuffer &buffer2x, 
 	if(!buffer1x.Pixels())
 		return;
 
-	// Only use the 2x resolution image if it is provided.
+	// Use only the 2x resolution image if it is provided.
 	if(buffer2x.Pixels())
 	{
 		AddBuffer(name, buffer2x, &swizzleMask, noReduction);


### PR DESCRIPTION
**Feature**

This PR addresses the bug found when testing #12639.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Within Sprite::ValidateFrames, the game will print a warning if a sprite has more 2x or mask frames than 1x frames, and Sprite::Load will print a warning if the mask has less frames than the 1x frames (with 1 shared frame being allowed), but there is no check to ensure that the number of 2x frames isn't less than the number of 1x frames. If you do have less 2x frames than 1x frames, due to #12043 causing the 2x frames to always be used if present, Sprite::Load sizes the 2x buffer to match the number of 1x frames, but does not have enough 2x paths to populate the 2x buffer. 

This PR changes Sprite::ValidateFrames to discard all 2x paths if there are less 2x paths than 1x paths, and print a warning if this occurs.

This also moves the check from #12049 to ensure that the swizzle masks either only have 1 frame or the same number of frames as the 1x resolution images from Sprite::Load to Sprite::ValidateFrames, as this seems more fitting a location. This check was also missing the prefix to say which sprite had this problem.

## Testing Done

Gave the 1x shuttle thumbnail two frames while leaving the 2x shuttle thumbnail at only one frame. Tested #12639 with and without this change. Without it, I got junk frames after the first frame. With it, I see the two expected 1x frames without issue and get a warning logged.