### PR TITLE
feat(content): Don't let the Author government fine the player

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -47,6 +47,7 @@ government "Alpha"
 government "Author"
 	"player reputation" 1
 	"bribe" 0
+	"fine" 0
 	"friendly disabled hail" "friendly disabled"
 	"hostile disabled hail" "hostile disabled"
 


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Right now, some Author ships (the Waverider from the Patrol Team) are equipped with scanners and are capable of fining the player. This is annoying. Being annoying is what Cap'n Pester is for.

This PR adds `fine 0` to the Author government. Author ships may still scan you, but they won't fine you if you have illegal goods on you.

## Testing Done

I'll trust that setting `fine` to zero is working as intended.