### PR TITLE
feat(content): Update the Pond Strider's description

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -882,7 +882,7 @@ ship "Pond Strider"
 	explode "large explosion" 40
 	explode "huge explosion" 10
 	"final explode" "final explosion large"
-	description "The Pond Strider is a drone carrier augmented with hull repair technology acquired through alien diplomacy. Its deployment, together with the Flea drone, has greatly reduced Hai casualties in their conflict with the Unfettered. The built-in hull repair technology serves both the Pond Strider and any carried drones, allowing them to be repaired in space when damaged. The Hai have also cleverly codesigned the Skipper Railgun with the Pond Strider and Flea as a means of very efficient fleet combat support."
+	description "The Pond Strider is a drone carrier augmented with hull repair technology acquired through alien diplomacy. Its deployment, together with the Flea drone, has greatly reduced Hai casualties in their conflict with the Unfettered. The Hai have also cleverly codesigned the Skipper Railgun with the Pond Strider and Flea as a means of very efficient fleet combat support."
 
 ship "Pond Strider" "Pond Strider (Tracker)"
 	outfits

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -882,7 +882,7 @@ ship "Pond Strider"
 	explode "large explosion" 40
 	explode "huge explosion" 10
 	"final explode" "final explosion large"
-	description "The Hai upgraded their original Pond Strider after acquiring hull repair technology through alien diplomacy. These improvements have greatly reduced casualties in their conflict with the Unfettered, since the light Pond Striders become vulnerable as they collect damaged drones. Besides enabling the ship to repair damaged drones, the Hai have cleverly innovated the Skipper Railgun to make the Pond Strider and Fleas into very efficient combat support for their fleets."
+	description "The Pond Strider is a drone carrier augmented with hull repair technology acquired through alien diplomacy. Its deployment, together with the Flea drone, has greatly reduced Hai casualties in their conflict with the Unfettered. The built-in hull repair technology serves both the Pond Strider and any carried drones, allowing them to be repaired in space when damaged. The Hai have also cleverly codesigned the Skipper Railgun with the Pond Strider and Flea as a means of very efficient fleet combat support."
 
 ship "Pond Strider" "Pond Strider (Tracker)"
 	outfits

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -882,7 +882,7 @@ ship "Pond Strider"
 	explode "large explosion" 40
 	explode "huge explosion" 10
 	"final explode" "final explosion large"
-	description "The Pond Strider is a drone carrier augmented with hull repair technology acquired through alien diplomacy. Its deployment, together with the Flea drone, has greatly reduced Hai casualties in their conflict with the Unfettered. The Hai have also cleverly codesigned the Skipper Railgun with the Pond Strider and Flea as a means of very efficient fleet combat support."
+	description "The Pond Strider is a drone carrier augmented with hull repair technology acquired through alien diplomacy. Its deployment, together with the Flea drone, has greatly reduced Hai casualties in their conflict with the Unfettered. The Hai have also cleverly designed the Skipper Railgun for the Pond Strider and Flea as a means of equipping them with a very efficient fleet combat support weapon."
 
 ship "Pond Strider" "Pond Strider (Tracker)"
 	outfits


### PR DESCRIPTION
**Content**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
- Removed references to a non-existent "original" version of the Pond Strider. The present Pond Strider is a newly developed ship per the Pond Strider mission chain. It seems that early on in #4494, the intention was that the Pond Strider was made available soon after the appearance of the Solifuge, and afterwards the player could help the Hai upgrade it. This never eventuated, but the description was never updated to reflect this.
- Edited the description for clarity and flow.