### PR TITLE
feat(ui): add optional physical units for ships info and outfits info displays

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1804,3 +1804,6 @@ tip "Default max escort crew"
 
 tip `Default admin cap`
 	`If the fleet size limitation is "admin cap," then this is the default maximum administrative capacity. Ships will have individual administrative costs that count toward your capacity. This value may be increased through story events. Changing this value on an existing pilot will have no effect.`
+
+tip "Use physical units"
+	`Use physical units instead of unitless for metrics; wherever applicable.`

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -20,9 +20,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
+#include "Preferences.h"
 #include "Weapon.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <map>
 #include <set>
@@ -250,6 +252,34 @@ namespace {
 			SCALE.find(label) != SCALE.end() ||
 			BOOLEAN_ATTRIBUTES.find(label) != BOOLEAN_ATTRIBUTES.end();
 	}
+
+	const static std::array<std::string, 5> energyAttributesWeapon = {
+		"energy damage",
+		"firing heat",
+		"firing energy",
+		"heat damage",
+		"ion damage"
+	};
+
+	const static std::array<std::string, 2> energyAmountAttributes = {"firing discharge", "discharge damage"};
+	const static std::array<std::string, 2> fuelAmountAttributes = {"firing fuel", "fuel damage"};
+
+	const static std::array<std::string, 14> energyAttributes = {
+		"hull energy",
+		"shield energy",
+		"energy generation",
+		"hull heat",
+		"shield heat",
+		"heat generation",
+		"energy consumption",
+		"cooling energy",
+		"cooling",
+		"active cooling",
+		"thrusting heat",
+		"thrusting energy",
+		"afterburner heat",
+		"afterburner energy"
+	};
 }
 
 
@@ -260,6 +290,28 @@ std::string OutfitInfoDisplay::FormatAttribute(const std::string &attribute, dou
 	double scale = (sit == SCALE.end() ? 1. : SCALE_LABELS[sit->second].first);
 	string units = (sit == SCALE.end() ? "" : SCALE_LABELS[sit->second].second);
 
+	if(Preferences::UsePhysicalUnits())
+	{
+		if(std::find(energyAttributes.begin(), energyAttributes.end(), attribute) != energyAttributes.end())
+		{
+			return Format::EnergyRate(value * scale) + units;
+		}
+		else if(attribute == "thrust" || attribute == "afterburner thrust")
+		{
+			return Format::Thrust(value * scale) + units;
+		}
+		else if(attribute == "energy capacity" || attribute == "heat capacity")
+		{
+			return Format::EnergyAmount(value * scale) + units;
+		}
+		else if(attribute == "fuel consumption" || attribute == "fuel generation" || attribute == "fuel capacity" ||
+				 attribute == "hyperdrive fuel" || attribute == "jump drive fuel" || attribute == "afterburner fuel" ||
+				 attribute == "thrusting fuel")
+		{
+			return Format::Number(value * scale) + " tons " + units;
+		}
+		return Format::Number(value * scale) + units;
+	}
 	return Format::Number(value * scale) + units;
 }
 
@@ -509,7 +561,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 
 	double range = weapon->Range();
 	attributeLabels.emplace_back("range:");
-	attributeValues.emplace_back(Format::Number(range));
+	attributeValues.emplace_back(Format::Number(range) + (Preferences::UsePhysicalUnits() ? " km" : ""));
 	attributesHeight += 20;
 
 	attributeLabels.emplace_back("velocity:");
@@ -517,7 +569,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	if(velocity == range)
 		attributeValues.emplace_back("instantaneous");
 	else
-		attributeValues.emplace_back(Format::Number(velocity * 60.));
+		attributeValues.emplace_back(Format::Number(velocity * 60.) + (Preferences::UsePhysicalUnits() ? " km/s" : ""));
 	attributesHeight += 20;
 
 	// Identify the dropoff at range and inform the player.
@@ -626,7 +678,28 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			if(values[i])
 			{
 				attributeLabels.emplace_back(VALUE_NAMES[i].first + PER_SECOND);
-				attributeValues.emplace_back(Format::Number(60. * values[i] / reload) + VALUE_NAMES[i].second);
+				if(std::find(energyAttributesWeapon.begin(), energyAttributes.end(), VALUE_NAMES[i].first) !=
+					energyAttributes.end())
+				{
+					attributeValues.emplace_back(Format::EnergyRate(60. * values[i] / reload) + VALUE_NAMES[i].second);
+				}
+				else if(std::find(energyAmountAttributes.begin(), energyAmountAttributes.end(), VALUE_NAMES[i].first) !=
+						 energyAmountAttributes.end())
+				{
+					attributeValues.emplace_back(Format::EnergyAmount(60. * values[i] / reload) +
+												 VALUE_NAMES[i].second);
+				}
+				else if(Preferences::UsePhysicalUnits() &&
+						 (std::find(fuelAmountAttributes.begin(), fuelAmountAttributes.end(), VALUE_NAMES[i].first) !=
+						  fuelAmountAttributes.end()))
+				{
+					attributeValues.emplace_back(Format::Number(60. * values[i] / reload) + VALUE_NAMES[i].second +
+												 " tons");
+				}
+				else
+				{
+					attributeValues.emplace_back(Format::Number(60. * values[i] / reload) + VALUE_NAMES[i].second);
+				}
 				attributesHeight += 20;
 			}
 	}
@@ -650,7 +723,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	if(turretTurn)
 	{
 		attributeLabels.emplace_back("turret turn rate:");
-		attributeValues.emplace_back(Format::Number(turretTurn));
+		attributeValues.emplace_back(Format::Number(turretTurn) + (Preferences::UsePhysicalUnits() ? " deg/s" : ""));
 		attributesHeight += 20;
 	}
 	double arc = weapon->Arc();
@@ -714,7 +787,26 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 			if(values[i])
 			{
 				attributeLabels.emplace_back(VALUE_NAMES[i].first + PER_SHOT);
-				attributeValues.emplace_back(Format::Number(values[i]) + VALUE_NAMES[i].second);
+				if(std::find(energyAttributesWeapon.begin(), energyAttributes.end(), VALUE_NAMES[i].first) !=
+					energyAttributes.end())
+				{
+					attributeValues.emplace_back(Format::EnergyRate(values[i]) + VALUE_NAMES[i].second);
+				}
+				else if(std::find(energyAmountAttributes.begin(), energyAmountAttributes.end(), VALUE_NAMES[i].first) !=
+						 energyAmountAttributes.end())
+				{
+					attributeValues.emplace_back(Format::EnergyAmount(values[i]) + VALUE_NAMES[i].second);
+				}
+				else if(Preferences::UsePhysicalUnits() &&
+						 (std::find(fuelAmountAttributes.begin(), fuelAmountAttributes.end(), VALUE_NAMES[i].first) !=
+						  fuelAmountAttributes.end()))
+				{
+					attributeValues.emplace_back(Format::Number(values[i]) + VALUE_NAMES[i].second + " tons");
+				}
+				else
+				{
+					attributeValues.emplace_back(Format::Number(values[i]) + VALUE_NAMES[i].second);
+				}
 				attributesHeight += 20;
 			}
 	}

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -46,6 +46,8 @@ namespace {
 	const string EXPEND_AMMO = "Escorts expend ammo";
 	const string FRUGAL_ESCORTS = "Escorts use ammo frugally";
 
+    const string PHYSICAL_UNITS = "Use physical units";
+
 	const vector<string> DATEFMT_OPTIONS = {"dd/mm/yyyy", "mm/dd/yyyy", "yyyy-mm-dd"};
 	int dateFormatIndex = 0;
 
@@ -543,6 +545,13 @@ int Preferences::TooltipActivation()
 void Preferences::SetTooltipActivation(int steps)
 {
 	tooltipActivation = steps;
+}
+
+
+
+bool Preferences::UsePhysicalUnits()
+{
+	return Preferences::Has(PHYSICAL_UNITS);
 }
 
 
@@ -1133,6 +1142,13 @@ void Preferences::ToggleBlockScreenSaver()
 {
 	GameWindow::ToggleBlockScreenSaver();
 	Set(BLOCK_SCREEN_SAVER, !Has(BLOCK_SCREEN_SAVER));
+}
+
+
+
+void Preferences::ToggleUsePhysicalUnits()
+{
+	Set(PHYSICAL_UNITS, !Has(PHYSICAL_UNITS));
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -205,6 +205,8 @@ public:
 	static int TooltipActivation();
 	static void SetTooltipActivation(int steps);
 
+	static bool UsePhysicalUnits();
+
 	static double ViewZoom();
 	static bool ZoomViewIn();
 	static bool ZoomViewOut();
@@ -316,6 +318,7 @@ public:
 	static int GetFontSize();
 
 	static void ToggleBlockScreenSaver();
+	static void ToggleUsePhysicalUnits();
 
 	static int GetPreviousSaveCount();
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -95,6 +95,7 @@ namespace {
 	const string MINIMAP_DISPLAY = "Show mini-map";
 	const string HUD_SHIP_OUTLINES = "Ship outlines in HUD";
 	const string BLOCK_SCREEN_SAVER = "Block screen saver";
+	const string PHYSICAL_UNITS = "Use physical units";
 	const string TRIBUTE_CONFIRMATION = "Tribute confirmation";
 	const string AMMO_REFILL = "Auto refill ammo";
 	const string TEXT_ALIGNMENT = "Text alignment";
@@ -792,9 +793,7 @@ void PreferencesPanel::DrawSettings()
 		"Sell outfits without outfitter",
 		"Confirm selling outfits",
 		"Confirm selling minables",
-		"",
-		"Gameplay",
-		TRIBUTE_CONFIRMATION,
+		PHYSICAL_UNITS,
 		"\n",
 		"Flagship Behavior",
 		"Control ship with mouse",
@@ -832,6 +831,9 @@ void PreferencesPanel::DrawSettings()
 		"Clickable radar display",
 		ALERT_INDICATOR,
 		"Extra fleet status messages",
+		"",
+		"Gameplay",
+		TRIBUTE_CONFIRMATION,
 		"\n",
 		"Other",
 		"Always underline shortcuts",
@@ -1485,6 +1487,8 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleMinimapDisplay();
 	else if(str == BLOCK_SCREEN_SAVER)
 		Preferences::ToggleBlockScreenSaver();
+	else if(str == PHYSICAL_UNITS)
+		Preferences::ToggleUsePhysicalUnits();
 	else if(str == TRIBUTE_CONFIRMATION)
 		Preferences::ToggleTributeConfirmation();
 	else if(str == AMMO_REFILL)

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -25,6 +25,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "GameData.h"
 #include "Outfit.h"
 #include "PlayerInfo.h"
+#include "Preferences.h"
 #include "Ship.h"
 #include "text/Table.h"
 #include "Weapon.h"
@@ -245,9 +246,10 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeLabels.push_back(isGeneric ? "fuel capacity:" : "fuel:");
 	double fuelCapacity = ship.MaxFuel();
 	if(isGeneric)
-		attributeValues.push_back(Format::Number(fuelCapacity));
+	  attributeValues.push_back(Format::Number(fuelCapacity) + (Preferences::UsePhysicalUnits()?" tons" : ""));
 	else
-		attributeValues.push_back(Format::Number(ship.FuelLevel()) + " / " + Format::Number(fuelCapacity));
+      attributeValues.push_back(Format::Number(ship.FuelLevel()) + " / " +
+                                Format::Number(fuelCapacity) + (Preferences::UsePhysicalUnits()?" tons" : ""));
 	attributesHeight += 20;
 
 	double fullMass = emptyMass + attributes.Get("cargo space");
@@ -260,7 +262,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeValues.push_back(string());
 	attributesHeight += 20;
 	attributeLabels.push_back("max speed:");
-	attributeValues.push_back(Format::Number(60. * forwardThrust / ship.Drag()));
+	attributeValues.push_back(Format::Number(60. * forwardThrust / ship.Drag()) +
+							(Preferences::UsePhysicalUnits()?" km/s" : ""));
 	attributesHeight += 20;
 
 	// Movement stats are influenced by inertia reduction.
@@ -271,19 +274,20 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	attributeLabels.push_back("acceleration:");
 	double baseAccel = 3600. * forwardThrust * (1. + attributes.Get("acceleration multiplier"));
 	if(!isGeneric)
-		attributeValues.push_back(Format::Number(baseAccel / currentMass));
+		attributeValues.push_back(Format::Number(baseAccel / currentMass) + (Preferences::UsePhysicalUnits()?" km/s^2" : ""));
 	else
 		attributeValues.push_back(Format::Number(baseAccel / fullMass)
-			+ " - " + Format::Number(baseAccel / emptyMass));
+			+ " - " + Format::Number(baseAccel / emptyMass)+ (Preferences::UsePhysicalUnits()?" km/s^2" : ""));
 	attributesHeight += 20;
 
 	attributeLabels.push_back("turning:");
 	double baseTurn = 60. * attributes.Get("turn") * (1. + attributes.Get("turn multiplier"));
 	if(!isGeneric)
-		attributeValues.push_back(Format::Number(baseTurn / currentMass));
+		attributeValues.push_back(Format::Number(baseTurn / currentMass)
+							+ (Preferences::UsePhysicalUnits()?" deg/s" : ""));
 	else
 		attributeValues.push_back(Format::Number(baseTurn / fullMass)
-			+ " - " + Format::Number(baseTurn / emptyMass));
+			+ " - " + Format::Number(baseTurn / emptyMass)+ (Preferences::UsePhysicalUnits()?" deg/s" : ""));
 	attributesHeight += 20;
 
 	// Find out how much outfit, engine, and weapon space the chassis has.
@@ -345,8 +349,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		+ attributes.Get("fuel heat")
 		- ship.CoolingEfficiency() * (attributes.Get("cooling") + attributes.Get("active cooling"));
 	tableLabels.push_back("idle:");
-	energyTable.push_back(Format::Number(60. * idleEnergyPerFrame));
-	heatTable.push_back(Format::Number(60. * idleHeatPerFrame));
+	energyTable.push_back(Format::EnergyRate(60. * idleEnergyPerFrame));
+	heatTable.push_back(Format::EnergyRate(60. * idleHeatPerFrame));
 
 	// Add energy and heat while moving to the table.
 	attributesHeight += 20;
@@ -358,8 +362,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		+ attributes.Get("turning heat")
 		+ attributes.Get("afterburner heat");
 	tableLabels.push_back("moving:");
-	energyTable.push_back(Format::Number(-60. * movingEnergyPerFrame));
-	heatTable.push_back(Format::Number(60. * movingHeatPerFrame));
+	energyTable.push_back(Format::EnergyRate(-60. * movingEnergyPerFrame));
+	heatTable.push_back(Format::EnergyRate(60. * movingHeatPerFrame));
 
 	// Add energy and heat while firing to the table.
 	attributesHeight += 20;
@@ -375,8 +379,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		}
 	}
 	tableLabels.push_back("firing:");
-	energyTable.push_back(Format::Number(-60. * firingEnergy));
-	heatTable.push_back(Format::Number(60. * firingHeat));
+	energyTable.push_back(Format::EnergyRate(-60. * firingEnergy));
+	heatTable.push_back(Format::EnergyRate(60. * firingHeat));
 
 	// Add energy and heat when doing shield and hull repair to the table.
 	attributesHeight += 20;
@@ -388,14 +392,14 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		* (1. + attributes.Get("hull energy multiplier")) : 0.;
 	tableLabels.push_back((shieldEnergy && hullEnergy) ? "shields / hull:" :
 		hullEnergy ? "repairing hull:" : "charging shields:");
-	energyTable.push_back(Format::Number(-60. * (shieldEnergy + hullEnergy)));
+	energyTable.push_back(Format::EnergyRate(-60. * (shieldEnergy + hullEnergy)));
 	double shieldHeat = (hasShieldRegen) ? (attributes.Get("shield heat")
 		+ attributes.Get("delayed shield heat"))
 		* (1. + attributes.Get("shield heat multiplier")) : 0.;
 	double hullHeat = (hasHullRepair) ? (attributes.Get("hull heat")
 		+ attributes.Get("delayed hull heat"))
 		* (1. + attributes.Get("hull heat multiplier")) : 0.;
-	heatTable.push_back(Format::Number(60. * (shieldHeat + hullHeat)));
+	heatTable.push_back(Format::EnergyRate(60. * (shieldHeat + hullHeat)));
 
 	if(scrollingPanel)
 	{
@@ -412,8 +416,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 			+ shieldHeat
 			+ hullHeat;
 		tableLabels.push_back("net change:");
-		energyTable.push_back(Format::Number(60. * overallEnergy));
-		heatTable.push_back(Format::Number(60. * overallHeat));
+		energyTable.push_back(Format::EnergyRate(60. * overallEnergy));
+		heatTable.push_back(Format::EnergyRate(60. * overallHeat));
 	}
 
 	// Add maximum values of energy and heat to the table.
@@ -421,8 +425,8 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 	const double maxEnergy = attributes.Get("energy capacity");
 	const double maxHeat = 60. * ship.HeatDissipation() * ship.MaxHeat();
 	tableLabels.push_back("capacity:");
-	energyTable.push_back(Format::Number(maxEnergy));
-	heatTable.push_back(Format::Number(maxHeat));
+	energyTable.push_back(Format::EnergyAmount(maxEnergy));
+	heatTable.push_back(Format::EnergyAmount(maxHeat));
 	// Pad by 10 pixels on the top and bottom.
 	attributesHeight += 30;
 }

--- a/source/text/Format.cpp
+++ b/source/text/Format.cpp
@@ -582,6 +582,108 @@ string Format::AmmoCount(int64_t value)
 
 
 
+string Format::WattagePerSec(double value, optional<int> decimalPlaces, bool trimTrailingZeros)
+{
+	string suf = "W-s";
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "kW-s";
+	}
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "MW-s";
+	}
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "GW-s";
+	}
+	return Format::Number(value, decimalPlaces, trimTrailingZeros) + " " + suf;
+}
+
+
+
+string Format::Wattage(double value, optional<int> decimalPlaces, bool trimTrailingZeros)
+{
+	string suf = "W";
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "kW";
+	}
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "MW";
+	}
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "GW";
+	}
+	return Format::Number(value, decimalPlaces, trimTrailingZeros) + " " + suf;
+}
+
+
+
+string Format::KiloNewtons(double value, optional<int> decimalPlaces, bool trimTrailingZeros)
+{
+	string suf = "kN";
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "MN";
+	}
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "GN";
+	}
+	if(abs(value) >= 1000)
+	{
+		value /= 1000;
+		suf = "TN";
+	}
+	return Format::Number(value, decimalPlaces, trimTrailingZeros) + " " + suf;
+}
+
+
+
+string Format::EnergyAmount(double value, std::optional<int> decimalPlaces, bool trimTrailingZeros)
+{
+	if(Preferences::UsePhysicalUnits())
+	{
+		return WattagePerSec(value, decimalPlaces, trimTrailingZeros);
+	}
+	return Number(value, decimalPlaces, trimTrailingZeros);
+}
+
+
+
+string Format::EnergyRate(double value, std::optional<int> decimalPlaces, bool trimTrailingZeros)
+{
+	if(Preferences::UsePhysicalUnits())
+	{
+		return Wattage(value, decimalPlaces, trimTrailingZeros);
+	}
+	return Number(value, decimalPlaces, trimTrailingZeros);
+}
+
+
+
+string Format::Thrust(double value, std::optional<int> decimalPlaces, bool trimTrailingZeros)
+{
+	if(Preferences::UsePhysicalUnits())
+	{
+		return KiloNewtons(value, decimalPlaces, trimTrailingZeros);
+	}
+	return Number(value, decimalPlaces, trimTrailingZeros);
+}
+
+
+
 string Format::Number(double value, optional<int> decimalPlaces, bool trimTrailingZeros)
 {
 	if(!value)

--- a/source/text/Format.h
+++ b/source/text/Format.h
@@ -36,6 +36,29 @@ public:
 
 
 public:
+
+  // Automatically switch between unitless and physical units for energy amount related quantities.
+  // Uses wattage-second scale
+	static std::string EnergyAmount(double value, std::optional<int> decimalPlaces = std::nullopt,
+									  bool trimTrailingZeros = true);
+  // Automatically switch between unitless and physical units for energy related quantities.
+  // Uses wattage scale
+	static std::string EnergyRate(double value, std::optional<int> decimalPlaces = std::nullopt,
+								  bool trimTrailingZeros = true);
+  // Automatically switch between unitless and physical units for thrust related quantities.
+  // Uses kilo newtons scale
+	static std::string Thrust(double value, std::optional<int> decimalPlaces = std::nullopt,
+							   bool trimTrailingZeros = true);
+  // Wattage scale for energy rate related quantities
+	static std::string Wattage(double value, std::optional<int> decimalPlaces = std::nullopt,
+							   bool trimTrailingZeros = true);
+  // Wattage scale for energy amount related quantities
+	static std::string WattagePerSec(double value, std::optional<int> decimalPlaces = std::nullopt,
+									 bool trimTrailingZeros = true);
+  // Kilo Newton scale for thrust related quantities
+	static std::string KiloNewtons(double value, std::optional<int> decimalPlaces = std::nullopt,
+							   bool trimTrailingZeros = true);
+
 	// Convert the given number into abbreviated format with a suffix like
 	// "M" for million, "B" for billion, or "T" for trillion. Any number
 	// above 1 quadrillion is instead shown in scientific notation.


### PR DESCRIPTION
**Feature**

This PR addresses the bug/feature described in issue ```N/A```

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
This commit adds an option in preferences to display various ship and outfit metrics, formatted with physical units, namely ```(W)wattage```, ```(W-s)Watt-seconds```, ```(T)tonnage(for fuel)``` and ```(kN)kilonewtons```.

These units scale from their base symbol to upto ```Kilo```, ```Mega``` and ```Giga``` symbolic prefixes, except for ```KiloNewtons``` which starts from ```Kilo``` scales upto ```Terra```.

Heat and electricity use ```Watt``` for per second values and ```Watt-seconds``` for amount/accumulation. ```Watt-seconds``` preserves the intuitive calculations possible in unitless representation.
Thrust uses ```KiloNewtons```. But mostly ```MegaNewtons``` is displayed since real world propulsion often operates in ```MN``` ranges of thrust.

This option is disabled by default, and comes with its tooltip.

To allocate room for the new option, gameplay options section had to be shifted to the adjacent page of the settings panel.

## Screenshots
Unitless metrics:
<img width="781" height="1080" alt="Screenshot_2026-08-25_21-56-13" src="https://github.com/user-attachments/assets/b830fb00-b2b9-4171-b951-c32acec0e03a" />
With units:
<img width="780" height="1076" alt="Screenshot_2026-08-25_21-55-50" src="https://github.com/user-attachments/assets/7472d6b8-9e05-4c96-beae-6bc96611b92e" />
Kilo Newtons:
<img width="425" height="441" alt="Screenshot_2026-08-25_21-57-09" src="https://github.com/user-attachments/assets/45558b9f-375e-4605-a979-c4fceb8b3d35" />


The option:
<img width="617" height="385" alt="Screenshot_2026-08-25_21-52-19" src="https://github.com/user-attachments/assets/db101ee9-871e-4aad-a227-cd4fe27bbb92" />
The shifting of the gameplay settings section:
<img width="982" height="721" alt="Screenshot_2026-08-25_21-52-43" src="https://github.com/user-attachments/assets/5639ee95-5cf7-4723-85c4-415fa2c9beb2" />



## Usage examples
N/A

## Testing Done
Played a few FW missions with plugins as well. No issues observed.

## Save File
```N/A```
```This is an engine modification```

## Artwork Checklist
```N/A```

## Wiki Update
```Minor UI feature```

## Performance Impact
```N/A```
```std::find``` has been used in ```ShipInfoDisplay::UpdateAtrributes()``` and ``````OutfitInfoDisplay::UpdateAtrributes()`````` functions.
