### PR TITLE
Adjust Human Missile Pods for Consistency

### DIFF
--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -1308,7 +1308,7 @@ outfit "Torpedo Launcher"
 	index 01110
 	cost 80000
 	thumbnail "outfit/torpedo launcher"
-	"mass" 18
+	"mass" 15
 	"outfit space" -30
 	"weapon capacity" -30
 	"gun ports" -1

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -964,7 +964,7 @@ outfit "Meteor Missile Pod"
 		"velocity" 11
 		"lifetime" 350
 		"reload" 200
-		"burst count" 7
+		"burst count" 10
 		"burst reload" 80
 		"firing energy" 1
 		"firing heat" 20
@@ -1095,7 +1095,7 @@ outfit "Sidewinder Missile Pod"
 		"velocity" 14
 		"lifetime" 350
 		"reload" 150
-		"burst count" 6
+		"burst count" 10
 		"burst reload" 60
 		"firing energy" 1
 		"firing heat" 15
@@ -1214,7 +1214,7 @@ outfit "Javelin Mini Pod"
 		"velocity" 10
 		"lifetime" 60
 		"reload" 40
-		"burst count" 30
+		"burst count" 50
 		"burst reload" 20
 		"firing energy" .2
 		"firing heat" 12
@@ -1371,7 +1371,7 @@ outfit "Torpedo Pod"
 		"velocity override" 6
 		"lifetime" 900
 		"reload" 320
-		"burst count" 3
+		"burst count" 6
 		"burst reload" 150
 		"firing energy" 2
 		"firing heat" 45
@@ -1501,7 +1501,7 @@ outfit "Typhoon Pod"
 		"velocity" 4
 		"lifetime" 1600
 		"reload" 320
-		"burst count" 3
+		"burst count" 6
 		"burst reload" 150
 		"firing energy" 4
 		"firing heat" 50
@@ -1625,7 +1625,7 @@ outfit "Heavy Rocket Pod"
 		"velocity" 8
 		"lifetime" 125
 		"reload" 500
-		"burst count" 2
+		"burst count" 4
 		"burst reload" 240
 		"firing energy" 1
 		"firing heat" 250

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -949,7 +949,7 @@ outfit "Meteor Missile Pod"
 	"outfit space" -3
 	"weapon capacity" -3
 	"gun ports" -1
-	"meteor capacity" 7
+	"meteor capacity" 10
 	weapon
 		sprite "projectile/meteor"
 			"no repeat"
@@ -1080,7 +1080,7 @@ outfit "Sidewinder Missile Pod"
 	"outfit space" -4
 	"weapon capacity" -4
 	"gun ports" -1
-	"sidewinder capacity" 6
+	"sidewinder capacity" 10
 	weapon
 		sprite "projectile/sidewinder"
 			"no repeat"
@@ -1203,7 +1203,7 @@ outfit "Javelin Mini Pod"
 	"outfit space" -3
 	"weapon capacity" -3
 	"gun ports" -1
-	"javelin capacity" 30
+	"javelin capacity" 50
 	weapon
 		sprite "projectile/javelin"
 		sound "javelin"
@@ -1286,7 +1286,7 @@ outfit "Torpedo"
 	category "Ammunition"
 	cost 1400
 	thumbnail "outfit/torpedo"
-	"mass" .4
+	"mass" .5
 	"torpedo capacity" -1
 	description "Torpedoes are ammunition for the Torpedo Launcher. Each Torpedo Launcher can hold 30 of them. You cannot install torpedoes unless you have also installed a launcher to fire them from."
 
@@ -1355,7 +1355,7 @@ outfit "Torpedo Pod"
 	"outfit space" -8
 	"weapon capacity" -8
 	"gun ports" -1
-	"torpedo capacity" 3
+	"torpedo capacity" 6
 	weapon
 		sprite "projectile/torpedo"
 			"frame rate" 2
@@ -1482,11 +1482,11 @@ outfit "Typhoon Pod"
 	index 01120
 	cost 100000
 	thumbnail "outfit/typhoonpod"
-	"mass" 6
+	"mass" 9
 	"outfit space" -12
 	"weapon capacity" -12
 	"gun ports" -1
-	"typhoon capacity" 3
+	"typhoon capacity" 6
 	weapon
 		sprite "projectile/typhoon"
 			"frame rate" 4
@@ -1608,11 +1608,11 @@ outfit "Heavy Rocket Pod"
 	index 01080
 	cost 15000
 	thumbnail "outfit/rocket pod"
-	"mass" 3
+	"mass" 4
 	"outfit space" -6
 	"weapon capacity" -6
 	"gun ports" -1
-	"rocket capacity" 2
+	"rocket capacity" 4
 	weapon
 		sprite "projectile/rocket"
 			"frame rate" 4


### PR DESCRIPTION
## Objective

This PR continues the intention of [PR 12239](https://github.com/endless-sky/endless-sky/pull/12239) to balance the game's missile weapons. Here it shall be focused on Human Missile Pods.

## Issue

A basic equation for secondary weapons is
`weapon_outfit_space = weapon_mass + (capacity * ammo_mass)`.
Human missile pods violate this rule, giving them less ammo capacity then necessary and such also less firing time, which in turn requires to equip ships which employ them with additional missile storage to reach a minimum feasible amount of firing time. Naturally this adds up outfit space, rendering missile pods widely useless.

## Solution

This PR increases the capacity of all human missile pods to fill up the difference between their outfit space and their ammo-less mass. It is beared in mind, that a reasonable firing time should not exceed 30-40 seconds (nominal, not taking into account the burstfire pattern of pods). For comparison, currently the pods have a firing time of 15-20 seconds, and the larger launchers of 40-80 seconds.

For the following pods the solution was straightforward by increasing the capacity as follows.
| Outfit | Stat | old | new |
|--------|------|-----|-----|
| Javelin Mini Pod | capacity | 30 | 50 |
| Meteor Missile Pod | capacity | 7 | 10 |
| Sidewinder Missile Pod | capacity | 6 | 10 |

With the same approach, the *Heavy Rocky Pod* had to get a capacity of 6 instead of 2, however that would have exceeded the targeted firing time. Therefore:
| Outfit | Stat | old | new |
|--------|------|-----|-----|
| Heavy Rocket Pod | mass | 2 | 3 |
|             | capacity | 2 | 4 |

The *Typhoon Pod* has a similar issue, as we would have to increase the capacity from 3 to 12, which is clearly too much. However, the Pod has a strangely low mass. The corresponding launcher has 2.2 times the fire rate, but 4.2 times the mass. So we can increase the mass of the Typhoon Pod, too, and get a reasonable result:
| Outfit | Stat | old | new |
|--------|------|-----|-----|
| Typhoon Pod | mass | 6 | 9 |
|             | capacity | 3 | 6 |

The *Torpedo Pod* is a bit tricky because of the strange mass of Torpedoes of 0.4. It is not quite clear why fat torpedoes should have lower mass than Heavy Rockets or the slightly slimmer Typhoons. Hence we should set the mass to 0.5, too. As we have to lower than the mass of the Torpedo Launcher correspondingly, as a side-effect we get a more reasonable ratio in the mass of launcher to pod. In total:
| Outfit | Stat | old | new |
|--------|------|-----|-----|
| Torpedo | mass | 0.4 | 0.5 |
| Torpedo Pod | capacity | 3 | 6 |
| Torpedo Launcher | mass | 18 | 15 |

## Note

For a discussion of the actual firing durations under consideration of the burstfire pattern of pods, see my comment below.



## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.
