### PR TITLE
Remove the Advanced Pirate Outfitter from Stormhold

### DIFF
--- a/data/map planets.txt
+++ b/data/map planets.txt
@@ -5733,7 +5733,6 @@ planet Stormhold
 	outfitter "Ammo South"
 	outfitter "Pirate Outfits"
 	outfitter "Pirate Basics"
-	outfitter "Pirate Advanced"
 	bribe 0.03
 	security 0
 	tribute 500


### PR DESCRIPTION
This PR can be considered a follow-up of [PR 11417](https://github.com/endless-sky/endless-sky/pull/11417).

## Issue

When comparing the description and services (list of outfitters and shipyards) of planets and stations with the outfitter "Pirate Advanced", then **Stormhold** is a clear outlier, being very sparsely populated, poorly developed, and providing only basic services. In other words, there's no infrastructure for advanced pirate outfits like nerve gas.

## Solution

This PR removes the outfitter "Pirate Advanced" from Stormhold.

## Impact

8 of 18 (44%) settled Pirate locations (planets/stations, not counting Mutiny) would still have the "Pirate Advanced" outfitter.
| Region | Advanced Pirate Locations | Number of Total |
|---|---|---|
| Core | Buccaneer Bay, Covert, New Tortuga | 3 of 5 (60%)
| North | Haven | 1 of 3 (33%) |
| South | Greenrock, Mordente-Bridi, Smuggler's Den, Thule | 4 of 10 (40%) |

Despite the removal of the advanced outfitter from Stormhold, the percentage for the core locations is still above average, which seems justified considering the vicinity to the Korath.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.