### PR TITLE
fix(ui): Correct the error message in the outfitter when you're unable to install ammo storage

### DIFF
--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -623,9 +623,11 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 				if(selectedOutfit->Get("installable") < 0.)
 					errors.emplace_back("This item is not an outfit that can be installed in a ship.");
 
-				// If the outfit category is ammo and the problem wasn't one of the above attributes,
-				// assume that the issue is a lack of ammo storage.
-				if(errors.empty() && selectedOutfit->Category() == "Ammunition")
+				// If the outfit category is ammo, the problem wasn't one of the above attributes, and this outfit
+				// could never have its installation limited by usual means, then assume that the issue is a lack
+				// of ammo storage.
+				if(errors.empty() && selectedOutfit->Category() == "Ammunition" && !outfitNeeded && !weaponNeeded
+						&& !engineNeeded && !cargoNeeded && !mountsNeeded && !gunsNeeded)
 					errors.emplace_back(!playerShip->OutfitCount(selectedOutfit) ?
 						"This outfit is ammunition for a weapon. "
 						"You cannot install it without first installing the appropriate weapon."

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -579,36 +579,34 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 
 			if(!canPlace)
 			{
+				auto TonsFree = [](double needed, double space, const string &name) -> string {
+					return "You cannot install this outfit, because it takes up "
+						+ Format::CargoString(needed, name) + ", and this ship has "
+						+ Format::MassString(space) + " free.";
+				};
+
 				// If no selected ship can install the outfit, report error based on playerShip.
 				double outfitNeeded = -selectedOutfit->Get("outfit space");
 				double outfitSpace = playerShip->Attributes().Get("outfit space");
 				if(outfitNeeded > outfitSpace)
-					errors.push_back("You cannot install this outfit, because it takes up "
-						+ Format::CargoString(outfitNeeded, "outfit space") + ", and this ship has "
-						+ Format::MassString(outfitSpace) + " free.");
+					errors.push_back(TonsFree(outfitNeeded, outfitSpace, "outfit space"));
 
 				double weaponNeeded = -selectedOutfit->Get("weapon capacity");
 				double weaponSpace = playerShip->Attributes().Get("weapon capacity");
 				if(weaponNeeded > weaponSpace)
 					errors.push_back("Only part of your ship's outfit capacity is usable for weapons. "
-						"You cannot install this outfit, because it takes up "
-						+ Format::CargoString(weaponNeeded, "weapon space") + ", and this ship has "
-						+ Format::MassString(weaponSpace) + " free.");
+						+ TonsFree(weaponNeeded, weaponSpace, "weapon space"));
 
 				double engineNeeded = -selectedOutfit->Get("engine capacity");
 				double engineSpace = playerShip->Attributes().Get("engine capacity");
 				if(engineNeeded > engineSpace)
 					errors.push_back("Only part of your ship's outfit capacity is usable for engines. "
-						"You cannot install this outfit, because it takes up "
-						+ Format::CargoString(engineNeeded, "engine space") + ", and this ship has "
-						+ Format::MassString(engineSpace) + " free.");
+						+ TonsFree(engineNeeded, engineSpace, "engine space"));
 
-				if(selectedOutfit->Category() == "Ammunition")
-					errors.emplace_back(!playerShip->OutfitCount(selectedOutfit) ?
-						"This outfit is ammunition for a weapon. "
-						"You cannot install it without first installing the appropriate weapon."
-						: "You already have the maximum amount of ammunition for this weapon. "
-						"If you want to install more ammunition, you must first install another of these weapons.");
+				double cargoNeeded = -selectedOutfit->Get("cargo space");
+				double cargoSpace = playerShip->Attributes().Get("cargo space");
+				if(cargoNeeded > cargoSpace)
+					errors.push_back(TonsFree(cargoNeeded, cargoSpace, "cargo space"));
 
 				int mountsNeeded = -selectedOutfit->Get("turret mounts");
 				int mountsFree = playerShip->Attributes().Get("turret mounts");
@@ -624,6 +622,16 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 
 				if(selectedOutfit->Get("installable") < 0.)
 					errors.emplace_back("This item is not an outfit that can be installed in a ship.");
+
+				// If the outfit category is ammo and the problem wasn't one of the above attributes,
+				// assume that the issue is a lack of ammo storage.
+				if(errors.empty() && selectedOutfit->Category() == "Ammunition")
+					errors.emplace_back(!playerShip->OutfitCount(selectedOutfit) ?
+						"This outfit is ammunition for a weapon. "
+						"You cannot install it without first installing the appropriate weapon."
+						: "You already have the maximum amount of ammunition for this weapon. "
+						"If you want to install more ammunition, you must first install more ammunition storage "
+						"or another of these weapons.");
 
 				// Handle other attributes more generically, if none of the above are the problem.
 				if(errors.empty())


### PR DESCRIPTION
**Bug fix**

This PR fixes #12585.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

When the outfitter reports installation errors, it is currently making an assumption that the reason that an outfit in the "Ammunition" category can't be installed is because there is not enough ammo storage. It has been the case for quite some time now (a3fb17d0ff5f5e5a6cd5cf78b59e7b1973c32428) that we have placed ammo storage outfits in the ammunition category, meaning that not everything in the ammunition category is actually usable as ammo, so the aforementioned assumption no longer holds.

The linked issue reports this problem with a plugin outfit, but this is also reproducible with normal ammo storage outfits in vanilla. The following is the result of me trying to install a tracker storage pod.
<img width="299" height="330" alt="image" src="https://github.com/user-attachments/assets/f0d8d097-09a6-4e3e-b5e4-b0788951de31" />

This PR updates the installation error check to move the ammunition check to just before the generic error reporting and only report that the problem is a lack of ammo storage if none of the other space errors were the problem or could ever be the problem. I've also added a cargo space check to the other standard space attribute checks, instead of missing cargo space being a generic issue.

Note that this is still making an assumption, but it's a stronger assumption than before, and we can't really accurately report this error when it is truly only the ammo storage attribute that is the problem because ammo storage attributes are ad-hoc. That is, the engine can't know if an attribute is being used as an ammo storage attribute. One could theoretically still erroneously hit this error if they had ammo that did something like remove shield generation when installed, for example.

## Testing Done

Attempting to install a tracker storage pod on the same ship with this pull request. It no longer assumes that the storage pod is used as ammunition.
<img width="322" height="214" alt="image" src="https://github.com/user-attachments/assets/1767b664-1024-4412-8127-471acc515c14" />
