### PR TITLE
feat(ui): Change the Sell Minables button keybind from 'm' to 'n'

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2217,7 +2217,7 @@ interface "trade"
 	active if "can sell minables"
 	sprite "ui/wide button"
 		center -90 355
-	button m "Sell _Minables"
+	button m "Sell Mi_nables"
 		center -90 355
 		dimensions 90 30
 
@@ -2255,7 +2255,7 @@ interface "trade (small screen)"
 	active if "can sell minables"
 	sprite "ui/wide button"
 		center -150 355
-	button m "Sell _Minables"
+	button m "Sell Mi_nables"
 		center -150 355
 		dimensions 90 30
 

--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2217,7 +2217,7 @@ interface "trade"
 	active if "can sell minables"
 	sprite "ui/wide button"
 		center -90 355
-	button m "Sell Mi_nables"
+	button n "Sell Mi_nables"
 		center -90 355
 		dimensions 90 30
 
@@ -2255,7 +2255,7 @@ interface "trade (small screen)"
 	active if "can sell minables"
 	sprite "ui/wide button"
 		center -150 355
-	button m "Sell Mi_nables"
+	button n "Sell Mi_nables"
 		center -150 355
 		dimensions 90 30
 

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -255,7 +255,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			player.Cargo().Remove(commodity, amount);
 		}
 	}
-	else if(key == 'n' && player.Cargo().MinablesSizePrecise())
+	else if((key == 'n' || (key == 'm' && (mod & KMOD_SHIFT))) && player.Cargo().MinablesSizePrecise())
 	{
 		if(Preferences::Has("Confirm selling minables"))
 			GetUI().Push(DialogPanel::CallFunctionIfOk([this]() { SellOutfitsOrMinables(true); },

--- a/source/TradingPanel.cpp
+++ b/source/TradingPanel.cpp
@@ -255,7 +255,7 @@ bool TradingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, 
 			player.Cargo().Remove(commodity, amount);
 		}
 	}
-	else if(key == 'm' && player.Cargo().MinablesSizePrecise())
+	else if(key == 'n' && player.Cargo().MinablesSizePrecise())
 	{
 		if(Preferences::Has("Confirm selling minables"))
 			GetUI().Push(DialogPanel::CallFunctionIfOk([this]() { SellOutfitsOrMinables(true); },


### PR DESCRIPTION
**UI**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

https://steamcommunity.com/app/404410/discussions/0/581680955258909520/?tscn=1788095245

Odds are, the player's keybind for opening the map will be 'm'. Therefore, we want to avoid having button keybinds that overlap with the map.

Changes the keybind to 'n', but also allows 'shift+m' to be used.