### PR TITLE
feat(ui): Allow purchasing outfits directly into storage and uninstalling directly into cargo

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -860,25 +860,32 @@ tip "scan concealment:"
 
 # Shop Tips:
 tip "outfitter: b"
-	`Buy from the outfitter and install onto the currently selected ship(s). Hold Shift, Control, or Alt to buy 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Buy from the outfitter and install onto the currently selected ship(s).`
+	`Hold Shift, Control, or Alt to buy 5, 20, or 500 outfits at once. Hold a combination of these keys for larger amounts.`
 
 tip "outfitter: s"
-	`Sell from cargo, storage, or the currently selected ship(s), in that order. Hold Shift, Control, or Alt to sell 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Sell from cargo, storage, or the currently selected ship(s), in that order.`
+	`Hold Shift, Control, or Alt to sell 5, 20, or 500 outfits at once. Hold a combination of these keys for larger amounts.`
 
 tip "outfitter: i"
-	`Install on the currently selected ship(s) from cargo or storage, in that order. Hold Shift, Control, or Alt to install 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Install on the currently selected ship(s) from cargo or storage, in that order.`
+	`Hold Shift, Control, or Alt to install 5, 20, or 500 outfits at once. Hold a combination of these keys for larger amounts.`
 
 tip "outfitter: u"
-	`Uninstall or move outfits from the currently selected ship(s) or cargo to storage, in that order. Hold Shift, Control, or Alt to uninstall 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Uninstall from the currently selected ship(s) to cargo if there is space or to storage if there isn't.`
+	`Hold Shift, Control, or Alt to uninstall 5, 20, or 500 outfits at once. Hold a combination of these keys for larger amounts.`
 
 tip "outfitter: c"
-	`Transfer the outfit from planetary storage to cargo if possible. Otherwise, buy it from the outfitter. Hold Shift, Control, or Alt to buy or move 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Transfer the outfit from planetary storage to cargo if possible. Otherwise, buy it from the outfitter.`
+	`Hold Shift, Control, or Alt to move 5, 20, or 500 outfits at once. Hold a combination of these keys for larger amounts.`
 
 tip "outfitter: r"
-	`Move the outfit from cargo, the currently selected ship(s), or the shop into planetary storage, in that order. Hold Shift, Control, or Alt to store 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Move the outfit from cargo, the currently selected ship(s), or the outfitter into planetary storage, in that order.`
+	`Hold Shift, Control, or Alt to store 5, 20, or 500 outfits at once. Hold a combination of these keys for larger amounts.`
 
 tip "shipyard: b"
-	`Buy this ship. Hold Shift, Control, or Alt to buy 5, 20, or 500 ships at once. Hold a combination of these keys for larger amounts.`
+	`Buy this ship.`
+	`Hold Shift, Control, or Alt to buy 5, 20, or 500 ships at once. Hold a combination of these keys for larger amounts.`
 
 tip "shipyard: s"
 	`Sell the selected ships and their outfits.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -875,7 +875,7 @@ tip "outfitter: c"
 	`Transfer the outfit from planetary storage to cargo if possible. Otherwise, buy it from the outfitter. Hold Shift, Control, or Alt to buy or move 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
 
 tip "outfitter: r"
-	`Move the outfit from cargo or the currently selected ship(s) into planetary storage, in that order. Hold Shift, Control, or Alt to store 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
+	`Move the outfit from cargo, the currently selected ship(s), or the shop into planetary storage, in that order. Hold Shift, Control, or Alt to store 5, 20, or 500 at once. Hold a combination of these keys for larger amounts.`
 
 tip "shipyard: b"
 	`Buy this ship. Hold Shift, Control, or Alt to buy 5, 20, or 500 ships at once. Hold a combination of these keys for larger amounts.`

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -369,8 +369,6 @@ ShopPanel::TransactionResult OutfitterPanel::CanMoveOutfit(OutfitLocation fromLo
 	// Prevent coding up bad combinations.
 	if(fromLocation == toLocation)
 		throw runtime_error("unreachable; to and from are the same");
-	if(fromLocation == OutfitLocation::Shop && toLocation == OutfitLocation::Storage)
-		throw runtime_error("unreachable; unsupported to/from combination");
 
 	// Handle special cases such as maps and licenses.
 	int mapSize = selectedOutfit->Get("map");
@@ -780,14 +778,19 @@ ShopPanel::TransactionResult OutfitterPanel::MoveOutfit(OutfitLocation fromLocat
 				}
 			}
 		}
-		else if(toLocation == OutfitLocation::Cargo)
+		else if(toLocation == OutfitLocation::Cargo || toLocation == OutfitLocation::Storage)
 		{
+			bool toCargo = toLocation == OutfitLocation::Cargo;
+			CargoHold &storeIn = toCargo ? player.Cargo() : player.Storage();
 			if(!outfitter.Has(selectedOutfit))
 				howManyPer = min(howManyPer, player.Stock(selectedOutfit));
-			// Buy up to <modifier> of the selected outfit and place them in fleet cargo.
-			double mass = selectedOutfit->Mass();
-			if(mass)
-				howManyPer = min(howManyPer, static_cast<int>(player.Cargo().FreePrecise() / mass));
+			if(toCargo)
+			{
+				// Buy up to <modifier> of the selected outfit and place them in fleet cargo.
+				double mass = selectedOutfit->Mass();
+				if(mass)
+					howManyPer = min(howManyPer, static_cast<int>(storeIn.FreePrecise() / mass));
+			}
 
 			// How much will it cost to buy all that we can fit?
 			int64_t price = player.StockDepreciation().Value(selectedOutfit, day, howManyPer);
@@ -808,11 +811,10 @@ ShopPanel::TransactionResult OutfitterPanel::MoveOutfit(OutfitLocation fromLocat
 				player.Accounts().AddCredits(-price);
 				player.AddStock(selectedOutfit, -howManyPer);
 
-				// Put them into fleet cargo.
-				player.Cargo().Add(selectedOutfit, howManyPer);
+				// Put them into fleet cargo or planetary storage.
+				storeIn.Add(selectedOutfit, howManyPer);
 			}
 		}
-		// Note: Buying into storage not implemented. Why waste your money?
 	}
 	else if(fromLocation == OutfitLocation::Ship)
 	{
@@ -961,9 +963,13 @@ bool OutfitterPanel::ButtonActive(char key, bool shipRelatedOnly)
 		return (!shipRelatedOnly && (CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Shop) ||
 			CanMoveOutfit(OutfitLocation::Storage, OutfitLocation::Shop))) ||
 			CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Shop);
-	if(key == 'u' || key == 'r')
+	if(key == 'u')
 		return CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage) ||
 			(!shipRelatedOnly && CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage));
+	if(key == 'r')
+		return CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage) ||
+			(!shipRelatedOnly && (CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage)
+			|| CanMoveOutfit(OutfitLocation::Shop, OutfitLocation::Storage)));
 	return false;
 }
 
@@ -1401,9 +1407,10 @@ ShopPanel::TransactionResult OutfitterPanel::HandleShortcuts(SDL_Keycode key)
 	}
 	else if(key == 'r')
 	{
-		// Move <modifier> of the selected outfit to storage from either cargo or else each of the selected ships.
-		if(!MoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage))
-			result = MoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage, "store");
+		// Move <modifier> of the selected outfit to storage from either cargo, the selected ships, or from the shop.
+		if(!MoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage)
+				&& !MoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage))
+			result = MoveOutfit(OutfitLocation::Shop, OutfitLocation::Storage, "store");
 	}
 	else if(key == 'c')
 	{

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -114,7 +114,7 @@ namespace {
 
 
 
-OutfitterPanel::OutfitterPanel(PlayerInfo &player, Sale<Outfit> stock)
+OutfitterPanel::OutfitterPanel(PlayerInfo &player, const Sale<Outfit> &stock)
 	: ShopPanel(player, true), outfitter(stock)
 {
 	for(const pair<const string, Outfit> &it : GameData::Outfits())

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -843,11 +843,21 @@ ShopPanel::TransactionResult OutfitterPanel::MoveOutfit(OutfitLocation fromLocat
 					player.Accounts().AddCredits(price);
 					player.AddStock(selectedOutfit, 1);
 				}
-				// If the context is uninstalling, move the outfit into Storage.
+				// If the context is uninstalling, move the outfit into Cargo or Storage.
+				else if(toLocation == OutfitLocation::Cargo)
+				{
+					if(player.Cargo().FreePrecise() > selectedOutfit->Mass())
+						player.Cargo().Add(selectedOutfit, 1);
+					else
+					{
+						// If the player's cargo has run out of room, start moving
+						// outfits into storage.
+						toLocation = OutfitLocation::Storage;
+						player.Storage().Add(selectedOutfit, 1);
+					}
+				}
 				else if(toLocation == OutfitLocation::Storage)
 					player.Storage().Add(selectedOutfit, 1);
-				// Note: It would be easy to add conditional statements above to also support uninstall into cargo,
-				// this is not supported in the outfitter at this time.
 
 				// Move linked outfits to storage.
 				// Since some outfits have linked outfits, remove any that must also be moved as there
@@ -892,16 +902,29 @@ ShopPanel::TransactionResult OutfitterPanel::MoveOutfit(OutfitLocation fromLocat
 							player.Accounts().AddCredits(price);
 							player.AddStock(linked, mustUninstall);
 						}
-						// If the context is uninstalling, move the outfit's linked outfit into Storage.
+						// If the context is uninstalling, move the outfit's linked outfit into Cargo or Storage.
+						else if(toLocation == OutfitLocation::Cargo)
+						{
+							int movable = mustUninstall;
+							while(player.Cargo().FreePrecise() < linked->Mass() * movable)
+								--movable;
+							if(movable)
+								player.Cargo().Add(linked, movable);
+							int remaining = mustUninstall - movable;
+							if(remaining)
+							{
+								// If the player's cargo has run out of room, start moving
+								// outfits into storage.
+								toLocation = OutfitLocation::Storage;
+								player.Storage().Add(linked, remaining);
+							}
+						}
 						else if(toLocation == OutfitLocation::Storage)
 							player.Storage().Add(linked, mustUninstall);
-						// Note: It would be easy to add conditional statements above to also support uninstall into
-						// cargo, this is not supported in the outfitter at this time.
 					}
 				}
 			}
 		}
-		// Note: Uninstalling into cargo could be implemented below, but not supported in current outfitter logic.
 	}
 	else if(fromLocation == OutfitLocation::Storage || fromLocation == OutfitLocation::Cargo)
 	{
@@ -954,8 +977,8 @@ bool OutfitterPanel::ButtonActive(char key, bool shipRelatedOnly)
 	if(key == 'b')
 		return static_cast<bool>(CanMoveOutfit(OutfitLocation::Shop, OutfitLocation::Ship));
 	if(key == 'i')
-		return CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Ship) ||
-			CanMoveOutfit(OutfitLocation::Storage, OutfitLocation::Ship);
+		return CanMoveOutfit(OutfitLocation::Storage, OutfitLocation::Ship)
+			|| CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Ship);
 	if(key == 'c')
 		return !shipRelatedOnly && (CanMoveOutfit(OutfitLocation::Storage, OutfitLocation::Cargo) ||
 			CanMoveOutfit(OutfitLocation::Shop, OutfitLocation::Cargo));
@@ -964,8 +987,8 @@ bool OutfitterPanel::ButtonActive(char key, bool shipRelatedOnly)
 			CanMoveOutfit(OutfitLocation::Storage, OutfitLocation::Shop))) ||
 			CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Shop);
 	if(key == 'u')
-		return CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage) ||
-			(!shipRelatedOnly && CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage));
+		return CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Cargo)
+			|| CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage);
 	if(key == 'r')
 		return CanMoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage) ||
 			(!shipRelatedOnly && (CanMoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage)
@@ -1414,7 +1437,7 @@ ShopPanel::TransactionResult OutfitterPanel::HandleShortcuts(SDL_Keycode key)
 	}
 	else if(key == 'c')
 	{
-		// Either move up to <multiple> outfits into cargo from storage if any are in storage, or else buy up to
+		// Either move up to <modifier> outfits into cargo from storage if any are in storage, or else buy up to
 		// <modifier> outfits into cargo.
 		// Note: If the outfit cannot be moved from storage or bought into cargo, give an error based on the buy
 		// condition.
@@ -1430,13 +1453,11 @@ ShopPanel::TransactionResult OutfitterPanel::HandleShortcuts(SDL_Keycode key)
 	}
 	else if(key == 'u')
 	{
-		// Uninstall up to <multiple> outfits from each of the selected ships if any are available to uninstall, or
-		// else unload up to <multiple> outfits from cargo and place them storage.
-		// Note: If the outfit cannot be uninstalled or unloaded, give an error based on the inability to uninstall the
-		// outfit from any ship.
-		result = MoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage, "uninstall");
-		if(!result && MoveOutfit(OutfitLocation::Cargo, OutfitLocation::Storage))
-			result = true;
+		// Uninstall up to <modifier> outfits from each of the selected ships if any are available to uninstall,
+		// moving the outfits into cargo if there is space, or to storage if there isn't.
+		result = MoveOutfit(OutfitLocation::Ship, OutfitLocation::Cargo, "uninstall");
+		if(!result && !result.canPlace)
+			result = MoveOutfit(OutfitLocation::Ship, OutfitLocation::Storage, "uninstall");
 	}
 
 	return result;

--- a/source/OutfitterPanel.h
+++ b/source/OutfitterPanel.h
@@ -48,7 +48,7 @@ public:
 
 
 public:
-	explicit OutfitterPanel(PlayerInfo &player, Sale<Outfit> stock);
+	OutfitterPanel(PlayerInfo &player, const Sale<Outfit> &stock);
 
 	virtual void Step() override;
 

--- a/source/ShipyardPanel.cpp
+++ b/source/ShipyardPanel.cpp
@@ -55,8 +55,8 @@ namespace {
 
 
 
-ShipyardPanel::ShipyardPanel(PlayerInfo &player, Sale<Ship> stock)
-	: ShopPanel(player, false), modifier(0), shipyard(std::move(stock)), initialFleetUsage(player.FleetCost())
+ShipyardPanel::ShipyardPanel(PlayerInfo &player, const Sale<Ship> &stock)
+	: ShopPanel(player, false), modifier(0), shipyard(stock), initialFleetUsage(player.FleetCost())
 {
 	for(const auto &it : GameData::Ships())
 		catalog[it.second.Attributes().Category()].push_back(it.first);

--- a/source/ShipyardPanel.h
+++ b/source/ShipyardPanel.h
@@ -34,7 +34,7 @@ class Ship;
 // a government that is particularly repressive of independent pilots.)
 class ShipyardPanel : public ShopPanel {
 public:
-	explicit ShipyardPanel(PlayerInfo &player, Sale<Ship> stock);
+	ShipyardPanel(PlayerInfo &player, const Sale<Ship> &stock);
 
 	virtual void Step() override;
 


### PR DESCRIPTION
**UI**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

https://steamcommunity.com/app/404410/discussions/2/581680955258858315/

You currently can't buy an outfit directly into storage. The argument in #10743 was that there's no good reason to do this. Well the linked Steam thread notes that it's possible to accidentally sell something you had stored into the shop, and then you can't buy it directly from the shop back into storage.

Additionally, Tom pointed out that Uninstall and Store overlap very heavily at the moment. As such, I've also updated Uninstall to now only pull from the ship instead of pulling from the ship and cargo, and to move outfits into cargo (if there's space) and then storage, instead of only moving into storage.

All button behaviors are now as follows:
* Buy: Shop -> Ship
* Install: Storage then Cargo -> Ship
* Sell: Cargo then Storage then Ship -> Shop
* Cargo: Storage then Shop -> Cargo
* Uninstall: Ship -> Cargo then Storage
* Store: Cargo then Ship then Shop -> Storage

So here are the routes for every location to every other location in the fewest steps. Previously, Ship -> Cargo required moving into storage using Uninstall or Store, and then using Cargo to move into cargo.
* Shop -> Ship = Buy
* Storage -> Ship = Install
* Cargo -> Ship = Install
* Ship -> Shop = Sell
* Storage -> Shop = Sell
* Cargo -> Shop = Sell
* Ship -> Cargo = Uninstall
* Shop -> Cargo =  Cargo
* Storage -> Cargo = Cargo
* Ship -> Storage = Store
* Cargo -> Storage = Store
* Shop -> Storage = Store

## Screenshots

<img width="1918" height="1010" alt="image" src="https://github.com/user-attachments/assets/bc0f8661-42c7-412b-a6d2-8e9df648bf8f" />

## Testing Done

Tested that buying directly from the shop into storage works, and buying into cargo still works (since they use a similar code path).

Installed two D14-RN shield generators on a shuttle and used ctrl+uninstall. One of the generators went into cargo while the other went into storage.