### PR TITLE
refactor: Replace Body with Drawable in a few locations

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -28,7 +28,6 @@ using namespace std;
 
 
 
-// Constructor, based on a Sprite.
 Body::Body(const Sprite *sprite, Point position, Point velocity, Angle facing, double zoom, Point scale, double alpha)
 	: Drawable(sprite, zoom, scale, alpha), position(position), velocity(velocity), angle(facing)
 {
@@ -36,8 +35,7 @@ Body::Body(const Sprite *sprite, Point position, Point velocity, Angle facing, d
 
 
 
-// Constructor, based on the animation from another Body object.
-Body::Body(const Body &other, Point position, Point velocity, Angle facing, double zoom, Point scale, double alpha)
+Body::Body(const Drawable &other, Point position, Point velocity, Angle facing, double zoom, Point scale, double alpha)
 	: Drawable(other, zoom, scale, alpha)
 {
 	this->position = position;

--- a/source/Body.h
+++ b/source/Body.h
@@ -34,7 +34,7 @@ public:
 	Body() = default;
 	Body(const Sprite *sprite, Point position, Point velocity = Point(), Angle facing = Angle(),
 		double zoom = 1., Point scale = Point(1., 1.), double alpha = 1.);
-	Body(const Body &other, Point position, Point velocity = Point(), Angle facing = Angle(),
+	Body(const Drawable &other, Point position, Point velocity = Point(), Angle facing = Angle(),
 		double zoom = 1., Point scale = Point(1., 1.), double alpha = 1.);
 
 	// Get the sprite mask for the given time step.

--- a/source/Effect.h
+++ b/source/Effect.h
@@ -32,16 +32,8 @@ class Sound;
 // game. Because this class is more heavyweight than it needs to be, actual
 // visual effects when they are placed use the Visual class, based on the
 // template provided by an Effect.
-class Effect : public Body {
+class Effect : public Drawable {
 public:
-	// Functions provided by the Body base class:
-	// Frame GetFrame(int step = -1) const;
-	// const Point &Position() const;
-	// const Point &Velocity() const;
-	// const Angle &Facing() const;
-	// Point Unit() const;
-	// double Zoom() const;
-
 	const std::string &TrueName() const;
 	void SetTrueName(const std::string &name);
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -147,7 +147,7 @@ namespace {
 	}
 
 	void DrawFlareSprites(const Ship &ship, DrawList &draw, const vector<Ship::EnginePoint> &enginePoints,
-		const vector<pair<Body, int>> &flareSprites, uint8_t side, bool reverse)
+		const vector<pair<Drawable, int>> &flareSprites, uint8_t side, bool reverse)
 	{
 		Point thrustScale = ScaledFlareCurve(ship, reverse ? Ship::ThrustKind::REVERSE : Ship::ThrustKind::FORWARD);
 		Point leftTurnScale = ScaledFlareCurve(ship, Ship::ThrustKind::LEFT);
@@ -161,7 +161,7 @@ namespace {
 			Angle gimbal = Angle(gimbalDirection * point.gimbal.Degrees());
 			Angle flareAngle = ship.Facing() + point.facing + gimbal;
 			Point pos = ship.Facing().Rotate(point) * ship.Zoom() + ship.Position();
-			auto DrawFlares = [&draw, &pos, &ship, &flareAngle, &point](const pair<Body, int> &it, const Point &scale)
+			auto DrawFlares = [&draw, &pos, &ship, &flareAngle, &point](const pair<Drawable, int> &it, const Point &scale)
 			{
 				// If multiple engines with the same flare are installed, draw up to
 				// three copies of the flare sprite.
@@ -2923,7 +2923,7 @@ void Engine::DrawShipSprites(const Ship &ship)
 		const Weapon *weapon = hardpoint.GetWeapon();
 		if(!weapon)
 			return;
-		const Body &sprite = weapon->HardpointSprite();
+		const Drawable &sprite = weapon->HardpointSprite();
 		if(!sprite.HasSprite())
 			return;
 

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -254,7 +254,7 @@ void HailPanel::Draw()
 			const Weapon *weapon = hardpoint.GetWeapon();
 			if(!weapon)
 				return;
-			const Body &sprite = weapon->HardpointSprite();
+			const Drawable &sprite = weapon->HardpointSprite();
 			if(!sprite.HasSprite())
 				return;
 			Body body(

--- a/source/Outfit.cpp
+++ b/source/Outfit.cpp
@@ -183,10 +183,10 @@ namespace {
 		{"turret turn multiplier", -1. * ATTRIBUTE_PRECISION},
 	};
 
-	void AddFlareSprites(vector<pair<Body, int>> &thisFlares, const pair<Body, int> &it, int count)
+	void AddFlareSprites(vector<pair<Drawable, int>> &thisFlares, const pair<Drawable, int> &it, int count)
 	{
 		auto oit = find_if(thisFlares.begin(), thisFlares.end(),
-			[&it](const pair<Body, int> &flare)
+			[&it](const pair<Drawable, int> &flare)
 			{
 				return (it.first.GetSprite() == flare.first.GetSprite()
 					&& it.first.Scale() == flare.first.Scale());
@@ -751,21 +751,21 @@ const set<const Outfit *> &Outfit::LinkedOutfits() const
 
 
 // Get this outfit's engine flare sprite, if any.
-const vector<pair<Body, int>> &Outfit::FlareSprites() const
+const vector<pair<Drawable, int>> &Outfit::FlareSprites() const
 {
 	return flareSprites;
 }
 
 
 
-const vector<pair<Body, int>> &Outfit::ReverseFlareSprites() const
+const vector<pair<Drawable, int>> &Outfit::ReverseFlareSprites() const
 {
 	return reverseFlareSprites;
 }
 
 
 
-const vector<pair<Body, int>> &Outfit::SteeringFlareSprites() const
+const vector<pair<Drawable, int>> &Outfit::SteeringFlareSprites() const
 {
 	return steeringFlareSprites;
 }

--- a/source/Outfit.h
+++ b/source/Outfit.h
@@ -26,9 +26,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 #include <vector>
 
-class Body;
 class ConditionsStore;
 class DataNode;
+class Drawable;
 class Effect;
 class Sound;
 class Sprite;
@@ -143,9 +143,9 @@ public:
 	const std::set<const Outfit *> &LinkedOutfits() const;
 
 	// Get this outfit's engine flare sprites, if any.
-	const std::vector<std::pair<Body, int>> &FlareSprites() const;
-	const std::vector<std::pair<Body, int>> &ReverseFlareSprites() const;
-	const std::vector<std::pair<Body, int>> &SteeringFlareSprites() const;
+	const std::vector<std::pair<Drawable, int>> &FlareSprites() const;
+	const std::vector<std::pair<Drawable, int>> &ReverseFlareSprites() const;
+	const std::vector<std::pair<Drawable, int>> &SteeringFlareSprites() const;
 	const std::map<const Sound *, int> &FlareSounds() const;
 	const std::map<const Sound *, int> &ReverseFlareSounds() const;
 	const std::map<const Sound *, int> &SteeringFlareSounds() const;
@@ -201,9 +201,9 @@ private:
 
 	// The integers in these pairs/maps indicate the number of
 	// sprites/effects/sounds to be placed/played.
-	std::vector<std::pair<Body, int>> flareSprites;
-	std::vector<std::pair<Body, int>> reverseFlareSprites;
-	std::vector<std::pair<Body, int>> steeringFlareSprites;
+	std::vector<std::pair<Drawable, int>> flareSprites;
+	std::vector<std::pair<Drawable, int>> reverseFlareSprites;
+	std::vector<std::pair<Drawable, int>> steeringFlareSprites;
 	std::map<const Sound *, int> flareSounds;
 	std::map<const Sound *, int> reverseFlareSounds;
 	std::map<const Sound *, int> steeringFlareSounds;

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -62,7 +62,7 @@ namespace {
 
 
 Projectile::Projectile(const Ship &parent, Point position, Angle angle, const Weapon *weapon)
-	: Body(weapon->WeaponSprite(), position, parent.Velocity(), angle),
+	: Body(weapon->ProjectileSprite(), position, parent.Velocity(), angle),
 	weapon(weapon), lifetime(weapon->Lifetime())
 {
 	shared_ptr<Ship> targetShip = parent.GetTargetShip();
@@ -102,7 +102,7 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 
 
 Projectile::Projectile(const Projectile &parent, const Point &offset, const Angle &angle, const Weapon *weapon)
-	: Body(weapon->WeaponSprite(), parent.position + parent.velocity + parent.angle.Rotate(offset),
+	: Body(weapon->ProjectileSprite(), parent.position + parent.velocity + parent.angle.Rotate(offset),
 	parent.velocity, parent.angle + angle),
 	weapon(weapon), target(parent.target), lifetime(weapon->Lifetime())
 {

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -122,7 +122,7 @@ void Weapon::Load(const DataNode &node)
 		else if(child.Size() < 2)
 			child.PrintTrace("Skipping weapon attribute with no value specified:");
 		else if(key == "sprite")
-			sprite.LoadSprite(child);
+			projectileSprite.LoadSprite(child);
 		else if(key == "hardpoint sprite")
 			hardpointSprite.LoadSprite(child);
 		else if(key == "sound")
@@ -466,14 +466,14 @@ bool Weapon::IsLoaded() const
 
 
 // Get assets used by this weapon.
-const Body &Weapon::WeaponSprite() const
+const Drawable &Weapon::ProjectileSprite() const
 {
-	return sprite;
+	return projectileSprite;
 }
 
 
 
-const Body &Weapon::HardpointSprite() const
+const Drawable &Weapon::HardpointSprite() const
 {
 	return hardpointSprite;
 }

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -16,8 +16,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "Angle.h"
-#include "Body.h"
 #include "Distribution.h"
+#include "Drawable.h"
 #include "Point.h"
 #include "Projectile.h"
 
@@ -68,8 +68,8 @@ public:
 	bool IsLoaded() const;
 
 	// Get assets used by this weapon.
-	const Body &WeaponSprite() const;
-	const Body &HardpointSprite() const;
+	const Drawable &ProjectileSprite() const;
+	const Drawable &HardpointSprite() const;
 	const Sound *WeaponSound() const;
 	const Sound *EmptySound() const;
 	const Sprite *Icon() const;
@@ -233,8 +233,8 @@ private:
 	bool isLoaded = false;
 
 	// Sprites and sounds.
-	Body sprite;
-	Body hardpointSprite;
+	Drawable projectileSprite;
+	Drawable hardpointSprite;
 	const Sound *sound = nullptr;
 	const Sound *emptySound = nullptr;
 	const Sprite *icon = nullptr;


### PR DESCRIPTION
**Refactor**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

There are various places in the game where Body was used for the purpose of enabling animated sprites to be read in from game data. With the introduction of the Drawable class, these locations can now use Drawable instead of Body since they don't actually make use of the positioning information that Body carries. These include the following:
- Weapon projectile and hardpoint sprites. Projectile sprites get instantiated into the Projectile class, which is a Body. Hardpoint sprites don't get instantiated into a Body until we go to render a ship, in which case the animation details are copied from the weapon definition into that Body.
- Outfit flare sprites. These get instantiated into Body in Engine.
- Effect now extends Drawable instead of Body. Effects get instantiated into Visual when they're actually placed, which is a Body.

## Testing Done

Flew around a little. Engine flares, effects, projectiles, and turret hardpoints all still work.