### PR TITLE
feat: Improve auto aiming when using guns with mixed velocities

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3757,7 +3757,7 @@ Point AI::TargetAim(const Ship &ship, const Body &target, const set<const Outfit
 		const Outfit *ammo = weapon->Ammo();
 		if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())
 			continue;
-		if(includeSecondaries && !includeSecondaries->contains(hardpoint.GetOutfit()))
+		if(includeSecondaries && weapon->Icon() && !includeSecondaries->contains(hardpoint.GetOutfit()))
 			continue;
 
 		Point start = ship.Position() + ship.Facing().Rotate(hardpoint.GetPoint());
@@ -3775,9 +3775,9 @@ Point AI::TargetAim(const Ship &ship, const Body &target, const set<const Outfit
 	}
 
 	// Determine which aim point yields the highest expected DPS on target.
-	auto bestIt = candidates.end();
+	auto bestIt = candidates.begin();
 	for(auto it = candidates.begin(); it != candidates.end(); ++it)
-		if(bestIt == candidates.end() || it->second.dps > bestIt->second.dps)
+		if(it->second.dps > bestIt->second.dps)
 			bestIt = it;
 	return bestIt != candidates.end() ? bestIt->second.aim : target.Position() - ship.Position();
 }
@@ -4046,7 +4046,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		if(!secondary && weapon->Icon())
 			return false;
 		// If this is for the player, only consider weapons the player has currently selected.
-		if(includeSecondaries && !includeSecondaries->contains(hardpoint.GetOutfit()))
+		if(includeSecondaries && weapon->Icon() && !includeSecondaries->contains(hardpoint.GetOutfit()))
 			return false;
 		// Don't expend ammo if trying to be frugal.
 		if(beFrugal && ammo)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -419,6 +419,13 @@ namespace {
 	// another in case they become too close.
 	constexpr double SCATTER_TOO_CLOSE = 20. * 20.;
 	constexpr double SCATTER_TRACK = 100. * 100.;
+
+	// When determining auto aiming, this represents the total DPS and average aim point of
+	// a set of hardpoints with the same weapon velocity.
+	struct AimCandidate {
+		double dps = 0.;
+		Point aim;
+	};
 }
 
 
@@ -3739,7 +3746,9 @@ Point AI::TargetAim(const Ship &ship, const set<const Outfit *> *includeSecondar
 
 Point AI::TargetAim(const Ship &ship, const Body &target, const set<const Outfit *> *includeSecondaries)
 {
-	Point result;
+	// Determine which hardpoints can hit the target.
+	// Construct a map of weapon velocity to the candidate aim points.
+	map<double, AimCandidate> candidates;
 	for(const Hardpoint &hardpoint : ship.Weapons())
 	{
 		const Weapon *weapon = hardpoint.GetWeapon();
@@ -3754,18 +3763,23 @@ Point AI::TargetAim(const Ship &ship, const Body &target, const set<const Outfit
 		Point start = ship.Position() + ship.Facing().Rotate(hardpoint.GetPoint());
 		Point p = target.Position() - start + ship.GetPersonality().Confusion();
 		Point v = target.Velocity() - ship.Velocity();
-		double steps = RendezvousTime(p, v, weapon->WeightedVelocity() + .5 * weapon->RandomVelocity());
+		double velocity = weapon->WeightedVelocity() + .5 * weapon->RandomVelocity();
+		double steps = RendezvousTime(p, v, velocity);
 		if(std::isnan(steps))
 			continue;
+		p += min(steps, weapon->TotalLifetime()) * v;
 
-		steps = min(steps, weapon->TotalLifetime());
-		p += steps * v;
-
-		double damage = weapon->ShieldDamage() + weapon->HullDamage();
-		result += p.Unit() * abs(damage);
+		auto &[dps, aim] = candidates[velocity];
+		dps += (weapon->ShieldDamage() + weapon->HullDamage()) / weapon->Reload();
+		aim += p.Unit();
 	}
 
-	return result ? result : target.Position() - ship.Position();
+	// Determine which aim point yields the highest expected DPS on target.
+	auto bestIt = candidates.end();
+	for(auto it = candidates.begin(); it != candidates.end(); ++it)
+		if(bestIt == candidates.end() || it->second.dps > bestIt->second.dps)
+			bestIt = it;
+	return bestIt != candidates.end() ? bestIt->second.aim : target.Position() - ship.Position();
 }
 
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4035,7 +4035,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		if(includeSecondaries && !includeSecondaries->contains(hardpoint.GetOutfit()))
 			return false;
 		// Don't expend ammo if trying to be frugal.
-		if(beFrugal && weapon->Ammo())
+		if(beFrugal && ammo)
 			return false;
 		// No point in sending a firing command to weapons without ammo.
 		if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3745,6 +3745,9 @@ Point AI::TargetAim(const Ship &ship, const Body &target)
 		const Weapon *weapon = hardpoint.GetWeapon();
 		if(!weapon || hardpoint.IsHoming() || hardpoint.IsTurret())
 			continue;
+		const Outfit *ammo = weapon->Ammo();
+		if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())
+			continue;
 
 		Point start = ship.Position() + ship.Facing().Rotate(hardpoint.GetPoint());
 		Point p = target.Position() - start + ship.GetPersonality().Confusion();
@@ -4019,11 +4022,18 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		if(hardpoint.IsReady())
 		{
 			const Weapon *weapon = hardpoint.GetWeapon();
-			if(!(!currentTarget && hardpoint.IsHoming() && weapon->Ammo())
-					&& !(!secondary && weapon->Icon())
-					&& !(beFrugal && weapon->Ammo())
-					&& !(isWaitingToJump && weapon->FiringForce()))
-				maxRange = max(maxRange, weapon->Range());
+			const Outfit *ammo = weapon->Ammo();
+			if(!currentTarget && hardpoint.IsHoming() && ammo)
+				continue;
+			if(!secondary && weapon->Icon())
+				continue;
+			if(beFrugal && ammo)
+				continue;
+			if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())
+				continue;
+			if(isWaitingToJump && weapon->FiringForce())
+				continue;
+			maxRange = max(maxRange, weapon->Range());
 		}
 	// Extend the weapon range slightly to account for velocity differences.
 	maxRange *= 1.5;

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4143,7 +4143,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 			// Merciful ships let fleeing ships go.
 			if(target->IsFleeing() && person.IsMerciful())
 				continue;
-			// Don't hit ships that cannot be hit without targeting
+			// Don't fire at ships that cannot be hit without targeting.
 			if(target != currentTarget.get() && !FighterHitHelper::IsValidTarget(target))
 				continue;
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3722,22 +3722,22 @@ Point AI::StoppingPoint(const Ship &ship, const Point &targetVelocity, bool &sho
 // maximum damaged to a target at the given position with its non-turret,
 // non-homing weapons. If the ship has no non-homing weapons, this just
 // returns the direction to the target.
-Point AI::TargetAim(const Ship &ship)
+Point AI::TargetAim(const Ship &ship, const set<const Outfit *> *includeSecondaries)
 {
 	shared_ptr<const Ship> target = ship.GetTargetShip();
 	if(target)
-		return TargetAim(ship, *target);
+		return TargetAim(ship, *target, includeSecondaries);
 
 	shared_ptr<const Minable> targetAsteroid = ship.GetTargetAsteroid();
 	if(targetAsteroid)
-		return TargetAim(ship, *targetAsteroid);
+		return TargetAim(ship, *targetAsteroid, includeSecondaries);
 
 	return Point();
 }
 
 
 
-Point AI::TargetAim(const Ship &ship, const Body &target)
+Point AI::TargetAim(const Ship &ship, const Body &target, const set<const Outfit *> *includeSecondaries)
 {
 	Point result;
 	for(const Hardpoint &hardpoint : ship.Weapons())
@@ -3747,6 +3747,8 @@ Point AI::TargetAim(const Ship &ship, const Body &target)
 			continue;
 		const Outfit *ammo = weapon->Ammo();
 		if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())
+			continue;
+		if(includeSecondaries && !includeSecondaries->contains(hardpoint.GetOutfit()))
 			continue;
 
 		Point start = ship.Position() + ship.Facing().Rotate(hardpoint.GetPoint());
@@ -3960,14 +3962,16 @@ void AI::AimTurrets(const Ship &ship, FireCommand &command, bool opportunistic,
 
 
 // Fire whichever of the given ship's weapons can hit a hostile target.
-void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool isFlagship) const
+void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool isFlagship,
+	const set<const Outfit *> *includeSecondaries) const
 {
 	const Personality &person = ship.GetPersonality();
 	if(person.IsPacifist() || ship.CannotAct(Ship::ActionType::FIRE))
 		return;
 
-	bool beFrugal = (ship.IsYours() && !escortsUseAmmo);
-	if(person.IsFrugal() || (ship.IsYours() && escortsAreFrugal && escortsUseAmmo))
+	bool isPlayerEscort = ship.IsYours() && !isFlagship;
+	bool beFrugal = (isPlayerEscort && !escortsUseAmmo);
+	if(person.IsFrugal() || (isPlayerEscort && escortsAreFrugal && escortsUseAmmo))
 	{
 		// The frugal personality is only active when ships have more than a certain fraction of their total health,
 		// and are not outgunned. The default threshold is 75%.
@@ -3988,7 +3992,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 	const Government *gov = ship.GetGovernment();
 	bool friendlyOverride = false;
 	bool disabledOverride = false;
-	if(ship.IsYours())
+	if(isPlayerEscort)
 	{
 		auto it = orders.find(&ship);
 		if(it != orders.end())
@@ -4015,26 +4019,39 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 	// Don't use weapons with firing force if you are preparing to jump.
 	bool isWaitingToJump = ship.Commands().Has(Command::JUMP | Command::WAIT);
 
+	auto CanUse = [&](const Hardpoint &hardpoint) -> bool {
+		// Skip weapons that are not ready to fire.
+		if(!hardpoint.IsReady())
+			return false;
+		const Weapon *weapon = hardpoint.GetWeapon();
+		const Outfit *ammo = weapon->Ammo();
+		// Don't expend ammo for homing weapons that have no target selected.
+		if(!currentTarget && weapon->Homing() && ammo)
+			return false;
+		// Don't fire secondary weapons if told not to.
+		if(!secondary && weapon->Icon())
+			return false;
+		// If this is for the player, only consider weapons the player has currently selected.
+		if(includeSecondaries && !includeSecondaries->contains(hardpoint.GetOutfit()))
+			return false;
+		// Don't expend ammo if trying to be frugal.
+		if(beFrugal && weapon->Ammo())
+			return false;
+		// No point in sending a firing command to weapons without ammo.
+		if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())
+			return false;
+		// Don't use weapons with firing force if you are preparing to jump.
+		if(isWaitingToJump && weapon->FiringForce())
+			return false;
+		return true;
+	};
+
 	// Find the longest range of any of your non-homing weapons. Homing weapons
 	// that don't consume ammo may also fire in non-homing mode.
 	double maxRange = 0.;
 	for(const Hardpoint &hardpoint : ship.Weapons())
-		if(hardpoint.IsReady())
-		{
-			const Weapon *weapon = hardpoint.GetWeapon();
-			const Outfit *ammo = weapon->Ammo();
-			if(!currentTarget && hardpoint.IsHoming() && ammo)
-				continue;
-			if(!secondary && weapon->Icon())
-				continue;
-			if(beFrugal && ammo)
-				continue;
-			if(ammo && ship.OutfitCount(ammo) < weapon->AmmoUsage())
-				continue;
-			if(isWaitingToJump && weapon->FiringForce())
-				continue;
-			maxRange = max(maxRange, weapon->Range());
-		}
+		if(CanUse(hardpoint))
+			maxRange = max(maxRange, hardpoint.GetWeapon()->Range());
 	// Extend the weapon range slightly to account for velocity differences.
 	maxRange *= 1.5;
 
@@ -4050,9 +4067,9 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 	for(const Hardpoint &hardpoint : ship.Weapons())
 	{
 		++index;
-		// Skip weapons that are not ready to fire.
-		if(!hardpoint.IsReady())
+		if(!CanUse(hardpoint))
 			continue;
+		const Weapon *weapon = hardpoint.GetWeapon();
 
 		// Skip weapons omitted by the "Automatic firing" preference.
 		if(isFlagship)
@@ -4063,20 +4080,6 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 			if(autoFireMode == Preferences::AutoFire::TURRETS_ONLY && !hardpoint.IsTurret())
 				continue;
 		}
-
-		const Weapon *weapon = hardpoint.GetWeapon();
-		// Don't expend ammo for homing weapons that have no target selected.
-		if(!currentTarget && weapon->Homing() && weapon->Ammo())
-			continue;
-		// Don't fire secondary weapons if told not to.
-		if(!secondary && weapon->Icon())
-			continue;
-		// Don't expend ammo if trying to be frugal.
-		if(beFrugal && weapon->Ammo())
-			continue;
-		// Don't use weapons with firing force if you are preparing to jump.
-		if(isWaitingToJump && weapon->FiringForce())
-			continue;
 
 		// Special case: if the weapon uses fuel, be careful not to spend so much
 		// fuel that you cannot leave the system if necessary.
@@ -4127,10 +4130,7 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 			// Calculate how long it will take the projectile to reach its target.
 			double steps = RendezvousTime(p, v, vp);
 			if(!std::isnan(steps) && steps <= lifetime)
-			{
 				command.SetFire(index);
-				continue;
-			}
 			continue;
 		}
 		// For non-homing weapons:
@@ -4804,7 +4804,7 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 	if(Preferences::GetAutoFire() != Preferences::AutoFire::OFF && !ship.IsBoarding()
 			&& !(autoPilot | activeCommands).Has(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD)
 			&& (!target || target->GetGovernment()->IsEnemy()))
-		AutoFire(ship, firingCommands, false, true);
+		AutoFire(ship, firingCommands, false, true, &player.SelectedSecondaryWeapons());
 
 	const bool mouseTurning = activeCommands.Has(Command::MOUSE_TURNING_HOLD);
 	if(mouseTurning && !ship.IsBoarding() && (!ship.IsReversing() || ship.ReverseThrust()))
@@ -4857,9 +4857,10 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 			&& !autoPilot.Has(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD))
 	{
 		if(target && target->GetSystem() == ship.GetSystem() && target->IsTargetable())
-			command.SetTurn(TurnToward(ship, TargetAim(ship)));
+			command.SetTurn(TurnToward(ship, TargetAim(ship, &player.SelectedSecondaryWeapons())));
 		else if(ship.GetTargetAsteroid())
-			command.SetTurn(TurnToward(ship, TargetAim(ship, *ship.GetTargetAsteroid())));
+			command.SetTurn(TurnToward(ship, TargetAim(ship, *ship.GetTargetAsteroid(),
+				&player.SelectedSecondaryWeapons())));
 		else if(ship.GetTargetStellar())
 			command.SetTurn(TurnToward(ship, ship.GetTargetStellar()->Position() - ship.Position()));
 	}
@@ -4881,7 +4882,7 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 	{
 		Point pos = (target ? target->Position() : ship.GetTargetAsteroid()->Position());
 		if((pos - ship.Position()).Unit().Dot(ship.Facing().Unit()) >= .8)
-			command.SetTurn(TurnToward(ship, TargetAim(ship)));
+			command.SetTurn(TurnToward(ship, TargetAim(ship, &player.SelectedSecondaryWeapons())));
 	}
 
 	if(autoPilot.Has(Command::JUMP | Command::FLEET_JUMP) && !(player.HasTravelPlan() || ship.GetTargetSystem()))

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4043,10 +4043,9 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, bool secondary, bool i
 		if(!currentTarget && weapon->Homing() && ammo)
 			return false;
 		// Don't fire secondary weapons if told not to.
-		if(!secondary && weapon->Icon())
-			return false;
 		// If this is for the player, only consider weapons the player has currently selected.
-		if(includeSecondaries && weapon->Icon() && !includeSecondaries->contains(hardpoint.GetOutfit()))
+		if(weapon->Icon() && (!secondary || (includeSecondaries
+				&& !includeSecondaries->contains(hardpoint.GetOutfit()))))
 			return false;
 		// Don't expend ammo if trying to be frugal.
 		if(beFrugal && ammo)

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -3746,7 +3746,8 @@ Point AI::TargetAim(const Ship &ship, FireCommand &targeting, const set<const Ou
 
 
 
-Point AI::TargetAim(const Ship &ship, const Body &target, FireCommand &targeting, const set<const Outfit *> *includeSecondaries)
+Point AI::TargetAim(const Ship &ship, const Body &target, FireCommand &targeting,
+	const set<const Outfit *> *includeSecondaries)
 {
 	// Determine which hardpoints can hit the target.
 	// Construct a map of weapon velocity to the candidate aim points.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4050,10 +4050,9 @@ void AI::AutoFire(const Ship &ship, FireCommand &command, FireCommand &targeting
 	bool isWaitingToJump = ship.Commands().Has(Command::JUMP | Command::WAIT);
 
 	auto CanUse = [&](const Hardpoint &hardpoint) -> bool {
-		// Skip weapons that are not ready to fire.
-		if(!hardpoint.IsReady())
-			return false;
 		const Weapon *weapon = hardpoint.GetWeapon();
+		if(!weapon)
+			return false;
 		const Outfit *ammo = weapon->Ammo();
 		// Don't expend ammo for homing weapons that have no target selected.
 		if(!currentTarget && weapon->Homing() && ammo)

--- a/source/AI.h
+++ b/source/AI.h
@@ -38,6 +38,7 @@ class ConditionsStore;
 class Flotsam;
 class Government;
 class Minable;
+class Outfit;
 class PlayerInfo;
 class Ship;
 class ShipEvent;
@@ -188,14 +189,18 @@ private:
 	// maximum damage to a target at the given position with its non-turret,
 	// non-homing weapons. If the ship has no non-homing weapons, this just
 	// returns the direction to the target.
-	static Point TargetAim(const Ship &ship);
-	static Point TargetAim(const Ship &ship, const Body &target);
+	// For only the player's flagship, which secondary weapons are currently selected should be provided
+	// so that the flagship doesn't try to aim with weapons that the player isn't even using.
+	static Point TargetAim(const Ship &ship, const std::set<const Outfit *> *includeSecondaries = nullptr);
+	static Point TargetAim(const Ship &ship, const Body &target,
+		const std::set<const Outfit *> *includeSecondaries = nullptr);
 	// Aim the given ship's turrets.
 	void AimTurrets(const Ship &ship, FireCommand &command, bool opportunistic = false,
 			const std::optional<Point> &targetOverride = std::nullopt) const;
 	// Fire whichever of the given ship's weapons can hit a hostile target.
 	// Return a bitmask giving the weapons to fire.
-	void AutoFire(const Ship &ship, FireCommand &command, bool secondary = true, bool isFlagship = false) const;
+	void AutoFire(const Ship &ship, FireCommand &command, bool secondary = true, bool isFlagship = false,
+		const std::set<const Outfit *> *includeSecondaries = nullptr) const;
 	void AutoFire(const Ship &ship, FireCommand &command, const Body &target) const;
 
 	// Calculate how long it will take a projectile to reach a target given the

--- a/source/AI.h
+++ b/source/AI.h
@@ -191,7 +191,8 @@ private:
 	// returns the direction to the target.
 	// For only the player's flagship, which secondary weapons are currently selected should be provided
 	// so that the flagship doesn't try to aim with weapons that the player isn't even using.
-	static Point TargetAim(const Ship &ship, FireCommand &targeting, const std::set<const Outfit *> *includeSecondaries = nullptr);
+	static Point TargetAim(const Ship &ship, FireCommand &targeting,
+		const std::set<const Outfit *> *includeSecondaries = nullptr);
 	static Point TargetAim(const Ship &ship, const Body &target, FireCommand &targeting,
 		const std::set<const Outfit *> *includeSecondaries = nullptr);
 	// Aim the given ship's turrets.


### PR DESCRIPTION
**Bug fix**

Fixes #4323 and #12152. Also mentioned in https://github.com/endless-sky/endless-sky/issues/12588#issuecomment-5539093842.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

AI::TargetAim, which is used for auto aiming, currently looks at the velocity of all your non-homing guns and weights them by their damage per shot to determine a point of aim. If you have multiple weapons with very different firing points (most noticeable when mixing lasers with other weapons), this can result in none of your weapons being able to hit the target.

Homing weapons are skipped because they don't need a perfect point of aim, but non-homing secondary weapons that are out of ammo or, for the player's flagship, aren't selected for firing are still included in the aim point calculation. Therefore, having lasers and non-homing secondary weapons installed results in a terrible aim point.

This PR updates AI::TargetAim to now skip weapons that are out of ammo, or that aren't selected by the player if the player's flagship is the one being aimed. Additionally, instead of taking a weighted average of the aim points of all of your weapons by their damage per shot, this function now groups all guns with the same velocity (and therefore very similar aim points) and chooses the aim point of the grouping of weapons that has the highest DPS. By doing this, we ensure that you have at least have one set of weapons that is capable of hitting the target when using auto aim, and unless you have some unholy abomination of a loadout on your ship, the highest DPS weapon group should also be the majority of your DPS.

AI::AutoFire is also updated so that weapons that aren't included in aiming also don't attempt to fire.

<img width="850" height="545" alt="image" src="https://github.com/user-attachments/assets/cfa1e5c1-9406-4b4e-aed4-434df4627ea4" />

## Testing Done

Outfitted a Headhunter with two heavy lasers, two Javelin pods, and an asteroid scanner.
- Testing in the game right now gave results as described in the linked issues. The lasers can't hit a targeted asteroid because the javelins being installed throw off the aim, regardless of whether the javelins are loaded or active.
- Testing with this PR, my lasers hit the target asteroid without issue. When switching my secondary weapon to make the javelins active, my point of aim changes to be perfect for the javelins, since active ammo weapons are preferred over primary weapons. After emptying the javelins of ammo, my point of aim returns to being perfect for the lasers. Swapping off and on the javelins without ammo has no effect. Swapped my loadout to two heavy lasers and two twin modified blasters. The heavy lasers have slightly more DPS, so they're used for aiming. If I sell one laser, the blasters get used.