### PR TITLE
feat(mechanics): Allow "to spawn" on NPCs to spawn ships when jumping between systems

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -420,74 +420,79 @@ void Engine::Place()
 void Engine::Place(const list<NPC> &npcs, const shared_ptr<Ship> &flagship)
 {
 	for(const NPC &npc : npcs)
+		Place(npc, flagship);
+}
+
+
+
+void Engine::Place(const NPC &npc, const shared_ptr<Ship> &flagship)
+{
+	if(!npc.ShouldSpawn())
+		return;
+
+	map<string, map<Ship *, int>> carriers;
+	for(const shared_ptr<Ship> &ship : npc.Ships())
 	{
-		if(!npc.ShouldSpawn())
+		// Skip ships that have been destroyed.
+		if(ship->IsDestroyed() || ship->IsDisabled())
 			continue;
 
-		map<string, map<Ship *, int>> carriers;
-		for(const shared_ptr<Ship> &ship : npc.Ships())
+		// Redo the loading up of fighters.
+		if(ship->HasBays())
 		{
-			// Skip ships that have been destroyed.
-			if(ship->IsDestroyed() || ship->IsDisabled())
-				continue;
-
-			// Redo the loading up of fighters.
-			if(ship->HasBays())
+			ship->UnloadBays();
+			for(const auto &cat : GameData::GetCategory(CategoryType::BAY))
 			{
-				ship->UnloadBays();
-				for(const auto &cat : GameData::GetCategory(CategoryType::BAY))
+				const string &bayType = cat.Name();
+				int baysTotal = ship->BaysTotal(bayType);
+				if(baysTotal)
+					carriers[bayType][&*ship] = baysTotal;
+			}
+		}
+	}
+
+	shared_ptr<Ship> npcFlagship;
+	for(const shared_ptr<Ship> &ship : npc.Ships())
+	{
+		// Skip ships that have been destroyed.
+		if(ship->IsDestroyed())
+			continue;
+
+		// Avoid the exploit where the player can wear down an NPC's
+		// crew by attrition over the course of many days.
+		ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
+		if(!ship->IsDisabled())
+			ship->Recharge();
+
+		if(ship->CanBeCarried())
+		{
+			bool docked = false;
+			const string &bayType = ship->Attributes().Category();
+			for(auto &it : carriers[bayType])
+				if(it.second && it.first->Carry(ship))
 				{
-					const string &bayType = cat.Name();
-					int baysTotal = ship->BaysTotal(bayType);
-					if(baysTotal)
-						carriers[bayType][&*ship] = baysTotal;
+					--it.second;
+					docked = true;
+					break;
 				}
-			}
-		}
-
-		shared_ptr<Ship> npcFlagship;
-		for(const shared_ptr<Ship> &ship : npc.Ships())
-		{
-			// Skip ships that have been destroyed.
-			if(ship->IsDestroyed())
+			if(docked)
 				continue;
-
-			// Avoid the exploit where the player can wear down an NPC's
-			// crew by attrition over the course of many days.
-			ship->AddCrew(max(0, ship->RequiredCrew() - ship->Crew()));
-			if(!ship->IsDisabled())
-				ship->Recharge();
-
-			if(ship->CanBeCarried())
-			{
-				bool docked = false;
-				const string &bayType = ship->Attributes().Category();
-				for(auto &it : carriers[bayType])
-					if(it.second && it.first->Carry(ship))
-					{
-						--it.second;
-						docked = true;
-						break;
-					}
-				if(docked)
-					continue;
-			}
-
-			ships.push_back(ship);
-			// The first (alive) ship in an NPC block
-			// serves as the flagship of the group.
-			if(!npcFlagship)
-				npcFlagship = ship;
-
-			// Only the flagship of an NPC considers the
-			// player: the rest of the NPC track it.
-			if(npcFlagship && ship != npcFlagship)
-				ship->SetParent(npcFlagship);
-			else if(!ship->GetPersonality().IsUninterested())
-				ship->SetParent(flagship);
-			else
-				ship->SetParent(nullptr);
 		}
+
+		ships.push_back(ship);
+		// The first (alive) ship in an NPC block
+		// serves as the flagship of the group.
+		if(!npcFlagship)
+			npcFlagship = ship;
+
+		// Only the flagship of an NPC considers the
+		// player: the rest of the NPC track it.
+		if(npcFlagship && ship != npcFlagship)
+			ship->SetParent(npcFlagship);
+		else if(!ship->GetPersonality().IsUninterested())
+			ship->SetParent(flagship);
+		else
+			ship->SetParent(nullptr);
 	}
 }
 
@@ -1865,6 +1870,12 @@ void Engine::CalculateUnpaused(const Ship *flagship, const System *playerSystem)
 		playerSystem = flagship->GetSystem();
 		player.SetSystem(*playerSystem);
 		EnterSystem();
+
+		// Now that all updates have been made to the player that could alter condition
+		// reads, check if any missions can spawn NPCs right now.
+		const shared_ptr<Ship> &flagshipPtr = player.FlagshipPtr();
+		for(const NPC *npc : player.UpdateMissionNPCs())
+			Place(*npc, flagshipPtr);
 	}
 	PrunePointers(ships);
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -498,6 +498,16 @@ void Engine::Place(const NPC &npc, const shared_ptr<Ship> &flagship)
 
 
 
+void Engine::CheckNpcSpawns()
+{
+	player.UpdateMissionNPCs();
+	const shared_ptr<Ship> &flagshipPtr = player.FlagshipPtr();
+	for(const NPC *npc : player.UpdateMissionNPCs())
+		Place(*npc, flagshipPtr);
+}
+
+
+
 // Wait for the previous calculations (if any) to be done.
 void Engine::Wait()
 {
@@ -1870,12 +1880,6 @@ void Engine::CalculateUnpaused(const Ship *flagship, const System *playerSystem)
 		playerSystem = flagship->GetSystem();
 		player.SetSystem(*playerSystem);
 		EnterSystem();
-
-		// Now that all updates have been made to the player that could alter condition
-		// reads, check if any missions can spawn NPCs right now.
-		const shared_ptr<Ship> &flagshipPtr = player.FlagshipPtr();
-		for(const NPC *npc : player.UpdateMissionNPCs())
-			Place(*npc, flagshipPtr);
 	}
 	PrunePointers(ships);
 

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -500,7 +500,6 @@ void Engine::Place(const NPC &npc, const shared_ptr<Ship> &flagship)
 
 void Engine::CheckNpcSpawns()
 {
-	player.UpdateMissionNPCs();
 	const shared_ptr<Ship> &flagshipPtr = player.FlagshipPtr();
 	for(const NPC *npc : player.UpdateMissionNPCs())
 		Place(*npc, flagshipPtr);

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -73,6 +73,7 @@ public:
 	void Place();
 	// Place NPCs spawned by a mission that offers when the player is not landed.
 	void Place(const std::list<NPC> &npcs, const std::shared_ptr<Ship> &flagship = nullptr);
+	void Place(const NPC &npc, const std::shared_ptr<Ship> &flagship = nullptr);
 
 	// Wait for the previous calculations (if any) to be done.
 	void Wait();

--- a/source/Engine.h
+++ b/source/Engine.h
@@ -74,6 +74,9 @@ public:
 	// Place NPCs spawned by a mission that offers when the player is not landed.
 	void Place(const std::list<NPC> &npcs, const std::shared_ptr<Ship> &flagship = nullptr);
 	void Place(const NPC &npc, const std::shared_ptr<Ship> &flagship = nullptr);
+	// Check the player's active missions to determine if any NPCs should be spawned
+	// right now.
+	void CheckNpcSpawns();
 
 	// Wait for the previous calculations (if any) to be done.
 	void Wait();

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -132,7 +132,16 @@ void MainPanel::Step()
 	StepEvents(isActive);
 
 	if(isActive)
+	{
+		// Now that all updates have been made to the player that could alter condition
+		// reads, check if any missions can spawn NPCs right now.
+		if(checkSpawns && !engine.IsPaused())
+		{
+			engine.CheckNpcSpawns();
+			checkSpawns = false;
+		}
 		engine.Go();
+	}
 	else
 		canDrag = false;
 	canClick = isActive;
@@ -691,7 +700,10 @@ void MainPanel::StepEvents(bool &isActive)
 		// Handle jump events from the player's flagship. This means we should check
 		// for entering missions that can be offered.
 		if((event.Type() & ShipEvent::JUMP) && flagship && event.Actor().get() == flagship)
+		{
 			player.CreateEnteringMissions();
+			checkSpawns = true;
+		}
 
 		// Remove the fully-handled event.
 		eventQueue.pop_front();

--- a/source/MainPanel.h
+++ b/source/MainPanel.h
@@ -74,6 +74,9 @@ private:
 	// These are the pending ShipEvents that have yet to be processed.
 	std::list<ShipEvent> eventQueue;
 	bool handledFront = false;
+	// If a ShipEvent::JUMP was sent by the player's flagship,
+	// check if new mission NPCs should spawn.
+	bool checkSpawns = false;
 
 	Command show;
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1301,7 +1301,7 @@ bool Mission::Do(Trigger trigger, PlayerInfo &player, UI *ui, const shared_ptr<S
 		++player.Conditions()[trueName + ": active"];
 		// Any potential on offer conversation has been finished, so update
 		// the active NPCs for the first time and cache any necessary information.
-		UpdateNPCs(player);
+		UpdateNPCs();
 		DistanceMap here(player);
 		player.CacheMissionInformation(*this, here);
 	}
@@ -1370,11 +1370,13 @@ const list<NPC> &Mission::NPCs() const
 
 
 
-// Update which NPCs are active based on their spawn and despawn conditions.
-void Mission::UpdateNPCs(const PlayerInfo &player)
+vector<const NPC *> Mission::UpdateNPCs()
 {
+	vector<const NPC *> spawn;
 	for(auto &npc : npcs)
-		npc.UpdateSpawning(player);
+		if(npc.UpdateSpawning())
+			spawn.emplace_back(&npc);
+	return spawn;
 }
 
 
@@ -1454,7 +1456,7 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI &ui)
 		// Perform an "on enter" action for this system, if possible, and if
 		// any was performed, update this mission's NPC spawn states.
 		if(Enter(system, player, ui))
-			UpdateNPCs(player);
+			UpdateNPCs();
 	}
 
 	for(NPC &npc : npcs)

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1453,10 +1453,8 @@ void Mission::Do(const ShipEvent &event, PlayerInfo &player, UI &ui)
 			Do(WAYPOINT, player, &ui);
 		}
 
-		// Perform an "on enter" action for this system, if possible, and if
-		// any was performed, update this mission's NPC spawn states.
-		if(Enter(system, player, ui))
-			UpdateNPCs();
+		// Perform an "on enter" action for this system, if possible.
+		Enter(system, player, ui);
 	}
 
 	for(NPC &npc : npcs)

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -193,7 +193,8 @@ public:
 	// Iterate through the timers and progress them if applicable.
 	void StepTimers(PlayerInfo &player, UI &ui);
 	// Update which NPCs are active based on their spawn and despawn conditions.
-	void UpdateNPCs(const PlayerInfo &player);
+	// Return the NPCs that should be spawned now.
+	std::vector<const NPC *> UpdateNPCs();
 	// Checks if the given ship belongs to one of the mission's NPCs.
 	bool HasShip(const std::shared_ptr<Ship> &ship) const;
 	// If any event occurs between two ships, check to see if this mission cares

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -175,6 +175,8 @@ void NPC::Load(const DataNode &node, const ConditionsStore *playerConditions,
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
+		else if(key == "instant spawning")
+			instantSpawning = true;
 		else if(key == "on" && hasValue)
 		{
 			static const map<string, Trigger> trigger = {
@@ -309,6 +311,8 @@ void NPC::Save(DataWriter &out) const
 			}
 			out.EndChild();
 		}
+		if(instantSpawning)
+			out.Write("instant spawning");
 
 		for(auto &it : npcActions)
 			it.second.Save(out);
@@ -420,7 +424,7 @@ bool NPC::UpdateSpawning()
 	// conditions. (Any such NPC will never be spawned in-game.)
 	if(passedSpawnConditions && !toDespawn.IsEmpty() && !passedDespawnConditions)
 		passedDespawnConditions = toDespawn.Test();
-	return spawnNow && !passedDespawnConditions;
+	return spawnNow && !passedDespawnConditions && instantSpawning;
 }
 
 

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -401,8 +401,7 @@ const EsUuid &NPC::UUID() const noexcept
 
 
 
-// Update spawning and despawning for this NPC.
-void NPC::UpdateSpawning(const PlayerInfo &player)
+bool NPC::UpdateSpawning()
 {
 	checkedSpawnConditions = true;
 	// The conditions are tested every time this function is called until
@@ -410,13 +409,18 @@ void NPC::UpdateSpawning(const PlayerInfo &player)
 	// cause an NPC to "un-spawn" or "un-despawn." Despawn conditions are
 	// only checked after the spawn conditions have passed so that an NPC
 	// doesn't "despawn" before spawning in the first place.
+	bool spawnNow = false;
 	if(!passedSpawnConditions)
+	{
 		passedSpawnConditions = toSpawn.Test();
+		spawnNow = passedSpawnConditions;
+	}
 
 	// It is allowable for an NPC to pass its spawning conditions and then immediately pass its despawning
 	// conditions. (Any such NPC will never be spawned in-game.)
 	if(passedSpawnConditions && !toDespawn.IsEmpty() && !passedDespawnConditions)
 		passedDespawnConditions = toDespawn.Test();
+	return spawnNow && !passedDespawnConditions;
 }
 
 

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -91,7 +91,8 @@ public:
 	const EsUuid &UUID() const noexcept;
 
 	// Update or check spawning and despawning for this NPC.
-	void UpdateSpawning(const PlayerInfo &player);
+	// Return true if this NPC should be spawned right now.
+	bool UpdateSpawning();
 	bool ShouldSpawn() const;
 
 	// Get the personality that dictates the behavior of the ships associated with this set of NPCs.

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -157,6 +157,11 @@ private:
 	// Whether we have actually checked spawning conditions yet. (This
 	// will generally be true, except when reloading a save.)
 	bool checkedSpawnConditions = false;
+	// If true, an NPC whose spawn conditions are met when they are checked
+	// mid-flight can instantly spawn. If false, this NPC's ships can only
+	// be spawned when the player departs from a planet, or upon immediately
+	// accepting an in-flight mission.
+	bool instantSpawning = false;
 
 	// The ships may be listed individually or referred to as a fleet, and may
 	// be customized or just refer to stock objects:

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2472,11 +2472,15 @@ const Mission *PlayerInfo::ActiveInFlightMission() const
 
 
 
-// Update mission NPCs with the player's current conditions.
-void PlayerInfo::UpdateMissionNPCs()
+vector<const NPC *> PlayerInfo::UpdateMissionNPCs()
 {
+	vector<const NPC *> spawn;
 	for(Mission &mission : missions)
-		mission.UpdateNPCs(*this);
+	{
+		vector<const NPC *> npcs = mission.UpdateNPCs();
+		spawn.insert(spawn.end(), npcs.begin(), npcs.end());
+	}
+	return spawn;
 }
 
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -269,7 +269,9 @@ public:
 	void SortAvailable();
 
 	const Mission *ActiveInFlightMission() const;
-	void UpdateMissionNPCs();
+	// Update mission NPCs with the player's current conditions.
+	// Return the NPCs that should be spawned right now.
+	std::vector<const NPC *> UpdateMissionNPCs();
 	void AcceptJob(const Mission &mission, UI &ui);
 	// Check to see if there is any mission to offer right now.
 	Mission *MissionToOffer(Mission::Location location);


### PR DESCRIPTION
**Feature**

This PR addresses a feature brought up on [Discord](https://discord.com/channels/251118043411775489/266345072554016768/1545671926893252739).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Currently, the "to spawn" and "to despawn" conditions of an NPC are re-evaluated at the current locations:
1. When you accept a mission. (Mission::Do)
2. When an `on enter` action is executed in a mission. (Mission::Do for ship events)
3. When you land on a planet. (PlayerInfo::Land)
4. When you depart from a planet. (Engine::Place)

Then, NPCs are actually placed according to their spawn/despawn conditions in the following locations:
1. When you take off from a planet. (Engine::Place)
2. When you accept an in-flight mission, but only that in-flight missions NPCs are considered. (Engine::SpawnFleets)

This PR removes the condition check that occurs when completing an `on enter` action and instead adds a check to MainPanel after StepEvents has completed if the player's flagship sent a JUMP event, meaning that we check mission NPC spawns on every jump. This is immediately followed with placing any NPCs that are freshly capable of spawning. (The reason for the placement being here is described in my comment below.)

Since this is a behavioral change to NPC spawn conditions, whether an NPC will spawn as you jump into a new system is tied to the following new tag:
- `"instant spawning"`: If present and the NPC has `to spawn` conditions, the NPC will be spawned in as you jump into another system after NPC spawn conditions are evaluated on each jump. If not present, continues to use the old behavior of only being able to spawn when the player departs from a planet.

## Testing Done

None yet.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/259