### PR TITLE
fix: Don't silently overwrite certain weapon data if a weapon is defined twice

### DIFF
--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -38,16 +38,10 @@ Weapon::Weapon(const DataNode &node)
 // Load from a "weapon" node, either in an outfit or in a ship (explosion).
 void Weapon::Load(const DataNode &node)
 {
+	bool isClustered = isLoaded ? !isStreamed : false;
 	isLoaded = true;
-
-	bool isClustered = false;
 	calculatedDamage = false;
 	doesDamage = false;
-	bool safeRangeOverriden = false;
-	bool disabledDamageSet = false;
-	bool minableDamageSet = false;
-	bool relativeDisabledDamageSet = false;
-	bool relativeMinableDamageSet = false;
 
 	for(const DataNode &child : node)
 	{

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -231,6 +231,11 @@ private:
 
 private:
 	bool isLoaded = false;
+	bool safeRangeOverriden = false;
+	bool disabledDamageSet = false;
+	bool minableDamageSet = false;
+	bool relativeDisabledDamageSet = false;
+	bool relativeMinableDamageSet = false;
 
 	// Sprites and sounds.
 	Drawable projectileSprite;


### PR DESCRIPTION
**Bug fix**

Fixes #12474.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Taking Tom's comment from the issue:

> If we want to change that, we could move the damageSet flags from Weapon::Load to the Weapon itself, but ideally this should be handled in GameData, since we don't need these flags anymore after the loading finishes.

For isClustered, I just take the opposite of isStreamed if this isn't the first time this weapon is being loaded.

For the rest of the bugged weapon attributes, I went with the first approach. I originally took a stab at fixing this by doing something similar to what I did with isClustered (for example, by checking if hull damage doesn't equal minable damage to determine if it had been explicitly set before or not), but those ran into edge cases (for example, imagine explicitly defining a weapon's hull and minable damage to 100, then a second load call sets the hull damage to 200; if we used the previously mentioned check, this would change the minable damage to 200 as well). As such, I figured it simple enough to just move the flags to Weapon itself. Sure, they take up a bit of extra space that isn't needed after loading is finished, but it's not the end of the world.

In response to the second approach, I don't really see how GameData could cleanly keep track of this. A FinishLoading function on weapons wouldn't work, because how could we tell during FinishLoading if a weapons does 0 minable damage because it was explicitly set that way or because it just wasn't defined? If not a FinishLoading function, what exactly would GameData be doing? Keep in mind that GameData doesn't directly load Weapon. Weapon is only ever loaded as a child of Ship or Outfit.

## Testing Done

Nope.