### PR TITLE
feat(mechanics): Update the scenarios in which autopilot is canceled to avoid unintended cancellations by the player

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -61,14 +61,19 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 using namespace std;
 
 namespace {
-	// If the player issues any of those commands, then any autopilot actions for the player get cancelled.
-	const Command &AutopilotCancelCommands()
+	bool ShouldCancelAutopilot(const Ship &flagship, const Command &activeCommands)
 	{
+		// If the player issues any of those commands, then any autopilot actions for the player get cancelled.
 		static const Command cancelers(Command::LAND | Command::JUMP | Command::FLEET_JUMP | Command::BOARD
-			| Command::AFTERBURNER | Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT
+			| Command::BACK | Command::FORWARD | Command::LEFT | Command::RIGHT
 			| Command::AUTOSTEER | Command::STOP);
-
-		return cancelers;
+		if(activeCommands.Has(cancelers))
+			return true;
+		// The afterburner command should only cancel the autopilot
+		// if the player actually has an afterburner installed.
+		if(activeCommands.Has(Command::AFTERBURNER) && flagship.CanUseAfterburner())
+			return true;
+		return false;
 	}
 
 	bool NeedsFuel(const Ship &ship)
@@ -552,7 +557,7 @@ void AI::UpdateKeys(PlayerInfo &player, const Command &activeCommands)
 		Messages::Add(*GameData::Messages().Get("coming to a stop"));
 
 	autoPilot |= activeCommands;
-	if(activeCommands.Has(AutopilotCancelCommands()))
+	if(ShouldCancelAutopilot(*flagship, activeCommands))
 	{
 		bool canceled = (autoPilot.Has(Command::JUMP) && !activeCommands.Has(Command::JUMP | Command::FLEET_JUMP));
 		canceled |= (autoPilot.Has(Command::STOP) && !activeCommands.Has(Command::STOP));
@@ -4863,7 +4868,7 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 		if(activeCommands.Has(Command::AFTERBURNER))
 			command |= Command::AFTERBURNER;
 
-		if(activeCommands.Has(AutopilotCancelCommands()))
+		if(ShouldCancelAutopilot(ship, activeCommands))
 			autoPilot = activeCommands;
 	}
 	bool shouldAutoAim = false;

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2259,6 +2259,15 @@ void Engine::HandleKeyboardInputs()
 		else if(keyHeld.Has(Command::JUMP))
 			activeCommands |= Command::FLEET_JUMP;
 	}
+	else if(keyHeld.Has(Command::BACK) && flagship->Commands().Has(Command::STOP))
+	{
+		// If the player previously sent a STOP command and hits the BACK key,
+		// maintain the STOP command. Since STOP is shift+BACK, releasing the shift
+		// key before releasing the BACK key after having sent a STOP command can
+		// cancel it, which likely isn't what the player wants.
+		activeCommands |= Command::STOP;
+		activeCommands.Clear(Command::BACK);
+	}
 
 	if(keyHeld.Has(Command::AUTOSTEER) && !activeCommands.Turn()
 			&& !activeCommands.Has(Command::LAND | Command::JUMP | Command::BOARD | Command::STOP))

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4002,6 +4002,15 @@ double Ship::ReverseThrust() const
 
 
 
+bool Ship::CanUseAfterburner() const
+{
+	if(!cache.afterburnerThrust)
+		return false;
+	return !CannotAct(ActionType::AFTERBURNER);
+}
+
+
+
 bool Ship::ShouldUseAfterburner() const
 {
 	if(!cache.afterburnerThrust)

--- a/source/Ship.h
+++ b/source/Ship.h
@@ -552,6 +552,9 @@ public:
 	bool CanCommunicateWhileCloaked() const;
 
 	double ReverseThrust() const;
+	// Whether this ship has an afterburner installed and it can be used. Does not consider
+	// the resource cost of using the afterburner.
+	bool CanUseAfterburner() const;
 	bool ShouldUseAfterburner() const;
 
 	bool SilentJumps() const;


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

If your flagship is in autopilot mode, sending certain commands will disengage autopilot. The afterburner command is one such command, although right now it will cancel the autopilot whether or not you actually have an afterburner installed.

This PR changes the behavior so that the afterburner command only cancels autopilot if you actually have an afterburner installed and you aren't using a cloak that prevents afterburner use. This does not check to see if you actually have the resources to use the afterburner.

Additionally, sending the back/reverse command while you have an active autopilot command to stop your ship no longer cancels the stop command. Since the stop command is triggered by shift+back, releasing shift before you release the back key causes the stop command to be canceled.

## Testing Done

Yes.