### PR TITLE
feat(ui): Add a highlight when hovering over the ship name in the ship info panel

### DIFF
--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -397,6 +397,7 @@ void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 	// Colors to draw with.
 	const Color &dim = *GameData::Colors().Get("medium");
 	const Color &bright = *GameData::Colors().Get("bright");
+	const Color &backColor = *GameData::Colors().Get("faint");
 	const Ship &ship = **shipIt;
 
 	// Two columns of opposite alignment are used to simulate a single visual column.
@@ -406,6 +407,8 @@ void ShipInfoPanel::DrawShipStats(const Rectangle &bounds)
 	table.SetUnderline(0, COLUMN_WIDTH);
 	table.DrawAt(bounds.TopLeft() + Point(10., 8.));
 
+	if(table.GetRowBounds().Contains(hoverPoint))
+		table.DrawHighlight(backColor);
 	table.DrawTruncatedPair("ship:", dim, ship.GivenName(), bright, Truncate::MIDDLE, true);
 
 	info.DrawAttributes(table.GetRowBounds().TopLeft() - Point(10., 10.));


### PR DESCRIPTION
**UI**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

There's a hidden button in the ship info panel tied to shift+r for renaming your ship. It overlaps with the name of your ship in the panel, and can be clicked on.
https://github.com/endless-sky/endless-sky/blob/0fc192c85a2d88a4beb2eb668305224a9e4e3144/data/_ui/interfaces.txt#L2584-L2586

There's really no way to know it's there otherwise, though, so this PR updates the panel to add a highlight when your mouse is hovering over the ship name to show that it's clickable, just as I did with the cargo and outfits in #12592.

## Screenshots

<img width="1035" height="681" alt="image" src="https://github.com/user-attachments/assets/7b59719e-b719-4bff-89f1-71c5ef19c15d" />

## Testing Done

Yes.