### PR TITLE
feat: Add an "optical size" attribute that gets used for optical tracking in place of mass

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -541,7 +541,7 @@ tip "optical jamming:"
 	`Reduces the ability of optical-guided missiles to track your ship, which is mostly useful for larger ships. The more optical jamming is installed, the greater the distance at which missiles can be jammed, and the greater the chance that a jammed missile will fly off in a random direction.`
 
 tip "optical size:"
-	`The size of this ship. Influences the targeting strength of optical-guided missiles targeting this ship.`
+	`Influences the tracking strength of optical-guided missiles targeting this ship. A larger value means the ship is easier to track.`
 
 tip "piercing:"
 	`Percentage of this weapon's damage that leaks through to the hull while the target's shields are still active.`

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -540,6 +540,9 @@ tip "overheat damage threshold:"
 tip "optical jamming:"
 	`Reduces the ability of optical-guided missiles to track your ship, which is mostly useful for larger ships. The more optical jamming is installed, the greater the distance at which missiles can be jammed, and the greater the chance that a jammed missile will fly off in a random direction.`
 
+tip "optical size:"
+	`The size of this ship. Influences the targeting strength of optical-guided missiles targeting this ship.`
+
 tip "piercing:"
 	`Percentage of this weapon's damage that leaks through to the hull while the target's shields are still active.`
 

--- a/source/Entity.cpp
+++ b/source/Entity.cpp
@@ -238,6 +238,13 @@ bool Entity::IsTargetable() const
 
 
 
+double Entity::OpticalSize() const
+{
+	return opticalSize ? opticalSize : Mass();
+}
+
+
+
 double Entity::OpticalJamming() const
 {
 	return opticalJamming;
@@ -390,6 +397,8 @@ void Entity::CreateSparks(vector<Visual> &visuals, const Effect *effect, double 
 void Entity::CacheAttributes()
 {
 	heatDissipation = attributes.Get("heat dissipation");
+
+	opticalSize = attributes.Get("optical size");
 	opticalJamming = attributes.Get("optical jamming");
 	radarJamming = attributes.Get("radar jamming");
 

--- a/source/Entity.h
+++ b/source/Entity.h
@@ -91,7 +91,8 @@ public:
 	// Whether this entity can be targeted by ships and projectiles.
 	virtual bool IsTargetable() const;
 
-	// Jamming attributes that influence projectiles tracking this entity.
+	// Attributes that influence projectiles tracking this entity.
+	double OpticalSize() const;
 	double OpticalJamming() const;
 	double RadarJamming() const;
 
@@ -143,7 +144,8 @@ protected:
 
 	double heatDissipation = 0.;
 
-	// Jamming attributes that influence projectiles tracking this entity.
+	// Attributes that influence projectiles tracking this entity.
+	double opticalSize = 0.;
 	double opticalJamming = 0.;
 	double radarJamming = 0.;
 

--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -459,8 +459,8 @@ void Projectile::CheckLock(const Entity &target)
 		double opticalJamming = target.IsDisabled() ? 0. : target.OpticalJamming();
 		if(opticalJamming)
 			opticalJamming *= RangeFraction(position.Distance(target.Position()), opticalJamming);
-		double targetMass = target.Mass() / (1. + opticalJamming);
-		double weight = targetMass * targetMass * targetMass / 1e9;
+		double opticalSize = target.OpticalSize() / (1. + opticalJamming);
+		double weight = opticalSize * opticalSize * opticalSize / 1e9;
 		double lockChance = weapon->OpticalTracking() * weight / (1. + weight);
 		double probability = lockChance / (RELOCK_RATE - (lockChance * RELOCK_RATE) + lockChance);
 		hasLock |= Check(probability, base);


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

Split from #12674. Fixes #12644. 

This PR changes optical tracking to be based off of the value of an OpticalSize function on Entity (shared by minable asteroids and ships). This function returns the value of the "optical size" attribute if it is non-zero. Otherwise, the mass of the ship is returned.

## Wiki Update

https://github.com/endless-sky/endless-sky-wiki/pull/260