### PR TITLE
fix: Properly remove uncompleted Ghosts keystone mission

### DIFF
--- a/data/successors/successor 2 ghosts aqrabe.txt
+++ b/data/successors/successor 2 ghosts aqrabe.txt
@@ -91,8 +91,9 @@ mission "Successors: Ghosts Aqrabe Remnant"
 	source "Kasii-Cavasaa-Oa"
 	mark "Pantica"
 	to fail
-		has "Successors: Ghosts Aqrabe Hai: done"
-		has "Successors: Ghosts Aqrabe 1: declined"
+		or
+			has "Successors: Ghosts Aqrabe Hai: done"
+			has "Successors: Ghosts Aqrabe 1: declined"
 	to offer
 		has "Successors: Ghosts 4: offered"
 		has "license: Remnant"
@@ -108,8 +109,9 @@ mission "Successors: Ghosts Aqrabe Hai"
 	source "Kasii-Cavasaa-Oa"
 	mark "Ya Hai"
 	to fail
-		has "Successors: Ghosts Aqrabe Remnant: done"
-		has "Successors: Ghosts Aqrabe 1: declined"
+		or
+			has "Successors: Ghosts Aqrabe Remnant: done"
+			has "Successors: Ghosts Aqrabe 1: declined"
 	to offer
 		has "Successors: Ghosts 4: offered"
 		has "First Contact: Hai: offered"


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug [on Discord](https://discord.com/channels/251118043411775489/1287895983207878686/1547713250710257787).

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
The missions `Successors: Ghosts Aqrabe Remnant` and `Successors: Ghosts Aqrabe Hai` were not properly `fail`ing the other when one was completed. I tracked this down to their needing an OR over their `to fail` conditions.

## Testing Done
Checked in-game that the appropriate mission is completed upon delivering 50 Hai or Remnant Keystones, and that the other mission correctly `fail`s when this happens. Both missions work as expected.