### PR TITLE
feat(content): Add a "start: vanilla" condition shared by all vanilla starts

### DIFF
--- a/data/starts.txt
+++ b/data/starts.txt
@@ -34,6 +34,7 @@ start "default"
 	set "species: human"
 	set "human space start"
 	set "start: default"
+	set "start: vanilla"
 
 
 # Patch for if the player started a game before 0.10.17
@@ -48,6 +49,23 @@ mission "Start: Default Patch"
 		set "species: human"
 		set "human space start"
 		set "start: default"
+		fail
+
+# Patch for if the player started a game before 0.11.3
+mission "Start: Vanilla Patch"
+	invisible
+	landing
+	non-blocking
+	to offer
+		not "start: vanilla"
+		or
+			has "start: default"
+			has "start: deep"
+			has "start: paradise"
+			has "start: syndicate"
+			has "start: hai"
+	on offer
+		set "start: vanilla"
 		fail
 
 
@@ -91,6 +109,7 @@ start "deep"
 	set "species: human"
 	set "human space start"
 	set "start: deep"
+	set "start: vanilla"
 
 conversation "deep intro"
 	action
@@ -128,6 +147,7 @@ start "paradise"
 	set "species: human"
 	set "human space start"
 	set "start: paradise"
+	set "start: vanilla"
 
 conversation "paradise intro"
 	action
@@ -168,6 +188,7 @@ start "syndicate"
 	set "species: human"
 	set "human space start"
 	set "start: syndicate"
+	set "start: vanilla"
 
 conversation "syndicate intro"
 	action
@@ -226,6 +247,7 @@ start "hai space"
 	set "species: human"
 	set "hai space start"
 	set "start: hai"
+	set "start: vanilla"
 	# need to set it here to not have it trigger alongside the invisible mission
 	set "First Contact: Hai: offered"
 	set "First Contact: Hai: declined"


### PR DESCRIPTION
**Content (Artwork / Missions / Jobs)**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

As noted in my comment in https://github.com/endless-sky/endless-sky/pull/12126#discussion_r3911082653, if we want to check if the player picked a starting scenario that isn't one of the vanilla starts, we need to check if the player doesn't have any of the individual conditions for the vanilla starting scenarios. As more vanilla starting scenarios are added in the future, such checks will only increase in size.

This PR makes it so that all vanilla starts gain a `"start: vanilla"` condition. Whenever we want to check if the player is using a plugin start, we can then just check `not "start: vanilla"`.

## Testing Done

Nope.